### PR TITLE
changing DATADOG_APP_KEY env variable to DATADOG_APPLICATION_KEY

### DIFF
--- a/app/models/datadog_monitor.rb
+++ b/app/models/datadog_monitor.rb
@@ -2,7 +2,7 @@ require 'dogapi'
 
 class DatadogMonitor
   API_KEY = ENV["DATADOG_API_KEY"]
-  APP_KEY = ENV["DATADOG_APP_KEY"]
+  APP_KEY = ENV["DATADOG_APPLICATION_KEY"]
 
   attr_reader :id
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,4 +53,4 @@ end
 ENV['SECRET_TOKEN'] = 'd6054cf90db212c8fbc070c896c30398e3275532c5602bdf00cb153b806c000e4e46fac2f3acc0783822b8f6d30b5913b6fbcfdd24914553e745b8aa8ddfa5a4'
 ENV['DEFAULT_URL'] = 'http://www.test-url.com'
 ENV['DATADOG_API_KEY'] = 'dapikey'
-ENV['DATADOG_APP_KEY'] = 'dappkey'
+ENV['DATADOG_APPLICATION_KEY'] = 'dappkey'


### PR DESCRIPTION
this is already added by chef_zendesk_samson and available in .env on staging

@zendesk/runway 