### PR TITLE
Resolve and track tag for deploy and export to Job as TAG environment variable

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -39,6 +39,16 @@ class GitRepository
     description.split('-').last.sub(/^g/, '')
   end
 
+  def tag_from_ref(git_reference)
+    Dir.chdir(repo_cache_dir) do
+      tag = IO.popen(['git', 'describe', '--tags', git_reference], err: [:child, :out]) do |io|
+        io.read.strip
+      end
+
+      tag if $?.success?
+    end
+  end
+
   def repo_cache_dir
     File.join(cached_repos_dir, @repository_directory)
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -82,8 +82,8 @@ class Job < ActiveRecord::Base
     update_attribute(:output, output)
   end
 
-  def update_commit!(commit)
-    update_attribute(:commit, commit)
+  def update_git_references!(commit:, tag:)
+    update_columns(commit: commit, tag: tag)
   end
 
   private

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -105,6 +105,7 @@ class JobExecution
       "export DEPLOYER_EMAIL=#{@job.user.email.shellescape}",
       "export DEPLOYER_NAME=#{@job.user.name.shellescape}",
       "export REVISION=#{@reference.shellescape}",
+      "export TAG=#{@job.tag.to_s.shellescape}",
       "export CACHE_DIR=#{artifact_cache_dir}",
       "cd #{dir}",
       *@job.commands
@@ -127,7 +128,8 @@ class JobExecution
     locked = lock_project do
       return false unless @repository.setup!(@executor, dir, @reference)
       commit = @repository.commit_from_ref(@reference)
-      @job.update_commit!(commit)
+      tag = @repository.tag_from_ref(@reference)
+      @job.update_git_references!(commit: commit, tag: tag)
     end
 
     if locked

--- a/db/migrate/20150317205551_jobs_add_tag.rb
+++ b/db/migrate/20150317205551_jobs_add_tag.rb
@@ -1,0 +1,5 @@
+class JobsAddTag < ActiveRecord::Migration
+  def change
+    add_column :jobs, :tag, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150312110723) do
+ActiveRecord::Schema.define(version: 20150317205551) do
 
   create_table "commands", force: true do |t|
     t.text     "command",    limit: 16777215
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20150312110723) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "commit"
+    t.string   "tag",        limit: 255
   end
 
   add_index "jobs", ["project_id"], name: "index_jobs_on_project_id", using: :btree

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -20,6 +20,7 @@ describe JobExecution do
       echo monkey > foo
       git add foo
       git commit -m "initial commit"
+      git tag v1
     SHELL
     user.name = 'John Doe'
     user.email = 'jdoe@test.com'
@@ -84,6 +85,7 @@ describe JobExecution do
     assert_equal 'mantis shrimp', last_line_of_output
     assert job.commit.present?, "Expected #{job} to record the commit"
     assert_includes commit, job.commit
+    assert_includes 'annotated_tag', job.tag
   end
 
   it "updates the branch to match what's in the remote repository" do
@@ -110,6 +112,17 @@ describe JobExecution do
     execute_job 'safari'
 
     assert_equal 'zebra', last_line_of_output
+  end
+
+  it "exports deploy information as environment variables" do
+    job.update(command: 'env')
+    execute_job
+    lines = job.output.split "\n"
+    lines.must_include "DEPLOYER=jdoe@test.com"
+    lines.must_include "DEPLOYER_EMAIL=jdoe@test.com"
+    lines.must_include "DEPLOYER_NAME=John Doe"
+    lines.must_include "REVISION=master"
+    lines.must_include "TAG=v1"
   end
 
   it 'maintains a cache of build artifacts between runs' do


### PR DESCRIPTION
For canary analysis, our applications must include the application version in metrics sent to statsd. The version string being sent should originate in Samson, so the string is uniform end-to-end. The tag is generated by `git describe`, so it will fall back to a unique human readable reference format (e.g. `v1.2.3-13-g1234abc`) if the deployed commit is not explicitly tagged.

The tag is exported to the execution so that capistrano can write the tag out on deploys. This also means we can (and need to) remove the `export TAG=$REVISION` global command in all of our projects.

### References

- Jira: [RUN-67](https://zendesk.atlassian.net/browse/RUN-67)

### Risks

Medium, due to our own capistrano scripts already using `ENV['TAG']`. We can toggle the `TAG=$REVISION` command per-stage until we're confident it's safe, and then delete the command entirely.

/cc @zendesk/runway @steved 