### PR TITLE
Fix problem with displaying dashboard waaaay back in time.

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,9 +1,11 @@
 class DashboardsController < ApplicationController
+  before_action :find_environment
+
   def show
     @before = Time.parse(params[:before] || Time.now.to_s(:db))
     @deploys = ordered_projects.each_with_object({}) do |project, hash|
       hash[project] = project.last_deploy_by_group(@before)
-      hash[project].select! { |id, _v| environment.deploy_group_ids.include?(id) }
+      hash[project].select! { |id, _v| @environment.deploy_group_ids.include?(id) }
     end
   end
 
@@ -13,7 +15,7 @@ class DashboardsController < ApplicationController
     Project.ordered_for_user(current_user).with_deploy_groups
   end
 
-  def environment
-    @environment ||= Environment.find_by_param!(params[:id])
+  def find_environment
+    @environment = Environment.find_by_param!(params[:id])
   end
 end


### PR DESCRIPTION
There is a bug where if you timetravel before time began, i.e. where there were no deploys, the environment which is lazy-loaded wouldn't get loaded.

/cc @zendesk/runway 

### References
 - Jira link:

### Risks
 - None