### PR TITLE
warning UI

### DIFF
--- a/app/assets/javascripts/stages.js
+++ b/app/assets/javascripts/stages.js
@@ -49,13 +49,10 @@ $(function() {
     });
   }
 
-  var $wantLock    = $(".want-lock"),
-      $beforeLock  = $(".before-lock"),
-      $description = $(".lock-description");
-
-  $wantLock.click(function() {
-    $wantLock.toggleClass("active");
-    $beforeLock.toggleClass("active");
-    $description.select();
+  $(".want-lock").not(":disabled").click(function() {
+    var $form = $(this).next();
+    $(this).toggleClass("active");
+    $form.toggleClass("active");
+    $form.find(".lock-description").select();
   });
 });

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -4,7 +4,7 @@ class LocksController < ApplicationController
 
   def create
     attributes = params.require(:lock).
-      permit(:description, :stage_id).
+      permit(:description, :stage_id, :warning).
       merge(user: current_user)
     Lock.create!(attributes)
     redirect_to :back, notice: "Locked"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,7 +76,7 @@ module ApplicationHelper
       when Project then [item.name, project_path(item)]
       when Stage then
         name = item.name
-        name = lock_icon + " " + name if item.locked?
+        name = (item.lock.warning? ? warning_icon : lock_icon) + " " + name if item.lock
         [name, project_stage_path(@project, item)]
       when Macro then
         [item.name, project_macro_path(@project, item)]
@@ -98,6 +98,14 @@ module ApplicationHelper
   end
 
   def lock_icon
-    content_tag :i, '', class: "glyphicon glyphicon-lock"
+    icon_tag "lock"
+  end
+
+  def warning_icon
+    icon_tag "warning-sign"
+  end
+
+  def icon_tag(type)
+    content_tag :i, '', class: "glyphicon glyphicon-#{type}"
   end
 end

--- a/app/helpers/stages_helper.rb
+++ b/app/helpers/stages_helper.rb
@@ -13,4 +13,14 @@ module StagesHelper
       link_to "", edit_url, title: "Edit in admin UI", class: "edit-command glyphicon glyphicon-edit no-hover"
     end
   end
+
+  def stage_lock_icon(stage)
+    return unless stage.lock
+    text = if stage.lock.warning?
+      "#{warning_icon} Warning"
+    else
+      "#{lock_icon} Locked"
+    end
+    content_tag :span, text.html_safe, class: "label label-warning", title: stage.lock.summary
+  end
 end

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -7,6 +7,7 @@ class Lock < ActiveRecord::Base
   belongs_to :user
 
   validates :user_id, presence: true
+  validates :description, presence: true, if: :warning?
   validate :unique_global_lock, on: :create
 
   def self.global

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -72,7 +72,11 @@ class Stage < ActiveRecord::Base
   end
 
   def locked?
-    lock.present?
+    !!lock && !lock.warning?
+  end
+
+  def warning?
+    !!lock && lock.warning?
   end
 
   def locked_for?(user)

--- a/app/views/locks/_button.html.erb
+++ b/app/views/locks/_button.html.erb
@@ -1,12 +1,18 @@
+<% warning = {warning: true, icon: warning_icon, text: "Warn", disabled: false} %>
+<% locking = {warning: false, icon: lock_icon, text: "Lock", disabled: false} %>
 <% if lock %>
-  <%= link_to lock, class: 'btn btn-default', method: :delete do %>
-    <%= lock_icon %> Unlock
+  <% if lock.warning? %>
+    <%= link_to lock, class: 'btn btn-default', method: :delete do %>
+      <%= warning_icon %> Resolve
+    <% end %>
+    <%= render '/locks/lock_button', locking.merge(disabled: true) %>
+  <% else %>
+    <%= render '/locks/lock_button', warning.merge(disabled: true) %>
+    <%= link_to lock, class: 'btn btn-default', method: :delete do %>
+      <%= lock_icon %> Unlock
+    <% end %>
   <% end %>
 <% else %>
-  <button class="btn btn-default want-lock"><%= lock_icon %> Lock</button>
-  <%= form_for Lock.new(stage: @stage), html: {class: 'before-lock'} do |f| %>
-    <%= f.hidden_field :stage_id %>
-    <%= f.text_field :description, class: "lock-description", placeholder: "Description" %>
-    <%= f.submit "Lock", class: "do-lock btn btn-warning" %>
-  <% end %>
+  <%= render '/locks/lock_button', warning %>
+  <%= render '/locks/lock_button', locking %>
 <% end %>

--- a/app/views/locks/_lock.html.erb
+++ b/app/views/locks/_lock.html.erb
@@ -1,5 +1,8 @@
 <div class="alert alert-warning">
-  Deployments to <%= lock.global? ? "ALL STAGES" : "this stage" %>
-  were locked by <%= lock.user.name %> <%= time_ago_in_words(lock.created_at) %> ago.
-  <%= lock.reason %>
+  <% if lock.warning? %>
+    <%= warning_icon %> Warning:
+  <% else %>
+    <%= lock_icon %> Deployments to <%= lock.global? ? "ALL STAGES" : "this stage" %> were locked
+  <% end %>
+  <%= lock.reason %> by <%= lock.user.name %> <%= time_ago_in_words(lock.created_at) %> ago.
 </div>

--- a/app/views/locks/_lock_button.html.erb
+++ b/app/views/locks/_lock_button.html.erb
@@ -1,0 +1,7 @@
+<button class="btn btn-default want-lock" <%= "disabled" if disabled %>><%= icon %> <%= text %></button>
+<%= form_for Lock.new(stage: @stage, warning: warning), html: {class: 'before-lock'} do |f| %>
+  <%= f.hidden_field :stage_id %>
+  <%= f.hidden_field :warning %>
+  <%= f.text_field :description, class: "lock-description", placeholder: "Description", required: warning %>
+  <%= f.submit text, class: "do-lock btn btn-warning" %>
+<% end %>

--- a/app/views/projects/_stage.html.erb
+++ b/app/views/projects/_stage.html.erb
@@ -2,9 +2,7 @@
   <tr>
     <td>
       <%= link_to stage.name, project_stage_path(project, stage) %>
-      <% if stage.locked? %>
-        <span class="label label-warning" title="<%= stage.lock.summary %>"><%= lock_icon %> Locked</span>
-      <% end %>
+      <%= stage_lock_icon stage %>
     </td>
     <% if stage.last_successful_deploy.nil? %>
       <td>-</td>

--- a/app/views/stages/index.html.erb
+++ b/app/views/stages/index.html.erb
@@ -5,9 +5,7 @@
     <% @stages.each.with_index do |stage, index| %>
       <li class="stage-bar bar list-unstyled clearfix<%= ' sortable' if current_user.is_admin? %>" data-id="stage_id_<%= stage.id %>">
         <%= link_to stage.name, project_stage_path(@project, stage) %>
-        <% if stage.locked? %>
-          <span class="label label-warning" title="<%= stage.lock.summary %>"><%= lock_icon %> Locked</span>
-        <% end %>
+        <%= stage_lock_icon stage %>
         <div class="btn-group pull-right">
           <% if current_user.is_admin? %>
             <%= link_to "Clone", clone_project_stage_path(@project, stage), class: "btn btn-default" %>

--- a/db/migrate/20150228003920_add_warning_to_locks.rb
+++ b/db/migrate/20150228003920_add_warning_to_locks.rb
@@ -1,0 +1,5 @@
+class AddWarningToLocks < ActiveRecord::Migration
+  def change
+    add_column :locks, :warning, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20150302060555) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string   "description"
+    t.boolean  "warning",     default: false, null: false
   end
 
   add_index "locks", ["stage_id", "deleted_at", "user_id"], name: "index_locks_on_stage_id_and_deleted_at_and_user_id", using: :btree

--- a/test/controllers/locks_controller_test.rb
+++ b/test/controllers/locks_controller_test.rb
@@ -25,7 +25,20 @@ describe LocksController do
 
         stage.reload
 
+        stage.warning?.must_equal(false)
         stage.locked?.must_equal(true)
+        stage.lock.description.must_equal "DESC"
+      end
+
+      it "creates a warning" do
+        post :create, lock: {stage_id: stage.id, description: "DESC", warning: true}
+        assert_redirected_to "/back"
+        assert flash[:notice]
+
+        stage.reload
+
+        stage.warning?.must_equal(true)
+        stage.locked?.must_equal(false)
         stage.lock.description.must_equal "DESC"
       end
     end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -105,6 +105,12 @@ describe ApplicationHelper do
       breadcrumb(stage).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\"><i class=\"glyphicon glyphicon-lock\"></i> Staging</li></ul>"
     end
 
+    it "renders warning stage" do
+      stage = stages(:test_staging)
+      stage.stubs(lock: Lock.new(warning: true))
+      breadcrumb(stage).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\"><i class=\"glyphicon glyphicon-warning-sign\"></i> Staging</li></ul>"
+    end
+
     it "renders project" do
       breadcrumb(@project).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Project</li></ul>"
     end


### PR DESCRIPTION
@zendesk/runway @jwswj 

https://zendesk.atlassian.net/browse/RUN-10

allowing to either set lock or warning and displaying them on all the places lock used to be displayed
 - warning needs a description
 - opposite button is disabled when other is active

(now resolve not Silence)
![screen shot 2015-02-27 at 5 54 59 pm](https://cloud.githubusercontent.com/assets/11367/6424362/957c2392-beac-11e4-915f-bcf8d968a07c.png)
![screen shot 2015-02-27 at 5 59 25 pm](https://cloud.githubusercontent.com/assets/11367/6424363/957df0f0-beac-11e4-86df-5e8aae65d669.png)
![screen shot 2015-02-27 at 6 10 20 pm](https://cloud.githubusercontent.com/assets/11367/6424364/95848384-beac-11e4-8d46-b38edd6f7efc.png)
![screen shot 2015-02-27 at 5 54 52 pm](https://cloud.githubusercontent.com/assets/11367/6424367/95f7c1d2-beac-11e4-8078-40c12c783538.png)
![screen shot 2015-02-27 at 6 00 13 pm](https://cloud.githubusercontent.com/assets/11367/6424366/95e30aa8-beac-11e4-91cc-a806eef4a177.png)
![screen shot 2015-02-27 at 6 12 21 pm](https://cloud.githubusercontent.com/assets/11367/6424365/95dcf0fa-beac-11e4-83c7-912a280335be.png)
