### PR TITLE
Fixing staging deploy

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,1 +1,1 @@
-load(File.expand_path("../production.rb"))
+load(File.join(File.dirname(__FILE__), 'production.rb'))


### PR DESCRIPTION
Fixing the path where the production.rb was being loaded. When assets where being pre-compiled the working dir would be ```tmp``` causing it to look on the wrong path.

/cc @zendesk/samson @grosser @zendesk-shender 

### References
 - Jira link: 

### Risks
 - None