### PR TITLE
Tweak deploy_groups timeline and upgrade the JS test framework libraries...

### DIFF
--- a/app/assets/javascripts/controllers/deploy_groups_ctrl.js
+++ b/app/assets/javascripts/controllers/deploy_groups_ctrl.js
@@ -1,15 +1,46 @@
 samson.controller('DeployGroupsCtrl', function($scope, $http, $location, $window) {
+  var MAX_PAGES = 20;
 
   function init() {
-    $http.get($location.path() + '.json').success(function(result) {
-      result.deploys.forEach(function(deploy) {
-        deploy.start = new Date(deploy.started_at || deploy.created_at);
+    getMoreDeploys(1);
+  }
+
+  function getMoreDeploys(page) {
+    if (page <= MAX_PAGES) {
+      $http.get($location.path() + '.json?page=' + page).success(function(result) {
+        if (result.deploys.length > 0) {
+          result.deploys.forEach(function(deploy) {
+            deploy.start = new Date(deploy.started_at || deploy.created_at);
+          });
+
+          $scope.items.add(result.deploys);
+          $scope.deployIds = $scope.deployIds.concat(_.pluck(result.deploys, 'id'));
+
+          adjustVisibleItems(result.deploys);
+          getMoreDeploys(page + 1);
+        }
       });
-      $scope.items.add(result.deploys);
-    });
+    }
+  }
+
+  function adjustVisibleItems() {
+    var visibleItems = $scope.timeline.getVisibleItems().length,
+        MIN_VIS_ITEMS = 10,
+        MAX_VIS_ITEMS = 20;
+
+    if (visibleItems > MAX_VIS_ITEMS) {
+      $scope.timeline.setOptions({
+        start: $scope.items.get($scope.deployIds[MAX_VIS_ITEMS-1]).start
+      });
+    } else if (visibleItems <= MIN_VIS_ITEMS && $scope.items.length > MIN_VIS_ITEMS) {
+      $scope.timeline.setOptions({
+        start: $scope.items.get($scope.deployIds[MIN_VIS_ITEMS-1]).start
+      });
+    }
   }
 
   $scope.items = new vis.DataSet([]);
+  $scope.deployIds = [];
 
   $scope.onDoubleClickItem = function(properties) {
     $window.location.href = $scope.items.get(properties.item).url;

--- a/app/assets/javascripts/directives/deploy_group_timeline_directive.js
+++ b/app/assets/javascripts/directives/deploy_group_timeline_directive.js
@@ -2,16 +2,14 @@ samson.directive('deployGroupTimeline', function() {
   return {
     restrict: 'E',
     link: function($scope, $element) {
-      var endDate = new Date(_.now() + 1*1000*60*60*24),
-        options = {
-        minHeight: '400px',
-        max: endDate,
-        end: endDate,
-        showMajorLabels: false,
-        showCurrentTime: false
-      };
+      var endDate = moment().add(1, 'days'),
+          options = {
+            max: endDate,
+            end: endDate,
+            showCurrentTime: false
+          };
 
-      $scope.timeline = new vis.Timeline($element[0])
+      $scope.timeline = new vis.Timeline($element[0]);
 
       options.template = function(item) {
         return item.project.name + '<br>' + item.reference;
@@ -21,5 +19,5 @@ samson.directive('deployGroupTimeline', function() {
       $scope.timeline.setOptions(options);
       $scope.timeline.on('doubleClick', $scope.onDoubleClickItem);
     }
-  }
+  };
 });

--- a/app/controllers/deploy_groups_controller.rb
+++ b/app/controllers/deploy_groups_controller.rb
@@ -7,7 +7,7 @@ class DeployGroupsController < ApplicationController
         @deploys = @deploy_group.deploys.page(params[:page])
       end
       format.json do
-        render json: { deploys: @deploy_group.deploys.successful.limit(300).as_json(include: :project, methods: :url) }
+        render json: { deploys: @deploy_group.deploys.successful.page(params[:page]).as_json(include: :project, methods: :url) }
       end
     end
   end

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 var gulp = require('gulp');
 
 // include plug-ins
-var gutil = require('gulp-util');
 var karma = require('gulp-karma');
 var jshint = require('gulp-jshint');
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "url": "git://github.com/zendesk/samson.git"
   },
   "devDependencies": {
-    "karma": "~0.10",
-    "gulp-util": "~2.2.14",
-    "gulp": "~3.5.2",
-    "gulp-karma": "0.0.2",
-    "gulp-jshint": "~1.4.2"
+    "karma": "~0.12",
+    "gulp": "~3.8",
+    "gulp-karma": "0.0.4",
+    "gulp-jshint": "~1.10",
+    "karma-jasmine": "~0.2.0",
+    "karma-phantomjs-launcher": "~0.1.4"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gulp test"
+    "test": "./node_modules/.bin/gulp test",
+    "jshint": "./node_modules/.bin/gulp jshint"
   }
 }

--- a/test/angular/controllers/deploy_groups_ctrl_spec.js
+++ b/test/angular/controllers/deploy_groups_ctrl_spec.js
@@ -11,6 +11,8 @@ describe('DeployGroupsCtrl', function() {
   beforeEach(inject(function(_$controller_, _$httpBackend_, _$location_, _$rootScope_) {
     $rootScope = _$rootScope_
     $scope = $rootScope.$new();
+    $scope.timeline = jasmine.createSpyObj('timeline', ['setOptions', 'getVisibleItems']);
+    $scope.timeline.getVisibleItems.and.returnValue([]);
     $httpBackend = _$httpBackend_;
     $location = _$location_;
     createController = function() {
@@ -27,11 +29,12 @@ describe('DeployGroupsCtrl', function() {
 
   describe('init', function() {
     it('gets list of deploys', function() {
-      $httpBackend.expectGET('/deploy_groups/1.json').respond({
+      $httpBackend.expectGET('/deploy_groups/1.json?page=1').respond({
         "deploys": [
           { "id": 1, "reference": "v1", "started_at": "2015-03-08", "project": { "name": "P0" }},
           { "id": 2, "reference": "v2", "created_at": "2015-03-10", "project": { "name": "P1" }}
         ]});
+      $httpBackend.expectGET('/deploy_groups/1.json?page=2').respond({ "deploys": [] });
       createController();
       $httpBackend.flush();
 
@@ -41,7 +44,7 @@ describe('DeployGroupsCtrl', function() {
     });
 
     it('gets empty list of deploys', function() {
-      $httpBackend.expectGET('/deploy_groups/1.json').respond({
+      $httpBackend.expectGET('/deploy_groups/1.json?page=1').respond({
         "deploys": []});
       createController();
       $httpBackend.flush();
@@ -50,11 +53,70 @@ describe('DeployGroupsCtrl', function() {
     });
 
     it('gets error requesting deploys', function() {
-      $httpBackend.expectGET('/deploy_groups/1.json').respond(500, '');
+      $httpBackend.expectGET('/deploy_groups/1.json?page=1').respond(500, '');
       createController();
       $httpBackend.flush();
 
       expect($scope.items.length).toEqual(0);
+    });
+
+    it('adjusts start time of timeline if too few objects are visible', function() {
+      $httpBackend.expectGET('/deploy_groups/1.json?page=1').respond({
+        "deploys": [
+          { "id": 100, "reference": "v1", "started_at": "2015-03-01"},
+          { "id": 102, "reference": "v1", "started_at": "2015-03-02"},
+          { "id": 103, "reference": "v1", "started_at": "2015-03-03"},
+          { "id": 104, "reference": "v1", "started_at": "2015-03-04"},
+          { "id": 105, "reference": "v1", "started_at": "2015-03-05"},
+          { "id": 106, "reference": "v1", "started_at": "2015-03-06"},
+          { "id": 107, "reference": "v1", "started_at": "2015-03-07"},
+          { "id": 108, "reference": "v1", "started_at": "2015-03-08"},
+          { "id": 109, "reference": "v1", "started_at": "2015-03-09"},
+          { "id": 110, "reference": "v1", "started_at": "2015-03-10"},
+          { "id": 111, "reference": "v1", "started_at": "2015-03-11"},
+          { "id": 112, "reference": "v1", "started_at": "2015-03-12"},
+          { "id": 113, "reference": "v1", "started_at": "2015-03-13"},
+          { "id": 114, "reference": "v1", "started_at": "2015-03-14"},
+        ]});
+      $httpBackend.expectGET('/deploy_groups/1.json?page=2').respond({ "deploys": [] });
+      createController();
+      $scope.timeline.getVisibleItems.and.returnValue(_.range(3));
+      $httpBackend.flush();
+      expect($scope.timeline.setOptions).toHaveBeenCalledWith({ start : (new Date('2015-03-10')) });
+    });
+
+    it('adjusts start time of timeline if too many objects are visible', function() {
+      $httpBackend.expectGET('/deploy_groups/1.json?page=1').respond({
+        "deploys": [
+          { "id": 100, "reference": "v1", "started_at": "2015-03-01"},
+          { "id": 102, "reference": "v1", "started_at": "2015-03-02"},
+          { "id": 103, "reference": "v1", "started_at": "2015-03-03"},
+          { "id": 104, "reference": "v1", "started_at": "2015-03-04"},
+          { "id": 105, "reference": "v1", "started_at": "2015-03-05"},
+          { "id": 106, "reference": "v1", "started_at": "2015-03-06"},
+          { "id": 107, "reference": "v1", "started_at": "2015-03-07"},
+          { "id": 108, "reference": "v1", "started_at": "2015-03-08"},
+          { "id": 109, "reference": "v1", "started_at": "2015-03-09"},
+          { "id": 110, "reference": "v1", "started_at": "2015-03-10"},
+          { "id": 111, "reference": "v1", "started_at": "2015-03-11"},
+          { "id": 112, "reference": "v1", "started_at": "2015-03-12"},
+          { "id": 113, "reference": "v1", "started_at": "2015-03-13"},
+          { "id": 114, "reference": "v1", "started_at": "2015-03-14"},
+          { "id": 115, "reference": "v1", "started_at": "2015-03-15"},
+          { "id": 116, "reference": "v1", "started_at": "2015-03-16"},
+          { "id": 117, "reference": "v1", "started_at": "2015-03-17"},
+          { "id": 118, "reference": "v1", "started_at": "2015-03-18"},
+          { "id": 119, "reference": "v1", "started_at": "2015-03-19"},
+          { "id": 120, "reference": "v1", "started_at": "2015-03-20"},
+          { "id": 121, "reference": "v1", "started_at": "2015-03-21"},
+          { "id": 122, "reference": "v1", "started_at": "2015-03-22"},
+          { "id": 123, "reference": "v1", "started_at": "2015-03-23"},
+        ]});
+      $httpBackend.expectGET('/deploy_groups/1.json?page=2').respond({ "deploys": [] });
+      createController();
+      $scope.timeline.getVisibleItems.and.returnValue(_.range(30));
+      $httpBackend.flush();
+      expect($scope.timeline.setOptions).toHaveBeenCalledWith({ start : (new Date('2015-03-20')) });
     });
   });
 });


### PR DESCRIPTION
Set the timescale appropriately depending on too few or too many deploys being shown initially.
Also, lazy load the timeline to get better responsiveness.

Screenshot with lots of deploys which would have made the default view too big:
![screen shot 2015-04-10 at 13 28 46](https://cloud.githubusercontent.com/assets/8860832/7087758/81cc3b20-df86-11e4-9250-7b96e2224742.png)

Screenshot with only a few deploys spread out over time, so we compress the timescale instead:
![screen shot 2015-04-10 at 13 35 34](https://cloud.githubusercontent.com/assets/8860832/7087761/83a66cea-df86-11e4-8fed-ca194069378c.png)

/cc @zendesk/runway @zendesk/samson

### References
 - Jira link:

### Risks
 - None