### PR TITLE
Correctly compute Github users' avatars

### DIFF
--- a/app/models/changeset/github_user.rb
+++ b/app/models/changeset/github_user.rb
@@ -1,10 +1,19 @@
+require 'uri'
+
 class Changeset::GithubUser
   def initialize(data)
     @data = data
   end
 
   def avatar_url
-    "https://www.gravatar.com/avatar/#{@data.gravatar_id}?s=20"
+    uri = URI(@data.avatar_url)
+    params = URI.decode_www_form(uri.query || [])
+
+    # The `s` parameter controls the size of the avatar.
+    params << ["s", "20"]
+
+    uri.query = URI.encode_www_form(params)
+    uri.to_s
   end
 
   def url

--- a/test/models/changeset/github_user_test.rb
+++ b/test/models/changeset/github_user_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+describe Changeset::GithubUser do
+  describe "#avatar_url" do
+    it "returns the URL for the user's avatar" do
+      data = stub("data", avatar_url: "https://avatars.githubusercontent.com/u/1337?v=2")
+
+      user = Changeset::GithubUser.new(data)
+      user.avatar_url.must_equal "https://avatars.githubusercontent.com/u/1337?v=2&s=20"
+    end
+  end
+end


### PR DESCRIPTION
Currently, avatars are broken – probably because Github is transitioning away from gravatar. This should fix it.
