### PR TITLE
Modify TMPDIR env variable for each deploy to prevent filling HDD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   global:
     - SECRET_TOKEN=d6054cf90db212c8fbc070c896c30398e3275532c5602bdf00cb153b806c000e4e46fac2f3acc0783822b8f6d30b5913b6fbcfdd24914553e745b8aa8ddfa5a4
     - DEFAULT_URL=http://www.test-url.com
+    - TMPDIR=/tmp
 script:
   - npm test
   - bundle exec rake

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -96,7 +96,9 @@ class JobExecution
   end
 
   def execute!(dir)
-    unless setup!(dir)
+    repo_dir = Dir.mktmpdir(nil, dir)
+
+    unless setup!(repo_dir)
       @job.error!
       return
     end
@@ -105,12 +107,13 @@ class JobExecution
     @output.write("Executing deploy\n")
 
     commands = [
+      "export TMPDIR=#{dir}",
       "export DEPLOYER=#{@job.user.email.shellescape}",
       "export DEPLOYER_EMAIL=#{@job.user.email.shellescape}",
       "export DEPLOYER_NAME=#{@job.user.name.shellescape}",
       "export REVISION=#{@reference.shellescape}",
       "export CACHE_DIR=#{artifact_cache_dir}",
-      "cd #{dir}",
+      "cd #{repo_dir}",
       *@job.commands
     ]
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -120,6 +120,8 @@ describe JobExecution, :model do
   end
 
   it 'deletes all tmp files after run' do
+    # Travis doesn't set tmpdir?
+    ENV['TMPDIR'] ||= File.join(Rails.root, 'tmp')
     job.command = 'echo hello > $TMPDIR/foo'
     execute_job
     assert_equal false, File.exists?(File.join(ENV['TMPDIR'], 'foo'))

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -120,11 +120,9 @@ describe JobExecution, :model do
   end
 
   it 'deletes all tmp files after run' do
-    # Travis doesn't set tmpdir?
-    ENV['TMPDIR'] ||= File.join(Rails.root, 'tmp')
     job.command = 'echo hello > $TMPDIR/foo'
     execute_job
-    assert_equal false, File.exists?(File.join(ENV['TMPDIR'], 'foo'))
+    refute File.exists?(File.join(ENV['TMPDIR'], 'foo'))
   end
 
   it "removes the job from the registry" do
@@ -164,6 +162,7 @@ describe JobExecution, :model do
   def execute_job(branch = "master")
     execution = JobExecution.new(branch, job)
     execution.send(:run!)
+    assert job.succeeded?
   end
 
   def execute_on_remote_repo(cmds)

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -119,6 +119,12 @@ describe JobExecution, :model do
     assert_equal "hello", last_line_of_output
   end
 
+  it 'deletes all tmp files after run' do
+    job.command = 'echo hello > $TMPDIR/foo'
+    execute_job
+    assert_equal false, File.exists?(File.join(ENV['TMPDIR'], 'foo'))
+  end
+
   it "removes the job from the registry" do
     execution = JobExecution.start_job("master", job)
 


### PR DESCRIPTION
Describe your PR
tldr; Each job gets its own TMPDIR within which the normal workflow applies. This gathers both the temporarily cloned repo and any temporary files/dirs Capistrano/Bundler/NPM create during deploys.

The HDD has been filling up on our deployment server every few weeks. And this is a more generic solution then creating a cron job to clean things up.
Currently Dir.mktmpdir is called to create a temporary directory to clone the target git repo into. This is cleaned up when the deploy finishes because it's wrapped in a block. What don't get cleaned up are any files/directories that are created as a result of running any job commands that rely on TMPDIR. So, for example, Capistrano creates a tmp dir from within it's own code to create the archive directory. This is created outside the original Dir.mktmpdir and isn't cleaned up afterwards. Bundler and NPM also create their temporary directories which don't get cleaned up.

Directory structure before fix:
```
/data/samson/tmp/d2014****a       # Dir.mktmpdir for git repo (cleaned up after job ends)
/data/samson/tmp/d2014****b       # Capistrano tmp dir
/data/samson/tmp/bundler*****
/data/samson/tmp/npm-*****
```

Directory structure after fix:
```
/data/samson/tmp/d2014*****a               # Dir.mktmpdir (cleaned up after job ends)
/data/samson/tmp/d2014*****a/d2014****b/   # tmp dir for git repo clone
/data/samson/tmp/d2014*****a/d2014****c/   # Capistrano tmp dir
/data/samson/tmp/d2014*****a/bundler****
/data/samson/tmp/d2014*****a/npm-*****
```
When the job ends, the root directory is cleaned up and and commands which dumped stuff in a temporary directory also gets cleaned up because they should be relying on TMPDIR for the location of temp stuff.

/cc @zendesk/samson @pswadi-zendesk 

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-127

### Risks
 - None