### PR TITLE
Add jshint parser to the travis checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ before_script:
   - bundle exec rake db:create
   - npm install
 script:
+  - npm run-script jshint
   - npm test
   - bundle exec rake

--- a/app/assets/javascripts/admin/users.js
+++ b/app/assets/javascripts/admin/users.js
@@ -19,8 +19,8 @@ function($scope, $http, $timeout) {
       roleId = $event.target.value;
 
       $http.put("/admin/users/" + userId, { user: { role_id: roleId } })
-        .success(function() { showStatus(SUCCESS) })
-        .error(function() { showStatus(FAILURE) })
+        .success(function() { showStatus(SUCCESS); })
+        .error(function() { showStatus(FAILURE); });
     }
   };
 }]);

--- a/app/assets/javascripts/changelog.js
+++ b/app/assets/javascripts/changelog.js
@@ -3,7 +3,7 @@ $(function () {
   $("#end-date").datepicker({ dateFormat: "yy-mm-dd"});
 
   $("input").change(function() {
-    $("#status-message").removeClass("hidden").text("Regenerating...")
+    $("#status-message").removeClass("hidden").text("Regenerating...");
     $("#date-chooser" ).submit();
   });
 });

--- a/app/assets/javascripts/controllers/dashboards_ctrl.js
+++ b/app/assets/javascripts/controllers/dashboards_ctrl.js
@@ -20,7 +20,7 @@ samson.controller("DashboardsCtrl", function DashboardsCtrl($scope, $http, $loca
           .success(function (deploys_result) {
             project.deploy_group_versions = _.pick(deploys_result, deploy_groups_ids);
             project.css = getProjectCss(project);
-          })
+          });
       });
     });
   }
@@ -35,7 +35,7 @@ samson.controller("DashboardsCtrl", function DashboardsCtrl($scope, $http, $loca
 
     if (num_versions > 1) {
       css.tr_class = "warning";
-    } else if (num_versions == 0) {
+    } else if (num_versions === 0) {
       css.tr_class = "no-deploys";
       css.style = "display: none;";
     }

--- a/app/assets/javascripts/current_deploys.js
+++ b/app/assets/javascripts/current_deploys.js
@@ -2,7 +2,7 @@ $(function() {
   var $badge = $('.current-deploys .badge');
 
   var updateBadgeDisplay = function(number) {
-    if (number != undefined) { $badge.text(number); }
+    if (number !== undefined) { $badge.text(number); }
 
     if (parseInt($badge.text()) > 0) {
       $badge.removeClass('hide');

--- a/app/assets/javascripts/streams.js
+++ b/app/assets/javascripts/streams.js
@@ -30,7 +30,7 @@ function startStream() {
 
       $('#header').html(data.html);
       window.document.title = data.title;
-      if ( doNotify && data.notification != undefined) {
+      if ( doNotify && data.notification !== undefined) {
         var notification = new Notification(data.notification, {icon: '/favicon.ico'});
         notification.onclick = function() { window.focus(); };
       }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,9 +19,10 @@ var testFiles = [
 ];
 
 gulp.task('jshint', function() {
-  gulp.src('./app/assets/javascripts/**/*.js')
+  return gulp.src('./app/assets/javascripts/**/*.js')
     .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe(jshint.reporter('default'))
+    .pipe(jshint.reporter('fail'));
 });
 
 gulp.task('test', function() {


### PR DESCRIPTION
Turn on JSHint for our JS files during Travis builds. Also tidied up the existing warnings, mostly missing semi-colons.

/cc @zendesk/samson @zendesk/runway 

### References
 - Jira link:

### Risks
 - None