### PR TITLE
Only show successful deploy for timeline.

### DIFF
--- a/app/assets/javascripts/controllers/deploy_groups_ctrl.js
+++ b/app/assets/javascripts/controllers/deploy_groups_ctrl.js
@@ -3,11 +3,7 @@ samson.controller('DeployGroupsCtrl', function($scope, $http, $location, $window
   function init() {
     $http.get($location.path() + '.json').success(function(result) {
       result.deploys.forEach(function(deploy) {
-        if (deploy.started_at != undefined) {
-          deploy.start = new Date(deploy.started_at);
-        } else {
-          deploy.start = new Date(deploy.created_at);
-        }
+        deploy.start = new Date(deploy.started_at || deploy.created_at);
       });
       $scope.items.add(result.deploys);
     });

--- a/app/assets/javascripts/controllers/deploy_groups_ctrl.js
+++ b/app/assets/javascripts/controllers/deploy_groups_ctrl.js
@@ -1,9 +1,13 @@
 samson.controller('DeployGroupsCtrl', function($scope, $http, $location, $window) {
 
   function init() {
-    $http.get($location.path() + '/deploys.json').success(function(result) {
+    $http.get($location.path() + '.json').success(function(result) {
       result.deploys.forEach(function(deploy) {
-        deploy.start = new Date(deploy.started_at);
+        if (deploy.started_at != undefined) {
+          deploy.start = new Date(deploy.started_at);
+        } else {
+          deploy.start = new Date(deploy.created_at);
+        }
       });
       $scope.items.add(result.deploys);
     });

--- a/app/assets/javascripts/directives/deploy_group_timeline_directive.js
+++ b/app/assets/javascripts/directives/deploy_group_timeline_directive.js
@@ -2,11 +2,13 @@ samson.directive('deployGroupTimeline', function() {
   return {
     restrict: 'E',
     link: function($scope, $element) {
-      var options = {
+      var endDate = new Date(_.now() + 1*1000*60*60*24),
+        options = {
         minHeight: '400px',
-        max: new Date(),
-        end: new Date(),
-        showMajorLabels: false
+        max: endDate,
+        end: endDate,
+        showMajorLabels: false,
+        showCurrentTime: false
       };
 
       $scope.timeline = new vis.Timeline($element[0])

--- a/app/controllers/deploy_groups_controller.rb
+++ b/app/controllers/deploy_groups_controller.rb
@@ -1,16 +1,25 @@
 class DeployGroupsController < ApplicationController
-  def show
-    @deploy_group = DeployGroup.find(params[:id])
-    @deploys = @deploy_group.deploys.page(params[:page])
-  end
+  before_action :find_deploy_group
 
-  def deploys
-    deploys = DeployGroup.find(params[:id]).stages.each_with_object([]) do |stage, array|
-      stage.deploys.each do |deploy|
-        array << deploy.as_json.merge(project: deploy.project.as_json,
-                                      url: project_deploy_path(deploy.project, deploy))
+  def show
+    respond_to do |format|
+      format.html do
+        @deploys = @deploy_group.deploys.page(params[:page])
+      end
+      format.json do
+        deploys = @deploy_group.deploys.successful.limit(300).each_with_object([]) do |deploy, array|
+          array << deploy.as_json.merge(
+            project: deploy.project.as_json,
+            url: project_deploy_path(deploy.project, deploy))
+        end
+        render json: { deploys: deploys }
       end
     end
-    render json: { deploys: deploys }
+  end
+
+  private
+
+  def find_deploy_group
+    @deploy_group = DeployGroup.find(params[:id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,11 +57,7 @@ Samson::Application.routes.draw do
     end
   end
 
-  resources :deploy_groups, only: [:show] do
-    member do
-      get :deploys
-    end
-  end
+  resources :deploy_groups, only: [:show]
 
   resource :profile, only: [:show, :update]
 

--- a/test/angular/controllers/deploy_groups_ctrl_spec.js
+++ b/test/angular/controllers/deploy_groups_ctrl_spec.js
@@ -1,16 +1,22 @@
 describe('DeployGroupsCtrl', function() {
   beforeEach(module("samson"));
 
-  var $scope = {},
+  var $rootScope,
+    $scope = {},
     $controller,
     $httpBackend,
+    $location,
     createController;
 
-  beforeEach(inject(function(_$controller_, _$httpBackend_) {
-    $scope = {};
+  beforeEach(inject(function(_$controller_, _$httpBackend_, _$location_, _$rootScope_) {
+    $rootScope = _$rootScope_
+    $scope = $rootScope.$new();
     $httpBackend = _$httpBackend_;
+    $location = _$location_;
     createController = function() {
+      $location.path('/deploy_groups/1');
       $controller = _$controller_('DeployGroupsCtrl', { $scope: $scope });
+      $rootScope.$apply();
     };
   }));
 
@@ -21,10 +27,10 @@ describe('DeployGroupsCtrl', function() {
 
   describe('init', function() {
     it('gets list of deploys', function() {
-      $httpBackend.expectGET('//deploys.json').respond({
+      $httpBackend.expectGET('/deploy_groups/1.json').respond({
         "deploys": [
           { "id": 1, "reference": "v1", "started_at": "2015-03-08", "project": { "name": "P0" }},
-          { "id": 2, "reference": "v2", "started_at": "2015-03-10", "project": { "name": "P1" }}
+          { "id": 2, "reference": "v2", "created_at": "2015-03-10", "project": { "name": "P1" }}
         ]});
       createController();
       $httpBackend.flush();
@@ -35,7 +41,7 @@ describe('DeployGroupsCtrl', function() {
     });
 
     it('gets empty list of deploys', function() {
-      $httpBackend.expectGET('//deploys.json').respond({
+      $httpBackend.expectGET('/deploy_groups/1.json').respond({
         "deploys": []});
       createController();
       $httpBackend.flush();
@@ -44,7 +50,7 @@ describe('DeployGroupsCtrl', function() {
     });
 
     it('gets error requesting deploys', function() {
-      $httpBackend.expectGET('//deploys.json').respond(500, '');
+      $httpBackend.expectGET('/deploy_groups/1.json').respond(500, '');
       createController();
       $httpBackend.flush();
 

--- a/test/controllers/deploy_groups_controller_test.rb
+++ b/test/controllers/deploy_groups_controller_test.rb
@@ -2,6 +2,7 @@ require_relative '../test_helper'
 
 describe DeployGroupsController do
   let(:deploy_group) { deploy_groups(:pod1) }
+  let(:production_deploy) { deploys(:succeeded_production_test) }
 
   as_a_viewer do
     describe "#show" do
@@ -9,13 +10,9 @@ describe DeployGroupsController do
         get :show, id: deploy_group
         assert_template :show
       end
-    end
-
-    describe '#deploys' do
-      let(:production_deploy) { deploys(:succeeded_production_test) }
 
       it 'renders json list of deploys with projects' do
-        get :deploys, id: deploy_group
+        get :show, id: deploy_group, format: 'json'
         result = Hashie::Mash.new(JSON.parse(response.body))
         result.deploys.map(&:id).include?(production_deploy.id).must_equal true
         deploy_index = result.deploys.index { |deploy| deploy['id'] == production_deploy.id }
@@ -25,9 +22,17 @@ describe DeployGroupsController do
 
       it 'handles a deploy_group with no deploys or stages' do
         new_deploy_group = DeployGroup.create!(name: 'test666', environment: deploy_group.environment)
-        get :deploys, id: new_deploy_group
+        get :show, id: new_deploy_group, format: 'json'
         result = Hashie::Mash.new(JSON.parse(response.body))
         result.deploys.must_equal []
+      end
+
+      it 'only shows successful deploy for json response' do
+        failed_deploy = Deploy.create!(stage: production_deploy.stage, job: jobs(:failed_test), reference: 'master')
+        get :show, id: deploy_group, format: 'json'
+        result = Hashie::Mash.new(JSON.parse(response.body))
+        result.deploys.map(&:id).include?(production_deploy.id).must_equal true
+        result.deploys.map(&:id).include?(failed_deploy.id).must_equal false
       end
     end
   end

--- a/test/fixtures/jobs.yml
+++ b/test/fixtures/jobs.yml
@@ -5,3 +5,11 @@ succeeded_test:
   status: succeeded
   output: This worked!
   commit: staging
+
+failed_test:
+  command: cap staging deploy
+  user: super_admin
+  project: test
+  status: failed
+  output: Error
+  commit: staging


### PR DESCRIPTION
Ensure only showing successful deploys on the timeline. Also use the existing controller action rather than creating new one.
Increase end-time on timeline to avoid cut-off nodes.
Use created_at timestamp as backup for deploys as older deploys didn't populate started_at.

/cc @zendesk/runway 

### References
 - Jira link:

### Risks
 - None