### PR TITLE
Fix Current Deploys badge

### DIFF
--- a/app/assets/javascripts/controllers/current_deploys_badge_ctrl.js
+++ b/app/assets/javascripts/controllers/current_deploys_badge_ctrl.js
@@ -23,8 +23,8 @@ samson.controller('currentDeployBadgeCtrl', function($scope, $http, SseFactory) 
   }
 
   function init() {
-    $http.get($('#currentDeploysBadge').data('url')).success(function(result) {
-      $scope.currentActiveDeploys = result.deploys.length;
+    $http.get('/deploys/active_count.json').success(function(result) {
+      $scope.currentActiveDeploys = result.deploy_count;
       updateBadge();
     });
   }

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -1,7 +1,7 @@
 class DeploysController < ApplicationController
   before_action :authorize_deployer!, only: [:new, :create, :confirm, :update, :destroy, :buddy_check, :pending_start]
   before_action :find_project
-  before_action :find_deploy, except: [:index, :recent, :active, :new, :create, :confirm]
+  before_action :find_deploy, except: [:index, :recent, :active, :active_count, :new, :create, :confirm]
   before_action :stage, only: :new
 
   def index
@@ -13,9 +13,12 @@ class DeploysController < ApplicationController
     end
   end
 
+  def active_count
+    render json: { deploy_count: active_deploy_scope.count }
+  end
+
   def active
-    scope = (@project ? @project.deploys : Deploy)
-    @deploys = scope.active.page(params[:page])
+    @deploys = active_deploy_scope.page(params[:page])
 
     respond_to do |format|
       format.html
@@ -124,5 +127,9 @@ class DeploysController < ApplicationController
 
   def find_deploy
     @deploy = Deploy.find(params[:id])
+  end
+
+  def active_deploy_scope
+    @project ? @project.deploys.active : Deploy.active
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -46,7 +46,7 @@
         <li class="current-deploys <%= 'active' if current_page?(controller: '/deploys', action: 'active') %>" ng-controller="currentDeployBadgeCtrl">
           <%= link_to active_deploys_path do %>
             Current Deploys
-            <%= content_tag(:span, '{{ currentActiveDeploys }}', class: 'badge badge-deploys', style: 'display: none', id: 'currentDeploysBadge', data: { url: active_deploys_url(format: 'json') }) %>
+            <%= content_tag(:span, '{{ currentActiveDeploys }}', class: 'badge badge-deploys', style: 'display: none', id: 'currentDeploysBadge') %>
           <% end %>
         </li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Samson::Application.routes.draw do
     resources :deploys, only: [:index, :show, :destroy] do
       collection do
         get :active
+        get :active_count
       end
 
       member do
@@ -53,6 +54,7 @@ Samson::Application.routes.draw do
   resources :deploys, only: [] do
     collection do
       get :active
+      get :active_count
       get :recent
     end
   end

--- a/test/angular/controllers/current_deploys_badge_ctrl_spec.js
+++ b/test/angular/controllers/current_deploys_badge_ctrl_spec.js
@@ -15,7 +15,6 @@ describe('currentDeployBadgeCtrl', function() {
     $httpBackend = _$httpBackend_;
     SseFactory = _SseFactory_;
     fakeBadgeElement = {
-      data: function() { return '/deploys/active.json'; },
       show: jasmine.createSpy('show'),
       hide: jasmine.createSpy('hide')
     };
@@ -34,14 +33,14 @@ describe('currentDeployBadgeCtrl', function() {
 
   describe('init', function() {
     it('gets current active deploys', function() {
-      $httpBackend.expectGET('/deploys/active.json').respond({ "deploys": [{ "id": 1 }, { "id": 2 }] });
+      $httpBackend.expectGET('/deploys/active_count.json').respond('{"deploy_count":2}');
       createController();
       expect($scope.currentActiveDeploys).toEqual(2);
       expect(fakeBadgeElement.show).toHaveBeenCalled();
     });
 
     it('hides badge if there are no deploys', function() {
-      $httpBackend.expectGET('/deploys/active.json').respond({ "deploys": [] });
+      $httpBackend.expectGET('/deploys/active_count.json').respond('{"deploy_count":0}');
       createController();
       expect($scope.currentActiveDeploys).toEqual(0);
       expect(fakeBadgeElement.hide).toHaveBeenCalled();

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -123,6 +123,24 @@ describe DeploysController do
       end
     end
 
+    describe "#active_count" do
+      before { stage.create_deploy(reference: 'reference', user: admin) }
+
+      it "renders json" do
+        get :active_count
+        assert_equal "application/json", @response.content_type
+        assert_response :ok
+        @response.body.must_equal "{\"deploy_count\":1}"
+      end
+
+      it "renders json" do
+        get :active_count, project_id: project.to_param
+        assert_equal "application/json", @response.content_type
+        assert_response :ok
+        @response.body.must_equal "{\"deploy_count\":1}"
+      end
+    end
+
     describe "a GET to :show" do
       describe "with a valid deploy" do
         setup { get :show, project_id: project.to_param, id: deploy.to_param }


### PR DESCRIPTION
Active Deploys route is paginated, so current deploys badge would never go above 30.

/cc @zendesk/runway @zendesk/samson 

### References
 - Jira link:

### Risks
 - None