### PR TITLE
fix bug in calculating last deploy for comparisons [BILL-1019]

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -110,7 +110,7 @@ class Deploy < ActiveRecord::Base
   end
 
   def self.prior_to(deploy)
-    deploy.persisted? ? where("#{table_name}.id < ?", deploy.id) : self
+    deploy.persisted? ? where("#{table_name}.id < ?", deploy.id) : all
   end
 
   def self.expired


### PR DESCRIPTION
Fixes a problem in comparing a new deploy with the "previous" deploy for that stage.

/cc @zendesk/samson, @zendesk/runway 

### References
 - Jira link: https://zendesk.atlassian.net/browse/BILL-1019

### Risks
 - None