### PR TITLE
refactor Changeset for better caching [RUN-64]

### DIFF
--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -6,7 +6,7 @@ class ChangelogsController < ApplicationController
     @end_date = Date.strptime(params[:end_date], '%Y-%m-%d')
 
     @project = Project.find_by_param!(params[:project_id])
-    @changeset = Changeset.find(@project.github_repo, "master@{#{@start_date}}", "master@{#{@end_date}}")
+    @changeset = Changeset.new(@project.github_repo, "master@{#{@start_date}}", "master@{#{@end_date}}")
   end
 
   private

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -72,7 +72,7 @@ class Changeset
 
   def find_comparison
     if empty?
-      NullComparison.new('Start and end commits are the same')
+      NullComparison.new(nil)
     else
       Rails.cache.fetch(cache_key) do
         GITHUB.compare(repo, previous_commit, commit)
@@ -80,10 +80,10 @@ class Changeset
     end
   rescue Octokit::NotFound, Octokit::InternalServerError => e
     error_msg = case e
-      when Octokit::NotFound then "Commit not found"
-      when Octokit::InternalServerError then "Internal error #{e.message}"
-      else
-        "Unknown error"
+    when Octokit::NotFound then "Commit not found"
+    when Octokit::InternalServerError then "Internal error #{e.message}"
+    else
+      "Unknown error"
     end
     NullComparison.new(error_msg)
   end

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -1,29 +1,9 @@
 class Changeset
-  attr_reader :comparison, :repo, :previous_commit, :commit
+  attr_reader :repo, :previous_commit, :commit
 
-  def initialize(comparison, repo, previous_commit, commit)
-    @comparison, @repo = comparison, repo
-    @previous_commit, @commit = previous_commit, commit
-  end
-
-  def self.find(repo, previous_commit, commit)
-    # If there's no previous commit, there's no basis no perform a comparison
-    # on. Just show an empty changeset then.
-    previous_commit ||= commit
-
-    comparison = Rails.cache.fetch([self, repo, previous_commit, commit].join("-")) do
-      GITHUB.compare(repo, previous_commit, commit)
-    end
-
-    new(comparison, repo, previous_commit, commit)
-  rescue Octokit::NotFound, Octokit::InternalServerError => e
-    message = case e
-    when Octokit::NotFound then "Commit not found"
-    when Octokit::InternalServerError then "Internal error #{e.message}"
-    else
-      "Unknown error"
-    end
-    new(NullComparison.new(message), repo, previous_commit, commit)
+  def initialize(repo, previous_commit, commit)
+    @repo, @commit = repo, commit
+    @previous_commit = previous_commit || @commit
   end
 
   def github_url
@@ -31,11 +11,17 @@ class Changeset
   end
 
   def hotfix?
-    commits.any?(&:hotfix?)
+    Rails.cache.fetch("#{cache_key}-hotfix", expires_in: 1.year) do
+      commits.any?(&:hotfix?)
+    end
   end
 
   def commit_range
     "#{previous_commit}...#{commit}"
+  end
+
+  def comparison
+    @comparison ||= find_comparison
   end
 
   def commits
@@ -84,9 +70,31 @@ class Changeset
 
   private
 
+  def find_comparison
+    if empty?
+      NullComparison.new('Start and end commits are the same')
+    else
+      Rails.cache.fetch(cache_key) do
+        GITHUB.compare(repo, previous_commit, commit)
+      end
+    end
+  rescue Octokit::NotFound, Octokit::InternalServerError => e
+    error_msg = case e
+      when Octokit::NotFound then "Commit not found"
+      when Octokit::InternalServerError then "Internal error #{e.message}"
+      else
+        "Unknown error"
+    end
+    NullComparison.new(error_msg)
+  end
+
   def find_pull_requests
     numbers = commits.map(&:pull_request_number).compact
     numbers.map {|num| PullRequest.find(repo, num) }.compact
+  end
+
+  def cache_key
+    [self.class, repo, previous_commit, commit].join('-')
   end
 
   class NullComparison

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -52,7 +52,7 @@ class Deploy < ActiveRecord::Base
   end
 
   def changeset_to(other)
-    Changeset.find(project.github_repo, other.try(:commit), commit)
+    Changeset.new(project.github_repo, other.try(:commit), commit)
   end
 
   def production

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -19,7 +19,7 @@ class Release < ActiveRecord::Base
   end
 
   def changeset
-    @changeset ||= Changeset.find(project.github_repo, previous_release.try(:commit), commit)
+    @changeset ||= Changeset.new(project.github_repo, previous_release.try(:commit), commit)
   end
 
   def previous_release

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -8,7 +8,7 @@ describe DeployMailer do
 
   def stub_empty_changeset
     changeset = stub_everything(files: [], commits: [], pull_requests: [])
-    Changeset.stubs(:find).returns(changeset)
+    Deploy.any_instance.stubs(:changeset).returns(changeset)
   end
 
   describe "#deploy_email" do

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -1,30 +1,29 @@
 require_relative '../test_helper'
 
 describe Changeset do
-  describe ".find" do
+  describe "#comparison" do
     it "builds a new changeset" do
       stub_github_api("repos/foo/bar/compare/a...b", "x" => "y")
-      Changeset.find("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
+      Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
     end
 
     it "caches" do
       stub_github_api("repos/foo/bar/compare/a...b", "x" => "y")
-      Changeset.find("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
+      Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
       stub_github_api("repos/foo/bar/compare/a...b", "x" => "z")
-      Changeset.find("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
+      Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
     end
 
     it "catches exceptions" do
       GITHUB.expects(:compare).raises(Octokit::NotFound)
-      comparison = Changeset.find("foo/bar", "a", "b").comparison
+      comparison = Changeset.new("foo/bar", "a", "b").comparison
       comparison.error.must_equal "Commit not found"
     end
   end
 
   describe "#github_url" do
     it "returns a URL to a GitHub comparison page" do
-      comparison = stub("comparison")
-      changeset = Changeset.new(comparison, "foo/bar", "a", "b")
+      changeset = Changeset.new("foo/bar", "a", "b")
       changeset.github_url.must_equal "https://github.com/foo/bar/compare/a...b"
     end
   end
@@ -36,19 +35,20 @@ describe Changeset do
       c1 = stub("commit1", commit: stub(message: "Merge pull request #42"))
       c2 = stub("commit2", commit: stub(message: "Fix typo"))
       comparison.stubs(:commits).returns([c1, c2])
+      GITHUB.stubs(:compare).with("foo/bar", "a", "b").returns(comparison)
 
       Changeset::PullRequest.stubs(:find).with("foo/bar", 42).returns("yeah!")
-      changeset = Changeset.new(comparison, "foo/bar", "a", "b")
-
+      changeset = Changeset.new("foo/bar", "a", "b")
       changeset.pull_requests.must_equal ["yeah!"]
     end
 
     it "ignores invalid pull request numbers" do
       commit = stub("commit", commit: stub(message: "Merge pull request #42"))
       comparison.stubs(:commits).returns([commit])
+      GITHUB.stubs(:compare).with("foo/bar", "a", "b").returns(comparison)
 
       Changeset::PullRequest.stubs(:find).with("foo/bar", 42).returns(nil)
-      changeset = Changeset.new(comparison, "foo/bar", "a", "b")
+      changeset = Changeset.new("foo/bar", "a", "b")
 
       changeset.pull_requests.must_equal []
     end
@@ -61,16 +61,18 @@ describe Changeset do
       c1 = stub("commit1", commit: stub(message: "ZD#1234 this fixes a very bad bug"))
       c2 = stub("commit2", commit: stub(message: "ZD4567 Fix typo"))
       comparison.stubs(:commits).returns([c1, c2])
+      GITHUB.stubs(:compare).with("foo/bar", "a", "b").returns(comparison)
 
-      changeset = Changeset.new(comparison, "foo/bar", "a", "b")
+      changeset = Changeset.new("foo/bar", "a", "b")
       changeset.zendesk_tickets.must_equal [1234, 4567]
     end
 
     it "returns an empty array if there are no ticket references" do
       commit = stub("commit", commit: stub(message: "Fix build error"))
       comparison.stubs(:commits).returns([commit])
+      GITHUB.stubs(:compare).with("foo/bar", "a", "b").returns(comparison)
 
-      changeset = Changeset.new(comparison, "foo/bar", "a", "b")
+      changeset = Changeset.new("foo/bar", "a", "b")
       changeset.zendesk_tickets.must_equal [nil]
     end
   end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -55,21 +55,19 @@ describe Release do
   describe "#changeset" do
     let(:project) { projects(:test) }
     let(:author) { users(:deployer) }
-    let(:changeset) { Changeset.new("url", "foo/bar", "a", "b") }
 
     it "returns changeset" do
       release_1 = project.create_release(commit: "bar", author: author, number: 50)
       release_2 = project.create_release(commit: "foo", author: author)
 
-      Changeset.expects(:find).with("bar/foo", "bar", "foo").returns(changeset)
-      assert_equal changeset, release_2.changeset
+      assert_equal 'bar...foo', release_2.changeset.commit_range
     end
 
     it 'returns empty changeset when there is no prior release' do
       release = project.releases.create!(author: author, commit: "bar", number: 50)
 
-      Changeset.expects(:find).with("bar/foo", nil, "bar").returns(changeset)
-      assert_equal changeset, release.changeset
+      assert_equal 'bar...bar', release.changeset.commit_range
+      assert_equal [], release.changeset.commits
     end
   end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -304,8 +304,7 @@ describe Stage do
 
     it "includes committers when there is no previous deploy" do
       previous_deploy.delete
-      GITHUB.expects(:compare).with(anything, "commita", "commita").returns simple_response
-      emails.must_equal ["static@example.com", "pete@example.com"]
+      emails.must_equal ["static@example.com"]
     end
 
     it "does not include commiiters if the author did not have a email" do


### PR DESCRIPTION
lazy load GitHub comparison information only when needed.
add a 1-year cached value whether a Changeset is a hotfix.

this is an alternative implementation to PR #264. I like this one better.

if we want to pre-warm the cache, we could run a command like this post-deploy:
```ruby
Deploy.where(created_at > 6.months.ago).each { |deploy| deploy.changeset.hotfix? }
```

/cc @zendesk/samson, @grosser. @dasch 

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-64

### Risks
 - Refactors some logic around Changesets, so could affect displays of commits, authors, files, etc. Basically, any information we get from Github.