### PR TITLE
Fix formatting for Slack messages

### DIFF
--- a/plugins/slack/app/models/slack_notification.rb
+++ b/plugins/slack/app/models/slack_notification.rb
@@ -9,8 +9,7 @@ class SlackNotification
     Slack.chat_postMessage(
       token: ENV['SLACK_TOKEN'],
       channel: @stage.slack_channels.first.channel_id,
-      text: content,
-      parse: "full")
+      text: content)
 
   rescue Slack::Error => e
     Rails.logger.error("Could not deliver slack message: #{e.message}")

--- a/plugins/slack/app/views/samson_slack/notification.text.erb
+++ b/plugins/slack/app/views/samson_slack/notification.text.erb
@@ -7,12 +7,12 @@ _<%= pluralize changeset.commits.count, "commit" %> by <%= changeset.author_name
 *Files changed*
 
 <% changeset.files.each do |file| %>
->>> <%= file.status[0].upcase %></strong> <%= file.filename %>
+> <%= file.status[0].upcase %> <%= file.filename %>
 <% end %>
 
 *Commits*
 
 <% changeset.commits.each do |commit| %>
->>> <%= link_to commit.summary, commit.url %> (<%= commit.author_name %>)
+> <<%= commit.url + '|' + commit.summary %>> (<%= commit.author_name %>)
 <% end %>
 <% end %>

--- a/plugins/slack/test/models/slack_notification_renderer_test.rb
+++ b/plugins/slack/test/models/slack_notification_renderer_test.rb
@@ -27,13 +27,13 @@ _2 commits by author1 and author2._
 
 *Files changed*
 
->>> A</strong> foo.rb
->>> M</strong> bar.rb
+> A foo.rb
+> M bar.rb
 
 *Commits*
 
->>> <a href=\"#\">Introduce bug</a> (author1)
->>> <a href=\"#\">Fix bug</a> (author2)
+> <#|Introduce bug> (author1)
+> <#|Fix bug> (author2)
     RESULT
   end
 end


### PR DESCRIPTION
Unfortunately there's a problem with the formatting of slack notifications in my previous PR. This fixes things so we get correctly formatted output.

![image](https://cloud.githubusercontent.com/assets/93839/7149856/272e0116-e356-11e4-8fec-eb4e764f227a.png)
