### PR TITLE
wait for threads to finish before going to the next test

### DIFF
--- a/test/models/event_streamer_test.rb
+++ b/test/models/event_streamer_test.rb
@@ -36,6 +36,8 @@ describe EventStreamer do
   let(:stream) { FakeStream.new }
   let(:streamer) { EventStreamer.new(stream) }
 
+  after { extra_threads.each(&:kill) } # heartbeat never finishes
+
   it "writes each message in the output into the stream" do
     streamer.start(output)
     stream.lines.must_include %(event: append\ndata: {"msg":"hello\\n"}\n\n)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -5,6 +5,11 @@ describe Project do
   let(:author) { users(:deployer) }
   let(:url) { "git://foo.com:hello/world.git" }
 
+  def clone_repository(project)
+    Project.any_instance.unstub(:clone_repository)
+    project.send(:clone_repository).join
+  end
+
   before { Project.any_instance.stubs(:valid_repository_url).returns(true) }
 
   it "generates a secure token when created" do
@@ -123,8 +128,6 @@ describe Project do
   end
 
   describe 'project repository initialization' do
-
-    before(:each) { unstub_project_callbacks }
     let(:repository_url) { 'git@github.com:zendesk/demo_apps.git' }
 
     it 'should not clean the project when the project is created' do
@@ -170,7 +173,7 @@ describe Project do
       repository.expects(:clone!).once
       project = Project.new(id: 9999, name: 'demo_apps', repository_url: repository_url)
       project.stubs(:repository).returns(repository)
-      project.send(:clone_repository).join
+      clone_repository(project)
     end
 
     it 'fails to clone the repository and logs the error' do
@@ -180,7 +183,7 @@ describe Project do
       project.stubs(:repository).returns(repository)
       expected_message = "Could not clone git repository #{project.repository_url} for project #{project.name} - "
       Rails.logger.expects(:error).with(expected_message)
-      project.send(:clone_repository).join
+      clone_repository(project)
     end
 
     it 'logs that it could not clone the repository when there is an unexpected error' do
@@ -191,7 +194,7 @@ describe Project do
       project.stubs(:repository).returns(repository)
       expected_message = "Could not clone git repository #{project.repository_url} for project #{project.name} - #{error}"
       Rails.logger.expects(:error).with(expected_message)
-      project.send(:clone_repository).join
+      clone_repository(project)
     end
 
     it 'does not validate with a bad repo url' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,6 +45,15 @@ class ActiveSupport::TestCase
     stubs_project_callbacks
   end
 
+  after { sleep 0.1 while extra_threads.present? }
+
+  def extra_threads
+    normal = ENV['CI'] ? 2 : 3 # there are always 3 threads hanging around, 2 unknown and 1 from the test timeout helper code
+    threads = (Thread.list - [Thread.current])
+    raise "too low threads, adjust minimum" if threads.size < normal
+    threads.sort_by(&:object_id)[normal..-1] # always kill the newest threads (run event_streamer_test.rb + stage_test.rb to make it blow up)
+  end
+
   def assert_valid(record)
     assert record.valid?, record.errors.full_messages
   end


### PR DESCRIPTION
@zendesk/runway

sometimes tests fail because a Thread is still running in the background and doing things,
we can either wait for them to finish (to see errors) or kill them all

### Risks
 - None