### PR TITLE
Shender/breadcrumb for deploygroup

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,12 +74,14 @@ module ApplicationHelper
     items = items.map do |item|
       case item
       when Project then [item.name, project_path(item)]
+      when Environment then [item.name, dashboard_path(item)]
+      when DeployGroup then [item.name, deploy_group_path(item)]
       when Stage then
         name = item.name
         name = (item.lock.warning? ? warning_icon : lock_icon) + " " + name if item.lock
-        [name, project_stage_path(@project, item)]
+        [name, project_stage_path(item.project, item)]
       when Macro then
-        [item.name, project_macro_path(@project, item)]
+        [item.name, project_macro_path(item.project, item)]
       when String then [item, nil]
       else
         raise "Unsupported breadcrumb for #{item}"

--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -1,3 +1,5 @@
+<%= breadcrumb @deploy_group.environment, @deploy_group %>
+
 <h1><%= @deploy_group.name %></h1>
 
 <deploy-group-timeline ng-controller="DeployGroupsCtrl" ></deploy-group-timeline>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -83,9 +83,10 @@ describe ApplicationHelper do
   end
 
   describe "#breadcrumb" do
-    before do
-      @project = projects(:test)
-    end
+    let(:stage) { stages(:test_staging) }
+    let(:project) { projects(:test) }
+    let(:environment) { environments(:production) }
+    let(:deploy_group) { deploy_groups(:pod1) }
 
     it "renders strings" do
       breadcrumb("Foobar").must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Foobar</li></ul>"
@@ -96,23 +97,33 @@ describe ApplicationHelper do
     end
 
     it "renders stage" do
-      breadcrumb(stages(:test_staging)).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Staging</li></ul>"
+      breadcrumb(stage).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Staging</li></ul>"
     end
 
     it "renders locked stage" do
-      stage = stages(:test_staging)
       stage.stubs(lock: Lock.new)
       breadcrumb(stage).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\"><i class=\"glyphicon glyphicon-lock\"></i> Staging</li></ul>"
     end
 
     it "renders warning stage" do
-      stage = stages(:test_staging)
       stage.stubs(lock: Lock.new(warning: true))
       breadcrumb(stage).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\"><i class=\"glyphicon glyphicon-warning-sign\"></i> Staging</li></ul>"
     end
 
     it "renders project" do
-      breadcrumb(@project).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Project</li></ul>"
+      breadcrumb(project).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Project</li></ul>"
+    end
+
+    it "renders environment" do
+      breadcrumb(environment).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Production</li></ul>"
+    end
+
+    it "renders deploy_group" do
+      breadcrumb(deploy_group).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Pod1</li></ul>"
+    end
+
+    it "renders multiple breadcrumbs" do
+      breadcrumb(project, stage, "stuff").must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"\"><a href=\"/projects/foo\">Project</a></li><li class=\"\"><a href=\"/projects/foo/stages/staging\">Staging</a></li><li class=\"active\">stuff</li></ul>"
     end
 
     it "refuses to render unknown" do
@@ -120,7 +131,6 @@ describe ApplicationHelper do
     end
 
     it "does not allow html injection" do
-      stage = stages(:test_staging)
       stage.name = "<script>alert(1)</script>"
       breadcrumb(stage).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">&lt;script&gt;alert(1)&lt;/script&gt;</li></ul>"
     end


### PR DESCRIPTION
Add breadcrumbs to the dashboard/deploy_group page:

![screen shot 2015-04-03 at 10 41 42](https://cloud.githubusercontent.com/assets/8860832/6980708/1268f040-d9ee-11e4-8401-a5b6f9372795.png)

/cc @zendesk/runway @zendesk/samson

### References
 - Jira link:

### Risks
 - None