### PR TITLE
Fix github_repo for names with hyphens and dots.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -64,7 +64,9 @@ class Project < ActiveRecord::Base
 
   # The user/repo part of the repository URL.
   def github_repo
-    repository_url.scan(/:(\w+\/\w+)\.git$/).join
+    # GitHub allows underscores, hyphens and dots in repo names
+    # but only hyphens in user/organisation names (as well as alphanumeric).
+    repository_url.scan(/:([A-Za-z0-9-]+\/[\w.-]+)\.git$/).join
   end
 
   def repository_homepage

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -73,6 +73,19 @@ describe Project do
       project = Project.new(repository_url: "git@github.com:foo/bar.git")
       project.github_repo.must_equal "foo/bar"
     end
+
+    it "handles user, organisation and repository names with hyphens" do
+      project = Project.new(repository_url: "git@github.com:inlight-media/lighthouse-ios.git")
+      project.github_repo.must_equal "inlight-media/lighthouse-ios"
+    end
+
+    it "handles repository names with dashes or dots" do
+      project = Project.new(repository_url: "git@github.com:angular/angular.js.git")
+      project.github_repo.must_equal "angular/angular.js"
+
+      project = Project.new(repository_url: "git@github.com:zendesk/demo_apps.git")
+      project.github_repo.must_equal "zendesk/demo_apps"
+    end
   end
 
   describe "nested stages attributes" do


### PR DESCRIPTION
Some GitHub repos (and user/organisation names) include characters that fall outside of the current RegExp. This fixes that.
