### PR TITLE
Add data dog monitors to stage

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -118,6 +118,7 @@ class StagesController < ApplicationController
       :notify_email_address,
       :deploy_on_release,
       :datadog_tags,
+      :datadog_monitor_ids,
       :update_github_pull_requests,
       :email_committers_on_automated_deploy_failure,
       :static_emails_on_automated_deploy_failure,

--- a/app/models/datadog_monitor.rb
+++ b/app/models/datadog_monitor.rb
@@ -1,0 +1,30 @@
+require 'dogapi'
+
+class DatadogMonitor
+  API_KEY = ENV["DATADOG_API_KEY"]
+  APP_KEY = ENV["DATADOG_APP_KEY"]
+
+  attr_reader :id
+
+  def initialize(id)
+    @id = id.to_i
+  end
+
+  def status
+    case response['overall_state']
+    when "OK" then :pass
+    when "Alert" then :fail
+    else :error
+    end
+  end
+
+  def name
+    response['name'] || 'error'
+  end
+
+  private
+
+  def response
+    @response ||= Dogapi::Client.new(API_KEY, APP_KEY, "").get_monitor(id).last
+  end
+end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -182,6 +182,10 @@ class Stage < ActiveRecord::Base
     emails.uniq.presence
   end
 
+  def datadog_monitors
+    datadog_monitor_ids.to_s.split(/, ?/).map { |id| DatadogMonitor.new(id) }
+  end
+
   private
 
   def build_new_project_command

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -166,6 +166,13 @@
       <span class="help-block">Enter the tags that should be used on deploy events, separated by <code>;</code></span>
     </div>
   </div>
+
+  <p>Datadog monitor ids (comma separated)</p>
+  <div class="form-group">
+    <div class="col-lg-6 col-lg-offset-2">
+      <%= form.text_field :datadog_monitor_ids, class: "form-control", placeholder: "Datadog Monitor Ids" %>
+    </div>
+  </div>
 </fieldset>
 
 <fieldset>

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -24,6 +24,14 @@
     <% end %>
   </div>
 
+  <% if datadog_monitors = @stage.datadog_monitors.presence %>
+    <h2>Datadog Monitors</h2>
+    <% datadog_monitors.each do |monitor| %>
+      <% label = {pass: "success", fail: "danger"}[monitor.status] || "warning" %>
+      <span class="label label-<%= label %>"><%= monitor.name %></span>
+    <% end %>
+  <% end %>
+
   <% if @stage.dashboard.present? %>
     <h2>Dashboard</h2>
     <div><%= sanitize @stage.dashboard, tags: Loofah::HTML5::WhiteList::ACCEPTABLE_ELEMENTS + %w[iframe] %></div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,3 +52,5 @@ end
 
 ENV['SECRET_TOKEN'] = 'd6054cf90db212c8fbc070c896c30398e3275532c5602bdf00cb153b806c000e4e46fac2f3acc0783822b8f6d30b5913b6fbcfdd24914553e745b8aa8ddfa5a4'
 ENV['DEFAULT_URL'] = 'http://www.test-url.com'
+ENV['DATADOG_API_KEY'] = 'dapikey'
+ENV['DATADOG_APP_KEY'] = 'dappkey'

--- a/db/migrate/20150309212516_add_datadog_monitor_id_to_stage.rb
+++ b/db/migrate/20150309212516_add_datadog_monitor_id_to_stage.rb
@@ -1,0 +1,7 @@
+class AddDatadogMonitorIdToStage < ActiveRecord::Migration
+  def change
+    change_table :stages do |t|
+      t.string :datadog_monitor_ids
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 20150312110723) do
     t.text     "dashboard",                   limit: 65535
     t.boolean  "email_committers_on_automated_deploy_failure",         default: false, null: false
     t.string   "static_emails_on_automated_deploy_failure", limit: 255
+    t.string   "datadog_monitor_ids",                          limit: 255
   end
 
   add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", using: :btree

--- a/test/models/datadog_monitor_test.rb
+++ b/test/models/datadog_monitor_test.rb
@@ -1,0 +1,53 @@
+require_relative '../test_helper'
+
+describe DatadogMonitor do
+  def stub_datadog(state)
+    stub_request(:get, monitor_url).
+      to_return(status: 200, body: api_response.merge("overall_state" => state).to_json)
+  end
+
+  def stub_datadog_timeout
+    stub_request(:get, monitor_url).to_timeout
+  end
+
+  let(:monitor) { DatadogMonitor.new(123) }
+  let(:monitor_url) { "https://app.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey" }
+  let(:api_response) { JSON.parse('{"name":"Monitor Slow foo","query":"max(last_30m):max:foo.metric.time.max{*} > 20000","overall_state":"Ok","type":"metric alert","message":"This is mostly informative... @foo@bar.com","org_id":1234,"id":123,"options":{"notify_no_data":false,"no_data_timeframe":60,"notify_audit":false,"silenced":{}}}') }
+
+  describe "#status" do
+    it "passes when it passes" do
+      stub_datadog("OK")
+      monitor.status.must_equal :pass
+    end
+
+    it "fails when it fails" do
+      stub_datadog("Alert")
+      monitor.status.must_equal :fail
+    end
+
+    it "errors when it times out" do
+      stub_datadog_timeout
+      silence_stderr { monitor.status.must_equal :error }
+    end
+  end
+
+  describe "#name" do
+    it "is there" do
+      stub_datadog("OK")
+      monitor.name.must_equal "Monitor Slow foo"
+    end
+
+    it "is error when request times out" do
+      stub_datadog_timeout
+      silence_stderr { monitor.name.must_equal "error" }
+    end
+  end
+
+  describe "caching" do
+    it "caches the api response" do
+      Dogapi::Client.any_instance.expects(:get_monitor).returns([{}])
+      monitor.name
+      monitor.status
+    end
+  end
+end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -403,4 +403,15 @@ describe Stage do
       stage.production?.must_equal false
     end
   end
+
+  describe '#datadog_monitors' do
+    it "is empty by default" do
+      stage.datadog_monitors.must_equal []
+    end
+
+    it "builds  multiple monitors" do
+      stage.datadog_monitor_ids = "1,2, 4"
+      stage.datadog_monitors  .map(&:id).must_equal [1,2,4]
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -98,6 +98,13 @@ class ActiveSupport::TestCase
     Samson::Hooks.with_callback(callback, lambda{ |*args| called << args }, &block)
     called
   end
+
+  def silence_stderr
+    old, $VERBOSE = $VERBOSE, nil
+    yield
+  ensure
+    $VERBOSE = old
+  end
 end
 
 Mocha::Expectation.class_eval do


### PR DESCRIPTION
RUN-47 Investigate and Implement integration with Datadog monitors
@zendesk/runway 

![datadog monitors](https://cloud.githubusercontent.com/assets/7716610/6630348/2ac2cd3e-c8d5-11e4-9264-3f915482e890.png)
