### PR TITLE
Jobs record the commit underneath an annotated tag.

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -148,7 +148,7 @@ class JobExecution
 
       @executor.execute!(*commands).tap do |status|
         if status
-          commit = `cd #{repo_cache_dir} && git rev-parse #{@reference}`.chomp
+          commit = commit_from_ref(repo_cache_dir, @reference)
           ActiveRecord::Base.connection.verify!
           @job.update_commit!(commit)
           ProjectLock.release(@job.project)
@@ -159,6 +159,14 @@ class JobExecution
 
       false
     end
+  end
+
+  def commit_from_ref(repo_dir, ref)
+    description = Dir.chdir(repo_dir) do
+      `git describe --long --tags --all #{ref}`
+    end
+
+    description.split("-").last.sub(/^g/, "")
   end
 
   def repo_cache_dir

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -64,6 +64,23 @@ class JobExecutionTest < ActiveSupport::TestCase
     assert_equal "lion", last_line_of_output
   end
 
+  it "records the commit properly when given an annotated tag" do
+    execute_on_remote_repo <<-SHELL
+      echo mantis shrimp > foo
+      git add foo
+      git commit -m "commit"
+      git tag -a annotated_tag -m "annotation"
+    SHELL
+
+    master = File.join(repository_url, ".git", "refs", "heads", "master")
+    commit = File.read(master).strip
+
+    execute_job "annotated_tag"
+
+    assert_equal "mantis shrimp", last_line_of_output
+    assert_match /^#{commit[0,7]}/, job.commit
+  end
+
   it "updates the branch to match what's in the remote repository" do
     execute_on_remote_repo <<-SHELL
       git checkout -b safari


### PR DESCRIPTION
Currently when jobs are executed for an annotated tag, the job records the sha of the annotated tag, not the commit it points to.

This will look up the commit that the annotated tag points to and store that sha instead.

@steved555 @jwswj @shajith @dbuchi @kruppel 
