### PR TITLE
make the changelog table responsive to prevent overflow

### DIFF
--- a/app/views/changelogs/show.html.erb
+++ b/app/views/changelogs/show.html.erb
@@ -2,8 +2,7 @@
 
 <h1><%= @project.name %> Changelog</h1>
 
-<section>
-
+<section class="table-responsive">
   <form id="date-chooser">
     <p class="form-inline">
       Changes made between


### PR DESCRIPTION
Small fix:
###### Before

![screen shot 2014-11-13 at 11 55 28 am](https://cloud.githubusercontent.com/assets/13248/5035433/026ba5d8-6b2c-11e4-84ec-1a1dfcd7cd2b.png)
###### After (scrolls right)

![screen shot 2014-11-13 at 11 55 17 am](https://cloud.githubusercontent.com/assets/13248/5035432/026b1168-6b2c-11e4-94aa-61418355cfde.png)

@ciaranarcher @zendesk/samson 
