### PR TITLE
Save log to db as deploy runs.

### DIFF
--- a/app/models/output_buffer.rb
+++ b/app/models/output_buffer.rb
@@ -28,10 +28,14 @@ class OutputBuffer
     @chunks = ThreadSafe::Array.new
     @closed = false
   end
+  
+  def add_write_callback(&block)
+    @listeners << block
+  end
 
   def write(data, event = :message)
     @chunks << [event, data] unless event == :close
-    @listeners.each {|listener| listener.push([event, data]) }
+    @listeners.each {|listener| listener.respond_to?(:push) ? listener.push([event, data]) : listener.call([event,data]) }
   end
 
   def to_s
@@ -45,6 +49,10 @@ class OutputBuffer
 
   def closed?
     @closed
+  end
+  
+  def to_a
+    Array.new(@chunks)
   end
 
   def each(&block)

--- a/test/models/output_buffer_test.rb
+++ b/test/models/output_buffer_test.rb
@@ -32,6 +32,19 @@ describe OutputBuffer do
 
     build_listener.value.must_equal ["hello"]
   end
+  
+  it "issues write callbacks" do
+    
+    issued = false
+    buffer.add_write_callback do |event|
+      issued = true
+      assert event[1], "hello"
+    end
+    
+    buffer.write("hello")
+    
+    assert issued
+  end
 
   def build_listener
     Thread.new do


### PR DESCRIPTION
Save the deploy output log to the db as it runs, rather than waiting until the end. Thus if samson crashes we have, at least, the log up to the crash.

Format and save the entire log into the job after each line is received. A rather ham-handed way to do it, but it works.

@zendesk/samson 
