### PR TITLE
bump sawyer gem to a real tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'active_model_serializers', '~> 0.8.0'
 # We need this specific version of Sawyer (which Octokit uses) because it supports
 # marshalling resources, which we use when caching responses. Once that's been released
 # we can use a normal gem version again.
-gem 'sawyer', git: 'https://github.com/dasch/sawyer.git', branch: 'dasch/fix-marshal-problem'
+gem 'sawyer', git: 'https://github.com/dasch/sawyer.git', tag: 'v0.5.3'
 
 # Logging
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/dasch/sawyer.git
-  revision: d71998f5829007ccd911adf17cf695d604d13619
-  branch: dasch/fix-marshal-problem
+  revision: 5f21bf1b4dbbcee76ad2f1cdfd184b3a14995faf
+  tag: v0.5.3
   specs:
     sawyer (0.5.3)
       addressable (~> 2.3.5)


### PR DESCRIPTION
Can we get rid of that branch reference for sawyer in the Gemfile now? That branch no longer exists in dasch/sawyer, so it makes it impossible to bundle any new clones of the repo.

@zendesk/samson 
