### PR TITLE
Temporarily disabling buddy check flowdock notifications.

### DIFF
--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -10,8 +10,6 @@ class DeployService
 
     if deploy.persisted? && !(BuddyCheck.enabled? && stage.production?)
       confirm_deploy!(deploy, stage, reference)
-    else
-      flowdock_buddy_request(stage, deploy)
     end
 
     deploy
@@ -32,10 +30,6 @@ class DeployService
   def send_before_notifications(stage, deploy, buddy)
     send_flowdock_notification(stage, deploy)
 
-    if BuddyCheck.enabled? && stage.production?
-      flowdock_buddy_request_completed(stage, deploy, buddy)
-    end
-
     if BuddyCheck.enabled? && buddy == deploy.user
       DeployMailer.bypass_email(stage, deploy, user).deliver
     end
@@ -49,20 +43,6 @@ class DeployService
     send_flowdock_notification(stage, deploy)
     send_datadog_notification(stage, deploy)
     send_github_notification(stage, deploy)
-  end
-
-  def flowdock_buddy_request_completed(stage, deploy, buddy)
-    return #TODO: Disable for now, configurable changes coming in soon
-    if stage.send_flowdock_notifications?
-      FlowdockNotification.new(stage, deploy).buddy_request_completed(buddy)
-    end
-  end
-
-  def flowdock_buddy_request(stage, deploy)
-    return #TODO: Disable for now, configurable changes coming in soon
-    if stage.send_flowdock_notifications?
-      FlowdockNotification.new(stage, deploy).buddy_request
-    end
   end
 
   def send_flowdock_notification(stage, deploy)

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -27,15 +27,6 @@ class DeployServiceTest < ActiveSupport::TestCase
     end
   end
 
-  describe "buddy request notifications" do
-    it "sends flowedock chat notifications for production stages" do
-      stage_production.stubs(:send_flowdock_notifications?).returns(true)
-      BuddyCheck.stubs(:enabled?).returns(true)
-      FlowdockNotification.any_instance.expects(:buddy_request).never
-      service.deploy!(stage_production, reference)
-    end
-  end
-
   describe "after notifications" do
     before do
       stage.stubs(:create_deploy).returns(deploy)


### PR DESCRIPTION
We will add more configuration to let users choose where to send the notifications and whom to include. For now, disabling it to reduce the noise

@jwswj  :-| ;-)

/cc @zendesk/samson 
### References
### Risks
- None
