### PR TITLE
Prevent shell injection when computing commit from sha.

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -163,7 +163,7 @@ class JobExecution
 
   def commit_from_ref(repo_dir, ref)
     description = Dir.chdir(repo_dir) do
-      Tempfile.create("foo") do |file|
+      Tempfile.create("ref-description") do |file|
         system("git", "describe", "--long", "--tags", "--all", ref, out: file.fileno)
         file.rewind
         file.read.strip

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -74,8 +74,8 @@ class JobExecutionTest < ActiveSupport::TestCase
       git checkout master
     SHELL
 
-    master = File.join(repository_url, ".git", "refs", "heads", "mantis_shrimp")
-    commit = File.read(master).strip
+    branch = File.join(repository_url, ".git", "refs", "heads", "mantis_shrimp")
+    commit = File.read(branch).strip
 
     execute_job "annotated_tag"
 


### PR DESCRIPTION
Passing multiple arguments to the `system` command limits shell execution to one and only one command. No matter what input is received it will all be passed to the command specified as the first argument, in this case the `git` command.

The downside is the `system` command returns `true` or `false` depending on its exit status, so we have to capture its output manually.

@steved555 @jwswj @cericksen 

The changes from this morning triggered a Code Climate shell injection warning. Although the changes were just a bugfix and no additional security thread was added, we might as well clean up the existing threat while we're in this area.
