### PR TITLE
Change from data-confirm to data-confirmation to avoid HTML reserved att...

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -94,7 +94,7 @@ $(function () {
 
   function toggleConfirmed() {
     confirmed = !confirmed;
-    $submit.val(!confirmed && $form.data('confirm') ? 'Review' : 'Deploy!');
+    $submit.val(!confirmed && $form.data('confirmation') ? 'Review' : 'Deploy!');
     if (!confirmed) {
       $("#deploy-confirmation").hide();
     }
@@ -124,7 +124,7 @@ $(function () {
         $this = $(this),
         $submit = $this.find('button[type=submit]');
 
-    if(!confirmed && $this.data('confirm')) {
+    if(!confirmed && $this.data('confirmation')) {
       toggleConfirmed();
       $("#deploy-confirmation").show();
       $("#deploy-confirmation .nav-tabs a:first").tab("show");

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -3,7 +3,7 @@
 <%= render_global_lock %>
 
 <section>
-  <%= form_for [@project, @stage, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_stage_deploys_path(@project, @stage), 'confirm' => @stage.confirm? } do |form| %>
+  <%= form_for [@project, @stage, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_stage_deploys_path(@project, @stage), 'confirmation' => @stage.confirm? } do |form| %>
     <fieldset>
       <% if @deploy.errors.any? %>
         <div class="row">


### PR DESCRIPTION
There was a conflict with the use of the 'data-confirm' element attribute (http://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html) with the rails helpers. So I changed it back to the 'data-confirmation' attribute.

![samson](https://cloud.githubusercontent.com/assets/8860832/6573862/071c110c-c717-11e4-898e-816f2c946f7f.png)

/cc @zendesk/samson @grosser @princemaple @sandlerr 

### References
 - Jira link:


### Risks
 - None