### PR TITLE
Fix deploy buddy not saving.

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -68,7 +68,8 @@ class Deploy < ActiveRecord::Base
   end
 
   def confirm_buddy!(buddy)
-    update_attributes(buddy: buddy, started_at: Time.now)
+    update_attribute(:buddy, buddy)
+    update_attribute(:started_at, Time.now)
     DeployService.new(project, user).confirm_deploy!(self, stage, reference, buddy)
   end
 


### PR DESCRIPTION
https://zendesk.atlassian.net/browse/SAMSON-117

Skips validation for updating the deploy buddy.

This issue is that the deploy always wants to validate as "deployable".
https://github.com/zendesk/samson/blob/master/app/models/deploy.rb#L11

Either we loosen the validation on the deploy model, or we skip validation when we update the buddy.
