### PR TITLE
remove bourne

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 group :test do
   gem 'minitest-rails', '~> 2.0.0.beta1'
   gem 'minitest-rg'
-  gem 'bourne'
+  gem 'mocha', require: false
   gem 'webmock', require: false
   gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,6 @@ GEM
       sass (~> 3.2)
     bootstrap-x-editable-rails (1.5.1.1)
       railties (>= 3.0)
-    bourne (1.5.0)
-      mocha (>= 0.13.2, < 0.15)
     builder (3.2.2)
     coderay (1.1.0)
     crack (0.4.2)
@@ -238,7 +236,6 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   bootstrap-x-editable-rails
-  bourne
   bundler
   coderay (~> 1.1.0)
   dalli (~> 2.7.0)
@@ -255,6 +252,7 @@ DEPENDENCIES
   logstash-event
   minitest-rails (~> 2.0.0.beta1)
   minitest-rg
+  mocha
   momentjs-rails
   mysql2 (~> 0.3)
   newrelic_api

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -8,10 +8,11 @@ describe DeploysController do
   let(:job) { Job.create!(command: command, project: project, user: deployer) }
   let(:deploy) { Deploy.create!(stage: stage, job: job, reference: "foo") }
   let(:deploy_service) { stub(deploy!: nil) }
+  let(:deploy_called) { [] }
 
   setup do
     DeployService.stubs(:new).with(project, deployer).returns(deploy_service)
-    deploy_service.stubs(:deploy!).returns(deploy)
+    deploy_service.stubs(:deploy!).capture(deploy_called).returns(deploy)
 
     Changeset.stubs(:find).returns(stub(hotfix?: false))
   end
@@ -184,9 +185,7 @@ describe DeploysController do
         end
 
         it "creates a deploy" do
-          assert_received(deploy_service, :deploy!) do |expect|
-            expect.with stage, "master"
-          end
+          assert_equal [[stage, "master"]], deploy_called
         end
       end
 
@@ -198,9 +197,7 @@ describe DeploysController do
         end
 
         it "creates a deploy" do
-          assert_received(deploy_service, :deploy!) do |expect|
-            expect.with stage, "master"
-          end
+          assert_equal [[stage, "master"]], deploy_called
         end
       end
     end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -7,10 +7,11 @@ describe JobsController do
   let(:command) { "echo hello" }
   let(:job) { Job.create!(command: command, project: project, user: deployer) }
   let(:job_service) { stub(execute!: nil) }
+  let(:execute_called) { [] }
 
   setup do
     JobService.stubs(:new).with(project, deployer).returns(job_service)
-    job_service.stubs(:execute!).returns(job)
+    job_service.stubs(:execute!).capture(execute_called).returns(job)
   end
 
   as_a_viewer do
@@ -76,9 +77,7 @@ describe JobsController do
       end
 
       it "creates a job" do
-        assert_received(job_service, :execute!) do |expect|
-          expect.with "master", [], command
-        end
+        assert_equal [["master", [], command]], execute_called
       end
     end
 

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -6,11 +6,11 @@ class ReleaseServiceTest < ActiveSupport::TestCase
   let(:service) { ReleaseService.new(project) }
   let(:commit) { "abcd" }
   let(:release_tagger) { stub("release_tagger") }
+  let(:tag_release_called) { [] }
 
   before do
     ReleaseTagger.stubs(:new).with(project).returns(release_tagger)
-
-    release_tagger.stubs(:tag_release!)
+    release_tagger.stubs(:tag_release!).capture(tag_release_called)
   end
 
   it "creates a new release" do
@@ -23,10 +23,7 @@ class ReleaseServiceTest < ActiveSupport::TestCase
 
   it "tags the release" do
     release = service.create_release(commit: commit, author: author)
-
-    assert_received release_tagger, :tag_release! do |expect|
-      expect.with(release)
-    end
+    assert_equal [[release]], tag_release_called
   end
 
   it "deploys the commit to stages if they're configured to" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,12 @@ class MiniTest::Spec
   include StubGithubAPI
 end
 
+Mocha::Expectation.class_eval do
+  def capture(into)
+    with { |*args| into << args }
+  end
+end
+
 class ActionController::TestCase
   include StubGithubAPI
 


### PR DESCRIPTION
in the past bourne always was a blocker to upgrading mocha, so this should make things simpler ... 

@steved555 @pswadi-zendesk 
