### PR TITLE
Bootstrap script sets up the mysql database adapter.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -49,7 +49,7 @@ echo
 bold "Copying example files"
 try "Creating .env" "test -e .env || cp .env.example .env"
 try "Generating a Rails secret" 'secret=`bundle exec rake secret` && sed -i "" -e "s/{bundle exec rake secret}/$secret/" .env'
-try "Creating config/database.yml" "test -e config/database.yml || cp config/database.sqlite.yml.example config/database.yml"
+try "Creating config/database.yml" "test -e config/database.yml || cp config/database.mysql.yml.example config/database.yml"
 try "Creating databases" "bundle exec rake db:setup > /dev/null"
 
 echo


### PR DESCRIPTION
The test suite does not run properly using the sqlite adapter. This will setup the mysql adapter instead during bootstrap.

@steved555 @jwswj 
