### PR TITLE
validate uniqueness against permalink scope

### DIFF
--- a/app/models/concerns/permalinkable.rb
+++ b/app/models/concerns/permalinkable.rb
@@ -2,8 +2,8 @@ module Permalinkable
   extend ActiveSupport::Concern
 
   included do
-    validates :permalink, uniqueness: true
     before_create :generate_permalink
+    validate :validate_unique_permalink
   end
 
   module ClassMethods
@@ -19,14 +19,24 @@ module Permalinkable
   private
 
   def permalink_scope
-    self.class
+    self.class.unscoped
   end
 
   def generate_permalink
     base = permalink_base.parameterize
     self.permalink = base
-    if permalink_scope.where(permalink: permalink).exists?
+    if permalink_taken?
       self.permalink = "#{base}-#{SecureRandom.hex(4)}"
     end
+  end
+
+  def permalink_taken?
+    scope = permalink_scope.where(permalink: permalink)
+    scope = scope.where("id <> ?", id) if persisted?
+    scope.exists?
+  end
+
+  def validate_unique_permalink
+    errors.add(:permalink, :taken) if permalink_taken?
   end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -183,6 +183,6 @@ class Stage < ActiveRecord::Base
   end
 
   def permalink_scope
-    project.stages
+    Stage.unscoped.where(project_id: project_id)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,14 @@ class ActiveSupport::TestCase
   before do
     Rails.cache.clear
   end
+
+  def assert_valid(record)
+    assert record.valid?, record.errors.full_messages
+  end
+
+  def refute_valid(record)
+    refute record.valid?
+  end
 end
 
 module StubGithubAPI


### PR DESCRIPTION
@pswadi-zendesk @steved555 

before old records were invalid when updated since validation was global and did not mirror the db-index that is scoped to project_id for stages, also did not do validations when other project/stage was deleted
### Risks
- None
