### PR TITLE
nicer dashes in stage name badges

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -108,9 +108,7 @@ class StagesController < ApplicationController
   def badge_safe(string)
     CGI.escape(string.gsub('&', '&amp;'))
       .gsub('+','%20')
-      .gsub /([^-])(--)*-([^-])/ do |r|
-        "#{$1}--#{$3}"
-      end
+      .gsub(/-+/,'--')
   end
 
   def check_token

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -106,7 +106,7 @@ class StagesController < ApplicationController
   private
 
   def badge_safe(string)
-    CGI.escape(string.gsub('&', '&amp;'))
+    CGI.escape(string.gsub('&', '%26'))
       .gsub('+','%20')
       .gsub(/-+/,'--')
   end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -106,7 +106,7 @@ class StagesController < ApplicationController
   private
 
   def badge_safe(string)
-    CGI.escape(string.gsub('&', '%26'))
+    CGI.escape(string)
       .gsub('+','%20')
       .gsub(/-+/,'--')
   end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -106,7 +106,11 @@ class StagesController < ApplicationController
   private
 
   def badge_safe(string)
-    CGI.escape(string.gsub('&', '&amp;')).gsub('-', '&mdash;').gsub('+','%20')
+    CGI.escape(string.gsub('&', '&amp;'))
+      .gsub('+','%20')
+      .gsub /([^-])(--)*-([^-])/ do |r|
+        "#{$1}--#{$3}"
+      end
   end
 
   def check_token

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -38,7 +38,7 @@ describe StagesController do
 
     it "renders strange characters" do
       subject.update_column(:name, 'Foo & Bar 1-4')
-      stub_request(:get, "http://img.shields.io/badge/Foo%20&amp;%20Bar%201--4-staging-green.svg")
+      stub_request(:get, "http://img.shields.io/badge/Foo%20%26%20Bar%201--4-staging-green.svg")
       get :show, valid_params
       assert_response :success
       response.content_type.must_equal Mime::SVG

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -38,7 +38,7 @@ describe StagesController do
 
     it "renders strange characters" do
       subject.update_column(:name, 'Foo & Bar 1-4')
-      stub_request(:get, "http://img.shields.io/badge/Foo%20&amp;%20Bar%201&mdash;4-staging-green.svg")
+      stub_request(:get, "http://img.shields.io/badge/Foo%20&amp;%20Bar%201--4-staging-green.svg")
       get :show, valid_params
       assert_response :success
       response.content_type.must_equal Mime::SVG


### PR DESCRIPTION
Stages with dashes in them don't look great. The badge service renders `--` as a dash but `&mdash;` literally.

cc @princemaple @pswadi-zendesk @grosser 