### PR TITLE
Fix bug where some buildkite integrations would not create a relase

### DIFF
--- a/app/controllers/integrations/buildkite_controller.rb
+++ b/app/controllers/integrations/buildkite_controller.rb
@@ -2,26 +2,26 @@ class Integrations::BuildkiteController < Integrations::BaseController
   protected
 
   def deploy?
-    build_event? && build_passed? && no_skip_token_present?
-  end
-
-  def build_event?
-    request.headers['X-Buildkite-Event'] == 'build'
+    build_passed? && no_skip_token_present?
   end
 
   def build_passed?
-    params[:build][:state] == 'passed'
+    build_param[:state] == 'passed'
   end
 
   def no_skip_token_present?
-    !contains_skip_token?(params[:build][:message])
+    !contains_skip_token?(build_param[:message])
   end
 
   def commit
-    params[:build][:commit]
+    build_param[:commit]
   end
 
   def branch
-    params[:build][:branch]
+    build_param[:branch]
+  end
+
+  def build_param
+    @build_param ||= params.fetch(:build, { })
   end
 end

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -36,8 +36,6 @@ describe Integrations::BuildkiteController do
   before { Deploy.delete_all }
 
   context 'when buildkite passes a build event' do
-    before { request.headers['X-Buildkite-Event'] = 'build' }
-
     test_regular_commit 'Buildkite', failed: { build: { state: 'failed' }}, no_mapping: { build: { branch: 'non-existent-branch' } } do
       project.webhooks.create!(stage: stages(:test_staging), branch: 'master')
     end


### PR DESCRIPTION
Buildkite sometimes sends `build.finished` events rather than `build`
and in those cases we weren't creating a release. I have removed that
check because we don't actually need to check the event type, because we
can get enough info from the fact that we have a successful build with a
valid commit.