### PR TITLE
Fix a bug where you could not selectively load plugins

### DIFF
--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -15,11 +15,11 @@ module Samson
       def initialize(path)
         @path = path
         @folder = File.expand_path("../../../", @path)
-        @name = File.dirname(@folder)
+        @name = File.basename(@folder)
       end
 
       def active?
-        Rails.env.test? || ENV["PLUGINS"] == "all" || ENV["PLUGINS"].to_s.split(",").include?(@name)
+        Rails.env.test? || ENV["PLUGINS"] == "all" || ENV["PLUGINS"].to_s.split(',').map(&:strip).include?(@name)
       end
 
       def require

--- a/test/lib/samson/hooks_test.rb
+++ b/test/lib/samson/hooks_test.rb
@@ -1,0 +1,51 @@
+require_relative '../../test_helper'
+
+describe Samson::Hooks do
+  let(:number_of_plugins) { 3 }
+  let(:plugins) { 'nope' }
+
+  describe '.plugins' do
+    before do
+      Rails.stubs(:env).returns(env.inquiry)
+      ENV['PLUGINS'] = plugins
+
+      # Clear cached plugins
+      Samson::Hooks.instance_variable_set('@plugins', nil)
+    end
+
+    context 'when in the test environment' do
+      let(:env) { 'test' }
+
+      it 'returns all the plugins regardless of the PLUGINS env variable' do
+        Samson::Hooks.plugins.size.must_equal number_of_plugins
+      end
+    end
+
+    context 'when in other environments' do
+      let(:env) { 'other' }
+
+      context 'when the plugins env is not set to anything' do
+        it 'returns no plugins by default' do
+          Samson::Hooks.plugins.size.must_equal 0
+        end
+      end
+
+      context 'when the plugins env is set to all' do
+        let(:plugins) { 'all' }
+
+        it 'returns all the plugins' do
+          Samson::Hooks.plugins.size.must_equal number_of_plugins
+        end
+      end
+
+      context 'when the plugins env is set to include some plugins' do
+        let(:plugins) { 'slack, zendesk' }
+
+        it 'only returns those plugins' do
+          Samson::Hooks.plugins.size.must_equal 2
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
If you set the PLUGINS environment variable to only load some plugins,
it would not work properly as the name for each plugin was being
calculated incorrectly. It still worked fine if you had it set to ALL.

This patch fixes the name for plugins and so the loading then works
correctly. You can verify this by running this before/after the patch.

```ruby
Samson::Hooks.plugins.map { |plugin| plugin.instance_variable_get('@name') }
```