### PR TITLE
Check commit status when creating a manual build

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -79,12 +79,6 @@ class Changeset
       last_commit_status.error
   end
 
-  class StatusResult < Struct.new(:state, :error)
-    def self.null_result
-      new(nil, nil)
-    end
-  end
-
   private
 
   def find_comparison

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -28,6 +28,17 @@ class Changeset
     @commits ||= comparison.commits.map {|data| Commit.new(repo, data) }
   end
 
+  def last_commit_status
+    if comparison.commits.nil? || comparison.commits.empty?
+      nil
+    else
+      ref = comparison.commits.last["sha"]
+      Rails.cache.fetch(status_cache_key) do
+        GITHUB.combined_status(repo, ref)[:state]
+      end
+    end
+  end
+
   def files
     comparison.files
   end
@@ -85,6 +96,10 @@ class Changeset
 
   def cache_key
     [self.class, repo, previous_commit, commit].join('-')
+  end
+
+  def status_cache_key
+    [self.class, "status", repo, commit].join('-')
   end
 
   class NullComparison

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -107,7 +107,7 @@ class Changeset
   end
 
   def status_cache_key
-    [self.class, "status", repo, previous_commit, commit].join('-')
+    [self.class, "status", repo, commit].join('-')
   end
 
   class NullComparison

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -29,11 +29,11 @@ class Changeset
   end
 
   def last_commit_status
-    if comparison.commits.nil? || comparison.commits.empty?
+    if comparison.blank?
       StatusResult.null_result
     else
       ref = comparison.commits.last["sha"]
-      state = Rails.cache.fetch(status_cache_key) do
+      state = Rails.cache.fetch(status_cache_key, expires_in: 1.minute)  do
         GITHUB.combined_status(repo, ref)[:state]
       end
       StatusResult.new(state, nil)

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -130,5 +130,9 @@ class Changeset
     def files
       []
     end
+
+    def blank?
+      true
+    end
   end
 end

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -37,6 +37,8 @@ class Changeset
         GITHUB.combined_status(repo, ref)[:state]
       end
     end
+  rescue Octokit::Error => e
+    "Unable to retrieve commit status. #{humanize_exception(e)}"
   end
 
   def files
@@ -86,7 +88,11 @@ class Changeset
       end
     end
   rescue Octokit::Error => e
-    NullComparison.new("Github: #{e.message.sub("Octokit::", "").underscore.humanize}")
+    NullComparison.new(humanize_exception(e))
+  end
+
+  def humanize_exception(e)
+    "Github: #{e.message.sub("Octokit::", "").underscore.humanize}"
   end
 
   def find_pull_requests
@@ -99,7 +105,7 @@ class Changeset
   end
 
   def status_cache_key
-    [self.class, "status", repo, commit].join('-')
+    [self.class, "status", repo, previous_commit, commit].join('-')
   end
 
   class NullComparison

--- a/app/models/changeset/status_result.rb
+++ b/app/models/changeset/status_result.rb
@@ -1,0 +1,5 @@
+class Changeset::StatusResult < Struct.new(:state, :error)
+  def self.null_result
+    new(nil, nil)
+  end
+end

--- a/app/views/changeset/_files.html.erb
+++ b/app/views/changeset/_files.html.erb
@@ -3,9 +3,9 @@
   <p class="alert alert-warning"><%= changeset.error %></p>
 <% end %>
 
-<% if changeset.last_commit_status == "pending" %>
+<% if changeset.last_commit_status.state == "pending" %>
   <p class="alert alert-warning">No status information available for the last commit.</p>
-<% elsif changeset.last_commit_status != "success" %>
+<% elsif changeset.last_commit_status.state && changeset.last_commit_status.state != "success" %>
   <p class="alert alert-warning">Warning. Status of the last commit status is: <%= changeset.last_commit_status %></p>
 <% end %>
 

--- a/app/views/changeset/_files.html.erb
+++ b/app/views/changeset/_files.html.erb
@@ -5,8 +5,8 @@
 
 <% if changeset.last_commit_status.state == "pending" %>
   <p class="alert alert-warning">No status information available for the last commit.</p>
-<% elsif changeset.last_commit_status.state && changeset.last_commit_status.state != "success" %>
-  <p class="alert alert-warning">Warning. Status of the last commit status is: <%= changeset.last_commit_status %></p>
+<% elsif changeset.last_commit_status.state == "failure" %>
+  <p class="alert alert-warning">Warning. The last commit you're about to commit has a failure registered against it.</p>
 <% end %>
 
 <% if changeset.files.any? %>

--- a/app/views/changeset/_files.html.erb
+++ b/app/views/changeset/_files.html.erb
@@ -3,7 +3,14 @@
   <p class="alert alert-warning"><%= changeset.error %></p>
 <% end %>
 
+<% if changeset.last_commit_status == "pending" %>
+  <p class="alert alert-warning">No status information available for the last commit.</p>
+<% elsif changeset.last_commit_status != "success" %>
+  <p class="alert alert-warning">Warning. Status of the last commit status is: <%= changeset.last_commit_status %></p>
+<% end %>
+
 <% if changeset.files.any? %>
+
   <table class="table changeset-files">
     <tbody>
     <% changeset.files.each do |file| %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,8 +47,6 @@ Samson::Application.configure do
   config.samson.github.admin_team = 'admins'
   config.samson.github.deploy_team = 'deployers'
 
-  config.cache_store = :memory_store, { size: 64.megabytes }
-
   config.active_support.test_order = :random
 end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,6 +47,8 @@ Samson::Application.configure do
   config.samson.github.admin_team = 'admins'
   config.samson.github.deploy_team = 'deployers'
 
+  config.cache_store = :memory_store, { size: 64.megabytes }
+
   config.active_support.test_order = :random
 end
 

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -9,7 +9,7 @@ describe DeploysController do
   let(:deploy) { deploys(:succeeded_test) }
   let(:deploy_service) { stub(deploy!: nil) }
   let(:deploy_called) { [] }
-  let(:changeset) { stub_everything(commits: [], files: [], pull_requests: [], jira_issues: []) }
+  let(:changeset) { stub_everything(commits: [], files: [], pull_requests: [], jira_issues: [], last_commit_status: stub(error: nil, state: nil)) }
 
   setup do
     DeployService.stubs(:new).with(project, deployer).returns(deploy_service)

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -39,7 +39,7 @@ describe Changeset do
     end
 
     it "returns the status of the last commit message according to github" do
-      last_status = Changeset.new("foo/bar", "a", "b").last_commit_status
+      last_status = Changeset.new("foo/bar", "a", "b").last_commit_status.state
       last_status.must_equal "success"
     end
 
@@ -48,7 +48,7 @@ describe Changeset do
       change_set.last_commit_status
       GITHUB.stubs(:combined_status).with("foo/bar", "b").returns({:state => "failure"})
       last_status = change_set.last_commit_status
-      last_status.must_equal "success"
+      last_status.state.must_equal "success"
     end
 
     {
@@ -59,7 +59,7 @@ describe Changeset do
       it "catches #{exception} exceptions" do
         GITHUB.expects(:combined_status).raises(exception)
         last_commit_status = Changeset.new("foo/bar", "a", "b").last_commit_status
-        last_commit_status.must_equal message
+        last_commit_status.error.must_equal message
       end
     end
   end

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -27,6 +27,43 @@ describe Changeset do
     end
   end
 
+  describe "#last_commit_status" do
+    let(:comparison) { OpenStruct.new }
+
+    before do
+      c1 = { "sha" => "a", "message" => "Merge pull request #42"}
+      c2 = { "sha" => "b", "message" => "Fix typo"}
+      comparison.stubs(:commits).returns([c1, c2])
+      GITHUB.stubs(:compare).with("foo/bar", "a", "b").returns(comparison)
+      GITHUB.stubs(:combined_status).with("foo/bar", "b").returns({:state => "success"})
+    end
+
+    it "returns the status of the last commit message according to github" do
+      last_status = Changeset.new("foo/bar", "a", "b").last_commit_status
+      last_status.must_equal "success"
+    end
+
+    it "caches" do
+      change_set = Changeset.new("foo/bar", "a", "b")
+      change_set.last_commit_status
+      GITHUB.stubs(:combined_status).with("foo/bar", "b").returns({:state => "failure"})
+      last_status = change_set.last_commit_status
+      last_status.must_equal "success"
+    end
+
+    {
+      Octokit::NotFound => "Unable to retrieve commit status. Github: Not found",
+      Octokit::Unauthorized => "Unable to retrieve commit status. Github: Unauthorized",
+      Octokit::InternalServerError => "Unable to retrieve commit status. Github: Internal server error",
+    }.each do |exception, message|
+      it "catches #{exception} exceptions" do
+        GITHUB.expects(:combined_status).raises(exception)
+        last_commit_status = Changeset.new("foo/bar", "a", "b").last_commit_status
+        last_commit_status.must_equal message
+      end
+    end
+  end
+
   describe "#github_url" do
     it "returns a URL to a GitHub comparison page" do
       changeset = Changeset.new("foo/bar", "a", "b")


### PR DESCRIPTION
A lot of CI tools use the github status API to indicate whether a given build is okay.

When doing a manual release this change queries the status and displays a warning if the build failed. It does not prevent the release, it just gives a warning.

It will look like this:

![image](https://cloud.githubusercontent.com/assets/93839/6955055/ac71f486-d924-11e4-802f-e92020cc8c61.png)

This could be extended to provide more information if desired but at the moment we're just keeping it reasonably simple.