### PR TITLE
[WIP] support flexible versioning schemas

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -75,6 +75,8 @@ class ProjectsController < ApplicationController
       :name,
       :repository_url,
       :release_branch,
+      :versioning_schema,
+      :version_bump_component,
       stages_attributes: [
         :name, :confirm, :command,
         :deploy_on_release,

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -33,6 +33,6 @@ class ReleasesController < ApplicationController
   end
 
   def release_params
-    params.require(:release).permit(:commit).merge(author: current_user)
+    params.require(:release).permit(:commit, :version).merge(author: current_user)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -34,9 +34,8 @@ class Project < ActiveRecord::Base
   end
 
   def build_release(attrs = {})
-    latest_release_number = releases.last.try(:number) || 0
-    release_number = latest_release_number + 1
-    releases.build(attrs.merge(number: release_number))
+    attrs[:version] ||= Release.next_version_for(self)
+    releases.build(attrs)
   end
 
   def auto_release_stages
@@ -78,7 +77,7 @@ class Project < ActiveRecord::Base
   end
 
   def release_prior_to(release)
-    releases.where("number < ?", release.number).order(:number).last
+    releases.where("version < ?", release.version).order(:version).last
   end
 
   private

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,0 +1,73 @@
+class Version
+  attr_reader :data
+
+  def initialize(versioning_schema, version_str = "")
+    @versioning_schema = versioning_schema
+    @data = build_version_data(version_str)
+  end
+
+  def component_keys
+    @component_keys ||= @versioning_schema.scan(/{(\w+)}/).flatten
+  end
+
+  def default_bump_component
+    component_keys.last
+  end
+
+  def bump(bump_type = 'default')
+    if (bump_type == 'default')
+      bump_component(default_bump_component)
+    else
+      bump_component(bump_type)
+    end
+
+    value
+  end
+
+  def value
+    delimiters.zip(component_values).flatten.join("")
+  end
+
+  def to_s
+    value
+  end
+
+  private
+
+  def delimiters
+    @delimiters ||= @versioning_schema.scan(/([\w|\-|\.]+){\w+}/).flatten
+  end
+
+  def component_values
+    [].tap do |values|
+      component_keys.each do |component|
+        values << @data[component]
+      end
+    end
+  end
+
+  def build_version_data(version_str)
+    if (version_str.length > 0)
+      parse_version_data(version_str)
+    else
+      build_initial_version
+    end
+  end
+
+  def parse_version_data(version_str)
+    component_keys.zip(parse_component_values(version_str)).to_h
+  end
+
+  def parse_component_values(version_str)
+    version_str.scan(/\d+/).map(&:to_i)
+  end
+
+  def build_initial_version
+    component_values = [0] * (component_keys.length - 1) + [1]
+    component_keys.zip(component_values).to_h
+  end
+
+  def bump_component(component)
+    @data[component] += 1
+  end
+end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -22,6 +22,24 @@
       </div>
     </div>
 
+    <div class="form-group">
+      <%= form.label :versioning_schema, class: "col-lg-2 control-label" %>
+      <div class="col-lg-4">
+        <%= form.text_field :versioning_schema, class: "form-control" %>
+        <p class="help-block">Define a versioning schema by wrapping version components in curly braces</p>
+        <p class="help-block">example: v{major}.{minor}.{patch} => "v1.53.2"</p>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= form.label :version_bump_component, class: "col-lg-2 control-label" %>
+      <div class="col-lg-4">
+        <%= form.text_field :version_bump_component, class: "form-control" %>
+        <p class="help-block">If tracking a branch for commits, auto-release will bump this version component.</p>
+        <p class="help-block">example: patch</p>
+      </div>
+    </div>
+
     <% unless project.persisted? %>
       <%= form.fields_for :stages do |stage_fields| %>
         <%= render 'stages/fields', form: stage_fields %>

--- a/db/migrate/20140604182542_change_version_format_in_releases.rb
+++ b/db/migrate/20140604182542_change_version_format_in_releases.rb
@@ -1,0 +1,11 @@
+class ChangeVersionFormatInReleases < ActiveRecord::Migration
+  def up
+    rename_column :releases, :number, :version
+    change_column :releases, :version, :string, :default => nil, :null => false
+  end
+
+  def down
+    rename_column :releases, :version, :number
+    change_column :releases, :number, :integer, :default => 1
+  end
+end

--- a/db/migrate/20140604182729_migrate_versions_in_releases.rb
+++ b/db/migrate/20140604182729_migrate_versions_in_releases.rb
@@ -1,0 +1,6 @@
+class MigrateVersionsInReleases < ActiveRecord::Migration
+  def up
+    Release.reset_column_information
+    Release.update_all(version: "v#{version}")
+  end
+end

--- a/db/migrate/20140605233021_add_versioning_schema_to_projects.rb
+++ b/db/migrate/20140605233021_add_versioning_schema_to_projects.rb
@@ -1,0 +1,5 @@
+class AddVersioningSchemaToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :versioning_schema, :string
+  end
+end

--- a/db/migrate/20140609214652_add_version_bump_component_to_projects.rb
+++ b/db/migrate/20140609214652_add_version_bump_component_to_projects.rb
@@ -1,0 +1,5 @@
+class AddVersionBumpComponentToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :version_bump_component, :string
+  end
+end

--- a/db/migrate/20140610215613_add_versioning_data_to_existing_projects.rb
+++ b/db/migrate/20140610215613_add_versioning_data_to_existing_projects.rb
@@ -1,0 +1,5 @@
+class AddVersioningDataToExistingProjects < ActiveRecord::Migration
+  def up
+    Project.where("release_branch IS NOT NULL").update_all("versioning_schema = 'v{number}', version_bump_component = 'number'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140520043144) do
+ActiveRecord::Schema.define(version: 20140610215613) do
 
   create_table "commands", force: true do |t|
     t.text     "command",    limit: 16777215
@@ -69,28 +69,30 @@ ActiveRecord::Schema.define(version: 20140520043144) do
   add_index "new_relic_applications", ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true, using: :btree
 
   create_table "projects", force: true do |t|
-    t.string   "name",           null: false
-    t.string   "repository_url", null: false
+    t.string   "name",                   null: false
+    t.string   "repository_url",         null: false
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "token"
     t.string   "release_branch"
+    t.string   "versioning_schema"
+    t.string   "version_bump_component"
   end
 
   add_index "projects", ["token"], name: "index_projects_on_token", using: :btree
 
   create_table "releases", force: true do |t|
-    t.integer  "project_id",              null: false
-    t.string   "commit",                  null: false
-    t.integer  "number",      default: 1
-    t.integer  "author_id",               null: false
-    t.string   "author_type",             null: false
+    t.integer  "project_id",                null: false
+    t.string   "commit",                    null: false
+    t.string   "version",     default: "1", null: false
+    t.integer  "author_id",                 null: false
+    t.string   "author_type",               null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true, using: :btree
+  add_index "releases", ["project_id", "version"], name: "index_releases_on_project_id_and_version", unique: true, using: :btree
 
   create_table "stage_commands", force: true do |t|
     t.integer  "stage_id"

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -2,3 +2,6 @@ test:
   name: Project
   repository_url: ssh://git@example.com:bar/foo.git
   token: kanyewest
+  release_branch: master
+  versioning_schema: v{number}
+  version_bump_component: number

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -16,17 +16,16 @@ describe Project do
       assert release.persisted?
     end
 
-    it "defaults to release number 1" do
+    it "defaults to release version v1" do
       release = project.create_release(commit: "foo", author: author)
 
-      assert_equal 1, release.number
+      assert_equal "v1", release.version
     end
 
-    it "increments the release number" do
-      project.releases.create!(author: author, commit: "bar", number: 41)
+    it "increments the release version" do
+      first_release = project.releases.create!(author: author, commit: "bar", version: "v41")
       release = project.create_release(commit: "foo", author: author)
-
-      assert_equal 42, release.number
+      assert_equal "v42", release.version
     end
   end
 
@@ -37,7 +36,7 @@ describe Project do
 
     it "returns changeset" do
       changeset = Changeset.new("url", "foo/bar", "a", "b")
-      project.releases.create!(author: author, commit: "bar", number: 50)
+      project.releases.create!(author: author, commit: "bar", version: "v50")
       release = project.create_release(commit: "foo", author: author)
 
       Changeset.stubs(:find).with("bar/foo", "bar", "foo").returns(changeset)
@@ -46,7 +45,7 @@ describe Project do
 
     it "returns empty changeset" do
       changeset = Changeset.new("url", "foo/bar", "a", "a")
-      release = project.releases.create!(author: author, commit: "bar", number: 50)
+      release = project.releases.create!(author: author, commit: "bar", version: "v50")
 
       Changeset.stubs(:find).with("bar/foo", nil, "bar").returns(changeset)
       assert_equal changeset, project.changeset_for_release(release)

--- a/test/models/release_tagger_test.rb
+++ b/test/models/release_tagger_test.rb
@@ -6,7 +6,7 @@ class ReleaseTaggerTest < ActiveSupport::TestCase
   let(:author) { users(:deployer) }
   let(:release_tagger) { ReleaseTagger.new(project) }
   let(:sha) { execute_on_remote_repo("git rev-parse HEAD").strip }
-  let(:release) { project.releases.create!(author: author, number: 22, commit: sha) }
+  let(:release) { project.releases.create!(author: author, version: "v22", commit: sha) }
 
   before do
     JobExecution.enabled = true
@@ -29,12 +29,12 @@ class ReleaseTaggerTest < ActiveSupport::TestCase
   it "creates and pushes a git tag on the commit" do
     release_tagger.tag_release!(release)
 
-    remote_sha = execute_on_remote_repo("git rev-parse #{release.version}").strip 
+    remote_sha = execute_on_remote_repo("git rev-parse #{release.version}").strip
     assert_equal sha, remote_sha
   end
 
   it "raises InvalidCommit if the commit was not a valid reference" do
-    release = project.releases.create!(author: author, number: 12, commit: "nanana")
+    release = project.releases.create!(author: author, version: "v12", commit: "nanana")
 
     assert_raises ReleaseTagger::InvalidCommit do
       release_tagger.tag_release!(release)

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -1,0 +1,18 @@
+require_relative '../test_helper'
+
+describe Release do
+
+  let(:project) { projects(:test) }
+  let(:author) { users(:admin) }
+
+  describe "validations" do
+
+    it "validates uniqueness of version scoped to the project" do
+      Release.create!(project: project, author: author, commit: "foo", version: "v2345")
+      release = Release.new(project: project, author: author, commit: "foo", version: "v2345")
+
+      assert_equal release.invalid?(:version), true
+    end
+  end
+
+end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -49,9 +49,9 @@ describe Stage do
     let(:author) { users(:deployer) }
     let(:job) { project.jobs.create!(user: author, commit: "x", command: "echo", status: "succeeded") }
 
-    let(:previous_release) { project.releases.create!(number: 3, author: author, commit: "A") }
-    let(:last_release) { project.releases.create!(number: 4, author: author, commit: "B") }
-    let(:undeployed_release) { project.releases.create!(number: 5, author: author, commit: "C") }
+    let(:previous_release) { project.releases.create!(version: "v3", author: author, commit: "A") }
+    let(:last_release) { project.releases.create!(version: "v4", author: author, commit: "B") }
+    let(:undeployed_release) { project.releases.create!(version: "v5", author: author, commit: "C") }
 
     before do
       stage.deploys.create!(reference: "v3", job: job)

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1,0 +1,67 @@
+require_relative '../test_helper'
+
+describe Version do
+
+  describe "#initialize" do
+
+    let(:versioning_schema) { "v{major}.{minor}.{patch}" }
+    let(:version_str) { "v1.86.2" }
+
+    describe "when given a versioning schema and version_str" do
+      let(:version) { Version.new(versioning_schema, version_str) }
+
+      it "parses the version_str values" do
+        assert_send([version, :parse_version_data, version_str])
+        assert_equal version.to_s, "v1.86.2"
+      end
+    end
+
+    describe "when given only a versioning schema " do
+      let(:version) { Version.new(versioning_schema) }
+
+      it "builds the initial version" do
+        assert_send([version, :build_initial_version])
+        assert_equal version.to_s, "v0.0.1"
+      end
+    end
+
+  end
+
+  describe "instance methods" do
+
+    let(:versioning_schema) { "v{major}.{minor}.{patch}" }
+    let(:version_str) { "v1.86.2" }
+    let(:version) { Version.new(versioning_schema, version_str) }
+
+    describe "#component_keys" do
+      it "returns an array of version components parsed from the versioning schema" do
+        assert_equal version.component_keys, ['major', 'minor', 'patch']
+      end
+    end
+
+    describe "#parse_version_data" do
+      it "returns a hash with component_keys and their values" do
+        assert_equal version.data['major'], 1
+        assert_equal version.data['minor'], 86
+        assert_equal version.data['patch'], 2
+      end
+    end
+
+    describe "#bump" do
+      describe "when given no arguments" do
+        it "bumps the version's last component by 1" do
+          assert_equal version.bump.to_s, "v1.86.3"
+        end
+      end
+
+      describe "when given a bump_type" do
+        it "bumps the specified component" do
+          assert_equal version.bump('major'), "v2.86.2"
+          assert_equal version.bump('minor'), "v2.87.2"
+          assert_equal version.bump('patch'), "v2.87.3"
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
:construction:

This PR adds support for unique versioning schemas. Users can specify a unique schema for each project. See test/models/version_test.rb for a quick overview of how this will work.
#### TODO
- [ ] Write tests for the Release model (some already exist within models/project_test.rb)
- [ ] Write database migration for projects that are using auto-release feature, they need to have a versioning schema, "v{number}"
- [ ] Add seed data and test that the migrations work as expected
