### PR TITLE
fix deploy link

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -16,7 +16,7 @@ class Deploy < ActiveRecord::Base
   delegate :production?, :project, to: :stage
 
   def cache_key
-    [self, commit]
+    [super, commit]
   end
 
   def summary

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Samson
 
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
-    config.cache_store = :dalli_store, { value_max_bytes: 3000000, compress: true }
+    config.cache_store = :dalli_store, { value_max_bytes: 3000000, compress: true, expires_in: 1.day }
 
     # Allow streaming
     config.preload_frameworks = true

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -134,6 +134,12 @@ describe Deploy do
     end
   end
 
+  describe "#cache_key" do
+    it "includes self and commit" do
+      deploys(:succeeded_test).cache_key.must_equal ["deploys/178003093-20140102201000000000000", "staging"]
+    end
+  end
+
   def create_deploy!(attrs = {})
     default_attrs = {
       reference: "baz",


### PR DESCRIPTION
atm deploys point to old project urls since they are cached since 2+months

@pswadi-zendesk @steved555 

### Risks
 - Low: more resource usage due to cache expiration