### PR TITLE
fix bug where buddy checks didn't work when deploy groups feature enabled

### DIFF
--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -9,6 +9,10 @@ class DeployGroup < ActiveRecord::Base
 
   default_scope { order(:name) }
 
+  def self.enabled?
+    ENV['DEPLOY_GROUP_FEATURE'].present?
+  end
+
   def deploys
     Deploy.where(stage: stage_ids)
   end

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -32,16 +32,13 @@ class DeployService
   end
 
   def latest_approved_deploy(reference, project)
-    deploy = nil
-    Deploy.where(reference: reference).where(' buddy_id is NOT NULL AND started_at > ?', BuddyCheck.period.hours.ago)
+    Deploy.where(reference: reference).where('buddy_id is NOT NULL AND started_at > ?', BuddyCheck.period.hours.ago)
       .includes(:stage)
-      .where(stages: {project_id: project, production: true})
+      .where(stages: {project_id: project})
       .each do |d|
-        next if bypassed?(d.stage, d, d.buddy)
-        deploy = d
-        break
+        return d if d.production? && !bypassed?(d.stage, d, d.buddy)
       end
-      deploy
+    nil
   end
 
   def release_approved?(deploy)

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -154,7 +154,7 @@ class Stage < ActiveRecord::Base
   end
 
   def production?
-    if ENV['DEPLOY_GROUP_FEATURE']
+    if DeployGroup.enabled?
       deploy_groups.empty? ? super : deploy_groups.any? { |deploy_group| deploy_group.environment.is_production? }
     else
       super

--- a/app/views/projects/_stage.html.erb
+++ b/app/views/projects/_stage.html.erb
@@ -4,7 +4,7 @@
       <%= link_to stage.name, [project, stage] %>
       <%= stage_lock_icon stage %>
     </td>
-    <% if ENV['DEPLOY_GROUP_FEATURE'] %>
+    <% if DeployGroup.enabled? %>
       <td><%= stage.deploy_groups.map(&:name).join(', ') %></td>
     <% end %>
     <% if (deploy = stage.last_successful_deploy) %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -8,7 +8,7 @@
       <thead>
         <tr>
           <th>Stage Name</th>
-          <% if ENV['DEPLOY_GROUP_FEATURE'] %>
+          <% if DeployGroup.enabled? %>
             <th>Deploy Groups</th>
           <% end %>
           <th>Last Deploy</th>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,7 +26,7 @@
             <% end %>
           </ul>
         </li>
-        <% if ENV['DEPLOY_GROUP_FEATURE'] %>
+        <% if DeployGroup.enabled? %>
           <li class="dropdown <%= 'active' if request.path.starts_with?('/dashboards') %>">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Environments <b class="caret"></b></a>
             <ul class="dropdown-menu">
@@ -55,7 +55,7 @@
         <li class="dropdown <%= 'active' if request.path.starts_with?('/admin') %>">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Admin <b class="caret"></b></a>
           <ul class="dropdown-menu">
-            <% if ENV['DEPLOY_GROUP_FEATURE'] %>
+            <% if DeployGroup.enabled? %>
               <li><%= link_to "Environments", admin_environments_path %></li>
               <li><%= link_to "Deploy Groups", admin_deploy_groups_path %></li>
             <% end %>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -23,7 +23,7 @@
     </div>
   </div>
 
-  <% if ENV['DEPLOY_GROUP_FEATURE'] %>
+  <% if DeployGroup.enabled? %>
     <div class="form-group">
       <%= form.label :name, 'Deploy Groups', class: 'col-lg-2 control-label' %>
       <div class="col-lg-5">

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -376,8 +376,7 @@ describe Stage do
 
   describe 'production flag' do
     let(:stage) { stages(:test_production) }
-    before { ENV['DEPLOY_GROUP_FEATURE'] = '1' }
-    after { ENV['DEPLOY_GROUP_FEATURE'] = nil }
+    before { DeployGroup.stubs(:enabled?).returns(true) }
 
     it 'is true for stage with production deploy_group' do
       stage.update!(production: false)


### PR DESCRIPTION
since we redefined the Stage#production? method, that logic needs to be run in ruby instead of via a SQL query.
also refactored code to consolidate the places we check the DEPLOY_GROUP_FEATURE env var.

/cc @zendesk/samson, @zendesk/runway 

### Risks
 - Logic fix around buddy checks, when a past approval affects a new deploy