### PR TITLE
fixtures do not get their model name in their name

### DIFF
--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -38,7 +38,7 @@ describe Admin::DeployGroupsController do
     describe '#create' do
       it 'creates a deploy group' do
         assert_difference 'DeployGroup.count', +1 do
-          post :create, deploy_group: {name: 'pod666', environment_id: environments(:staging_env).id}
+          post :create, deploy_group: {name: 'pod666', environment_id: environments(:staging).id}
           assert_redirected_to admin_deploy_groups_path
         end
       end
@@ -54,7 +54,7 @@ describe Admin::DeployGroupsController do
 
     describe '#delete' do
       it 'succeeds' do
-        id = deploy_groups(:deploy_group_pod100).id
+        id = deploy_groups(:pod100).id
         delete :destroy, id: id
         assert_redirected_to admin_deploy_groups_path
         DeployGroup.where(id: id).must_equal []
@@ -68,12 +68,12 @@ describe Admin::DeployGroupsController do
     end
 
     describe '#update' do
-      let(:deploy_group) { deploy_groups(:deploy_group_pod100) }
+      let(:deploy_group) { deploy_groups(:pod100) }
 
       before { request.env["HTTP_REFERER"] = admin_deploy_groups_url }
 
       it 'save' do
-        post :update, deploy_group: {name: 'Test Update', environment_id: environments(:production_env)}, id: deploy_group.id
+        post :update, deploy_group: {name: 'Test Update', environment_id: environments(:production)}, id: deploy_group.id
         assert_redirected_to admin_deploy_groups_path
         DeployGroup.find(deploy_group.id).name.must_equal 'Test Update'
       end

--- a/test/controllers/admin/environments_controller_test.rb
+++ b/test/controllers/admin/environments_controller_test.rb
@@ -54,7 +54,7 @@ describe Admin::EnvironmentsController do
 
     describe '#delete' do
       it 'succeeds' do
-        env = environments(:production_env)
+        env = environments(:production)
         delete :destroy, id: env
         assert_redirected_to admin_environments_path
         Environment.where(id: env.id).must_equal []
@@ -68,7 +68,7 @@ describe Admin::EnvironmentsController do
     end
 
     describe '#update' do
-      let(:environment){ environments(:production_env) }
+      let(:environment){ environments(:production) }
 
       before { request.env["HTTP_REFERER"] = admin_environments_url }
 

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 describe DashboardsController do
-  let(:production) { environments(:production_env) }
+  let(:production) { environments(:production) }
 
   as_a_viewer do
     describe '#show' do

--- a/test/controllers/macros_controller_test.rb
+++ b/test/controllers/macros_controller_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 describe MacrosController do
   let(:project) { projects(:test) }
   let(:deployer) { users(:deployer) }
-  let(:macro) { macros(:test_macro) }
+  let(:macro) { macros(:test) }
   let(:macro_service) { stub(execute!: nil) }
   let(:execute_called) { [] }
   let(:job) { Job.create!(commit: macro.reference, command: macro.command, project: project, user: deployer) }

--- a/test/fixtures/commands.yml
+++ b/test/fixtures/commands.yml
@@ -2,5 +2,5 @@ echo:
   command: echo hello
   project: test
 
-global_command:
+global:
   command: true

--- a/test/fixtures/deploy_groups.yml
+++ b/test/fixtures/deploy_groups.yml
@@ -1,11 +1,11 @@
-deploy_group_pod1:
+pod1:
   name: Pod1
-  environment: production_env
+  environment: production
 
-deploy_group_pod2:
+pod2:
   name: Pod2
-  environment: production_env
+  environment: production
 
-deploy_group_pod100:
+pod100:
   name: Pod 100
-  environment: staging_env
+  environment: staging

--- a/test/fixtures/environments.yml
+++ b/test/fixtures/environments.yml
@@ -1,9 +1,9 @@
-production_env:
+production:
   name: Production
   is_production: true
   permalink: production
 
-staging_env:
+staging:
   name: Staging
   is_production: false
   permalink: staging

--- a/test/fixtures/macro_commands.yml
+++ b/test/fixtures/macro_commands.yml
@@ -1,3 +1,3 @@
-test_macro_echo:
-  macro: test_macro
+test_echo:
+  macro: test
   command: echo

--- a/test/fixtures/macros.yml
+++ b/test/fixtures/macros.yml
@@ -1,4 +1,4 @@
-test_macro:
+test:
   name: Test Macro
   project: test
   reference: master

--- a/test/fixtures/stages.yml
+++ b/test/fixtures/stages.yml
@@ -3,7 +3,7 @@ test_staging:
   project: test
   confirm: false
   permalink: staging
-  deploy_groups: [ deploy_group_pod100 ]
+  deploy_groups: [ pod100 ]
 
 test_production:
   name: Production
@@ -11,7 +11,7 @@ test_production:
   confirm: false
   production: true
   permalink: production
-  deploy_groups: [ deploy_group_pod1, deploy_group_pod2 ]
+  deploy_groups: [ pod1, pod2 ]
 
 test_production_pod:
   name: Production Pod
@@ -19,4 +19,4 @@ test_production_pod:
   confirm: false
   production: true
   permalink: production-pod
-  deploy_groups: [ deploy_group_pod1 ]
+  deploy_groups: [ pod1 ]

--- a/test/helpers/stages_helper_test.rb
+++ b/test/helpers/stages_helper_test.rb
@@ -6,17 +6,15 @@ describe StagesHelper do
       let(:current_user) { users(:admin) }
 
       it "links to global edit" do
-        html = Nokogiri::HTML(edit_command_link(commands(:global_command)))
-        assert_select html, 'a.edit-command.no-hover.glyphicon.glyphicon-globe'
-        assert_select html, 'a[href="/admin/commands/625879608/edit"]'
-        assert_select html, 'a[title="Edit global command"]'
+        command = commands(:global)
+        html = edit_command_link(command)
+        html.must_equal "<a title=\"Edit global command\" class=\"edit-command glyphicon glyphicon-globe no-hover\" href=\"/admin/commands/#{command.id}/edit\"></a>"
       end
 
       it "links to local edit" do
-        html = Nokogiri::HTML(edit_command_link(commands(:echo)))
-        assert_select html, 'a.edit-command.no-hover.glyphicon.glyphicon-edit'
-        assert_select html, 'a[href="/admin/commands/386150450/edit"]'
-        assert_select html, 'a[title="Edit in admin UI"]'
+        command = commands(:echo)
+        html = edit_command_link(command)
+        html.must_equal "<a title=\"Edit in admin UI\" class=\"edit-command glyphicon glyphicon-edit no-hover\" href=\"/admin/commands/#{command.id}/edit\"></a>"
       end
     end
 
@@ -24,10 +22,8 @@ describe StagesHelper do
       let(:current_user) { users(:deployer) }
 
       it "explains global commands" do
-        html = Nokogiri::HTML(edit_command_link(commands(:global_command)))
-        assert_select html, 'a.edit-command.no-hover.glyphicon.glyphicon-globe'
-        assert_select html, 'a[href="#"]'
-        assert_select html, 'a[title^="Global command"]'
+        html = edit_command_link(commands(:global))
+        html.must_equal "<a title=\"Global command, can only be edited via Admin UI\" class=\"edit-command glyphicon glyphicon-globe no-hover\" href=\"#\"></a>"
       end
 
       it "does not show local edit" do

--- a/test/models/deploy_group_test.rb
+++ b/test/models/deploy_group_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 describe DeployGroup do
-  let(:prod_env) { environments(:production_env) }
+  let(:prod_env) { environments(:production) }
 
   describe '.new' do
     it 'saves' do

--- a/test/models/macro_service_test.rb
+++ b/test/models/macro_service_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 describe MacroService do
-  let(:macro) { macros(:test_macro) }
+  let(:macro) { macros(:test) }
   let(:user) { users(:deployer) }
   let(:project) { projects(:test) }
   let(:service) { MacroService.new(project, user) }

--- a/test/models/macro_test.rb
+++ b/test/models/macro_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 describe Macro do
-  subject { macros(:test_macro) }
+  subject { macros(:test) }
 
   describe '#command' do
     describe 'adding + sorting a command' do

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -223,34 +223,34 @@ describe Project do
   end
 
   describe '#last_deploy_by_group' do
-    let(:deploy_group_pod1) { deploy_groups(:deploy_group_pod1) }
-    let(:deploy_group_pod2) { deploy_groups(:deploy_group_pod2) }
-    let(:deploy_group_pod100) { deploy_groups(:deploy_group_pod100) }
+    let(:pod1) { deploy_groups(:pod1) }
+    let(:pod2) { deploy_groups(:pod2) }
+    let(:pod100) { deploy_groups(:pod100) }
     let(:prod_deploy) { deploys(:succeeded_production_test) }
     let(:staging_deploy) { deploys(:succeeded_test) }
     let!(:user) { users(:deployer) }
 
     it 'contains releases per deploy group' do
       deploys = project.last_deploy_by_group(Time.now)
-      deploys[deploy_group_pod1.id].must_equal prod_deploy
-      deploys[deploy_group_pod2.id].must_equal prod_deploy
-      deploys[deploy_group_pod100.id].must_equal staging_deploy
+      deploys[pod1.id].must_equal prod_deploy
+      deploys[pod2.id].must_equal prod_deploy
+      deploys[pod100.id].must_equal staging_deploy
     end
 
     it "does not contain releases after requested time" do
       staging_deploy.update_column(:updated_at, prod_deploy.updated_at - 2.days)
       deploys = project.last_deploy_by_group(prod_deploy.updated_at - 1.day)
-      deploys[deploy_group_pod1.id].must_equal nil
-      deploys[deploy_group_pod2.id].must_equal nil
-      deploys[deploy_group_pod100.id].must_equal staging_deploy
+      deploys[pod1.id].must_equal nil
+      deploys[pod2.id].must_equal nil
+      deploys[pod100.id].must_equal staging_deploy
     end
 
     it 'contains no releases for undeployed projects' do
       project = Project.create!(name: 'blank_new_project', repository_url: url)
       deploys = project.last_deploy_by_group(Time.now)
-      deploys[deploy_group_pod1.id].must_be_nil
-      deploys[deploy_group_pod2.id].must_be_nil
-      deploys[deploy_group_pod100.id].must_be_nil
+      deploys[pod1.id].must_be_nil
+      deploys[pod2.id].must_be_nil
+      deploys[pod100.id].must_be_nil
     end
 
     it 'performs minimal number of queries' do


### PR DESCRIPTION
avoid redundancy and make things easier to read `users(:admin)` not `users(:admin_user)`

@zendesk/runway 

### Risks
 - None