### PR TITLE
Remove plugin migrations as they are included in the main migration path...

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Samson
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
     # Add DB migrations from plugins
-    config.paths["db/migrate"] << File.join(config.root, 'plugins/**/db/migrate')
+    config.paths["db/migrate"] << config.root.join('plugins/**/db/migrate')
 
     config.cache_store = :dalli_store, { value_max_bytes: 3000000, compress: true, expires_in: 1.day }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150317205551) do
+ActiveRecord::Schema.define(version: 20150331084621) do
 
   create_table "commands", force: :cascade do |t|
     t.text     "command",    limit: 10485760
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20150317205551) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "commit"
-    t.string   "tag",        limit: 255
+    t.string   "tag"
   end
 
   add_index "jobs", ["project_id"], name: "index_jobs_on_project_id"
@@ -155,6 +155,16 @@ ActiveRecord::Schema.define(version: 20150317205551) do
 
   add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
 
+  create_table "slack_channels", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.string   "channel_id", null: false
+    t.integer  "stage_id",   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "slack_channels", ["stage_id"], name: "index_slack_channels_on_stage_id"
+
   create_table "stage_commands", force: :cascade do |t|
     t.integer  "stage_id"
     t.integer  "command_id"
@@ -222,15 +232,5 @@ ActiveRecord::Schema.define(version: 20150317205551) do
 
   add_index "webhooks", ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch"
   add_index "webhooks", ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch"
-
-  create_table "slack_channels", force: :cascade do |t|
-    t.string   "name",       limit: 255, null: false
-    t.string   "channel_id", limit: 255, null: false
-    t.integer  "stage_id",   limit: 4,   null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "slack_channels", ["stage_id"], name: "index_slack_channels_on_stage_id", using: :btree
 
 end

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -25,11 +25,6 @@ module Samson
       def require
         super @path
       end
-
-      def add_migrations
-        migrations = File.join(@folder, "db/migrate")
-        Rails.application.config.paths["db/migrate"] << migrations if Dir.exist?(migrations)
-      end
     end
 
     class << self
@@ -81,5 +76,4 @@ end
 Dir["plugins/*/lib"].each { |f| $LOAD_PATH << f } # treat included plugins like gems
 
 Samson::Hooks.plugins.
-  each(&:require).
-  each(&:add_migrations)
+  each(&:require)


### PR DESCRIPTION
Don't need the plugin specific migration cmd, as the path glob is included in the application.rb.
Also, the slack db migration looked like it was hand-copied into the schema.rb and don't know why they limited the stage_id since those limits aren't in the migration file.

/cc @zendesk/runway @zendesk/samson

### References
 - Jira link:

### Risks
 - None