### PR TITLE
Fix soft_delete bugs and update one buddy test

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -1,4 +1,6 @@
 class Deploy < ActiveRecord::Base
+  has_soft_deletion default_scope: true
+
   belongs_to :stage, touch: true
   belongs_to :job
   belongs_to :buddy, class_name: 'User'

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,7 +5,7 @@ class Project < ActiveRecord::Base
   before_create :generate_token
 
   has_many :releases
-  has_many :stages
+  has_many :stages, dependent: :destroy
   has_many :deploys, through: :stages
   has_many :jobs, -> { order(created_at: :desc) }
   has_many :webhooks

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -2,7 +2,7 @@ class Stage < ActiveRecord::Base
   has_soft_deletion default_scope: true
 
   belongs_to :project, touch: true
-  has_many :deploys
+  has_many :deploys, dependent: :destroy
   has_many :flowdock_flows
   has_many :new_relic_applications
   has_one :lock

--- a/db/migrate/20140804204455_add_soft_deletion_to_deploys.rb
+++ b/db/migrate/20140804204455_add_soft_deletion_to_deploys.rb
@@ -1,0 +1,5 @@
+class AddSoftDeletionToDeploys < ActiveRecord::Migration
+  def change
+    add_column :deploys, :deleted_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140717013754) do
+ActiveRecord::Schema.define(version: 20140804204455) do
 
   create_table "commands", force: true do |t|
     t.text     "command",    limit: 16777215
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20140717013754) do
     t.datetime "updated_at"
     t.integer  "buddy_id"
     t.datetime "started_at"
+    t.datetime "deleted_at"
   end
 
   add_index "deploys", ["created_at"], name: "index_deploys_on_created_at", using: :btree

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -47,6 +47,7 @@ describe DeployMailer do
 
     before do
       BuddyCheck.stubs(:bypass_email_address).returns("test1@test.com")
+      BuddyCheck.stubs(:bypass_jira_email_address).returns("")
 
       user.update_attributes!(email: 'user_email@test.com')
 


### PR DESCRIPTION
When a samson project or a stage is deleted (and the project/stage has associated deploys), we end up with orphaned deploys.  This bug breaks the Current Deploys and Recent Deploys views.  When the Current Deploys view is broken in this way, the contents of the view cannot be seen, and _all_ pending production deploys wait indefinitely.

/cc @zendesk/samson @jwswj @pswadi-zendesk 
### TODO
- [x] refactor one buddy_check test
- [x] modify deploys schema to include deleted_at column
- [x] add cascading delete to project, stage, and deploy models
### RISKS
- need to verify that only soft_deletes occur
