### PR TITLE
refactor places where both deploy and stage passed as params

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -37,7 +37,7 @@ class DeploysController < ApplicationController
   end
 
   def create
-    deploy_service = DeployService.new(@project, current_user)
+    deploy_service = DeployService.new(current_user)
     @deploy = deploy_service.deploy!(stage, reference)
 
     respond_to do |format|

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -27,7 +27,7 @@ class Integrations::BaseController < ApplicationController
 
   def deploy_to_stages
     stages = project.webhook_stages_for_branch(branch)
-    deploy_service = DeployService.new(project, user)
+    deploy_service = DeployService.new(user)
 
     stages.all? do |stage|
       deploy_service.deploy!(stage, commit).persisted?

--- a/app/mailers/deploy_mailer.rb
+++ b/app/mailers/deploy_mailer.rb
@@ -3,14 +3,14 @@ class DeployMailer < ApplicationMailer
   add_template_helper(DeploysHelper)
   add_template_helper(ApplicationHelper)
 
-  def deploy_email(stage, deploy)
-    prepare_mail(stage, deploy)
+  def deploy_email(deploy)
+    prepare_mail(deploy)
 
-    mail(to: stage.notify_email_addresses, subject: deploy_subject(deploy))
+    mail(to: deploy.stage.notify_email_addresses, subject: deploy_subject(deploy))
   end
 
-  def bypass_email(stage, deploy, user)
-    prepare_mail(stage, deploy)
+  def bypass_email(deploy, user)
+    prepare_mail(deploy)
 
     subject = "[BYPASS]#{deploy_subject(deploy)}"
 
@@ -20,8 +20,8 @@ class DeployMailer < ApplicationMailer
     mail(to: to_email, cc: user.email, subject: subject)
   end
 
-  def deploy_failed_email(stage, deploy, emails)
-    prepare_mail(stage, deploy)
+  def deploy_failed_email(deploy, emails)
+    prepare_mail(deploy)
 
     mail(
       to: emails,
@@ -36,9 +36,9 @@ class DeployMailer < ApplicationMailer
     "[#{Rails.application.config.samson.email.prefix}] #{deploy.summary_for_email}"
   end
 
-  def prepare_mail(stage, deploy)
-    @project = stage.project
+  def prepare_mail(deploy)
     @deploy = deploy
+    @project = @deploy.stage.project
     @changeset = @deploy.changeset
   end
 end

--- a/app/models/datadog_notification.rb
+++ b/app/models/datadog_notification.rb
@@ -2,8 +2,9 @@ require 'dogapi'
 require 'digest/md5'
 
 class DatadogNotification
-  def initialize(stage, deploy)
-    @stage, @deploy = stage, deploy
+  def initialize(deploy)
+    @deploy = deploy
+    @stage = @deploy.stage
   end
 
   def deliver

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -67,9 +67,13 @@ class Deploy < ActiveRecord::Base
     end
   end
 
+  def bypassed_approval?
+    stage.deploy_requires_approval? && buddy == user
+  end
+
   def confirm_buddy!(buddy)
     update_attributes!(buddy: buddy, started_at: Time.now)
-    DeployService.new(project, user).confirm_deploy!(self, stage, reference, buddy)
+    DeployService.new(user).confirm_deploy!(self)
   end
 
   def start_time
@@ -82,7 +86,7 @@ class Deploy < ActiveRecord::Base
 
   def pending_start!
     update_attributes(updated_at: Time.now)       # hack: refresh is immediate with update
-    DeployService.new(project, user).confirm_deploy!(self, stage, reference, buddy)
+    DeployService.new(user).confirm_deploy!(self)
   end
 
   def waiting_for_buddy?

--- a/app/models/github_deployment.rb
+++ b/app/models/github_deployment.rb
@@ -1,8 +1,9 @@
 class GithubDeployment
   DEPLOYMENTS_PREVIEW_MEDIA_TYPE = "application/vnd.github.cannonball-preview+json".freeze
 
-  def initialize(stage, deploy)
-    @stage, @deploy = stage, deploy
+  def initialize(deploy)
+    @deploy = deploy
+    @stage = @deploy.stage
     @project = @stage.project
   end
 

--- a/app/models/github_notification.rb
+++ b/app/models/github_notification.rb
@@ -1,6 +1,7 @@
 class GithubNotification
-  def initialize(stage, deploy)
-    @stage, @deploy = stage, deploy
+  def initialize(deploy)
+    @deploy = deploy
+    @stage = @deploy.stage
     @project = @stage.project
   end
 

--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -17,7 +17,7 @@ class ReleaseService
   end
 
   def start_deploys(release)
-    deploy_service = DeployService.new(@project, release.author)
+    deploy_service = DeployService.new(release.author)
 
     @project.auto_release_stages.each do |stage|
       deploy_service.deploy!(stage, release.version)

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -161,6 +161,10 @@ class Stage < ActiveRecord::Base
     end
   end
 
+  def deploy_requires_approval?
+    BuddyCheck.enabled? && production?
+  end
+
   def automated_failure_emails(deploy)
     return if !email_committers_on_automated_deploy_failure? && static_emails_on_automated_deploy_failure.blank?
     return unless deploy.failed?

--- a/plugins/flowdock/lib/samson_flowdock/samson_plugin.rb
+++ b/plugins/flowdock/lib/samson_flowdock/samson_plugin.rb
@@ -14,8 +14,8 @@ Samson::Hooks.callback :stage_permitted_params do
   { flowdock_flows_attributes: [:id, :name, :token, :_destroy, :enabled] }
 end
 
-notify = -> (stage, deploy, _buddy) do
-  if stage.send_flowdock_notifications?
+notify = -> (deploy, _buddy) do
+  if deploy.stage.send_flowdock_notifications?
     FlowdockNotification.new(deploy).deliver
   end
 end

--- a/plugins/flowdock/test/models/hooks_test.rb
+++ b/plugins/flowdock/test/models/hooks_test.rb
@@ -8,12 +8,12 @@ describe "flowdock hooks" do
     it "sends notification on before hook" do
       stage.stubs(:send_flowdock_notifications?).returns(true)
       FlowdockNotification.any_instance.expects(:deliver)
-      Samson::Hooks.fire(:before_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:before_deploy, deploy, nil)
     end
 
     it "does not send notifications when disabled" do
       FlowdockNotification.any_instance.expects(:deliver).never
-      Samson::Hooks.fire(:before_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:before_deploy, deploy, nil)
     end
   end
 
@@ -21,12 +21,12 @@ describe "flowdock hooks" do
     it "sends notification on after hook" do
       stage.stubs(:send_flowdock_notifications?).returns(true)
       FlowdockNotification.any_instance.expects(:deliver)
-      Samson::Hooks.fire(:after_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
     end
 
     it "does not send notifications when disabled" do
       FlowdockNotification.any_instance.expects(:deliver).never
-      Samson::Hooks.fire(:after_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
     end
   end
 end

--- a/plugins/slack/app/models/slack_notification.rb
+++ b/plugins/slack/app/models/slack_notification.rb
@@ -1,6 +1,7 @@
 class SlackNotification
-  def initialize(stage, deploy)
-    @stage, @deploy = stage, deploy
+  def initialize(deploy)
+    @deploy = deploy
+    @stage = deploy.stage
     @project = @stage.project
     @user = @deploy.user
   end

--- a/plugins/slack/lib/samson_slack/samson_plugin.rb
+++ b/plugins/slack/lib/samson_slack/samson_plugin.rb
@@ -14,9 +14,9 @@ Samson::Hooks.callback :stage_permitted_params do
   { slack_channels_attributes: [:id, :name, :token, :_destroy] }
 end
 
-notify = -> (stage, deploy, _buddy) do
-  if stage.send_slack_notifications?
-    SlackNotification.new(stage, deploy).deliver
+notify = -> (deploy, _buddy) do
+  if deploy.stage.send_slack_notifications?
+    SlackNotification.new(deploy).deliver
   end
 end
 

--- a/plugins/slack/test/models/hooks_test.rb
+++ b/plugins/slack/test/models/hooks_test.rb
@@ -8,12 +8,12 @@ describe "slack hooks" do
     it "sends notification on before hook" do
       stage.stubs(:send_slack_notifications?).returns(true)
       SlackNotification.any_instance.expects(:deliver)
-      Samson::Hooks.fire(:before_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:before_deploy, deploy, nil)
     end
 
     it "does not send notifications when disabled" do
       SlackNotification.any_instance.expects(:deliver).never
-      Samson::Hooks.fire(:before_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:before_deploy, deploy, nil)
     end
   end
 
@@ -21,12 +21,12 @@ describe "slack hooks" do
     it "sends notification on after hook" do
       stage.stubs(:send_slack_notifications?).returns(true)
       SlackNotification.any_instance.expects(:deliver)
-      Samson::Hooks.fire(:after_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
     end
 
     it "does not send notifications when disabled" do
       SlackNotification.any_instance.expects(:deliver).never
-      Samson::Hooks.fire(:after_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
     end
   end
 end

--- a/plugins/slack/test/models/slack_notification_test.rb
+++ b/plugins/slack/test/models/slack_notification_test.rb
@@ -4,8 +4,8 @@ describe SlackNotification do
   let(:project) { stub(name: "Glitter") }
   let(:user) { stub(name: "John Wu", email: "wu@rocks.com") }
   let(:stage) { stub(name: "staging", slack_channels: [stub(channel_id: "x123yx")], project: project) }
-  let(:deploy) { stub(summary: "hello world!", user: user) }
-  let(:notification) { SlackNotification.new(stage, deploy) }
+  let(:deploy) { stub(summary: "hello world!", user: user, stage: stage) }
+  let(:notification) { SlackNotification.new(deploy) }
   let(:endpoint) { "https://slack.com/api/chat.postMessage" }
 
   before do

--- a/plugins/zendesk/app/models/zendesk_notification.rb
+++ b/plugins/zendesk/app/models/zendesk_notification.rb
@@ -5,8 +5,9 @@ class ZendeskNotification
   cattr_accessor(:zendesk_url) { ENV['ZENDESK_URL'] }
   cattr_accessor(:access_token) { ENV['ZENDESK_TOKEN'] }
 
-  def initialize(stage, deploy)
-    @stage, @deploy = stage, deploy
+  def initialize(deploy)
+    @deploy = deploy
+    @stage = deploy.stage
   end
 
   def deliver

--- a/plugins/zendesk/lib/samson_zendesk/samson_plugin.rb
+++ b/plugins/zendesk/lib/samson_zendesk/samson_plugin.rb
@@ -9,9 +9,9 @@ Samson::Hooks.callback :stage_permitted_params do
   :comment_on_zendesk_tickets
 end
 
-Samson::Hooks.callback :after_deploy do |stage, deploy, _buddy|
-  if stage.comment_on_zendesk_tickets?
-    ZendeskNotification.new(stage, deploy).deliver
+Samson::Hooks.callback :after_deploy do |deploy, _buddy|
+  if deploy.stage.comment_on_zendesk_tickets?
+    ZendeskNotification.new(deploy).deliver
   end
 end
 

--- a/plugins/zendesk/test/models/hooks_test.rb
+++ b/plugins/zendesk/test/models/hooks_test.rb
@@ -8,12 +8,12 @@ describe "zendesk hooks" do
     it "sends Zendesk notifications if the stage has them enabled" do
       stage.stubs(:comment_on_zendesk_tickets?).returns(true)
       ZendeskNotification.any_instance.expects(:deliver)
-      Samson::Hooks.fire(:after_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
     end
 
     it "does not send notifications when disabled" do
       ZendeskNotification.any_instance.expects(:deliver).never
-      Samson::Hooks.fire(:after_deploy, stage, deploy, nil)
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
     end
   end
 end

--- a/plugins/zendesk/test/models/zendesk_notification_test.rb
+++ b/plugins/zendesk/test/models/zendesk_notification_test.rb
@@ -8,8 +8,8 @@ describe ZendeskNotification do
   let(:stage) { stub(name: "Production")}
   let(:user) { stub(email: "deploys@example.org")}
   let(:changeset) { stub("changeset", commits: [commit("ZD#18 this fixes a very bad bug")]) }
-  let(:deploy) { stub(changeset: changeset, user: user) }
-  let(:notification) { ZendeskNotification.new(stage, deploy) }
+  let(:deploy) { stub(changeset: changeset, user: user, stage: stage) }
+  let(:notification) { ZendeskNotification.new(deploy) }
   let(:api_response_headers) { {:headers => {:content_type => "application/json"}} }
 
   describe 'when commit messages include Zendesk tickets' do
@@ -28,7 +28,7 @@ describe ZendeskNotification do
   end
 
   describe "#zendesk_tickets" do
-    let(:notification) { ZendeskNotification.new(nil, nil) }
+    let(:notification) { ZendeskNotification.new(deploy) }
 
     it "returns a list of Zendesk tickets mentioned in commit messages" do
       commits = [

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -12,7 +12,7 @@ describe DeploysController do
   let(:changeset) { stub_everything(commits: [], files: [], pull_requests: [], jira_issues: []) }
 
   setup do
-    DeployService.stubs(:new).with(project, deployer).returns(deploy_service)
+    DeployService.stubs(:new).with(deployer).returns(deploy_service)
     deploy_service.stubs(:deploy!).capture(deploy_called).returns(deploy)
 
     Deploy.any_instance.stubs(:changeset).returns(changeset)
@@ -214,7 +214,7 @@ describe DeploysController do
       before { deploy.job.update_column(:status, 'pending') }
 
       it "confirms and redirects to the deploy" do
-        DeployService.stubs(:new).with(project, deploy.user).returns(deploy_service)
+        DeployService.stubs(:new).with(deploy.user).returns(deploy_service)
         deploy_service.expects(:confirm_deploy!)
         refute deploy.buddy
 

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -15,7 +15,7 @@ describe DeployMailer do
     before do
       stage.update_attributes!(notify_email_address: 'test@test.com')
       stub_empty_changeset
-      DeployMailer.deploy_email(stage, deploy).deliver_now
+      DeployMailer.deploy_email(deploy).deliver_now
     end
 
     it 'is from deploys@' do
@@ -42,7 +42,7 @@ describe DeployMailer do
 
       stub_empty_changeset
 
-      DeployMailer.bypass_email(stage, deploy, user).deliver_now
+      DeployMailer.bypass_email(deploy, user).deliver_now
     end
 
     it 'is from deploys@' do
@@ -73,7 +73,7 @@ describe DeployMailer do
   describe "#deploy_failed_email" do
     it "sends" do
       stub_empty_changeset
-      DeployMailer.deploy_failed_email(stage, deploy, ["foo@bar.com"]).deliver_now
+      DeployMailer.deploy_failed_email(deploy, ["foo@bar.com"]).deliver_now
       subject.subject.must_equal "[AUTO-DEPLOY][DEPLOY] Super Admin deployed Project to Staging (staging)"
     end
   end

--- a/test/models/buddy_check_test.rb
+++ b/test/models/buddy_check_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 describe BuddyCheck do
   let(:project) { job.project }
   let(:user) { job.user }
-  let(:service) { DeployService.new(project, user) }
+  let(:service) { DeployService.new(user) }
   let(:stage) { deploy.stage }
   let(:reference) { deploy.reference }
   let(:job) { jobs(:succeeded_test) }
@@ -76,7 +76,8 @@ describe BuddyCheck do
 
         DeployMailer.expects(:bypass_email).returns( stub("DeployMailer", :deliver_now => true) )
 
-        service.confirm_deploy!(deploy, stage, reference, user)
+        deploy.buddy = user
+        service.confirm_deploy!(deploy)
         job_execution.send(:run!)
       end
     end
@@ -85,7 +86,8 @@ describe BuddyCheck do
       it "does not send bypass alert email notification" do
         DeployMailer.expects(:bypass_email).never
 
-        service.confirm_deploy!(deploy, stage, reference, other_user)
+        deploy.buddy = other_user
+        service.confirm_deploy!(deploy)
         job_execution.send(:run!)
       end
     end
@@ -103,7 +105,8 @@ describe BuddyCheck do
       it "sends bypass alert email notification" do
         DeployMailer.expects(:bypass_email).never
 
-        service.confirm_deploy!(deploy, stage, reference, user)
+        deploy.buddy = user
+        service.confirm_deploy!(deploy)
         job_execution.send(:run!)
       end
     end
@@ -113,7 +116,8 @@ describe BuddyCheck do
 
         DeployMailer.expects(:bypass_email).never
 
-        service.confirm_deploy!(deploy, stage, reference, other_user)
+        deploy.buddy = other_user
+        service.confirm_deploy!(deploy)
         job_execution.send(:run!)
       end
     end

--- a/test/models/github_deployment_test.rb
+++ b/test/models/github_deployment_test.rb
@@ -8,7 +8,7 @@ describe GithubDeployment do
   let(:stage) { stages(:test_staging) }
   let(:job) { Job.new(status: 'succeeded', project: project, user: user) }
   let(:deploy) { Deploy.new(id: 1, job: job, reference: "0dfa439", stage: stage) }
-  let(:github_deployment) { GithubDeployment.new(stage, deploy) }
+  let(:github_deployment) { GithubDeployment.new(deploy) }
 
   describe "#create_github_deployment" do
     let(:endpoint) { "https://api.github.com/repos/bar/foo/deployments" }

--- a/test/models/github_notification_test.rb
+++ b/test/models/github_notification_test.rb
@@ -4,8 +4,8 @@ describe GithubNotification do
   let(:project) { stub(name: "Glitter", github_repo: "glitter/glitter", to_param: "3-glitter") }
   let(:stage) { stub(name: "staging", project: project) }
   let(:changeset) { stub_everything(commits: [], files: [], pull_requests: [pull_requests]) }
-  let(:deploy) { stub(changeset: changeset, short_reference: "7e6c415", id: 18) }
-  let(:notification) { GithubNotification.new(stage, deploy) }
+  let(:deploy) { stub(changeset: changeset, short_reference: "7e6c415", id: 18, stage: stage) }
+  let(:notification) { GithubNotification.new(deploy) }
   let(:endpoint) { "https://api.github.com/repos/glitter/glitter/issues/9/comments" }
 
   describe 'when there are pull requests' do


### PR DESCRIPTION
`deploy belongs_to stage`, so there's no point in passing both of those,
and it's unclear what the behavior should be if you pass in a deploy
that doesn't belong to the stage.

/cc @zendesk/samson, @zendesk/runway 

### Risks
 - Code refactoring. Should not change any behavior, but touches a lot of files.