### PR TITLE
do not compile assets during test runs for faster tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,9 @@ Samson::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_files  = true
+  # We don't need assets in test, so no need to compile/serve them
+  config.serve_static_files  = false
+  config.assets.compile = false
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
not sure how this worked on travis before, but if I don't have public/assets compiled tests refuse to run or time out while trying to compile, so just disable assets in test ... nice side effect is that tests get faster

@zendesk/runway 

### Risks
 - None