### PR TITLE
make projects controller tests test for specifica roles and not be admin...

### DIFF
--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -1,61 +1,78 @@
 require_relative '../test_helper'
 
 describe ProjectsController do
-
   let(:project) { projects(:test) }
-  let(:user) { users(:admin) }
 
   setup do
     Project.any_instance.stubs(:clone_repository).returns(true)
     Project.any_instance.stubs(:valid_repository_url).returns(true)
-    request.env['warden'].set_user(user)
   end
 
   describe "a GET to #index" do
-
-    it "renders a template" do
-      get :index
-      assert_template :index
+    as_a_viewer do
+      it "renders" do
+        get :index
+        assert_template :index
+      end
     end
 
-    it "assigns the user's starred projects to @projects" do
-      unstarred_project = projects(:test)
-      starred_project = Project.create!(name: "a", repository_url: "a")
-
-      user.stars.create!(project: starred_project)
-
-      get :index
-
-      assert_equal [starred_project], assigns(:projects)
+    as_a_deployer do
+      it "renders" do
+        get :index
+        assert_template :index
+      end
     end
 
-    it "assigns all projects to @projects if the user has no starred projects" do
-      project = projects(:test)
+    as_a_admin do
+      it "renders" do
+        get :index
+        assert_template :index
+      end
 
-      get :index
+      it "assigns the user's starred projects to @projects" do
+        starred_project = Project.create!(name: "a", repository_url: "a")
+        users(:admin).stars.create!(project: starred_project)
 
-      assert_equal [project], assigns(:projects)
+        get :index
+
+        assert_equal [starred_project], assigns(:projects)
+      end
+
+      it "assigns all projects to @projects if the user has no starred projects" do
+        get :index
+
+        assert_equal [projects(:test)], assigns(:projects)
+      end
     end
   end
 
   describe "a GET to #new" do
-    describe "as an admin" do
-      setup do
-        get :new
-      end
-
-      it "renders a template" do
-        assert_template :new
-      end
+    as_a_viewer do
+      unauthorized :get, :new
     end
 
     as_a_deployer do
       unauthorized :get, :new
     end
+
+    as_a_admin do
+      it "renders" do
+        get :new
+        assert_template :new
+      end
+    end
   end
 
   describe "a POST to #create" do
-    describe "as an admin" do
+    as_a_viewer do
+      unauthorized :post, :create
+    end
+
+    as_a_deployer do
+      unauthorized :post, :create
+    end
+
+    as_a_admin do
       setup do
         post :create, params
       end
@@ -90,23 +107,19 @@ describe ProjectsController do
           assert_template :new
         end
       end
-
-      describe "with no parameters" do
-        let(:params) {{}}
-
-        it "redirects to root url" do
-          assert_redirected_to root_path
-        end
-      end
-    end
-
-    as_a_deployer do
-      unauthorized :post, :create
     end
   end
 
   describe "a DELETE to #destroy" do
-    describe "as an admin" do
+    as_a_viewer do
+      unauthorized :delete, :destroy, id: 1
+    end
+
+    as_a_deployer do
+      unauthorized :delete, :destroy, id: 1
+    end
+
+    as_a_admin do
       setup do
         delete :destroy, id: project.to_param
       end
@@ -124,135 +137,97 @@ describe ProjectsController do
         request.flash[:notice].wont_be_nil
       end
     end
-
-    as_a_deployer do
-      unauthorized :delete, :destroy, id: 1
-    end
   end
 
   describe "a PUT to #update" do
-    describe "as an admin" do
-      setup do
-        put :update, params.merge(id: project.to_param)
-      end
-
-      describe "with valid parameters" do
-        let(:params) { { project: { name: "Hi-yo" } } }
-
-        it "redirects to root url" do
-          assert_redirected_to project_path(project.reload)
-        end
-
-        it "creates a new project" do
-          Project.where(name: "Hi-yo").first.wont_be_nil
-        end
-      end
-
-      describe "with invalid parameters" do
-        let(:params) { { project: { name: "" } } }
-
-        it "sets the flash error" do
-          request.flash[:error].wont_be_nil
-        end
-
-        it "renders edit template" do
-          assert_template :edit
-        end
-      end
-
-      describe "with no parameters" do
-        let(:params) {{}}
-
-        it "redirects to root url" do
-          assert_redirected_to root_path
-        end
-      end
-    end
-
-    describe "non-existant" do
-      setup do
-        project.soft_delete!
-        put :update, id: project.to_param
-      end
-
-      it "sets the flash error" do
-        request.flash[:error].wont_be_nil
-      end
-
-      it "redirects to root url" do
-        assert_redirected_to root_path
-      end
+    as_a_viewer do
+      unauthorized :put, :update, id: 1
     end
 
     as_a_deployer do
       unauthorized :put, :update, id: 1
     end
+
+    as_a_admin do
+      it "does not find soft deleted" do
+        project.soft_delete!
+        put :update, id: project.to_param
+        assert_redirected_to "/"
+      end
+
+      describe "common" do
+        setup do
+          put :update, params.merge(id: project.to_param)
+        end
+
+        describe "with valid parameters" do
+          let(:params) { { project: { name: "Hi-yo" } } }
+
+          it "redirects to root url" do
+            assert_redirected_to project_path(project.reload)
+          end
+
+          it "creates a new project" do
+            Project.where(name: "Hi-yo").first.wont_be_nil
+          end
+        end
+
+        describe "with invalid parameters" do
+          let(:params) { { project: { name: "" } } }
+
+          it "sets the flash error" do
+            request.flash[:error].wont_be_nil
+          end
+
+          it "renders edit template" do
+            assert_template :edit
+          end
+        end
+      end
+    end
   end
 
   describe "a GET to #edit" do
-    describe "as an admin" do
-      setup do
-        get :edit, id: project.to_param
-      end
-
-      it "renders a template" do
-        assert_template :edit
-      end
-    end
-
-    describe "non-existant" do
-      setup do
-        project.soft_delete!
-        get :edit, id: project.to_param
-      end
-
-      it "sets the flash error" do
-        request.flash[:error].wont_be_nil
-      end
-
-      it "redirects to root url" do
-        assert_redirected_to root_path
-      end
+    as_a_viewer do
+      unauthorized :get, :edit, id: 1
     end
 
     as_a_deployer do
       unauthorized :get, :edit, id: 1
     end
+
+    as_a_admin do
+      it "renders" do
+        get :edit, id: project.to_param
+        assert_template :edit
+      end
+
+      it "does not find soft deleted" do
+        project.soft_delete!
+        get :edit, id: project.to_param
+        assert_redirected_to "/"
+      end
+    end
   end
 
   describe "a GET to #show" do
-    as_a_deployer do
-      setup do
+    as_a_viewer do
+      it "redirects to the deploys page" do
         get :show, id: project.to_param
+        assert_redirected_to project_deploys_path(project)
       end
+    end
 
-      it "renders a template" do
+    as_a_deployer do
+      it "renders" do
+        get :show, id: project.to_param
         assert_template :show
       end
-    end
 
-    describe "non-existant" do
-      setup do
+      it "does not find soft deleted" do
         project.soft_delete!
-        get :edit, id: project.to_param
-      end
-
-      it "sets the flash error" do
-        request.flash[:error].wont_be_nil
-      end
-
-      it "redirects to root url" do
-        assert_redirected_to root_path
-      end
-    end
-
-    as_a_viewer do
-      setup do
         get :show, id: project.to_param
-      end
-
-      it "redirects to the deploys page" do
-        assert_redirected_to project_deploys_path(project)
+        assert_redirected_to "/"
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,12 +76,9 @@ class ActionController::TestCase
 
   class << self
     def unauthorized(method, action, params = {})
-      describe "a #{method} to #{action} with #{params}" do
-        before { send(method, action, params) }
-
-        it 'is unauthorized' do
-          assert_equal true, @unauthorized
-        end
+      it "is unauthorized when doing a #{method} to #{action} with #{params}" do
+        send(method, action, params)
+        @unauthorized.must_equal true, "Request was not marked unauthorized"
       end
     end
 


### PR DESCRIPTION
... by default

cleanup I did not want to mess up another PR with

 - controller tests should have no user by default
 - should test users in order of least permissions

also simplifying the `unauthorized` helper + giving it  a nicer failure message

@zendesk/runway 

### Risks
 - None