### PR TITLE
Status display box

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -11,6 +11,7 @@ $(function () {
       $form = $("#new_deploy"),
       $submit = $form.find('input[type=submit]'),
       $reference = $("#deploy_reference");
+      $ref_status_label = $("#ref-problem-warning");
 
   $("#deploy-tabs a[data-type=github]").click(function (e) {
       e.preventDefault();
@@ -82,10 +83,13 @@ $(function () {
       data: { ref: ref },
       success: function(data, status, xhr) {
         if(data.status == "pending") {
+          $ref_status_label.addClass("hidden");
           tag_form_group.addClass("has-warning");
         } else if(data.status == "success") {
+          $ref_status_label.addClass("hidden");
           tag_form_group.addClass("has-success");
         } else if(data.status == "failure" || data.status == "error") {
+          $ref_status_label.removeClass("hidden");
           tag_form_group.addClass("has-error");
         }
       }
@@ -102,6 +106,7 @@ $(function () {
   toggleConfirmed();
 
   $reference.keyup(function(e) {
+    $ref_status_label.addClass("hidden");
     tag_form_group.removeClass("has-success has-warning has-error");
 
     var ref = $(this).val();

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -6,15 +6,13 @@ class CommitStatus
   end
 
   def status
-    if statuses.any?
-      statuses.first.state
-    end
+    combined_status.state
   rescue Octokit::NotFound
   end
 
   private
 
-  def statuses
-    @statuses ||= GITHUB.statuses(@repo, @sha)
+  def combined_status
+    @combined_status ||= GITHUB.combined_status(@repo, @sha)
   end
 end

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -24,6 +24,11 @@
           <%= form.text_field :reference, class: "form-control", autofocus: true, placeholder: "e.g. v2.1.43, master, fa0b4671", data: { prefetch_url: project_references_path(@project, format: "json") } %>
         </div>
       </div>
+      <div>
+        <div id="ref-problem-warning" class="col-lg-5 col-lg-offset-2 alert alert-warning hidden">
+          There is currently a problem registered for this Tag or SHA. Are you sure you wish to deploy?
+        </div>
+      </div>
 
       <div class="form-group" id="new-deploy-buttons">
         <div class="col-lg-offset-2 col-lg-10">

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -12,22 +12,19 @@ describe CommitStatus do
 
   describe 'with a proper sha' do
     before do
-      stub_github_api('repos/' + repo + '/statuses/' + sha, statuses)
+      stub_github_api("repos/#{repo}/commits/#{sha}/status", statuses)
     end
 
-    describe 'with multiple statuses' do
-      let(:statuses) {[
-        { state: 'success' },
-        { state: 'pending' }
-      ]}
+    describe 'with combined status' do
+      let(:statuses) { { :state => "success" }}
 
       it 'is the first status' do
         subject.status.must_equal('success')
       end
     end
 
-    describe 'with no statuses' do
-      let(:statuses) {[]}
+    describe 'with no status' do
+      let(:statuses) { { :state => nil } }
 
       it 'is nil' do
         subject.status.must_be_nil
@@ -37,7 +34,7 @@ describe CommitStatus do
 
   describe 'when API cannot find the sha' do
     before do
-      stub_github_api('repos/' + repo + '/statuses/' + sha, nil, 404)
+      stub_github_api('repos/' + repo + '/commits/' + sha + "/status", nil, 404)
     end
 
     it 'is nil' do


### PR DESCRIPTION
Replaces my previous PR to show the current github status.

Includes two changes:

- A nice obvious warning box when there's a problem (pictured below)
- Change API to use combined status API rather than picking the first status seen.

![image](https://cloud.githubusercontent.com/assets/93839/6958118/b8a1931e-d952-11e4-8f16-57e2e4d602ee.png)
