### PR TITLE
Stop viewers being able to create releases

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,5 +1,6 @@
 class ReleasesController < ApplicationController
   before_filter :find_project
+  before_filter :authorize_deployer!, except: [:show, :index]
 
   def show
     @release = @project.releases.find_by_version(params[:id])

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -1,16 +1,23 @@
 require_relative '../test_helper'
 
 describe ReleasesController do
+  let(:project) { projects(:test) }
+
   describe "#create" do
+    let(:release_params) { { commit: "abcd" } }
+
+    as_a_viewer do
+      it "doesn't creates a new release" do
+        count = Release.count
+        post :create, project_id: project.id, release: release_params
+        assert_equal count, Release.count
+      end
+    end
+
     as_a_deployer do
       it "creates a new release" do
-        project = projects(:test)
-        release_params = { commit: "abcd" }
-
         count = Release.count
-
         post :create, project_id: project.id, release: release_params
-
         assert_equal count + 1, Release.count
       end
     end


### PR DESCRIPTION
A viewer can currently create a new release (which they shouldn't be able to do).

/cc @zendesk/samson
