### PR TITLE
also cache nil deploys to generate less queries if there is no current/l...

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -60,15 +60,18 @@ class Stage < ActiveRecord::Base
   end
 
   def current_deploy
-    @current_deploy ||= deploys.active.first
+    return @current_deploy if defined?(@current_deploy)
+    @current_deploy = deploys.active.first
   end
 
   def last_deploy
-    @last_deploy ||= deploys.first
+    return @last_deploy if defined?(@last_deploy)
+    @last_deploy = deploys.first
   end
 
   def last_successful_deploy
-    @last_successful_deploy ||= deploys.successful.first
+    return @last_successful_deploy if defined?(@last_successful_deploy)
+    @last_successful_deploy = deploys.successful.first
   end
 
   def locked?

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -2,6 +2,7 @@ require_relative '../test_helper'
 
 describe Stage do
   subject { stages(:test_staging) }
+  let(:stage) { subject }
 
   describe ".where_reference_being_deployed" do
     it "returns stages where the reference is currently being deployed" do
@@ -60,12 +61,12 @@ describe Stage do
     let(:project) { projects(:test) }
     let(:stage) { stages(:test_staging) }
 
-    it 'returns the last successful deploy for the stage' do
-      successful_job = project.jobs.create!(command: 'cat foo', user: users(:deployer), status: 'succeeded')
-      stage.deploys.create!(reference: 'master', job: successful_job)
-      job = project.jobs.create!(command: 'cat foo', user: users(:deployer), status: 'failed')
-      deploy = stage.deploys.create!(reference: 'master', job: successful_job)
-      assert_equal deploy, stage.last_successful_deploy
+    it 'caches nil' do
+      stage
+      ActiveRecord::Relation.any_instance.expects(:first).returns nil
+      stage.last_deploy.must_equal nil
+      ActiveRecord::Relation.any_instance.expects(:first).never
+      stage.last_deploy.must_equal nil
     end
 
     it 'returns the last deploy for the stage' do
@@ -74,6 +75,26 @@ describe Stage do
       job = project.jobs.create!(command: 'cat foo', user: users(:deployer), status: 'failed')
       deploy = stage.deploys.create!(reference: 'master', job: job)
       assert_equal deploy, stage.last_deploy
+    end
+  end
+
+  describe '#last_successful_deploy' do
+    let(:project) { projects(:test) }
+
+    it 'caches nil' do
+      subject
+      ActiveRecord::Relation.any_instance.expects(:first).returns nil
+      stage.last_successful_deploy.must_equal nil
+      ActiveRecord::Relation.any_instance.expects(:first).never
+      stage.last_successful_deploy.must_equal nil
+    end
+
+    it 'returns the last successful deploy for the stage' do
+      successful_job = project.jobs.create!(command: 'cat foo', user: users(:deployer), status: 'succeeded')
+      stage.deploys.create!(reference: 'master', job: successful_job)
+      job = project.jobs.create!(command: 'cat foo', user: users(:deployer), status: 'failed')
+      deploy = stage.deploys.create!(reference: 'master', job: successful_job)
+      assert_equal deploy, stage.last_successful_deploy
     end
   end
 
@@ -127,6 +148,14 @@ describe Stage do
 
   describe "#current_deploy" do
     it "is nil when not deploying" do
+      subject.current_deploy.must_equal nil
+    end
+
+    it 'caches nil' do
+      subject
+      ActiveRecord::Relation.any_instance.expects(:first).returns nil
+      subject.current_deploy.must_equal nil
+      ActiveRecord::Relation.any_instance.expects(:first).never
       subject.current_deploy.must_equal nil
     end
 


### PR DESCRIPTION
...ast deploy

@zendesk/runway 

### Risks
 - None