### PR TITLE
Live update the current deploys status

### DIFF
--- a/app/assets/javascripts/current_deploys.js
+++ b/app/assets/javascripts/current_deploys.js
@@ -1,0 +1,30 @@
+$(function() {
+  var $badge = $('.current-deploys .badge');
+
+  var updateBadgeDisplay = function(number) {
+    if (number != undefined) { $badge.text(number); }
+
+    if (parseInt($badge.text()) > 0) {
+      $badge.removeClass('hide');
+    } else {
+      $badge.addClass('hide');
+    }
+  };
+
+  var getBadgeStatus = function() {
+    $.ajax({
+      url: $badge.attr('data-refresh-url'),
+      success: function(data) {
+        updateBadgeDisplay(data.deploys.length);
+        setTimeout(getBadgeStatus, 5000);
+      },
+      error: function(data) {
+        console.log('Unable to get currently deploy count. Retrying in 60 seconds.');
+        setTimeout(getBadgeStatus, 60000);
+      }
+    });
+  };
+
+  updateBadgeDisplay();
+  getBadgeStatus();
+});

--- a/app/assets/stylesheets/deploys.scss
+++ b/app/assets/stylesheets/deploys.scss
@@ -106,3 +106,22 @@ td.status {
 .deployment-alert-popover {
   max-width: 340px;
 }
+
+@-webkit-keyframes pulsate
+{
+  0%   { background: $samsonDark; color: $info; }
+  50%  { background: $info; color: $samsonDark; }
+  100% { background: $samsonDark; color: $info; }
+}
+
+@keyframes pulsate
+{
+  0%   { background: $samsonDark; color: $info; }
+  50%  { background: $info; color: $samsonDark; }
+  100% { background: $samsonDark; color: $info; }
+}
+
+.badge-deploys {
+  -webkit-animation: pulsate 6s infinite;
+  animation: pulsate 6s infinite;
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -43,10 +43,10 @@
         <li class="<%= 'active' if current_page?(controller: '/deploys', action: 'recent') %>">
           <%= link_to "Recent Deploys", recent_deploys_path %>
         </li>
-        <li class="<%= 'active' if current_page?(controller: '/deploys', action: 'active') %>">
+        <li class="current-deploys <%= 'active' if current_page?(controller: '/deploys', action: 'active') %>">
           <%= link_to active_deploys_path do %>
             Current Deploys
-            <%= content_tag(:span, Deploy.active.count, class: "badge") unless Deploy.active.count.zero? %>
+            <%= content_tag(:span, Deploy.active.count, class: "badge badge-deploys hide", data: { refresh_url: active_deploys_url(format: 'json') })  %>
           <% end %>
         </li>
       <% end %>


### PR DESCRIPTION
Every 5 seconds, poll to check the current deploy status and update the
number next to the current deploys link. If there are any active deploys
then also pulsate the number on the badge to indicate there is some
activity.

Here is a gif showing how it works:

![current_deploys_feature](https://cloud.githubusercontent.com/assets/112153/7040337/9b909cb8-de00-11e4-995a-887c922e7ff4.gif)
