### PR TITLE
deploy badges

### DIFF
--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -10,7 +10,10 @@
  <div class="alert alert-warning">Deployments to this stage were locked by <%= @stage.lock.user.name %> <%= time_ago_in_words(@stage.lock.created_at) %> ago. <%= @stage.lock.reason %></div>
 <% end %>
 
-<h1><%= @stage.name %></h1>
+<h1>
+  <%= @stage.name %>
+  <%= image_tag project_stage_path(@project, @stage, format: :svg, token: Rails.application.config.samson.badge_token), title: "Deploy badge" %>
+</h1>
 
 <section>
   <h2>Actions</h2>

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,5 +57,10 @@ module Samson
       host: config.samson.uri.host,
       protocol: config.samson.uri.scheme
     }
+
+    config.after_initialize do
+      # Token used to request badges
+      config.samson.badge_token = Digest::MD5.hexdigest('badge_token' << Samson::Application.config.secret_key_base)
+    end
   end
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,5 +1,1 @@
-# Be sure to restart your server when you modify this file.
-
-# Add new mime types for use in respond_to blocks:
-# Mime::Type.register "text/richtext", :rtf
-# Mime::Type.register_alias "text/html", :iphone
+Mime::Type.register "image/svg+xml", :svg


### PR DESCRIPTION
Now we can show the current deploy status on github project pages / anywhere on the web

![screen shot 2014-09-10 at 9 19 20 pm](https://cloud.githubusercontent.com/assets/11367/4229202/ee390bc0-396a-11e4-9106-57c63a10de00.png)
![screen shot 2014-09-10 at 8 28 36 pm](https://cloud.githubusercontent.com/assets/11367/4229203/f18a4fbe-396a-11e4-95c3-d543a7d32af4.png)

@steved555 @pswadi-zendesk @jwswj @princemaple 
