### PR TITLE
Fixing the tag list command

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -54,7 +54,7 @@ class GitRepository
   end
 
   def tags
-    cmd = 'git describe --tags --abbrev=0 `git rev-list --tags --max-count=600`'
+    cmd = "git for-each-ref refs/tags --sort=-authordate --format='%(refname)' --count=600 | sed 's/refs\\/tags\\///g'"
     success, output = run_single_command(cmd) { |line| line.strip }
     success ? output : []
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 
 ActiveRecord::Schema.define(version: 20150317205551) do
 
-  create_table "commands", force: :cascade do |t|
+  create_table "commands", force: true do |t|
     t.text     "command",    limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20150317205551) do
   add_index "deploy_groups_stages", ["deploy_group_id"], name: "index_deploy_groups_stages_on_deploy_group_id"
   add_index "deploy_groups_stages", ["stage_id"], name: "index_deploy_groups_stages_on_stage_id"
 
-  create_table "deploys", force: :cascade do |t|
+  create_table "deploys", force: true do |t|
     t.integer  "stage_id",   null: false
     t.integer  "job_id",     null: false
     t.string   "reference",  null: false
@@ -49,9 +49,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "deleted_at"
   end
 
-  add_index "deploys", ["deleted_at"], name: "index_deploys_on_deleted_at"
-  add_index "deploys", ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
-  add_index "deploys", ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at"
+  add_index "deploys", ["deleted_at"], name: "index_deploys_on_deleted_at", using: :btree
+  add_index "deploys", ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at", using: :btree
+  add_index "deploys", ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at", using: :btree
 
   create_table "environments", force: :cascade do |t|
     t.string   "name",                          null: false
@@ -64,16 +64,15 @@ ActiveRecord::Schema.define(version: 20150317205551) do
 
   add_index "environments", ["permalink"], name: "index_environments_on_permalink", unique: true
 
-  create_table "flowdock_flows", force: :cascade do |t|
-    t.string   "name",                          null: false
-    t.string   "token",                         null: false
-    t.integer  "stage_id",                      null: false
+  create_table "flowdock_flows", force: true do |t|
+    t.string   "name",       null: false
+    t.string   "token",      null: false
+    t.integer  "stage_id",   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "notifications", default: false
   end
 
-  create_table "jobs", force: :cascade do |t|
+  create_table "jobs", force: true do |t|
     t.text     "command",                                           null: false
     t.integer  "user_id",                                           null: false
     t.integer  "project_id",                                        null: false
@@ -82,15 +81,15 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "commit"
-    t.string   "tag"
+    t.string   "tag",        limit: 255
   end
 
-  add_index "jobs", ["project_id"], name: "index_jobs_on_project_id"
-  add_index "jobs", ["status"], name: "index_jobs_on_status"
+  add_index "jobs", ["project_id"], name: "index_jobs_on_project_id", using: :btree
+  add_index "jobs", ["status"], name: "index_jobs_on_status", using: :btree
 
-  create_table "locks", force: :cascade do |t|
+  create_table "locks", force: true do |t|
     t.integer  "stage_id"
-    t.integer  "user_id",                     null: false
+    t.integer  "user_id",     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -98,9 +97,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.boolean  "warning",     default: false, null: false
   end
 
-  add_index "locks", ["stage_id", "deleted_at", "user_id"], name: "index_locks_on_stage_id_and_deleted_at_and_user_id"
+  add_index "locks", ["stage_id", "deleted_at", "user_id"], name: "index_locks_on_stage_id_and_deleted_at_and_user_id", using: :btree
 
-  create_table "macro_commands", force: :cascade do |t|
+  create_table "macro_commands", force: true do |t|
     t.integer  "macro_id"
     t.integer  "command_id"
     t.integer  "position",   default: 0, null: false
@@ -108,7 +107,7 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  create_table "macros", force: :cascade do |t|
+  create_table "macros", force: true do |t|
     t.string   "name",       null: false
     t.string   "reference",  null: false
     t.text     "command",    null: false
@@ -119,32 +118,32 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  add_index "macros", ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at"
+  add_index "macros", ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at", using: :btree
 
-  create_table "new_relic_applications", force: :cascade do |t|
+  create_table "new_relic_applications", force: true do |t|
     t.string  "name"
     t.integer "stage_id"
   end
 
-  add_index "new_relic_applications", ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true
+  add_index "new_relic_applications", ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true, using: :btree
 
-  create_table "projects", force: :cascade do |t|
-    t.string   "name",                         null: false
-    t.string   "repository_url",               null: false
+  create_table "projects", force: true do |t|
+    t.string   "name",           null: false
+    t.string   "repository_url", null: false
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "token"
     t.string   "release_branch"
-    t.string   "permalink",                    null: false
+    t.string   "permalink",      null: false
     t.text     "description",    limit: 65535
     t.string   "owner",          limit: 255
   end
 
-  add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at"
-  add_index "projects", ["token", "deleted_at"], name: "index_projects_on_token_and_deleted_at"
+  add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at", using: :btree
+  add_index "projects", ["token", "deleted_at"], name: "index_projects_on_token_and_deleted_at", using: :btree
 
-  create_table "releases", force: :cascade do |t|
+  create_table "releases", force: true do |t|
     t.integer  "project_id",              null: false
     t.string   "commit",                  null: false
     t.integer  "number",      default: 1
@@ -154,9 +153,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
+  add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true, using: :btree
 
-  create_table "stage_commands", force: :cascade do |t|
+  create_table "stage_commands", force: true do |t|
     t.integer  "stage_id"
     t.integer  "command_id"
     t.integer  "position",   default: 0, null: false
@@ -164,40 +163,40 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  create_table "stages", force: :cascade do |t|
-    t.string   "name",                                                         null: false
-    t.integer  "project_id",                                                   null: false
+  create_table "stages", force: true do |t|
+    t.string   "name",                                        null: false
+    t.integer  "project_id",                                  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "notify_email_address"
     t.integer  "order"
     t.datetime "deleted_at"
-    t.boolean  "confirm",                                      default: true
+    t.boolean  "confirm",                     default: true
     t.string   "datadog_tags"
     t.boolean  "update_github_pull_requests"
-    t.boolean  "deploy_on_release",                            default: false
+    t.boolean  "deploy_on_release",           default: false
     t.boolean  "comment_on_zendesk_tickets"
-    t.boolean  "production",                                   default: false
+    t.boolean  "production",                  default: false
     t.boolean  "use_github_deployment_api"
-    t.string   "permalink",                                                    null: false
-    t.text     "dashboard"
-    t.boolean  "email_committers_on_automated_deploy_failure", default: false, null: false
-    t.string   "static_emails_on_automated_deploy_failure"
-    t.string   "datadog_monitor_ids"
+    t.string   "permalink",                                   null: false
+    t.text     "dashboard",                   limit: 65535
+    t.boolean  "email_committers_on_automated_deploy_failure",         default: false, null: false
+    t.string   "static_emails_on_automated_deploy_failure", limit: 255
+    t.string   "datadog_monitor_ids",                          limit: 255
   end
 
-  add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at"
+  add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", using: :btree
 
-  create_table "stars", force: :cascade do |t|
+  create_table "stars", force: true do |t|
     t.integer  "user_id",    null: false
     t.integer  "project_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "stars", ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true
+  add_index "stars", ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true, using: :btree
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", force: true do |t|
     t.string   "name"
     t.string   "email"
     t.datetime "created_at"
@@ -210,9 +209,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.boolean  "integration",    default: false, null: false
   end
 
-  add_index "users", ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at"
+  add_index "users", ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at", using: :btree
 
-  create_table "webhooks", force: :cascade do |t|
+  create_table "webhooks", force: true do |t|
     t.integer  "project_id", null: false
     t.integer  "stage_id",   null: false
     t.string   "branch",     null: false
@@ -221,7 +220,7 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "deleted_at"
   end
 
-  add_index "webhooks", ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch"
-  add_index "webhooks", ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch"
+  add_index "webhooks", ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch", using: :btree
+  add_index "webhooks", ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch", using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 
 ActiveRecord::Schema.define(version: 20150317205551) do
 
-  create_table "commands", force: true do |t|
+  create_table "commands", force: :cascade do |t|
     t.text     "command",    limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20150317205551) do
   add_index "deploy_groups_stages", ["deploy_group_id"], name: "index_deploy_groups_stages_on_deploy_group_id"
   add_index "deploy_groups_stages", ["stage_id"], name: "index_deploy_groups_stages_on_stage_id"
 
-  create_table "deploys", force: true do |t|
+  create_table "deploys", force: :cascade do |t|
     t.integer  "stage_id",   null: false
     t.integer  "job_id",     null: false
     t.string   "reference",  null: false
@@ -49,9 +49,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "deleted_at"
   end
 
-  add_index "deploys", ["deleted_at"], name: "index_deploys_on_deleted_at", using: :btree
-  add_index "deploys", ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at", using: :btree
-  add_index "deploys", ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at", using: :btree
+  add_index "deploys", ["deleted_at"], name: "index_deploys_on_deleted_at"
+  add_index "deploys", ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
+  add_index "deploys", ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at"
 
   create_table "environments", force: :cascade do |t|
     t.string   "name",                          null: false
@@ -64,15 +64,16 @@ ActiveRecord::Schema.define(version: 20150317205551) do
 
   add_index "environments", ["permalink"], name: "index_environments_on_permalink", unique: true
 
-  create_table "flowdock_flows", force: true do |t|
-    t.string   "name",       null: false
-    t.string   "token",      null: false
-    t.integer  "stage_id",   null: false
+  create_table "flowdock_flows", force: :cascade do |t|
+    t.string   "name",                          null: false
+    t.string   "token",                         null: false
+    t.integer  "stage_id",                      null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "notifications", default: false
   end
 
-  create_table "jobs", force: true do |t|
+  create_table "jobs", force: :cascade do |t|
     t.text     "command",                                           null: false
     t.integer  "user_id",                                           null: false
     t.integer  "project_id",                                        null: false
@@ -81,15 +82,15 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "commit"
-    t.string   "tag",        limit: 255
+    t.string   "tag"
   end
 
-  add_index "jobs", ["project_id"], name: "index_jobs_on_project_id", using: :btree
-  add_index "jobs", ["status"], name: "index_jobs_on_status", using: :btree
+  add_index "jobs", ["project_id"], name: "index_jobs_on_project_id"
+  add_index "jobs", ["status"], name: "index_jobs_on_status"
 
-  create_table "locks", force: true do |t|
+  create_table "locks", force: :cascade do |t|
     t.integer  "stage_id"
-    t.integer  "user_id",     null: false
+    t.integer  "user_id",                     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
@@ -97,9 +98,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.boolean  "warning",     default: false, null: false
   end
 
-  add_index "locks", ["stage_id", "deleted_at", "user_id"], name: "index_locks_on_stage_id_and_deleted_at_and_user_id", using: :btree
+  add_index "locks", ["stage_id", "deleted_at", "user_id"], name: "index_locks_on_stage_id_and_deleted_at_and_user_id"
 
-  create_table "macro_commands", force: true do |t|
+  create_table "macro_commands", force: :cascade do |t|
     t.integer  "macro_id"
     t.integer  "command_id"
     t.integer  "position",   default: 0, null: false
@@ -107,7 +108,7 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  create_table "macros", force: true do |t|
+  create_table "macros", force: :cascade do |t|
     t.string   "name",       null: false
     t.string   "reference",  null: false
     t.text     "command",    null: false
@@ -118,32 +119,32 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  add_index "macros", ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at", using: :btree
+  add_index "macros", ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at"
 
-  create_table "new_relic_applications", force: true do |t|
+  create_table "new_relic_applications", force: :cascade do |t|
     t.string  "name"
     t.integer "stage_id"
   end
 
-  add_index "new_relic_applications", ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true, using: :btree
+  add_index "new_relic_applications", ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true
 
-  create_table "projects", force: true do |t|
-    t.string   "name",           null: false
-    t.string   "repository_url", null: false
+  create_table "projects", force: :cascade do |t|
+    t.string   "name",                         null: false
+    t.string   "repository_url",               null: false
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "token"
     t.string   "release_branch"
-    t.string   "permalink",      null: false
+    t.string   "permalink",                    null: false
     t.text     "description",    limit: 65535
     t.string   "owner",          limit: 255
   end
 
-  add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at", using: :btree
-  add_index "projects", ["token", "deleted_at"], name: "index_projects_on_token_and_deleted_at", using: :btree
+  add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at"
+  add_index "projects", ["token", "deleted_at"], name: "index_projects_on_token_and_deleted_at"
 
-  create_table "releases", force: true do |t|
+  create_table "releases", force: :cascade do |t|
     t.integer  "project_id",              null: false
     t.string   "commit",                  null: false
     t.integer  "number",      default: 1
@@ -153,9 +154,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true, using: :btree
+  add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
 
-  create_table "stage_commands", force: true do |t|
+  create_table "stage_commands", force: :cascade do |t|
     t.integer  "stage_id"
     t.integer  "command_id"
     t.integer  "position",   default: 0, null: false
@@ -163,40 +164,40 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "updated_at"
   end
 
-  create_table "stages", force: true do |t|
-    t.string   "name",                                        null: false
-    t.integer  "project_id",                                  null: false
+  create_table "stages", force: :cascade do |t|
+    t.string   "name",                                                         null: false
+    t.integer  "project_id",                                                   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "notify_email_address"
     t.integer  "order"
     t.datetime "deleted_at"
-    t.boolean  "confirm",                     default: true
+    t.boolean  "confirm",                                      default: true
     t.string   "datadog_tags"
     t.boolean  "update_github_pull_requests"
-    t.boolean  "deploy_on_release",           default: false
+    t.boolean  "deploy_on_release",                            default: false
     t.boolean  "comment_on_zendesk_tickets"
-    t.boolean  "production",                  default: false
+    t.boolean  "production",                                   default: false
     t.boolean  "use_github_deployment_api"
-    t.string   "permalink",                                   null: false
-    t.text     "dashboard",                   limit: 65535
-    t.boolean  "email_committers_on_automated_deploy_failure",         default: false, null: false
-    t.string   "static_emails_on_automated_deploy_failure", limit: 255
-    t.string   "datadog_monitor_ids",                          limit: 255
+    t.string   "permalink",                                                    null: false
+    t.text     "dashboard"
+    t.boolean  "email_committers_on_automated_deploy_failure", default: false, null: false
+    t.string   "static_emails_on_automated_deploy_failure"
+    t.string   "datadog_monitor_ids"
   end
 
-  add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", using: :btree
+  add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at"
 
-  create_table "stars", force: true do |t|
+  create_table "stars", force: :cascade do |t|
     t.integer  "user_id",    null: false
     t.integer  "project_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "stars", ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true, using: :btree
+  add_index "stars", ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
     t.datetime "created_at"
@@ -209,9 +210,9 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.boolean  "integration",    default: false, null: false
   end
 
-  add_index "users", ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at", using: :btree
+  add_index "users", ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at"
 
-  create_table "webhooks", force: true do |t|
+  create_table "webhooks", force: :cascade do |t|
     t.integer  "project_id", null: false
     t.integer  "stage_id",   null: false
     t.string   "branch",     null: false
@@ -220,7 +221,7 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "deleted_at"
   end
 
-  add_index "webhooks", ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch", using: :btree
-  add_index "webhooks", ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch", using: :btree
+  add_index "webhooks", ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch"
+  add_index "webhooks", ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch"
 
 end


### PR DESCRIPTION
# Description
The previous command would list all shas associated with a tag. This was not efficient as it was iterating through all the list of shas to get its description. 
In some cases describe was failing because it could not find the commit. I am assuming this might happen because the history might have been rewritten.

This was having an impact in the autocomplete feature for some projects, causing the tags not to be displayed.

This command was fixed so that it now works for all projects even if history was modified.

The --sort command is only available in git 2.0+ so Travis git version had to be updated, and container based builds to be disabled on the travis file.

/cc @zendesk/samson @pswadi-zendesk @steved555 

### References
 - Jira link: 

### Risks
 - None