### PR TITLE
Error handling in the case the flowdock token is not set on the env

### DIFF
--- a/plugins/flowdock/app/controllers/flowdock_controller.rb
+++ b/plugins/flowdock/app/controllers/flowdock_controller.rb
@@ -1,3 +1,5 @@
+require 'flowdock'
+
 class FlowdockController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound do |error|
     render status: 404, json: { message: error.message }
@@ -8,6 +10,9 @@ class FlowdockController < ApplicationController
       flowdock_service.users
     end
     render json: { users: users }
+  rescue Flowdock::InvalidParameterError
+    Rails.logger.error('Could not fetch flowdock users! Please set the FLOWDOCK_API_TOKEN env variable')
+    render json: { error: 'Could not get the users from flowdock' }, status: 404
   end
 
   def notify

--- a/plugins/flowdock/lib/samson_flowdock/flowdock_service.rb
+++ b/plugins/flowdock/lib/samson_flowdock/flowdock_service.rb
@@ -20,7 +20,7 @@ module SamsonFlowdock
     end
 
     def flowdock_client
-      @flowdock_client ||= Flowdock::Client.new(api_token: ENV['FLOWDOCK_API_TOKEN'])
+      @flowdock_client ||= Flowdock::Client.new(api_token: flowdock_api_token)
     end
 
     def notify_chat(message, tags)
@@ -48,6 +48,10 @@ module SamsonFlowdock
 
     def tokens
       @deploy.stage.flowdock_tokens
+    end
+
+    def flowdock_api_token
+      ENV['FLOWDOCK_API_TOKEN']
     end
   end
 end


### PR DESCRIPTION
Just better error handling when the FLOWDOCK_API_TOKEN is not set on the environment. Avoiding a 500 server error.

/cc @zendesk/samson @zendesk-shender 

### References
 - Jira link: 

### Risks
 - None