### PR TITLE
make ruby hash syntax consistent across project

### DIFF
--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -13,7 +13,7 @@ class ChangelogsController < ApplicationController
 
   def check_params
     if params[:start_date].blank? || params[:end_date].blank?
-      redirect_to :start_date => (Date.today.beginning_of_week - 3.days).to_s, :end_date => Date.today.to_s
+      redirect_to start_date: (Date.today.beginning_of_week - 3.days).to_s, end_date: Date.today.to_s
     end
   end
 end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -35,7 +35,7 @@ class StagesController < ApplicationController
         end
 
         if stale?(etag: badge)
-          expires_in 1.minute, :public => true
+          expires_in 1.minute, public: true
           image = open("http://img.shields.io/badge/#{badge}.svg").read
           render text: image, content_type: Mime::SVG
         end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,7 +52,7 @@ module ApplicationHelper
   def sortable(column, title = nil)
     title ||= column.titleize
     direction = (column == sort_column && sort_direction == "asc") ? "desc" : "asc"
-    link_to title, :sort => column, :direction => direction
+    link_to title, sort: column, direction: direction
   end
 
   def github_ok?

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -159,7 +159,7 @@ class JobExecution
       new(reference, job).tap do |job_execution|
         if enabled
           registry[job.id] = job_execution.tap(&:start!)
-          ActiveSupport::Notifications.instrument "job.threads", :thread_count => registry.length
+          ActiveSupport::Notifications.instrument "job.threads", thread_count: registry.length
         end
       end
     end
@@ -170,7 +170,7 @@ class JobExecution
 
     def finished_job(job)
       registry.delete(job.id)
-      ActiveSupport::Notifications.instrument "job.threads", :thread_count => registry.length
+      ActiveSupport::Notifications.instrument "job.threads", thread_count: registry.length
     end
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -9,20 +9,20 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :github,
     ENV["GITHUB_CLIENT_ID"],
     ENV["GITHUB_SECRET"],
-    :scope => "user:email",
-    :client_options => {
-      :site          => "https://#{Rails.application.config.samson.github.api_url}",
-      :authorize_url => "https://#{Rails.application.config.samson.github.web_url}/login/oauth/authorize",
-      :token_url     => "https://#{Rails.application.config.samson.github.web_url}/login/oauth/access_token",
+    scope: "user:email",
+    client_options: {
+      site:          "https://#{Rails.application.config.samson.github.api_url}",
+      authorize_url: "https://#{Rails.application.config.samson.github.web_url}/login/oauth/authorize",
+      token_url:     "https://#{Rails.application.config.samson.github.web_url}/login/oauth/access_token",
     }
 
   provider OmniAuth::Strategies::GoogleOauth2,
     ENV["GOOGLE_CLIENT_ID"],
     ENV["GOOGLE_CLIENT_SECRET"],
     {
-      :name => "google",
-      :scope => "email,profile",
-      :prompt => "select_account",
+      name:   "google",
+      scope:  "email,profile",
+      prompt: "select_account",
     }
 
 end

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,5 +1,5 @@
 ActionMailer::Base.smtp_settings = {
-  :authentication => 'plain',
-  :enable_starttls_auto => false,
-  :openssl_verify_mode => 'none'
+  authentication:       'plain',
+  enable_starttls_auto: false,
+  openssl_verify_mode:  'none'
 }

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -19,9 +19,9 @@ ActiveSupport::Notifications.subscribe("execute_shell.samson") do |*args|
 
   tags = [event.payload[:project], event.payload[:stage]]
 
-  $statsd.histogram "execute_shell.time", event.duration, :tags => tags
-  $statsd.event "Executed shell command", event.payload[:command], :tags => tags
-  $statsd.increment "execute_shells", :tags => tags
+  $statsd.histogram "execute_shell.time", event.duration, tags: tags
+  $statsd.event "Executed shell command", event.payload[:command], tags: tags
+  $statsd.increment "execute_shells", tags: tags
 
   Rails.logger.debug("Executed shell command in %.2fms" % event.duration)
 end
@@ -41,8 +41,8 @@ ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |*a
   status = event.payload[:status]
   tags = [controller, action, format]
 
-  $statsd.histogram "web.request.time", event.duration, :tags => tags
-  $statsd.histogram "web.db_query.time", event.payload[:db_runtime], :tags => tags
-  $statsd.histogram "web.view.time", event.payload[:view_runtime], :tags => tags
-  $statsd.increment "web.request.status.#{status}", :tags => tags
+  $statsd.histogram "web.request.time", event.duration, tags: tags
+  $statsd.histogram "web.db_query.time", event.payload[:db_runtime], tags: tags
+  $statsd.histogram "web.view.time", event.payload[:view_runtime], tags: tags
+  $statsd.increment "web.request.status.#{status}", tags: tags
 end

--- a/lib/references_service.rb
+++ b/lib/references_service.rb
@@ -8,7 +8,7 @@ class ReferencesService
   end
 
   def find_git_references
-    Rails.cache.fetch(cache_key, :expires_in => references_ttl) { references_from_cached_repo } || []
+    Rails.cache.fetch(cache_key, expires_in: references_ttl) { references_from_cached_repo } || []
   end
 
   private

--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -29,7 +29,7 @@ module Samson
     private
 
     def client
-      @@client ||= JenkinsApi::Client.new(:server_url => URL, :username => USERNAME, :password => API_KEY)
+      @@client ||= JenkinsApi::Client.new(server_url: URL, username: USERNAME, password: API_KEY)
     end
   end
 end

--- a/plugins/jenkins/test/helpers/jenkins_helper_test.rb
+++ b/plugins/jenkins/test/helpers/jenkins_helper_test.rb
@@ -11,7 +11,7 @@ describe JenkinsHelper do
 
   def stub_build_detail(result)
     stub_request(:get, "http://user%40test.com:japikey@www.test-url.com/job/test_job/111//api/json").
-      to_return(:status => 200, :body => build_detail_response.merge("result" => result).to_json, :headers => {}).to_timeout
+      to_return(status: 200, body: build_detail_response.merge("result" => result).to_json, headers: {}).to_timeout
   end
 
   let(:deploy) { deploys(:succeeded_test) }

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -3,24 +3,24 @@ require_relative '../../test_helper'
 describe Samson::Jenkins do
   def stub_crumb
     stub_request(:get, "http://user%40test.com:japikey@www.test-url.com/api/json?tree=useCrumbs").
-      to_return(:body => '{"crumb": "fb171d526b9cc9e25afe80b356e12cb7", "crumbRequestField": ".crumb"}')
+      to_return(body: '{"crumb": "fb171d526b9cc9e25afe80b356e12cb7", "crumbRequestField": ".crumb"}')
   end
 
   def stub_job_detail
     stub_request(:get, "http://user%40test.com:japikey@www.test-url.com/job/test_job/api/json").
-      to_return(:status => 200, :body => json_response)
+      to_return(status: 200, body: json_response)
   end
 
   def stub_build_with_parameters
     stub_request(:post, "http://user%40test.com:japikey@www.test-url.com/job/test_job/buildWithParameters").
-      with(:body => {"buildStartedBy"=>"Super Admin", "originatedFrom"=>"Staging"}).
-      to_return(:status => 200, :body => "", :headers => {}).to_timeout
+      with(body: {"buildStartedBy"=>"Super Admin", "originatedFrom"=>"Staging"}).
+      to_return(status: 200, body: "", headers: {}).to_timeout
   end
 
   # avoid polling logic
   def stub_build_detail(result)
     stub_request(:get, "http://user%40test.com:japikey@www.test-url.com/job/test_job/96//api/json").
-      to_return(:status => 200, :body => build_detail_response.merge("result" => result).to_json, :headers => {}).to_timeout
+      to_return(status: 200, body: build_detail_response.merge("result" => result).to_json, headers: {}).to_timeout
   end
 
   def stub_get_build_id_from_queue(build_id)
@@ -36,7 +36,7 @@ describe Samson::Jenkins do
   before do
     # trigger initial request that does a version check (stub with a version that signals we support queueing)
     stub_request(:get, "http://user%40test.com:japikey@www.test-url.com/").
-      to_return(:headers => {"X-Jenkins" => "1.600"})
+      to_return(headers: {"X-Jenkins" => "1.600"})
     Samson::Jenkins.new(nil, nil).send(:client).get_root
   end
 

--- a/plugins/zendesk/app/models/zendesk_notification.rb
+++ b/plugins/zendesk/app/models/zendesk_notification.rb
@@ -16,9 +16,9 @@ class ZendeskNotification
     if zendesk_tickets.any?
       zendesk_tickets.each do |ticket_id|
         attributes = {
-          :id => ticket_id,
-          :status => "open",
-          :comment => { :value => content(ticket_id), :public => false }
+          id:      ticket_id,
+          status:  "open",
+          comment: {value: content(ticket_id), public: false}
         }
 
         if zendesk_client.tickets.update(attributes)

--- a/plugins/zendesk/test/models/zendesk_notification_test.rb
+++ b/plugins/zendesk/test/models/zendesk_notification_test.rb
@@ -10,7 +10,7 @@ describe ZendeskNotification do
   let(:changeset) { stub("changeset", commits: [commit("ZD#18 this fixes a very bad bug")]) }
   let(:deploy) { stub(changeset: changeset, user: user, stage: stage) }
   let(:notification) { ZendeskNotification.new(deploy) }
-  let(:api_response_headers) { {:headers => {:content_type => "application/json"}} }
+  let(:api_response_headers) { {headers: {content_type: "application/json"}} }
 
   describe 'when commit messages include Zendesk tickets' do
     before do
@@ -19,7 +19,7 @@ describe ZendeskNotification do
 
     it "comments on the ticket" do
       comment = stub_api_request(:put, "api/v2/tickets/18").
-        with(:body => "{\"ticket\":{\"status\":\"open\",\"comment\":{\"value\":\"A fix to project has been deployed to Production. Deploy details: v2.14\",\"public\":false}}}")
+        with(body: "{\"ticket\":{\"status\":\"open\",\"comment\":{\"value\":\"A fix to project has been deployed to Production. Deploy details: v2.14\",\"public\":false}}}")
 
       notification.deliver
 
@@ -50,6 +50,6 @@ describe ZendeskNotification do
     url = ENV['ZENDESK_URL']
     body = '{ "ticket": { "id": 18, "comment": {"value": "Comment body", "public": true }, "status": "open"}}'
 
-    stub_request(method, "#{url}/#{path}").to_return(api_response_headers.merge(:status => 200, :body => body))
+    stub_request(method, "#{url}/#{path}").to_return(api_response_headers.merge(status: 200, body: body))
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -19,7 +19,7 @@ describe Admin::UsersController do
 
   describe 'a json GET to #show' do
     before do
-      get :index, :format => :json
+      get :index, format: :json
     end
 
     as_a_admin do
@@ -40,7 +40,7 @@ describe Admin::UsersController do
   describe 'a json get to #show with a search string' do
     as_a_admin do
       it 'succeeds and fetches a single user' do
-        get :index, search: 'Super Admin' , :format => :json
+        get :index, search: 'Super Admin' , format: :json
 
         response.success?.must_equal true
         assigns(:users).must_equal [users(:super_admin)]

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -34,8 +34,8 @@ describe ApplicationHelper do
     describe "with an OK response" do
       before do
         stub_request(:get, status_url).to_return(
-          :headers => { :content_type => 'application/json' },
-          :body => JSON.dump(:status => 'good')
+          headers: { content_type: 'application/json' },
+          body: JSON.dump(status: 'good')
         )
       end
 
@@ -48,8 +48,8 @@ describe ApplicationHelper do
     describe "with a bad response" do
       before do
         stub_request(:get, status_url).to_return(
-          :headers => { :content_type => 'application/json' },
-          :body => JSON.dump(:status => 'bad')
+          headers: { content_type: 'application/json' },
+          body: JSON.dump(status: 'bad')
         )
       end
 
@@ -61,7 +61,7 @@ describe ApplicationHelper do
 
     describe "with an invalid response" do
       before do
-        stub_request(:get, status_url).to_return(:status => 400)
+        stub_request(:get, status_url).to_return(status: 400)
       end
 
       it 'returns false and does not cache' do

--- a/test/models/buddy_check_test.rb
+++ b/test/models/buddy_check_test.rb
@@ -74,7 +74,7 @@ describe BuddyCheck do
       it "sends bypass alert email notification" do
         DeployMailer.stubs(:prepare_mail)
 
-        DeployMailer.expects(:bypass_email).returns( stub("DeployMailer", :deliver_now => true) )
+        DeployMailer.expects(:bypass_email).returns( stub("DeployMailer", deliver_now: true) )
 
         deploy.buddy = user
         service.confirm_deploy!(deploy)

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -16,7 +16,7 @@ describe CommitStatus do
     end
 
     describe 'with combined status' do
-      let(:statuses) { { :state => "success" }}
+      let(:statuses) { { state: "success" }}
 
       it 'is the first status' do
         subject.status.must_equal('success')
@@ -24,7 +24,7 @@ describe CommitStatus do
     end
 
     describe 'with no status' do
-      let(:statuses) { { :state => nil } }
+      let(:statuses) { { state: nil } }
 
       it 'is nil' do
         subject.status.must_be_nil

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -139,7 +139,7 @@ describe DeployService do
 
       stage.stubs(:use_github_deployment_api?).returns(true)
 
-      GithubDeployment.stubs(:new => deployment)
+      GithubDeployment.stubs(new: deployment)
       deployment.expects(:create_github_deployment)
 
       service.deploy!(stage, reference)
@@ -159,7 +159,7 @@ describe DeployService do
     it "sends email notifications if the stage has email addresses" do
       stage.stubs(:send_email_notifications?).returns(true)
 
-      DeployMailer.expects(:deploy_email).returns( stub("DeployMailer", :deliver_now => true) )
+      DeployMailer.expects(:deploy_email).returns( stub("DeployMailer", deliver_now: true) )
 
       service.deploy!(stage, reference)
       job_execution.send(:run!)
@@ -202,11 +202,11 @@ describe DeployService do
     end
 
     it "updates a github deployment status" do
-      deployment = stub(:create_github_deployment => deployment)
+      deployment = stub(create_github_deployment: deployment)
 
       stage.stubs(:use_github_deployment_api?).returns(true)
 
-      GithubDeployment.stubs(:new => deployment)
+      GithubDeployment.stubs(new: deployment)
       deployment.expects(:update_github_deployment_status)
 
       service.deploy!(stage, reference)
@@ -216,7 +216,7 @@ describe DeployService do
     it "email notification for failed deploys" do
       stage.stubs(:automated_failure_emails).returns(["foo@bar.com"])
 
-      DeployMailer.expects(:deploy_failed_email).returns( stub("DeployMailer", :deliver_now => true) )
+      DeployMailer.expects(:deploy_failed_email).returns( stub("DeployMailer", deliver_now: true) )
 
       service.deploy!(stage, reference)
       job_execution.send(:run!)

--- a/test/models/github_authorization_test.rb
+++ b/test/models/github_authorization_test.rb
@@ -17,7 +17,7 @@ describe GithubAuthorization do
         stub_github_api("teams/#{team[:id]}/members/test.user", {}, team[:member] ? 204 : 404)
       end
     else
-      config.stubs(:organization => nil)
+      config.stubs(organization: nil)
     end
   end
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -145,7 +145,7 @@ describe JobExecution do
   end
 
   it 'cannot setup project if project is locked' do
-    JobExecution.any_instance.stubs(:lock_timeout => 0.5) # 2 runs in the loop
+    JobExecution.any_instance.stubs(lock_timeout: 0.5) # 2 runs in the loop
     project.repository.expects(:setup!).never
     begin
       MultiLock.send(:try_lock, project.id, 'me')

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -85,7 +85,7 @@ describe User do
       }}
 
       let(:existing_user) do
-        User.create!(:name => "Test", :external_id => 9)
+        User.create!(name: "Test", external_id: 9)
       end
 
       setup { existing_user }

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 describe Webhook do
-  let(:webhook_attributes) { { :branch => 'master', :stage_id => 1, :project_id => 1, source: 'any_ci'} }
+  let(:webhook_attributes) { { branch: 'master', stage_id: 1, project_id: 1, source: 'any_ci'} }
 
   describe '#create' do
     it 'creates the webhook' do


### PR DESCRIPTION
Cleanup so we don't use some of one hash syntax, and some of another.

/cc @zendesk/runway

### Risks
 - None