### PR TITLE
add parameters we pass when creating a project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -79,6 +79,11 @@ class ProjectsController < ApplicationController
       :owner,
       :permalink,
       :release_branch,
+      :dashboard,
+      :email_committers_on_automated_deploy_failure,
+      :static_emails_on_automated_deploy_failure,
+      :new_relic_applications_attributes,
+      :datadog_monitor_ids,
       stages_attributes: [
         :name, :confirm, :command,
         :production,


### PR DESCRIPTION
trying to create a new project, got this:

```
ActionController::UnpermittedParameters (found unpermitted parameters: dashboard, email_committers_on_automated_deploy_failure, static_emails_on_automated_deploy_failure, new_relic_applications_attributes, datadog_monitor_ids):
ActionController::UnpermittedParameters (found unpermitted parameters: dashboard, email_committers_on_automated_deploy_failure, static_emails_on_automated_deploy_failure, new_relic_applications_attributes, datadog_monitor_ids):
  app/controllers/projects_controller.rb:67:in `project_params'
  app/controllers/projects_controller.rb:67:in `project_params'
  app/controllers/projects_controller.rb:27:in `create'
  app/controllers/projects_controller.rb:27:in `create'
```

cc @zendesk/runway @zendesk/samson 