### PR TITLE
Filter deploy list on user and project names

### DIFF
--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -68,10 +68,12 @@ samson.constant("StatusFilterMapping",
 samson.filter("projectUserFilter",
   function() {
     return function(deploys, search) {
-      if (search !== undefined && search !== null && search.length) {
-        var searchRegExp = new RegExp(search, 'i');
+      if (typeof search == 'string' && search.length) {
+        var lowerCaseSearch =  search.toLowerCase();
+
         return deploys.filter(function(deploy) {
-          return (deploy.project.name.match(searchRegExp) || deploy.user.name.match(searchRegExp));
+          return (deploy.project.name.toLowerCase().indexOf(lowerCaseSearch) > -1 ||
+              deploy.user.name.toLowerCase().indexOf(lowerCaseSearch) > -1);
         });
       }
       return deploys;

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -65,6 +65,20 @@ samson.constant("StatusFilterMapping",
   }
 );
 
+samson.filter("projectUserFilter",
+  function() {
+    return function(deploys, search) {
+      if (search !== undefined && search !== null && search.length) {
+        var searchRegExp = new RegExp(search, 'i');
+        return deploys.filter(function(deploy) {
+          return (deploy.project.name.match(searchRegExp) || deploy.user.name.match(searchRegExp));
+        });
+      }
+      return deploys;
+    };
+  }
+);
+
 samson.filter("userFilter",
   function() {
     var hookSources = /^(?:travis|tddium|semaphore|jenkins|github)$/i;

--- a/app/views/deploys/_timeline_entry.html.erb
+++ b/app/views/deploys/_timeline_entry.html.erb
@@ -1,6 +1,6 @@
 <tr class="timeline-entry"
   data-url="{{deploy.url}}" ng-click="jumpTo($event)"
-  ng-repeat="deploy in (deploys = (timelineDeploys.entries | filter:search | userFilter:userType | stageFilter:stageType | statusFilter:deployStatus))">
+  ng-repeat="deploy in (deploys = (timelineDeploys.entries | projectUserFilter:search | userFilter:userType | stageFilter:stageType | statusFilter:deployStatus))">
   <td>
     <a class="timeline-project" ng-href="{{deploy.project.url}}">{{deploy.project.name}}</a>
   </td>

--- a/test/angular/timeline_spec.js
+++ b/test/angular/timeline_spec.js
@@ -13,40 +13,75 @@ describe("Timeline", function() {
         deploys = [
           {
             user: { name: "abc" },
+            project: { name: "big project" },
             production: false,
             status: "succeeded"
           },
           {
             user: { name: "boss" },
+            project: { name: "big project" },
             production: true,
             status: "failed"
           },
           {
             user: { name: "travis" },
+            project: { name: "big project" },
             production: false,
             status: "cancelled"
           },
           {
             user: { name: "semaphore" },
+            project: { name: "bigger project" },
             production: false,
             status: "pending"
           },
           {
             user: { name: "admin" },
+            project: { name: "awesome app" },
             production: true,
             status: "errored"
           },
           {
             user: { name: "tddium" },
+            project: { name: "awesome app" },
             production: false,
             status: "cancelling"
           },
           {
             user: { name: "someone" },
+            project: { name: "super tool" },
             production: false,
             status: "running"
           }
         ];
+      });
+
+      describe("project and user filter", function() {
+        beforeEach(inject(function($filter) {
+          filter = $filter("projectUserFilter");
+        }));
+
+        it("does not filter if nothing is entered", function() {
+          expect(filter(deploys, null).length).toBe(deploys.length);
+          expect(filter(deploys, undefined).length).toBe(deploys.length);
+          expect(filter(deploys, "").length).toBe(deploys.length);
+        });
+
+        it("finds project names", function() {
+          expect(filter(deploys, "big project").length).toBe(3);
+        });
+
+        it("finds user name", function() {
+          expect(filter(deploys, "boss").length).toBe(1);
+        });
+
+        it("ignores case", function() {
+          expect(filter(deploys, "BOSS").length).toBe(1);
+        });
+
+        it("finds partial matches", function (){
+          expect(filter(deploys, "some").length).toBe(3);
+        });
       });
 
       describe("user filter", function() {


### PR DESCRIPTION

Fixed search filter on /deploys/recent. 

Was only filtering on top-level attributes of deploy object, which does not include the project or user name as displayed on the page. 

/cc @pswadi-zendesk, @steved555, @princemaple, @zendesk-shender   

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-137

### Risks
 - None