### PR TITLE
Add webhook integration for deploying latest release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ GITHUB_TOKEN={fill me in}
 # DEPLOY_GROUP_FEATURE={optional, set to 1 to enable Environments and DeployGroups}
 
 # SLACK_TOKEN={ required for the slack integration }
+
+# WEBHOOK_SECRET={secret to authorize deploying latest release via webhook}
+

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -83,7 +83,7 @@ samson.filter("projectUserFilter",
 
 samson.filter("userFilter",
   function() {
-    var hookSources = /^(?:travis|tddium|semaphore|jenkins|github)$/i;
+    var hookSources = /^(?:travis|tddium|semaphore|jenkins|github|webhook)$/i;
 
     return function(deploys, userType) {
       if (userType !== undefined && userType !== null) {

--- a/app/controllers/integrations/deploy_latest_controller.rb
+++ b/app/controllers/integrations/deploy_latest_controller.rb
@@ -1,0 +1,49 @@
+class Integrations::DeployLatestController < ApplicationController
+  skip_before_action :login_users
+  skip_before_action :verify_authenticity_token
+
+  before_filter :ensure_secret_token_matches
+
+  def create
+    if deploy_release?
+      DeployService.new(project, user).deploy!(stage, latest_release.commit)
+      head 200
+    else
+      head 422
+    end
+  end
+
+  private
+
+  def project
+    @project ||= Project.find_by_token!(params[:token])
+  end
+
+  def stage
+    @stage ||= project.stages.find_by_permalink!(params[:stage])
+  end
+
+  def latest_release
+    @latest_release ||= project.releases.last
+  end
+
+  def deploy_release?
+    latest_release.present? && !stage.currently_deploying? && !stage.current_release?(latest_release)
+  end
+
+  def user
+    return @user if defined?(@user)
+    email = "deploy+webhook@#{Rails.application.config.samson.email.sender_domain}"
+    @user = User.create_with(name: 'Webhook', integration: true).find_or_create_by(email: email)
+  end
+
+  def ensure_secret_token_matches
+    if webhook_secret.blank? || request.headers['X-Webhook-Secret'] != webhook_secret
+      render status: 401, text: 'incorrect webhook secret'
+    end
+  end
+
+  def webhook_secret
+    Rails.application.config.samson.webhook_secret
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,7 @@ module Samson
     config.samson.github.api_url = ENV["GITHUB_API_URL"].presence || 'api.github.com'
     config.samson.github.status_url = ENV["GITHUB_STATUS_URL"].presence || 'status.github.com'
     config.samson.references_cache_ttl = ENV['REFERENCES_CACHE_TTL'].presence || 10.minutes
+    config.samson.webhook_secret = ENV['WEBHOOK_SECRET'].presence
 
     config.samson.auth = ActiveSupport::OrderedOptions.new
     config.samson.auth.github = ENV["AUTH_GITHUB"] == "0" ? false : true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Samson::Application.routes.draw do
     post "/jenkins/:token" => "jenkins#create", as: :jenkins_deploy
     post "/buildkite/:token" => "buildkite#create", as: :buildkite_deploy
     post "/github/:token" => "github#create", as: :github_deploy
+    post "/deploy_latest/:token" => "deploy_latest#create", as: :deploy_latest
   end
 
   get '/ping', to: 'ping#show'

--- a/test/controllers/integrations/deploy_latest_controller_test.rb
+++ b/test/controllers/integrations/deploy_latest_controller_test.rb
@@ -1,0 +1,61 @@
+require_relative '../../test_helper'
+
+describe Integrations::DeployLatestController do
+  let(:project)        { projects(:test) }
+  let(:stage)          { project.stages.detect { |stage| stage.permalink == 'staging' } }
+  let(:latest_release) { project.releases.last }
+
+  before do
+    Deploy.delete_all
+
+    Rails.application.config.samson.webhook_secret = 'correct'
+  end
+
+  context 'when the correct webhook secret is provided' do
+    before { request.headers['X-Webhook-Secret'] = 'correct' }
+
+    context 'when the latest release is not yet deployed' do
+      it 'returns a 200 response and deploys the latest release' do
+        post :create, token: project.token, stage: 'staging'
+
+        project.deploys.size.must_equal 1
+        response.status.must_equal 200
+      end
+    end
+
+    context 'when the latest release is already deployed' do
+      let(:deploy) { stage.create_deploy(user: User.first, reference: latest_release.version) }
+      before { deploy.job.success! }
+
+      it 'returns a 422 response and does not create a new deploy' do
+        post :create, token: project.token, stage: 'staging'
+
+        project.deploys.must_equal [deploy]
+        response.status.must_equal 422
+      end
+    end
+
+    context 'when the stage is currently deploying' do
+      let(:deploy) { stage.create_deploy(user: User.first, reference: latest_release.version) }
+      before { puts deploy.job.run! }
+
+      it 'returns a 422 response and does not create a deploy' do
+        post :create, token: project.token, stage: 'staging'
+
+        project.deploys.must_equal [deploy]
+        response.status.must_equal 422
+      end
+    end
+  end
+
+  context 'when the webhook secret is incorrect' do
+    before { request.headers['X-Webhook-Secret'] = 'incorrect' }
+
+    it 'returns an anauthenticated error with incorrect webhook secret and does not create a deploy' do
+      post :create, token: project.token, stage: 'staging'
+
+      project.deploys.must_equal []
+      response.status.must_equal 401
+    end
+  end
+end


### PR DESCRIPTION
Add a webhook which allows deploying a release for a given project. The
use case for this is having external services that aren't CI servers
being able to trigger deploys. An example is that we have a button in
the office which can be physically pushed that will ping the endpoint to
perform a deploy.