### PR TITLE
Add validation for the repository URL during project creation/editing.

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -70,7 +70,7 @@ class GitRepository
   end
 
   def valid_url?
-    cmd = "GIT_ASKPASS='true' git ls-remote -h #{repository_url}"
+    cmd = "git -c core.askpass=true ls-remote -h #{repository_url}"
     output = StringIO.new
     executor = TerminalExecutor.new(output)
     return true if executor.execute!(cmd)

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -69,6 +69,15 @@ class GitRepository
     Dir.exist?("#{repo_dir}/.git") || File.exist?("#{repo_dir}/HEAD")
   end
 
+  def valid_url?
+    cmd = "GIT_ASKPASS='true' git ls-remote -h #{repository_url}"
+    output = StringIO.new
+    executor = TerminalExecutor.new(output)
+    return true if executor.execute!(cmd)
+    Rails.logger.error("#{repository_url} is invalid: #{output.string}")
+    false
+  end
+
   private
 
   def run_single_command(command, pwd: repo_cache_dir)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -163,7 +163,7 @@ class Project < ActiveRecord::Base
   end
 
   def valid_repository_url
-    unless GitRepository.new(repository_url: repository_url, repository_dir: '').valid_url?
+    unless repository.valid_url?
       errors.add(:repository_url, "is not valid or accessible")
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@ class Project < ActiveRecord::Base
   has_soft_deletion default_scope: true
 
   validates :name, :repository_url, presence: true
+  validate :valid_repository_url
   before_create :generate_token
   after_save :clone_repository, if: :repository_url_changed?
   before_update :clean_old_repository, if: :repository_url_changed?
@@ -161,4 +162,9 @@ class Project < ActiveRecord::Base
     end
   end
 
+  def valid_repository_url
+    unless GitRepository.new(repository_url: repository_url, repository_dir: '').valid_url?
+      errors.add(:repository_url, "is not valid or accessible")
+    end
+  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -7,6 +7,7 @@ describe ProjectsController do
 
   setup do
     Project.any_instance.stubs(:clone_repository).returns(true)
+    Project.any_instance.stubs(:valid_repository_url).returns(true)
     request.env['warden'].set_user(user)
   end
 

--- a/test/lib/references_service_test.rb
+++ b/test/lib/references_service_test.rb
@@ -21,7 +21,6 @@ describe ReferencesService, :model do
   let!(:project) { Project.create!(name: 'test_project', repository_url: repository_url) }
 
   before do
-    Project.any_instance.stubs(:valid_repository_url).returns(true)
     project.repository.clone!(mirror: true)
   end
 

--- a/test/lib/references_service_test.rb
+++ b/test/lib/references_service_test.rb
@@ -20,7 +20,10 @@ describe ReferencesService, :model do
 
   let!(:project) { Project.create!(name: 'test_project', repository_url: repository_url) }
 
-  before { project.repository.clone!(mirror: true) }
+  before do
+    Project.any_instance.stubs(:valid_repository_url).returns(true)
+    project.repository.clone!(mirror: true)
+  end
 
   it 'returns a sorted set of tags and branches' do
     ReferencesService.new(project).find_git_references.must_equal %w(v1 master test_user/test_branch )

--- a/test/models/concerns/permalinkable_test.rb
+++ b/test/models/concerns/permalinkable_test.rb
@@ -80,7 +80,6 @@ describe Permalinkable, :model do
 
       describe "with duplicate" do
         before do
-          Project.any_instance.stubs(:valid_repository_url).returns(true)
           duplicate.save!
           duplicate.permalink = record.permalink
         end
@@ -116,7 +115,6 @@ describe Permalinkable, :model do
 
       describe "with duplicate" do
         before do
-          # Project.any_instance.stubs(:valid_repository_url).returns(true)
           duplicate.name = 'dup'
           duplicate.save!
           duplicate.permalink = record.permalink

--- a/test/models/concerns/permalinkable_test.rb
+++ b/test/models/concerns/permalinkable_test.rb
@@ -5,6 +5,8 @@ describe Permalinkable, :model do
   let(:project_url) { "git://foo.com:hello/world.git" }
   let(:other_project) { Project.create!(name: "hello", repository_url: project_url) }
 
+  before { Project.any_instance.stubs(:valid_repository_url).returns(true) }
+
   describe "#to_param" do
     it "is permalink" do
       project.to_param.must_equal "foo"
@@ -77,7 +79,8 @@ describe Permalinkable, :model do
       end
 
       describe "with duplicate" do
-        setup do
+        before do
+          Project.any_instance.stubs(:valid_repository_url).returns(true)
           duplicate.save!
           duplicate.permalink = record.permalink
         end
@@ -112,7 +115,8 @@ describe Permalinkable, :model do
       end
 
       describe "with duplicate" do
-        setup do
+        before do
+          # Project.any_instance.stubs(:valid_repository_url).returns(true)
           duplicate.name = 'dup'
           duplicate.save!
           duplicate.permalink = record.permalink

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -79,6 +79,15 @@ describe GitRepository, :model do
     Dir.chdir(temp_dir) { current_branch.must_equal('test_user/test_branch') }
   end
 
+  it 'validates the repo url' do
+    create_repo_without_tags
+    project.repository.valid_url?.must_equal true
+  end
+
+  it 'invalidates the repo url without repo' do
+    project.repository.valid_url?.must_equal false
+  end
+
   def execute_on_remote_repo(cmds)
     `exec 2> /dev/null; cd #{repository_url}; #{cmds}`
   end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -12,6 +12,7 @@ describe JobExecution, :model do
   let(:deploy) { Deploy.create!(stage: stage, job: job, reference: 'masterCADF') }
 
   before do
+    Project.any_instance.stubs(:valid_repository_url).returns(true)
     execute_on_remote_repo <<-SHELL
       git init
       git config user.email "test@example.com"

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -212,6 +212,12 @@ describe Project do
       project.send(:clone_repository).join
     end
 
+    it 'does not validate with a bad repo url' do
+      Project.any_instance.unstub(:valid_repository_url)
+      project = Project.new(id: 9999, name: 'demo_apps', repository_url: 'my_bad_url')
+      project.valid?.must_equal false
+      project.errors.messages.must_equal repository_url: ["is not valid or accessible"]
+    end
   end
 
   describe 'lock project' do

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -5,6 +5,8 @@ describe Project do
   let(:author) { users(:deployer) }
   let(:url) { "git://foo.com:hello/world.git" }
 
+  before { Project.any_instance.stubs(:valid_repository_url).returns(true) }
+
   it "generates a secure token when created" do
     Project.create!(name: "hello", repository_url: url).token.wont_be_nil
   end


### PR DESCRIPTION
Describe your PR
Seemed there was an increase of people putting invalid github URLs in their project settings. So I added a validation function for it to give more immediate feedback about their mistake.

![samson](https://cloud.githubusercontent.com/assets/8860832/5920121/f54f55b6-a631-11e4-954c-37717a534764.png)

/cc @zendesk/samson @pswadi-zendesk  @steved555 @princemaple 

### References
 - Jira link:

### Risks
 - None