### PR TITLE
convert service objects into callbacks

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -20,7 +20,7 @@ class Integrations::BaseController < ApplicationController
     if project.create_releases_for_branch?(branch)
       unless project.last_released_with_commit?(commit)
         release_service = ReleaseService.new(project)
-        release_service.create_release(commit: commit, author: user)
+        release_service.create_release!(commit: commit, author: user)
       end
     end
   end

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -13,11 +13,11 @@ class ReleasesController < ApplicationController
   end
 
   def new
-    @release = @project.build_release
+    @release = @project.releases.build
   end
 
   def create
-    @release = ReleaseService.new(@project).create_release(release_params)
+    @release = ReleaseService.new(@project).create_release!(release_params)
     redirect_to project_release_path(@project, @release)
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -32,22 +32,6 @@ class Project < ActiveRecord::Base
     last_release && last_release.commit == commit
   end
 
-  # Creates a new Release, incrementing the release number. If the Release
-  # fails to save, `#persisted?` will be false.
-  #
-  # Returns the Release.
-  def create_release(attrs = {})
-    release = build_release(attrs)
-    release.save
-    release
-  end
-
-  def build_release(attrs = {})
-    latest_release_number = releases.last.try(:number) || 0
-    release_number = latest_release_number + 1
-    releases.build(attrs.merge(number: release_number))
-  end
-
   def auto_release_stages
     stages.deployed_on_release
   end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -2,6 +2,8 @@ class Release < ActiveRecord::Base
   belongs_to :project, touch: true
   belongs_to :author, polymorphic: true
 
+  before_create :assign_release_number
+
   def self.sort_by_version
     order(number: :desc)
   end
@@ -36,5 +38,12 @@ class Release < ActiveRecord::Base
 
   def self.find_by_version!(version)
     find_by_number!(version[/\Av(\d+)\Z/, 1].to_i)
+  end
+
+  private
+
+  def assign_release_number
+    latest_release_number = project.releases.last.try(:number) || 0
+    self.number = latest_release_number + 1
   end
 end

--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -3,14 +3,10 @@ class ReleaseService
     @project = project
   end
 
-  def create_release(attrs = {})
-    release = @project.create_release(attrs)
-
-    if release.persisted?
-      push_tag_to_git_repository(release)
-      start_deploys(release)
-    end
-
+  def create_release!(attrs = {})
+    release = @project.releases.create!(attrs)
+    push_tag_to_git_repository(release)
+    start_deploys(release)
     release
   end
 

--- a/test/controllers/integrations/travis_controller_test.rb
+++ b/test/controllers/integrations/travis_controller_test.rb
@@ -10,8 +10,7 @@ describe Integrations::TravisController do
     Deploy.delete_all
     @orig_token, ENV["TRAVIS_TOKEN"] = ENV["TRAVIS_TOKEN"], "TOKEN"
     project.webhooks.create!(stage: stages(:test_staging), branch: "master")
-    ReleaseService.stubs(:new).returns(release_service)
-    release_service.stubs(:create_release)
+    Project.any_instance.stubs(releases: stub("releases", create!: nil))
   end
 
   teardown do

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -26,6 +26,10 @@ describe Project do
       project.releases.create!(commit: "123", author: author)
       assert !project.last_released_with_commit?("XYZ")
     end
+
+    it "returns false if there have been no releases" do
+      refute project.last_released_with_commit?("XYZ")
+    end
   end
 
   it "has separate repository_directories for same project but different url" do
@@ -34,36 +38,6 @@ describe Project do
     other_project.repository_url = 'git://hello'
 
     assert_not_equal project.repository_directory, other_project.repository_directory
-  end
-
-  describe "#create_release" do
-    let(:project) { projects(:test) }
-    let(:author) { users(:deployer) }
-
-    it "returns false if there have been no releases" do
-      assert !project.last_released_with_commit?("XYZ")
-    end
-  end
-
-  describe "#create_release" do
-    it "creates a new release" do
-      release = project.create_release(commit: "foo", author: author)
-
-      assert release.persisted?
-    end
-
-    it "increments release number" do
-      release = project.create_release(commit: "foo", author: author)
-
-      assert_equal 124, release.number
-    end
-
-    it "increments the release number" do
-      project.releases.create!(author: author, commit: "bar", number: 41)
-      release = project.create_release(commit: "foo", author: author)
-
-      assert_equal 42, release.number
-    end
   end
 
   describe "#webhook_stages_for_branch" do

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -14,19 +14,19 @@ describe ReleaseService do
   it "creates a new release" do
     count = Release.count
 
-    service.create_release(commit: commit, author: author)
+    service.create_release!(commit: commit, author: author)
 
     assert_equal count + 1, Release.count
   end
 
   it "tags the release" do
-    release = service.create_release(commit: commit, author: author)
+    service.create_release!(commit: commit, author: author)
     assert_equal [[project.github_repo, 'v124', target_commitish: commit]], release_params_used
   end
 
   it "deploys the commit to stages if they're configured to" do
     stage = project.stages.create!(name: "production", deploy_on_release: true)
-    release = service.create_release(commit: commit, author: author)
+    release = service.create_release!(commit: commit, author: author)
 
     assert_equal release.version, stage.deploys.first.reference
   end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -103,26 +103,23 @@ describe Stage do
     let(:stage) { stages(:test_staging) }
     let(:author) { users(:deployer) }
     let(:job) { project.jobs.create!(user: author, commit: "x", command: "echo", status: "succeeded") }
-
-    let(:previous_release) { project.releases.create!(number: 3, author: author, commit: "A") }
-    let(:last_release) { project.releases.create!(number: 4, author: author, commit: "B") }
-    let(:undeployed_release) { project.releases.create!(number: 5, author: author, commit: "C") }
+    let(:releases) { Array.new(3).map { project.releases.create!(author: author, commit: "A") } }
 
     before do
-      stage.deploys.create!(reference: "v3", job: job)
-      stage.deploys.create!(reference: "v4", job: job)
+      stage.deploys.create!(reference: "v124", job: job)
+      stage.deploys.create!(reference: "v125", job: job)
     end
 
     it "returns true if the release was the last thing deployed to the stage" do
-      assert stage.current_release?(last_release)
+      assert stage.current_release?(releases[1])
     end
 
     it "returns false if the release is not the last thing deployed to the stage" do
-      refute stage.current_release?(previous_release)
+      refute stage.current_release?(releases[0])
     end
 
     it "returns false if the release has never been deployed to the stage" do
-      refute stage.current_release?(undeployed_release)
+      refute stage.current_release?(releases[2])
     end
   end
 


### PR DESCRIPTION
This service objects looks like unnecessary indirection/abstraction to me,
now we had to remember to never create a release, but let the release service do it for us.
The service also hides the normal AR callbacks like .create / .create! / .create(validate: false) etc that can be useful.
Also now the release knows how to create itself and does not spread that logic between itself+project+service, resulting in tests no longer running with half-set-up releases -> a few more stubs necessary.

@jwswj @zendesk/runway 

### Risks
 - None