### PR TITLE
Allow periods (full stops) in project permalinks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Samson::Application.routes.draw do
-  resources :projects do
+  resources :projects, constraints: { id: /[^\/]+/ } do
     resources :jobs, only: [:index, :new, :create, :show, :destroy]
 
     resources :macros, only: [:index, :new, :create, :edit, :update, :destroy] do


### PR DESCRIPTION
Hi there,

I experienced an issue with one of my Samson projects the other day when I changed the permalink of a project to something including a full stop - eg. `my.project` - and I could no longer access the project at `/projects/my.project` because only "my" was being matched as the `id` parameter.

So, I've added a constraint to the `id` parameter for the `projects` resource, such that it accepts any characters except a forward-slash and matches them appropriately.

I'm not quite sure if this change has wider implications than just fixing the above, so would be happy with a resolution that disables the user changing the permalink to something with a "." in it as an alternative, but I figured it wouldn't hurt to see what you thought of just allowing them in the URL slug as GitHub does.