### PR TITLE
fallback to commit ref if repo has no tags

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -105,7 +105,7 @@ class JobExecution
       "export DEPLOYER_EMAIL=#{@job.user.email.shellescape}",
       "export DEPLOYER_NAME=#{@job.user.name.shellescape}",
       "export REVISION=#{@reference.shellescape}",
-      "export TAG=#{@job.tag.to_s.shellescape}",
+      "export TAG=#{(@job.tag || @job.commit).to_s.shellescape}",
       "export CACHE_DIR=#{artifact_cache_dir}",
       "cd #{dir}",
       *@job.commands


### PR DESCRIPTION
If a git repository has no tags, previously we would `export TAGS=`, which was causing issues for capistrano scripts that acted on ENV['TAG'] without an empty string check. This falls back to the commit reference for these uncommon repositories.

/cc @zendesk/runway @steved 