### PR TITLE
simple fix for RUN-28

### DIFF
--- a/app/views/projects/_stage.html.erb
+++ b/app/views/projects/_stage.html.erb
@@ -4,12 +4,12 @@
       <%= link_to stage.name, project_stage_path(project, stage) %>
       <%= stage_lock_icon stage %>
     </td>
-    <% if stage.last_successful_deploy.nil? %>
-      <td>-</td>
-      <td>-</td>
-    <% else %>
+    <% if stage.last_successful_deploy %>
       <td><%= stage.last_successful_deploy.user.name %></td>
-      <td><%= link_to stage.last_successful_deploy.short_reference, project_deploy_path(project, stage.last_successful_deploy), title: stage.last_successful_deploy.reference %></td>
+      <td><%= link_to stage.last_successful_deploy.short_reference, project_deploy_path(project, stage.last_successful_deploy), title: "#{stage.last_successful_deploy.reference} at #{stage.last_successful_deploy.updated_at.to_s(:db)}" %></td>
+    <% else %>
+      <td>-</td>
+      <td>-</td>
     <% end %>
     <td align="right"><%= deploy_link @project, stage %></td>
   </tr>


### PR DESCRIPTION
@zendesk/runway 

basically RUN-28 asks for considering all deploys to belongs to all stages that include all the deploy groups, for example:

stage A: 1,2
stage B: 1
stage C: 2,3

so deploy to A would show up in B, but not in C

adding this logic is pretty difficult sql wise and maybe no longer necessary since we already have the dashboard + adding a small fix here to show the deploy date, so in the overview of A and B it is obvious what was deployed last / is correct

![screen shot 2015-03-11 at 4 53 25 pm](https://cloud.githubusercontent.com/assets/11367/6609515/b0555c3a-c80f-11e4-959f-0b369edca0d0.png)


### Risks
 - None