### PR TITLE
make slow or hanging tests blow up

### DIFF
--- a/test/support/timeout.rb
+++ b/test/support/timeout.rb
@@ -1,0 +1,18 @@
+# tests sometimes hang locally or on ci and with this we can actually debug the cause instead of just hanging forever
+module TimeoutEveryTestCase
+  # travis randomly fails on some tests with this enabled
+  def timeout_for_test
+    ENV["CI"] ? false : 5
+  end
+
+  def capture_exceptions(*args, &block)
+    if timeout_for_test == false
+      super
+    else
+      super do
+        Timeout.timeout(timeout_for_test, &block)
+      end
+    end
+  end
+end
+Minitest::Test.prepend TimeoutEveryTestCase


### PR DESCRIPTION
@steved555 @pswadi-zendesk @jonmoter 

```
..........E...

Finished in 1.578309s, 8.8703 runs/s, 15.2061 assertions/s.

  1) Error:
ApplicationHelper::#breadcrumb#test_0001_renders strings:
Timeout::Error: execution expired
    test/helpers/application_helper_test.rb:91:in `sleep'
    test/helpers/application_helper_test.rb:91:in `block (3 levels) in <main>'
    test/support/timeout.rb:12:in `block in capture_exceptions'
    test/support/timeout.rb:11:in `capture_exceptions'
```

### Risks
 - None