### PR TITLE
Add a retroactive approver address for deploy bypass

### DIFF
--- a/app/mailers/deploy_mailer.rb
+++ b/app/mailers/deploy_mailer.rb
@@ -17,7 +17,8 @@ class DeployMailer < ApplicationMailer
     to_email = [BuddyCheck.bypass_email_address]
     to_email << BuddyCheck.bypass_jira_email_address if BuddyCheck.bypass_jira_email_address
 
-    mail(to: to_email, cc: user.email, subject: subject)
+    cc_email = [user.email, BuddyCheck.bypass_retroactive_approval_email]
+    mail(to: to_email, cc: cc_email, subject: subject)
   end
 
   def deploy_failed_email(stage, deploy, emails)

--- a/lib/policies/buddy_check.rb
+++ b/lib/policies/buddy_check.rb
@@ -9,6 +9,10 @@ module BuddyCheck
     ENV["BYPASS_EMAIL"]
   end
 
+  def bypass_retroactive_approval_email
+    ENV["BYPASS_RETROACTIVE_APPROVAL_EMAIL"]
+  end
+
   def period
     (ENV["BUDDY_CHECK_GRACE_PERIOD"].presence || "4").to_i
   end

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -37,6 +37,7 @@ describe DeployMailer do
     before do
       BuddyCheck.stubs(:bypass_email_address).returns("test1@test.com")
       BuddyCheck.stubs(:bypass_jira_email_address).returns(jira_address)
+      BuddyCheck.stubs(:bypass_retroactive_approval_email).returns("foo@bar.com")
 
       user.update_attributes!(email: 'user_email@test.com')
 
@@ -53,8 +54,8 @@ describe DeployMailer do
       subject.to.must_equal(['test1@test.com'])
     end
 
-    it 'CCs user email' do
-      subject.cc.must_equal(['user_email@test.com'])
+    it 'CCs user email and bypass_retroactive_approval_email' do
+      subject.cc.must_equal(['user_email@test.com', 'foo@bar.com'])
     end
 
     it 'sets a bypass subject' do


### PR DESCRIPTION
Reviewers: @pswadi-zendesk @gabetax @jonmoter 

Description:

Adding one extra CC, the person who will do the retroactive approval when the bypass deploy is utilized.

cc: @pdeuter 