### PR TITLE
Only show buddy confirmationsettings when the feature is enabled

### DIFF
--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -41,7 +41,7 @@
         ) %>
       </div>
     </div>
-  <% else %>
+  <% elsif BuddyCheck.enabled? %>
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">
         <div class="checkbox">
@@ -54,16 +54,18 @@
     </div>
   <% end %>
 
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <div class="checkbox">
-        <%= form.label :confirm do %>
-          <%= form.check_box :confirm %>
-          Confirm before deployment
-        <% end %>
+  <% if BuddyCheck.enabled? %>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10">
+        <div class="checkbox">
+          <%= form.label :confirm do %>
+            <%= form.check_box :confirm %>
+            Confirm before deployment
+          <% end %>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 
   <% if @project.manage_releases? %>
     <div class="form-group">


### PR DESCRIPTION
The 'Does this stage impact production servers?' and 'Confirm before
deployment' options for a stage are only ever used to confirm
deployments when the buddy feature is activated. Therefore we do not
need to display them when the feature is disabled. Simiarly to how
fields are hidden when the 'deploy group feature' is not enabled.