### PR TITLE
Use structs over stubs when testing serialized data

### DIFF
--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -1,16 +1,19 @@
 require_relative '../../test_helper'
 
 describe Changeset::PullRequest do
-  let(:data) { stub("data", user: user, merged_by: merged_by, body: body) }
+  DataStruct = Struct.new(:user, :merged_by, :body, :title)
+  UserStruct = Struct.new(:login)
+
+  let(:data) { DataStruct.new(user, merged_by, body) }
   let(:pr) { Changeset::PullRequest.new("xxx", data) }
-  let(:user) { stub(login: "foo") }
-  let(:merged_by) { stub(login: "bar") }
+  let(:user) { UserStruct.new("foo") }
+  let(:merged_by) { UserStruct.new("bar") }
   let(:body) { "" }
 
   describe ".find" do
     it "finds the pull request" do
       GITHUB.stubs(:pull_request).with("foo/bar", 42).returns(data)
-      data.stubs(:title).returns("Make it bigger!")
+      data.title = "Make it bigger!"
 
       pr = Changeset::PullRequest.find("foo/bar", 42)
 


### PR DESCRIPTION
Currently samson is setup to use memcached via dalli in all
environemnts, although for our testing we don't really need a persisted
cache store, and it saves us having to install memcached on our CI
server, so we've set the test environment to use a in memory cache.

The problem with this is that you can't actually serialize a stub
object. If you run the following code:
```ruby
Marshal.dump(stub("data", body: stub("body", {})))
```

You'll run into this error:
  > TypeError: no _dump_data is defined for class UnboundMethod

Dalli must either rescue from serlialization errors or uses another
method of serialization avoiding the issue.

Anyways, if you just change the stubs to open structs the tests pass
with other caches apart from dalli.