### PR TITLE
hardcode test env values so tests do not fail locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,7 @@ env:
     - DB=sqlite BUNDLE_WITHOUT=mysql2:postgresql
     - DB=mysql BUNDLE_WITHOUT=sqlite:postgresql
     - DB=postgresql BUNDLE_WITHOUT=sqlite:mysql2
-  global:
-    - SECRET_TOKEN=d6054cf90db212c8fbc070c896c30398e3275532c5602bdf00cb153b806c000e4e46fac2f3acc0783822b8f6d30b5913b6fbcfdd24914553e745b8aa8ddfa5a4
-    - DEFAULT_URL=http://www.test-url.com
-    - ZENDESK_TOKEN=c30398e3275532c5602bdf00cb153b806c000e4e46fac2f3acc0783822b8f6d3
-    - ZENDESK_URL=https://test.support.zendesk
+
 before_script:
   - cp config/database.travis.yml config/database.yml
   - bundle exec rake db:create

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,3 +47,8 @@ Samson::Application.configure do
 
   config.active_support.test_order = :random
 end
+
+ENV['ZENDESK_URL'] = 'https://test.support.zendesk'
+ENV['SECRET_TOKEN'] = 'd6054cf90db212c8fbc070c896c30398e3275532c5602bdf00cb153b806c000e4e46fac2f3acc0783822b8f6d30b5913b6fbcfdd24914553e745b8aa8ddfa5a4'
+ENV['DEFAULT_URL'] = 'http://www.test-url.com'
+ENV['ZENDESK_TOKEN'] = 'c30398e3275532c5602bdf00cb153b806c000e4e46fac2f3acc0783822b8f6d3'

--- a/test/models/zendesk_notification_test.rb
+++ b/test/models/zendesk_notification_test.rb
@@ -15,7 +15,7 @@ describe ZendeskNotification do
 
     it "comments on the ticket" do
       comment = stub_api_request(:put, "api/v2/tickets/18").
-                  with(:body => "{\"ticket\":{\"status\":\"open\",\"comment\":{\"value\":\"A fix to project has been deployed to Production. Deploy details: v2.14\",\"public\":false}}}")
+        with(:body => "{\"ticket\":{\"status\":\"open\",\"comment\":{\"value\":\"A fix to project has been deployed to Production. Deploy details: v2.14\",\"public\":false}}}")
 
       notification.deliver
 


### PR DESCRIPTION
@zendesk/runway 

tests should not fail locally and have consistent env variables -> hardcode them

### Risks
 - None