### PR TITLE
Display the time taken for a deploy again

### DIFF
--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -9,6 +9,8 @@ class DeployService
     deploy = stage.create_deploy(reference: reference, user: user)
 
     if deploy.persisted? && !(BuddyCheck.enabled? && stage.production?)
+      deploy.started_at = Time.new
+      deploy.save
       confirm_deploy!(deploy, stage, reference)
     end
 

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -28,6 +28,8 @@ class DeployServiceTest < ActiveSupport::TestCase
     before do
       stage.stubs(:create_deploy).returns(deploy)
       deploy.stubs(:persisted?).returns(true)
+      deploy.stubs(:started_at=).returns(true)
+      deploy.stubs(:save).returns(true)
       job_execution.stubs(:execute!)
 
       JobExecution.stubs(:start_job).with(reference, deploy.job).returns(job_execution)


### PR DESCRIPTION
Once again show the time taken for a deploy. This stopped working when BuddyCheck was enabled, because it reverted to checking `updated_at`. This always gave a result of zero.

Fixes #56 

/cc @zendesk/samson 
### References
- Jira link: 
### Risks
- None
