### PR TITLE
Add Buildkite integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Set up your webhooks and the deployment process can be automated.
     * Samson will match url to see if the webhook call is for the correct project
 * Jenkins
     * Setup using the [Notification Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Notification+Plugin)
+* Buildkite
+    * You can add a webhook per project under settings/notifications
+    * You can add any value to the 'Token' field, as it is not used
 * Github
     * You may add a webhook for push events
 

--- a/app/controllers/integrations/buildkite_controller.rb
+++ b/app/controllers/integrations/buildkite_controller.rb
@@ -1,0 +1,27 @@
+class Integrations::BuildkiteController < Integrations::BaseController
+  protected
+
+  def deploy?
+    build_event? && build_passed? && no_skip_token_present?
+  end
+
+  def build_event?
+    request.headers['X-Buildkite-Event'] == 'build'
+  end
+
+  def build_passed?
+    params[:build][:state] == 'passed'
+  end
+
+  def no_skip_token_present?
+    !contains_skip_token?(params[:build][:message])
+  end
+
+  def commit
+    params[:build][:commit]
+  end
+
+  def branch
+    params[:build][:branch]
+  end
+end

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -9,6 +9,7 @@
     <dt>Tddium:</dt><dd><%= link_to_url integrations_tddium_deploy_url(@project.token) %></dd>
     <dt>Travis:</dt><dd><%= link_to_url integrations_travis_deploy_url(@project.token) %></dd>
     <dt>Jenkins:</dt><dd><%= link_to_url integrations_jenkins_deploy_url(@project.token) %></dd>
+    <dt>Buildkite:</dt><dd><%= link_to_url integrations_buildkite_deploy_url(@project.token) %></dd>
     <dt>Github Push:</dt><dd><%= link_to_url integrations_github_deploy_url(@project.token) %></dd>
   </dl>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Samson::Application.routes.draw do
     post "/semaphore/:token" => "semaphore#create", as: :semaphore_deploy
     post "/tddium/:token" => "tddium#create", as: :tddium_deploy
     post "/jenkins/:token" => "jenkins#create", as: :jenkins_deploy
+    post "/buildkite/:token" => "buildkite#create", as: :buildkite_deploy
     post "/github/:token" => "github#create", as: :github_deploy
   end
 

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -1,0 +1,65 @@
+require_relative '../../test_helper'
+
+describe Integrations::BuildkiteController do
+  extend IntegrationsControllerTestHelper
+
+  let(:commit) { 'dc395381e650f3bac18457909880829fc20e34ba' }
+  let(:commit_message) { 'test' }
+  let(:project) { projects(:test) }
+  let(:payload) do
+    {
+      'build' => {
+        'id'=>'e711180f-b318-4559-be4e-de119d2ac5eb',
+        'url'=> 'https://api.buildkite.com/v1/organizations/my-org/projects/test/builds/9',
+        'number'=>9,
+        'state'=>'passed',
+        'message'=>commit_message,
+        'commit'=>commit,
+        'branch'=>'master',
+        'created_at'=>'2015-03-30 03:46:11 UTC',
+        'scheduled_at'=>'2015-03-30 03:46:11 UTC',
+        'started_at'=>'2015-03-30 03:46:15 UTC',
+        'finished_at'=>'2015-03-30 03:46:22 UTC'
+      },
+      'project'=> {
+        'id'=>'1db912ed-ca71-4d16-9c16-e453b88432cc',
+        'url'=>'https://api.buildkite.com/v1/organizations/my-org/projects/test',
+        'name'=>'We Build',
+        'repository'=>'git@github.com:my-org/test.git'
+      },
+      'sender'=> {
+        'id'=>'4fb41f57-c1d7-41b0-91e3-941edf19ac16', 'name'=>'Dude Rock'
+      }
+    }.with_indifferent_access
+  end
+
+  before { Deploy.delete_all }
+
+  context 'when buildkite passes a build event' do
+    before { request.headers['X-Buildkite-Event'] = 'build' }
+
+    test_regular_commit 'Buildkite', failed: { build: { state: 'failed' }}, no_mapping: { build: { branch: 'non-existent-branch' } } do
+      project.webhooks.create!(stage: stages(:test_staging), branch: 'master')
+    end
+
+    context 'when the commit message contains the skip message' do
+      let(:commit_message) { 'I like to [deploy skip]' }
+
+      it 'does not trigger a deploy' do
+        project.webhooks.create!(stage: stages(:test_staging), branch: 'master')
+        post :create, payload.merge(token: project.token)
+
+        project.deploys.must_equal []
+      end
+    end
+  end
+
+  context 'when buildkite does not pass a build event' do
+    it 'does not create a deploy' do
+      post :create, payload.merge(token: project.token)
+
+      project.deploys.must_equal []
+      response.status.must_equal 200
+    end
+  end
+end

--- a/test/support/integration_controller_test_helper.rb
+++ b/test/support/integration_controller_test_helper.rb
@@ -4,55 +4,55 @@ module IntegrationsControllerTestHelper
       before(&block) if block
 
       it "triggers a deploy if there's a webhook mapping for the branch" do
-        post :create, payload.merge(token: project.token)
+        post :create, payload.deep_merge(token: project.token)
 
         deploy = project.deploys.first
         deploy.commit.must_equal commit
       end
 
       it "doesn't trigger a deploy if there's no webhook mapping for the branch" do
-        post :create, payload.merge(token: project.token).merge(options.fetch(:no_mapping))
+        post :create, payload.deep_merge(token: project.token).deep_merge(options.fetch(:no_mapping))
 
         project.deploys.must_equal []
       end
 
       if failed = options[:failed]
         it "doesn't trigger a deploy if the build did not pass" do
-          post :create, payload.merge(token: project.token).merge(failed)
+          post :create, payload.deep_merge(token: project.token).deep_merge(failed)
 
           project.deploys.must_equal []
         end
       end
 
       it "deploys as the correct user" do
-        post :create, payload.merge(token: project.token)
+        post :create, payload.deep_merge(token: project.token)
 
         user = project.deploys.first.user
         user.name.must_equal user_name
       end
 
       it "creates the ci user if it does not exist" do
-        post :create, payload.merge(token: project.token)
+        post :create, payload.deep_merge(token: project.token)
 
         User.find_by_name(user_name).wont_be_nil
       end
 
       it "responds with 200 OK if the request is valid" do
-        post :create, payload.merge(token: project.token)
+        post :create, payload.deep_merge(token: project.token)
 
         response.status.must_equal 200
       end
 
       it "responds with 422 OK if deploy cannot be started" do
-        post :create, payload.merge(token: project.token)
-        post :create, payload.merge(token: project.token)
+        post :create, payload.deep_merge(token: project.token)
+        post :create, payload.deep_merge(token: project.token)
 
         response.status.must_equal 422
       end
 
       it "responds with 404 Not Found if the token is invalid" do
         assert_raises ActiveRecord::RecordNotFound do
-          post :create, payload.merge(token: "foobar")
+          post :create, payload.deep_merge(token: "foobar")
         end
       end
     end


### PR DESCRIPTION
Allow samson to receive webhooks from the [Buildkite CI service](https://buildkite.com/) to notify of successful builds that can then kick off a deploy.

Looks like this: 
![buildkite_hook](https://cloud.githubusercontent.com/assets/112153/6890700/03337054-d6fc-11e4-9cdb-353c2ec1f55c.png)


FYI: Some of the tests seem to be failing, this is due to the github API not returning an 'up' status due to the ongoing DDOS attacks.