### PR TITLE
Fix preload test when executing rake tasks.

### DIFF
--- a/config/initializers/zz.rb
+++ b/config/initializers/zz.rb
@@ -4,7 +4,7 @@ if Rails.env.development? && !ENV['SERVER_MODE']
     [
       ActiveRecord::Base.send(:descendants).map(&:name),
       ActionController::Base.descendants,
-      (File.basename($0) != "rake" && defined?(Rake) && "rake"),
+      (File.basename($0) != "rake" ? (defined?(Rake) && "rake") : nil),
       (defined?(Mocha) && "mocha"),
     ].compact.flatten.each { |c| raise "#{c} should not be loaded" }
   end


### PR DESCRIPTION
When executing certain rake tasks that initialize the rails environment, it was throwing an error due to the preload check in /initializers/zz.rb

```
$  bundle exec rake db:setup
rake aborted!
false should not be loaded
/Users/shender/Code/zendesk/samson/config/initializers/zz.rb:14:in `block (2 levels) in <top (required)>'
/Users/shender/Code/zendesk/samson/config/initializers/zz.rb:14:in `each'
/Users/shender/Code/zendesk/samson/config/initializers/zz.rb:14:in `block in <top (required)>'
/Users/shender/Code/zendesk/samson/config/environment.rb:5:in `<top (required)>'
Tasks: TOP => db:setup => db:schema:load_if_ruby => environment
(See full trace by running task with --trace)
```

/cc @zendesk/runway @samson

### References
 - Jira link:

### Risks
 - None