### PR TITLE
Send an email when a new project is created

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,5 @@ GITHUB_TOKEN={fill me in}
 # BUDDY_CHECK_FEATURE={optional, set to 1 to enable buddy_check feature; 0 to disable}
 
 # DEPLOY_MAX_MINUTES_PENDING={optional, set to 20 for max minutes a deploy is pending}
+
+# PROJECT_CREATED_NOTIFY_ADDRESS=bobby-the-security-auditor@yourcompany.com

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,6 +33,9 @@ class ProjectsController < ApplicationController
     @project = Project.new(project_params)
 
     if @project.save
+      if ENV['PROJECT_CREATED_NOTIFY_ADDRESS']
+        ProjectMailer.created_email(@current_user,@project).deliver_later
+      end
       redirect_to project_path(@project)
       Rails.logger.info("#{@current_user.name_and_email} created a new project #{@project.to_param}")
     else

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,3 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: "deploys@#{Rails.application.config.samson.email.sender_domain}"
+end

--- a/app/mailers/deploy_mailer.rb
+++ b/app/mailers/deploy_mailer.rb
@@ -1,5 +1,4 @@
-class DeployMailer < ActionMailer::Base
-  default from: "deploys@#{Rails.application.config.samson.email.sender_domain}"
+class DeployMailer < ApplicationMailer
 
   add_template_helper(DeploysHelper)
   add_template_helper(ApplicationHelper)

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,6 +1,4 @@
 class ProjectMailer < ApplicationMailer
-  layout 'mailer'
-
   def created_email(user, project)
     address = ENV['PROJECT_CREATED_NOTIFY_ADDRESS']
     subject = "Samson Project Created: #{project.name}"

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -2,6 +2,9 @@ class ProjectMailer < ApplicationMailer
   layout 'mailer'
 
   def created_email(user, project)
-    mail(to: ENV['PROJECT_CREATED_NOTIFY_ADDRESS'], subject: "Samson Project Created: #{project.name}", body: "#{user.name_and_email} just created a new project #{project.name}")
+    address = ENV['PROJECT_CREATED_NOTIFY_ADDRESS']
+    subject = "Samson Project Created: #{project.name}"
+    body = "#{user.name_and_email} just created a new project #{project.name}"
+    mail(to: address, subject: subject, body: body)
   end
 end

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,0 +1,7 @@
+class ProjectMailer < ApplicationMailer
+  layout 'mailer'
+
+  def created_email(user, project)
+    mail(to: ENV['PROJECT_CREATED_NOTIFY_ADDRESS'], subject: "Samson Project Created: #{project.name}", body: "#{user.name_and_email} just created a new project #{project.name}")
+  end
+end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -67,6 +67,11 @@ describe ProjectsController do
         it "creates a new project" do
           project.wont_be_nil
         end
+
+        it "notifies about creation" do
+          ActionMailer::Base.deliveries.last.subject.include?("Samson Project Created")
+          ActionMailer::Base.deliveries.last.subject.include?(project.name)
+        end
       end
 
       describe "with invalid parameters" do

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -20,7 +20,7 @@ describe DeployMailer do
     end
 
     subject do
-      ActionMailer::Base.deliveries.first
+      ActionMailer::Base.deliveries.last
     end
 
     it 'is from deploys@' do
@@ -58,7 +58,7 @@ describe DeployMailer do
     end
 
     subject do
-      ActionMailer::Base.deliveries.first
+      ActionMailer::Base.deliveries.last
     end
 
     it 'is from deploys@' do
@@ -100,7 +100,7 @@ describe DeployMailer do
     end
 
     subject do
-      ActionMailer::Base.deliveries.first
+      ActionMailer::Base.deliveries.last
     end
 
     it 'sends to bypass_email_address, jira_email_address' do

--- a/test/mailers/project_mailer_test.rb
+++ b/test/mailers/project_mailer_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class ProjectMailerTest < ActionMailer::TestCase
+  let(:user) { users(:admin) }
+  let(:project) { projects(:test) }
+
+  it "contains user and project name" do
+    ProjectMailer.created_email(user, project).deliver_now
+    mail_sent = ActionMailer::Base.deliveries.first
+    assert mail_sent.subject.include?('Project')
+    assert mail_sent.body.include?('Admin')
+    assert mail_sent.body.include?('Project')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 
+ENV['PROJECT_CREATED_NOTIFY_ADDRESS'] = 'blah@example.com'
+
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails'


### PR DESCRIPTION
Needed for security compliance.
https://zendesk.atlassian.net/browse/INFR-823

The email sent is rather simple. It should come from the same address as all other deploy emails.
```
Subject: Samson Project Created: Lotus

Jason Stillwell (jstillwell@zendesk.com) just created a new project Lotus
```

@zendesk/samson 
cc @pswadi-zendesk @lcore 