### PR TITLE
speed up lookup of whether deploy is a hotfix [RUN-64]

### DIFF
--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -3,7 +3,7 @@ module ReleasesHelper
     path = project_release_path(project, release)
     classes = %w(release-label label)
 
-    if release.changeset.hotfix?
+    if release.hotfix?
       classes << "label-warning"
     else
       classes << "label-success"
@@ -11,7 +11,7 @@ module ReleasesHelper
 
     content = link_to(release.version, path, class: classes.join(" "))
 
-    if release.changeset.hotfix?
+    if release.hotfix?
       warning = content_tag(:span, "", class: "glyphicon glyphicon-exclamation-sign", title: "Hotfix!")
       content + " " + warning
     else

--- a/app/models/concerns/has_changeset.rb
+++ b/app/models/concerns/has_changeset.rb
@@ -1,0 +1,24 @@
+# Assumes the following methods are defined:
+#   - id
+#   - commit
+#   - previous
+#   - project
+module HasChangeset
+  extend ActiveSupport::Concern
+
+  def changeset
+    @changeset ||= changeset_to(previous)
+  end
+
+  def changeset_to(other)
+    Changeset.find(project.github_repo, other.try(:commit), commit)
+  end
+
+  def hotfix?
+    cached_val = Rails.cache.fetch([self.class, id, 'hotfix'].join('-'), expires_in: 1.year) do
+      changeset.hotfix? ? 1 : 0
+    end
+
+    cached_val == 1
+  end
+end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -1,4 +1,5 @@
 class Deploy < ActiveRecord::Base
+  include HasChangeset
   has_soft_deletion default_scope: true
 
   belongs_to :stage, touch: true
@@ -43,16 +44,8 @@ class Deploy < ActiveRecord::Base
     end
   end
 
-  def previous_deploy
+  def previous
     stage.deploys.successful.prior_to(self).first
-  end
-
-  def changeset
-    @changeset ||= changeset_to(previous_deploy)
-  end
-
-  def changeset_to(other)
-    Changeset.find(project.github_repo, other.try(:commit), commit)
   end
 
   def production

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,4 +1,5 @@
 class Release < ActiveRecord::Base
+  include HasChangeset
   belongs_to :project, touch: true
   belongs_to :author, polymorphic: true
 
@@ -18,11 +19,7 @@ class Release < ActiveRecord::Base
     @deployed_stages ||= project.stages.select {|stage| stage.current_release?(self) }
   end
 
-  def changeset
-    @changeset ||= Changeset.find(project.github_repo, previous_release.try(:commit), commit)
-  end
-
-  def previous_release
+  def previous
     project.release_prior_to(self)
   end
 

--- a/app/views/projects/_deploy.html.erb
+++ b/app/views/projects/_deploy.html.erb
@@ -2,7 +2,7 @@
   <tr>
     <td><%= deploy_time deploy %></td>
     <td>
-      <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.changeset.hotfix? %>
+      <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.hotfix? %>
       <%= link_to "#{deploy.summary}", project_deploy_path(@project || deploy.project, deploy) %>
     </td>
     <td><span class="label <%= deploy_status(deploy.status, 'label') %>"><%= deploy.status.titleize %></span></td>

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -63,15 +63,15 @@ describe Deploy do
     end
   end
 
-  describe "#previous_deploy" do
+  describe "#previous" do
     it "returns the deploy prior to that deploy" do
       deploy1 = create_deploy!
       deploy2 = create_deploy!
       deploy3 = create_deploy!
 
 
-      deploy2.previous_deploy.must_equal deploy1
-      deploy3.previous_deploy.must_equal deploy2
+      deploy2.previous.must_equal deploy1
+      deploy3.previous.must_equal deploy2
     end
 
     it "excludes non-successful deploys" do
@@ -79,7 +79,7 @@ describe Deploy do
       deploy2 = create_deploy!(job: create_job!(status: "errored"))
       deploy3 = create_deploy!
 
-      deploy3.previous_deploy.must_equal deploy1
+      deploy3.previous.must_equal deploy1
     end
   end
 


### PR DESCRIPTION
DRY up similar code between Release and Deploy.
add a 1-year cached value whether a Deploy or Release is a hotfix.

if we want to pre-warm the cache, post-deploy we can run a command like this in console:

```ruby
Deploy.where(created_at > 6.months.ago).each { |deploy| deploy.hotfix? }
```

/cc @zendesk/samson 

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-64

### Risks
 - None