### PR TITLE
Removing chdir that can cause problems with Puma multithreaded model

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -26,11 +26,11 @@ class GitRepository
   end
 
   def update!(executor: TerminalExecutor.new(StringIO.new), pwd: repo_cache_dir)
-    Dir.chdir(pwd) { executor.execute!('git fetch -ap') }
+    executor.execute!("cd #{pwd}",'git fetch -ap')
   end
 
   def checkout!(executor: TerminalExecutor.new(StringIO.new), pwd: repo_cache_dir, git_reference:)
-    Dir.chdir(pwd) { executor.execute!("git checkout #{git_reference}") }
+    executor.execute!("cd #{pwd}", "git checkout #{git_reference}")
   end
 
   def commit_from_ref(git_reference)
@@ -72,13 +72,11 @@ class GitRepository
   private
 
   def run_single_command(command, pwd: repo_cache_dir)
-    Dir.chdir(pwd) do
       output = StringIO.new
       executor = TerminalExecutor.new(output)
-      success = executor.execute!(command)
+      success = executor.execute!("cd #{pwd}", command)
       return [] unless success
       output.string.lines.map { |line| yield line if block_given? }.uniq.sort
-    end
   end
 
 end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -26,7 +26,7 @@ class GitRepository
   end
 
   def update!(executor: TerminalExecutor.new(StringIO.new), pwd: repo_cache_dir)
-    executor.execute!("cd #{pwd}",'git fetch -ap')
+    executor.execute!("cd #{pwd}", 'git fetch -ap')
   end
 
   def checkout!(executor: TerminalExecutor.new(StringIO.new), pwd: repo_cache_dir, git_reference:)


### PR DESCRIPTION
This PR removes the previously introduced chdir and replaces them with a cd #{pwd} that avoids changing the process working directory.

A chdir changes the process directory not the thread working directory. This causes problems whenever this is running on a multithreaded environment.

/cc @zendesk/samson @pswadi-zendesk 

### References
 - Jira link: 

### Risks
 - None
Describe your PR

/cc @zendesk/other

### References
 - Jira link:

### Risks
 - None