### PR TITLE
fix migration naming error

### DIFF
--- a/plugins/jenkins/db/migrate/20150318215604_add_jenkins_jobs_to_stage.rb
+++ b/plugins/jenkins/db/migrate/20150318215604_add_jenkins_jobs_to_stage.rb
@@ -1,4 +1,4 @@
-class AddJenkinsJobNamesToStage < ActiveRecord::Migration
+class AddJenkinsJobsToStage < ActiveRecord::Migration
   def change
     change_table :stages do |t|
       t.string :jenkins_job_names


### PR DESCRIPTION
@rdhanoa 

```
NameError: uninitialized constant AddJenkinsJobsToStage
```

### Risks
 - None