### PR TITLE
fix test fail in postgres

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ActiveRecord::Base
   end
 
   def self.create_or_update_from_hash(hash)
-    user = User.where(external_id: hash[:external_id]).first
+    user = User.where(external_id: hash[:external_id].to_s).first
     user ||= User.where(email: hash[:email]).first
     user ||= User.new
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20140520043144) do
     t.integer  "user_id",                                           null: false
     t.integer  "project_id",                                        null: false
     t.string   "status",                        default: "pending"
-    t.text     "output",     limit: 2147483647
+    t.text     "output",     limit: 1073741823
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "commit"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -34,6 +34,7 @@ describe User do
         name: "Test User",
         email: "test@example.org",
         role_id: Role::ADMIN.id,
+        external_id: 'strange-bug',
       }}
 
       it "creates a new user" do
@@ -45,7 +46,7 @@ describe User do
       end
 
       it "sets the role_id" do
-        user.role_id.must_equal(Role::SUPER_ADMIN.id)
+        user.role_id.must_equal(Role::ADMIN.id)
       end
     end
 


### PR DESCRIPTION
Don't know to keep it as one PR or make it two.
When i use Postgres, this line

``` ruby
user = User.where(external_id: hash[:external_id]).first
```

give me error 

``` bash
User::.create_or_update_from_hash::backfilling external_id#test_0001_should backfill user external_id:
ActiveRecord::StatementInvalid: PG::Error: ERROR:  operator does not exist: character varying = integer
LINE 1: ...s"."deleted_at" IS NULL AND "users"."external_id" = 9  ORDER...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: SELECT  "users".* FROM "users"  WHERE "users"."deleted_at" IS NULL AND "users"."external_id" = 9  ORDER BY "users"."id" ASC LIMIT 1
    app/models/user.rb:20:in `create_or_update_from_hash'
    test/models/user_test.rb:30:in `block (3 levels) in <top (required)>'
    test/models/user_test.rb:68:in `block (4 levels) in <top (required)>'
```

In short, it can't compare string and integer. So i made `hash[:external_id]` to string before compare. Then another problem appear. `external_id` in `User` model is unique. But in `user_test` `with a new user`, auth_hash doesn't have `external_id` # => nil. And that is `super_admin` `external_id`.
