### PR TITLE
Fix issue where integrations created releases with old commits. Closes #359

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -18,7 +18,7 @@ class Integrations::BaseController < ApplicationController
 
   def create_new_release
     if project.create_releases_for_branch?(branch)
-      unless project.last_released_with_commit?(commit)
+      unless project.last_release_contains_commit?(commit)
         release_service = ReleaseService.new(project)
         release_service.create_release!(commit: commit, author: user)
       end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -76,6 +76,12 @@ class GitRepository
     valid
   end
 
+  def downstream_commit?(old_commit, new_commit)
+    cmd = "git rev-list --boundary #{old_commit}..#{new_commit}"
+    success, output = run_single_command(cmd) { |line| line.strip }
+    success ? output.blank? : false
+  end
+
   private
 
   def checkout!(executor: TerminalExecutor.new(StringIO.new), pwd: repo_cache_dir, git_reference:)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -35,9 +35,9 @@ class Project < ActiveRecord::Base
     name.parameterize('_')
   end
 
-  def last_released_with_commit?(commit)
+  def last_release_contains_commit?(commit)
     last_release = releases.order(:id).last
-    last_release && last_release.commit == commit
+    last_release && repository.downstream_commit?(last_release.commit, commit)
   end
 
   def auto_release_stages

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -119,6 +119,29 @@ describe GitRepository do
     end
   end
 
+  describe "#downstream_commit?" do
+    before do
+      create_repo_with_second_commit
+      repository.clone!
+    end
+
+    it 'returns true when the commit is downstream' do
+      repository.downstream_commit?('HEAD', 'HEAD~1').must_equal true
+    end
+
+    it 'returns true when the commit is the same' do
+      repository.downstream_commit?('HEAD', 'HEAD').must_equal true
+    end
+
+    it 'returns false when the commit is upstream' do
+      repository.downstream_commit?('HEAD~1', 'HEAD').must_equal false
+    end
+
+    it 'returns false when the commit does not exist' do
+      repository.downstream_commit?('HEAD', 'non-existent').must_equal false
+    end
+  end
+
   describe "#setup!" do
     it 'creates a repository' do
       create_repo_with_an_additional_branch
@@ -195,6 +218,20 @@ describe GitRepository do
       git add foo2
       git commit -m "branch commit"
       git checkout master
+    SHELL
+  end
+
+  def create_repo_with_second_commit
+    execute_on_remote_repo <<-SHELL
+      git init
+      git config user.email "test@example.com"
+      git config user.name "Test User"
+      echo monkey > foo
+      git add foo
+      git commit -m "initial commit"
+      echo more-monkey >> foo
+      git add foo
+      git commit -m "added more monkey"
     SHELL
   end
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -16,19 +16,22 @@ describe Project do
     Project.create!(name: "hello", repository_url: url).token.wont_be_nil
   end
 
-  describe "#last_released_with_commit?" do
-    it "returns true if the last release had that commit" do
-      project.releases.create!(commit: "XYZ", author: author)
-      assert project.last_released_with_commit?("XYZ")
+  describe "#last_release_contains_commit?" do
+    let(:repository) { mock() }
+
+    before do
+      project.stubs(:repository).returns(repository)
+      repository.stubs(:downstream_commit?).with('LAST', 'NEW').returns(true)
     end
 
-    it "returns false if the last release had a different commit" do
-      project.releases.create!(commit: "123", author: author)
-      assert !project.last_released_with_commit?("XYZ")
+    it "returns true if the last release contains that commit" do
+      project.releases.create!(commit: "LAST", author: author)
+      assert project.last_release_contains_commit?("NEW")
     end
 
     it "returns false if there have been no releases" do
-      refute project.last_released_with_commit?("XYZ")
+      project.releases.destroy_all
+      refute project.last_release_contains_commit?("NEW")
     end
   end
 


### PR DESCRIPTION
If an integration is sent for a commit which is already included in a release,
it should not create a new release, this patch ensures that no new releases are
created when the latest release already contains the given commit.