### PR TITLE
on Environment dashboards, hide projects with no deploys

### DIFF
--- a/app/assets/javascripts/dashboards.js
+++ b/app/assets/javascripts/dashboards.js
@@ -1,0 +1,5 @@
+$(function () {
+  $('#no-deploy-toggler').click(function(e) {
+    $('tr.no-elements').toggleClass('hidden');
+  });
+});

--- a/app/assets/javascripts/dashboards.js
+++ b/app/assets/javascripts/dashboards.js
@@ -1,5 +1,0 @@
-$(function () {
-  $('#no-deploy-toggler').click(function(e) {
-    $('tr.no-elements').toggleClass('hidden');
-  });
-});

--- a/app/assets/javascripts/shared.js
+++ b/app/assets/javascripts/shared.js
@@ -1,0 +1,6 @@
+$(function () {
+  $('a.toggle').click(function(e) {
+    var target = $(this).data('target');
+    $(target).toggle();
+  });
+});

--- a/app/views/dashboards/_project.html.erb
+++ b/app/views/dashboards/_project.html.erb
@@ -1,4 +1,9 @@
-<tr class="<%= 'warning' if project_has_different_deploys?(deploy_group_versions) %>">
+<%
+   row_classes = []
+   row_classes << 'warning' if project_has_different_deploys?(deploy_group_versions)
+   row_classes << 'no-elements hidden' if deploy_group_versions.slice(*@environment.deploy_group_ids).empty?
+%>
+<tr class="<%= row_classes.join(' ') %>">
   <td><%= link_to project.name, project %></td>
   <% @environment.deploy_groups.each do |deploy_group| %>
     <td>

--- a/app/views/dashboards/_project.html.erb
+++ b/app/views/dashboards/_project.html.erb
@@ -1,9 +1,13 @@
 <%
-   row_classes = []
-   row_classes << 'warning' if project_has_different_deploys?(deploy_group_versions)
-   row_classes << 'no-elements hidden' if deploy_group_versions.slice(*@environment.deploy_group_ids).empty?
+   row_attr = {}
+   if deploy_group_versions.slice(*@environment.deploy_group_ids).empty?
+     row_attr[:class] = 'no-deploys'
+     row_attr[:style] = 'display: none;'
+   elsif project_has_different_deploys?(deploy_group_versions)
+     row_attr[:class] = 'warning'
+   end
 %>
-<tr class="<%= row_classes.join(' ') %>">
+<%= content_tag(:tr, row_attr) do -%>
   <td><%= link_to project.name, project %></td>
   <% @environment.deploy_groups.each do |deploy_group| %>
     <td>
@@ -12,4 +16,4 @@
       <% end %>
     </td>
   <% end %>
-</tr>
+<% end -%>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,7 +2,7 @@
 
 <section>
   <p style="float: right;">
-    <a id="no-deploy-toggler" href="#">Toggle Projects without Deploys</a>
+    <a class="toggle" data-target="tr.no-deploys" href="#">Toggle Projects without Deploys</a>
   </p>
 
   <p>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,6 +1,10 @@
 <h1><%= @environment.name %></h1>
 
 <section>
+  <p style="float: right;">
+    <a id="no-deploy-toggler" href="#">Toggle Projects without Deploys</a>
+  </p>
+
   <p>
     <%= form_tag "", method: :get do %>
       Status at <%= datetime_local_field_tag :before, @before.strftime("%Y-%m-%dT%H:%M:%S") %>


### PR DESCRIPTION
by default hides rows for Projects that don't have any deploys in that environment.  Adds a UI element to hide/show them.

/cc @zendesk/runway 

### Risks
 - None