### PR TITLE
have Jenkins client use Rails logger instead of logging to STDOUT

### DIFF
--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -29,7 +29,9 @@ module Samson
     private
 
     def client
-      @@client ||= JenkinsApi::Client.new(server_url: URL, username: USERNAME, password: API_KEY)
+      @@client ||= JenkinsApi::Client.new(server_url: URL, username: USERNAME, password: API_KEY).tap do |cli|
+        cli.logger = Rails.logger
+      end
     end
   end
 end


### PR DESCRIPTION
The Jenkins API client defaults to a logger pointing to stdout

/cc @zendesk/runway 