### PR TITLE
Change how stage edit page allows user to select deploy_groups

### DIFF
--- a/app/assets/javascripts/stages.js
+++ b/app/assets/javascripts/stages.js
@@ -55,4 +55,32 @@ $(function() {
     $form.toggleClass("active");
     $form.find(".lock-description").select();
   });
+
+  $(".env-toggle-all").each(function() {
+    $(this).change(function(toggleBox) {
+      $($(this).data('target')).each(function(index, checkBox) {
+        checkBox.checked = toggleBox.target.checked;
+      });
+    });
+
+    // Update top-level checkboxes if user selects subset of deploygroups
+    $($(this).data('target')).each(function() {
+      $(this).change(function() {
+        setEnvironmentCheckBox($(this).attr('class'));
+      });
+    });
+
+    setEnvironmentCheckBox(this.id);
+  });
+
+  function setEnvironmentCheckBox(envClass) {
+    var envCheckbox = $('#' + envClass),
+        checks = _.uniq(_.pluck($("." + envClass), 'checked'));
+    if (checks.length > 1) {
+      envCheckbox.prop('indeterminate', true);
+    } else if (checks.length > 0) {
+      envCheckbox.prop('checked', checks[0]);
+      envCheckbox.prop('indeterminate', false);
+    }
+  }
 });

--- a/app/assets/stylesheets/stages.scss
+++ b/app/assets/stylesheets/stages.scss
@@ -106,3 +106,24 @@
   vertical-align: bottom;
   width: 200px;
 }
+
+.deploy-groups {
+  thead {
+    tr {
+      th {
+        padding: 2px 20px;
+      }
+    }
+  }
+  tbody {
+    tr {
+      td {
+        padding: 2px 20px;
+        label {
+          font-weight: normal;
+          margin-bottom: 0px;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,6 +4,7 @@ class ProjectsController < ApplicationController
   before_action :authorize_admin!, except: [:show, :index, :deploy_group_versions]
   before_action :redirect_viewers!, only: [:show]
   before_action :project, only: [:show, :edit, :update, :deploy_group_versions]
+  before_action :get_environments, only: [:new, :create]
 
   helper_method :project
 
@@ -101,5 +102,9 @@ class ProjectsController < ApplicationController
     else
       Project
     end
+  end
+
+  def get_environments
+    @environments = Environment.all
   end
 end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -9,6 +9,7 @@ class StagesController < ApplicationController
   before_action :check_token, if: :badge?
   before_action :find_project
   before_action :find_stage, only: [:show, :edit, :update, :destroy, :clone]
+  before_action :get_environments, only: [:new, :create, :edit, :update, :clone]
 
   def index
     @stages = @project.stages
@@ -123,5 +124,9 @@ class StagesController < ApplicationController
 
   def find_stage
     @stage = @project.stages.find_by_param!(params[:id])
+  end
+
+  def get_environments
+    @environments = Environment.all
   end
 end

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -26,19 +26,50 @@
   <% if ENV['DEPLOY_GROUP_FEATURE'] %>
     <div class="form-group">
       <%= form.label :name, 'Deploy Groups', class: 'col-lg-2 control-label' %>
-      <div class="col-lg-4">
-        <%= form.collection_select(
-          :deploy_group_ids, DeployGroup.order(:environment_id, :name).all, :id, :long_name,
-          {
-            selected: (@stage.deploy_group_ids if @stage && @stage.deploy_groups),
-            include_blank: false,
-            include_hidden: false
-          },
-          {
-            multiple: 'true',
-            class: 'form-control'
-          }
-        ) %>
+      <div class="col-lg-5">
+        <% if @environments.count > 0 %>
+          <%= hidden_field_tag "stage[deploy_group_ids][]" %>
+          <table class="table table-condensed text-left deploy-groups">
+            <thead>
+              <tr>
+                <% @environments.each do |environment| %>
+                  <th>
+                    <%= label_tag do %>
+                      <%= check_box_tag('', nil, false, { id: "#{environment.name}_checkbox", class: "env-toggle-all", data: {target: ".#{environment.name}_checkbox" } }) %>
+                      <%= environment.name %>
+                    <% end %>
+                  </th>
+                <% end %>
+              </tr>
+            </thead>
+            <tbody>
+              <% @environments.map {|e| e.deploy_groups.count }.max.to_i.times do |index| %>
+                <tr>
+                  <% @environments.each do |environment| %>
+                    <% if environment.deploy_groups[index] %>
+                      <td>
+                        <%= label_tag do %>
+                          <%= check_box_tag(
+                            "stage[deploy_group_ids][]",
+                            environment.deploy_groups[index].id,
+                            (@stage && @stage.deploy_group_ids.include?(environment.deploy_groups[index].id)),
+                            class: "#{environment.name}_checkbox"
+                            )
+                          %>
+                          <%= environment.deploy_groups[index].name %>
+                        <% end %>
+                      </td>
+                    <% else %>
+                      <td></td>
+                    <% end %>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <p>-- No Deploy Groups configured --</p>
+        <% end %>
       </div>
     </div>
   <% else %>

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -77,6 +77,12 @@ describe ProjectsController do
         get :new
         assert_template :new
       end
+
+      it "renders with no environments" do
+        Environment.destroy_all
+        get :new
+        assert_template :new
+      end
     end
   end
 

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -168,6 +168,12 @@ describe StagesController do
 
         it 'renders' do
           assert_template :edit
+          assigns(:environments).wont_be_nil
+        end
+
+        it 'renders with no environments configured' do
+          Environment.destroy_all
+          assert_template :edit
         end
       end
 


### PR DESCRIPTION
Hopefully making things a bit easier to select deploy groups for a stage.
![apr 02 2015 14 01](https://cloud.githubusercontent.com/assets/8860832/6964412/d432ce48-d940-11e4-8235-9da73936712e.gif)


/cc @zendesk/runway @zendesk/samson

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-66

### Risks
 - None