### PR TITLE
Make deploy confirm workflow more intuitive

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -9,8 +9,7 @@ $(function () {
       $container = $(".deploy-details"),
       $placeholderPanes = $container.find(".changeset-placeholder"),
       $form = $("#new_deploy"),
-      $submit = $form.find('button[type=submit]'),
-      $cancel = $("#new-deploy-cancel"),
+      $submit = $form.find('input[type=submit]'),
       $reference = $("#deploy_reference");
 
   $("#deploy-tabs a[data-type=github]").click(function (e) {
@@ -95,8 +94,7 @@ $(function () {
 
   function toggleConfirmed() {
     confirmed = !confirmed;
-    $submit.text(!confirmed && $form.data('confirm') ? 'Review' : 'Deploy!');
-    $cancel.text(confirmed ? 'Edit' : 'Cancel');
+    $submit.val(!confirmed && $form.data('confirm') ? 'Review' : 'Deploy!');
     if (!confirmed) {
       $("#deploy-confirmation").hide();
     }
@@ -151,16 +149,6 @@ $(function () {
 
       event.preventDefault();
     }
-  });
-
-  $cancel.click(function(event) {
-    if(confirmed) {
-      toggleConfirmed();
-    } else {
-      window.location = $(this).data("url");
-    }
-
-    event.preventDefault();
   });
 
   function shrinkOutput() {

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -108,7 +108,7 @@ $(function () {
     var $selected_stage = $("#deploy_stage_id option:selected"),
         $this = $(this);
 
-    if(!confirmed && $selected_stage.data("confirmation")) {
+    if(!confirmed && $this.data('confirm')) {
       $("#confirm-button-text").show();
       $("#deploy-button-text").hide();
       $("#deploy-confirmation").show();

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -102,21 +102,30 @@ $(function () {
   // Shows confirmation dropdown using Github comparison
   var confirmed = false,
       $container = $(".deploy-details"),
-      $placeholderPanes = $container.find(".changeset-placeholder");
+      $placeholderPanes = $container.find(".changeset-placeholder"),
+      $form = $("#new_deploy"),
+      $submit = $form.find('button[type=submit]'),
+      $cancel = $("#new-deploy-cancel");
 
-  $("#new_deploy").submit(function(event) {
+  function changeDeployState() {
+    $submit.text(!confirmed && $form.data('confirm') ? 'Review' : 'Deploy!');
+    $cancel.text(confirmed ? 'Edit' : 'Cancel');
+  }
+  changeDeployState();
+
+  $form.submit(function(event) {
     var $selected_stage = $("#deploy_stage_id option:selected"),
-        $this = $(this);
+        $this = $(this),
+        $submit = $this.find('button[type=submit]');
 
     if(!confirmed && $this.data('confirm')) {
-      $("#confirm-button-text").show();
-      $("#deploy-button-text").hide();
+      confirmed = true;
+      changeDeployState();
       $("#deploy-confirmation").show();
       $("#deploy-confirmation .nav-tabs a:first").tab("show");
       $container.empty();
       $container.append($placeholderPanes);
 
-      confirmed = true;
 
       $.ajax({
         method: "POST",
@@ -137,14 +146,12 @@ $(function () {
     }
   });
 
-  $("#new-deploy-cancel").click(function(event) {
+  $cancel.click(function(event) {
     if(confirmed) {
       $("#deploy-confirmation").hide();
 
-      $("#confirm-button-text").hide();
-      $("#deploy-button-text").show();
-
       confirmed = false;
+      changeDeployState();
     } else {
       window.location = $(this).data("url");
     }

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -112,7 +112,7 @@ class DeploysController < ApplicationController
   end
 
   def stage
-    @stage ||= @project.stages.find(params[:stage_id])
+    @stage ||= @project.stages.find_by_param!(params[:stage_id])
   end
 
   def deploy_params

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -2,7 +2,7 @@ class DeploysController < ApplicationController
   before_action :authorize_deployer!, only: [:new, :create, :confirm, :update, :destroy, :buddy_check, :pending_start]
   before_action :find_project
   before_action :find_deploy, except: [:index, :recent, :active, :new, :create, :confirm]
-  before_action :stage_2, only: :new
+  before_action :stage, only: :new
 
   def index
     @page = params[:page]
@@ -112,10 +112,6 @@ class DeploysController < ApplicationController
   end
 
   def stage
-    @stage ||= @project.stages.find(deploy_params[:stage_id])
-  end
-
-  def stage_2
     @stage ||= @project.stages.find(params[:stage_id])
   end
 

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -2,6 +2,7 @@ class DeploysController < ApplicationController
   before_action :authorize_deployer!, only: [:new, :create, :confirm, :update, :destroy, :buddy_check, :pending_start]
   before_action :find_project
   before_action :find_deploy, except: [:index, :recent, :active, :new, :create, :confirm]
+  before_action :stage_2, only: :new
 
   def index
     @page = params[:page]
@@ -112,6 +113,10 @@ class DeploysController < ApplicationController
 
   def stage
     @stage ||= @project.stages.find(deploy_params[:stage_id])
+  end
+
+  def stage_2
+    @stage ||= @project.stages.find(params[:stage_id])
   end
 
   def deploy_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,7 @@ module ApplicationHelper
     elsif stage.locked_for?(current_user)
       content_tag :a, "Locked", class: "btn btn-primary disabled", disabled: true
     else
-      path = new_project_deploy_path(project, stage_id: stage.id)
+      path = new_project_stage_deploy_path(project, stage)
       link_to "Deploy", path, role: "button", class: "btn btn-primary"
     end
   end

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -3,8 +3,7 @@
 <%= render_global_lock %>
 
 <section>
-  <%= form_for [@project, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_deploys_path(@project), 'confirm' => @stage.confirm? } do |form| %>
-    <%= form.hidden_field :stage_id %>
+  <%= form_for [@project, @stage, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_stage_deploys_path(@project, @stage), 'confirm' => @stage.confirm? } do |form| %>
     <fieldset>
       <% if @deploy.errors.any? %>
         <div class="row">

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -29,8 +29,8 @@
       <div class="form-group" id="new-deploy-buttons">
         <div class="col-lg-offset-2 col-lg-10">
           <button type="submit" class="btn btn-primary" <%= 'disabled="disabled"' if global_lock %>>
-            <span id="deploy-button-text">Deploy!</span>
-            <span style="display: none;" id="confirm-button-text">Confirm!</span>
+            <span id="deploy-button-text"><%= @stage.confirm? ? 'Review' : 'Deploy!' %></span>
+            <span style="display: none;" id="confirm-button-text">Deploy!</span>
           </button>
 
           <%= link_to "cancel", '#', class: 'btn btn-default', data: { url: project_path(@project) }, id: 'new-deploy-cancel' %>

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -1,9 +1,10 @@
-<%= breadcrumb @project, "Deploy" %>
+<%= breadcrumb @project, @stage, "Deploy" %>
 
 <%= render_global_lock %>
 
 <section>
-  <%= form_for [@project, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_deploys_path(@project) } do |form| %>
+  <%= form_for [@project, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_deploys_path(@project), 'confirm' => @stage.confirm? } do |form| %>
+    <%= form.hidden_field :stage_id %>
     <fieldset>
       <% if @deploy.errors.any? %>
         <div class="row">
@@ -22,13 +23,6 @@
         <%= form.label :reference, "Tag or SHA", class: "col-lg-2 control-label" %>
         <div id="scrollable-dropdown-menu" class="col-lg-4">
           <%= form.text_field :reference, class: "form-control", autofocus: true, placeholder: "e.g. v2.1.43, master, fa0b4671", data: { prefetch_url: project_references_path(@project, format: "json") } %>
-        </div>
-      </div>
-
-      <div class="form-group">
-        <%= form.label :stage_id, "Stage", class: "col-lg-2 control-label" %>
-        <div class="col-lg-4">
-          <%= form.select :stage_id, stages_select_options, {}, class: "form-control" %>
         </div>
       </div>
 

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -27,9 +27,8 @@
 
       <div class="form-group" id="new-deploy-buttons">
         <div class="col-lg-offset-2 col-lg-10">
-          <button type="submit" class="btn btn-primary" <%= 'disabled="disabled"' if global_lock %> />
-
-          <%= link_to "", '#', class: 'btn btn-default', data: { url: project_path(@project) }, id: 'new-deploy-cancel' %>
+          <%= form.submit "", class: "btn btn-primary", disabled: global_lock %>
+          <%= link_to "Cancel", :back, class: 'btn btn-default' %>
         </div>
       </div>
 

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -28,12 +28,9 @@
 
       <div class="form-group" id="new-deploy-buttons">
         <div class="col-lg-offset-2 col-lg-10">
-          <button type="submit" class="btn btn-primary" <%= 'disabled="disabled"' if global_lock %>>
-            <span id="deploy-button-text"><%= @stage.confirm? ? 'Review' : 'Deploy!' %></span>
-            <span style="display: none;" id="confirm-button-text">Deploy!</span>
-          </button>
+          <button type="submit" class="btn btn-primary" <%= 'disabled="disabled"' if global_lock %> />
 
-          <%= link_to "cancel", '#', class: 'btn btn-default', data: { url: project_path(@project) }, id: 'new-deploy-cancel' %>
+          <%= link_to "", '#', class: 'btn btn-default', data: { url: project_path(@project) }, id: 'new-deploy-cancel' %>
         </div>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Samson::Application.routes.draw do
         get :new_relic, to: 'new_relic#show'
         get :clone, to: 'stages#clone'
       end
+
+      resources :deploys, only: :new
     end
 
     resource :changelog, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,8 @@ Samson::Application.routes.draw do
       member { post :execute }
     end
 
-    resources :deploys, only: [:index, :new, :create, :show, :destroy] do
+    resources :deploys, only: [:index, :show, :destroy] do
       collection do
-        post :confirm
         get :active
       end
 
@@ -31,7 +30,11 @@ Samson::Application.routes.draw do
         get :clone, to: 'stages#clone'
       end
 
-      resources :deploys, only: :new
+      resources :deploys, only: [:new, :create] do
+        collection do
+          post :confirm
+        end
+      end
     end
 
     resource :changelog, only: [:show]

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -18,6 +18,10 @@ describe DeploysController do
     Deploy.any_instance.stubs(:changeset).returns(changeset)
   end
 
+  it "routes" do
+    assert_routing "/projects/1/stages/2/deploys/new", controller: "deploys", action: "new", project_id: "1", stage_id: "2"
+  end
+
   as_a_viewer do
     describe "a GET to :index" do
       setup { get :index, project_id: project.to_param, format: format }

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -167,16 +167,15 @@ describe DeploysController do
   as_a_deployer do
     describe "a GET to :new" do
       it "sets stage and reference" do
-        get :new, project_id: project.to_param, stage_id: stage.id, reference: "abcd"
+        get :new, project_id: project.to_param, stage_id: stage.to_param, reference: "abcd"
         deploy = assigns(:deploy)
-        deploy.stage_id.must_equal stage.id
         deploy.reference.must_equal "abcd"
       end
     end
 
     describe "a POST to :create" do
       setup do
-        post :create, params.merge(project_id: project.to_param, stage_id: stage.id, format: format)
+        post :create, params.merge(project_id: project.to_param, stage_id: stage.to_param, format: format)
       end
 
       let(:params) {{ deploy: { reference: "master" }}}
@@ -210,7 +209,7 @@ describe DeploysController do
       setup do
         Deploy.delete_all # triggers more callbacks
 
-        post :confirm, project_id: project.to_param, stage_id: stage.id, deploy: { reference: "master" }
+        post :confirm, project_id: project.to_param, stage_id: stage.to_param, deploy: { reference: "master" }
       end
 
       it "renders the template" do

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -20,6 +20,8 @@ describe DeploysController do
 
   it "routes" do
     assert_routing "/projects/1/stages/2/deploys/new", controller: "deploys", action: "new", project_id: "1", stage_id: "2"
+    assert_routing({ method: "post", path: "/projects/1/stages/2/deploys" },
+      controller: "deploys", action: "create", project_id: "1", stage_id: "2")
   end
 
   as_a_viewer do
@@ -156,18 +158,14 @@ describe DeploysController do
       end
     end
 
-    unauthorized :get, :new, project_id: 1
-    unauthorized :post, :create, project_id: 1
+    unauthorized :get, :new, project_id: 1, stage_id: 2
+    unauthorized :post, :create, project_id: 1, stage_id: 2
     unauthorized :post, :buddy_check, project_id: 1, id: 1
     unauthorized :delete, :destroy, project_id: 1, id: 1
   end
 
   as_a_deployer do
     describe "a GET to :new" do
-      it "renders" do
-        get :new, project_id: project.to_param
-      end
-
       it "sets stage and reference" do
         get :new, project_id: project.to_param, stage_id: stage.id, reference: "abcd"
         deploy = assigns(:deploy)
@@ -178,13 +176,10 @@ describe DeploysController do
 
     describe "a POST to :create" do
       setup do
-        post :create, params.merge(project_id: project.to_param, format: format)
+        post :create, params.merge(project_id: project.to_param, stage_id: stage.id, format: format)
       end
 
-      let(:params) {{ deploy: {
-        stage_id: stage.id,
-        reference: "master"
-      }}}
+      let(:params) {{ deploy: { reference: "master" }}}
 
       describe "as html" do
         let(:format) { :html }
@@ -215,10 +210,7 @@ describe DeploysController do
       setup do
         Deploy.delete_all # triggers more callbacks
 
-        post :confirm, project_id: project.to_param, deploy: {
-          stage_id: stage.id,
-          reference: "master",
-        }
+        post :confirm, project_id: project.to_param, stage_id: stage.id, deploy: { reference: "master" }
       end
 
       it "renders the template" do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -9,7 +9,7 @@ describe ApplicationHelper do
 
     it "starts a deploy" do
       assert_includes link, ">Deploy<"
-      assert_includes link, %{href="/projects/#{project.to_param}/deploys/new?stage_id=#{stage.id}"}
+      assert_includes link, %{href="/projects/#{project.to_param}/stages/#{stage.to_param}/deploys/new"}
     end
 
     it "shows locked" do


### PR DESCRIPTION
 - stage is static
 - button initially reads "Review" if confirm is necessary and then changes to "Deploy!" (so users know that Deploy! triggers a deploy)
 - changing the reference while reviewing revert to initial state
 - removed unnecessary logic from cancel button
 - shows stage in route and breadcrumb

![screen shot 2015-03-06 at 4 29 00 pm](https://cloud.githubusercontent.com/assets/697824/6539001/cdd510ce-c41e-11e4-9f16-0df2c3743fff.png)

![screen shot 2015-03-06 at 4 31 27 pm](https://cloud.githubusercontent.com/assets/697824/6539004/d7f4d526-c41e-11e4-866a-138c3931ba71.png)

@grosser 