### PR TITLE
catch all kinds of Oktokit errors

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -74,14 +74,8 @@ class Changeset
         GITHUB.compare(repo, previous_commit, commit)
       end
     end
-  rescue Octokit::NotFound, Octokit::InternalServerError => e
-    error_msg = case e
-    when Octokit::NotFound then "Commit not found"
-    when Octokit::InternalServerError then "Internal error #{e.message}"
-    else
-      "Unknown error"
-    end
-    NullComparison.new(error_msg)
+  rescue Octokit::Error => e
+    NullComparison.new("Github: #{e.message.sub("Octokit::", "").underscore.humanize}")
   end
 
   def find_pull_requests

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -14,10 +14,16 @@ describe Changeset do
       Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
     end
 
-    it "catches exceptions" do
-      GITHUB.expects(:compare).raises(Octokit::NotFound)
-      comparison = Changeset.new("foo/bar", "a", "b").comparison
-      comparison.error.must_equal "Commit not found"
+    {
+      Octokit::NotFound => "Github: Not found",
+      Octokit::Unauthorized => "Github: Unauthorized",
+      Octokit::InternalServerError => "Github: Internal server error",
+    }.each do |exception, message|
+      it "catches #{exception} exceptions" do
+        GITHUB.expects(:compare).raises(exception)
+        comparison = Changeset.new("foo/bar", "a", "b").comparison
+        comparison.error.must_equal message
+      end
     end
   end
 


### PR DESCRIPTION
@zendesk/runway 

previously not catching Octokit::Unauthorized

### Risks
 - None