### PR TITLE
stop caching fast things

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -11,9 +11,7 @@ class Changeset
   end
 
   def hotfix?
-    Rails.cache.fetch("#{cache_key}-hotfix", expires_in: 1.year) do
-      commits.any?(&:hotfix?)
-    end
+    commits.any?(&:hotfix?)
   end
 
   def commit_range

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -55,6 +55,12 @@ class Deploy < ActiveRecord::Base
     Changeset.new(project.github_repo, other.try(:commit), commit)
   end
 
+  def hotfix?
+    Rails.cache.fetch("#{cache_key}-hotfix", expires_in: 1.year) do
+      changeset.hotfix?
+    end
+  end
+
   def production
     stage.production?
   end

--- a/app/views/projects/_deploy.html.erb
+++ b/app/views/projects/_deploy.html.erb
@@ -1,13 +1,11 @@
-<% cache [@project, deploy] do %>
-  <tr>
-    <% unless @project %>
-      <td><%= link_to deploy.project.name, deploy.project %></td>
-    <% end %>
-    <td><%= deploy_time deploy %></td>
-    <td>
-      <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.changeset.hotfix? %>
-      <%= link_to "#{deploy.summary}", project_deploy_path(@project || deploy.project, deploy) %>
-    </td>
-    <td><span class="label <%= deploy_status(deploy.status, 'label') %>"><%= deploy.status.titleize %></span></td>
-  </tr>
-<% end %>
+<tr>
+  <% unless @project %>
+    <td><%= link_to deploy.project.name, deploy.project %></td>
+  <% end %>
+  <td><%= deploy_time deploy %></td>
+  <td>
+    <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.hotfix? %>
+    <%= link_to "#{deploy.summary}", project_deploy_path(@project || deploy.project, deploy) %>
+  </td>
+  <td><span class="label <%= deploy_status(deploy.status, 'label') %>"><%= deploy.status.titleize %></span></td>
+</tr>


### PR DESCRIPTION
@zendesk/runway the only thing slow in the deploy is the hotfix check, which is already cached ... and the only n+1 query is the previous_deploy check which is only needed for the hotfix -> stop caching html and cache the data ?

### Risks
 - Deploy display being slow