### PR TITLE
Pswadi/buddy approval for release

### DIFF
--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -9,7 +9,7 @@ class DeployService
     deploy = stage.create_deploy(reference: reference, user: user)
 
     if deploy.persisted? && (auto_confirm?(stage) || release_approved?(deploy))
-      confirm_deploy!(deploy, stage, reference)
+      confirm_deploy!(deploy, stage, reference, deploy.buddy)
     end
 
     deploy
@@ -31,21 +31,26 @@ class DeployService
     !BuddyCheck.enabled? || !stage.production?
   end
 
-  def latest_approved_deploy(deploy)
-    Deploy.where('reference = ? AND buddy_id is NOT NULL AND started_at > ?', deploy.reference, (Time.now - (BuddyCheck.grace_period*60*60)))
-      .order(started_at: :asc)
+  def latest_approved_deploy(reference, project)
+    deploy = nil
+    Deploy.where(reference: reference).where(' buddy_id is NOT NULL AND started_at > ?', BuddyCheck.period.hours.ago)
       .includes(:stage)
-      .where(stages: {project_id: deploy.stage.project, production: true})
-      .first
+      .where(stages: {project_id: project, production: true})
+      .each do |d|
+        next if bypassed?(d.stage, d, d.buddy)
+        deploy = d
+        break
+      end
+      deploy
   end
 
   def release_approved?(deploy)
-    last_d = latest_approved_deploy(deploy)
+    last_d = latest_approved_deploy(deploy.reference, deploy.stage.project)
 
-    return false unless last_d && !bypassed?(last_d.stage, last_d, last_d.buddy)
+    return false if !last_d
 
-    deploy.buddy = last_d.buddy == @user ? last_d.job.user : last_d.buddy
-    deploy.update_attributes({started_at: Time.now, buddy_id: deploy.buddy.id})
+    deploy.buddy = (last_d.buddy == @user ? last_d.job.user : last_d.buddy)
+    deploy.update_attributes!({started_at: Time.now, buddy_id: deploy.buddy.id})
 
     return true
   end

--- a/lib/policies/buddy_check.rb
+++ b/lib/policies/buddy_check.rb
@@ -9,7 +9,7 @@ module BuddyCheck
     ENV["BYPASS_EMAIL"]
   end
 
-  def grace_period
+  def period
     (ENV["BUDDY_CHECK_GRACE_PERIOD"].presence || "4").to_i
   end
 

--- a/test/fixtures/stages.yml
+++ b/test/fixtures/stages.yml
@@ -10,3 +10,10 @@ test_production:
   confirm: false
   production: true
   permalink: production
+
+test_production_pod:
+  name: Production Pod
+  project: test
+  confirm: false
+  production: true
+  permalink: production-pod


### PR DESCRIPTION
The tag / SHA specified in the deploy will be used for checking if the same deploy to another production stage was already approved in last 4 hours. If so, the buddy will be "carried forward" for the new stage.   BUDDY_CHECK_GRACE_PERIOD decides how long we want to search for.

This does not start the queued up deploys, yet.

/cc @zendesk/samson @grosser @steved555 
### References
- Jira link: 
### Risks
- Buddy approval anomalies?
