### PR TITLE
make interrupt not blow up all tests

### DIFF
--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -42,7 +42,11 @@ describe TerminalExecutor do
       end
 
       Timeout.timeout(5) do
-        subject.execute!('sleep 100').must_equal(false)
+        begin
+          subject.execute!('sleep 100').must_equal(false)
+        rescue Interrupt
+          raise "Interrupted"
+        end
       end
 
       thr.join


### PR DESCRIPTION
@steved555 @pswadi-zendesk 

still having that issue, at least this way it just raises and does not kill all my tests ...
### Risks
- None
