### PR TITLE
always persist the output so users can start watching mid stream and …

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -75,7 +75,11 @@ class JobExecution
   def run!
     @job.run!
 
-    output_aggregator = OutputAggregator.new(@output)
+    Thread.new do
+      OutputAggregator.new(@output).each do |log|
+        @job.update_output!(log)
+      end
+    end
 
     result = Dir.mktmpdir do |dir|
       execute!(dir)
@@ -88,8 +92,6 @@ class JobExecution
     end
 
     @output.close
-    @job.update_output!(output_aggregator.to_s)
-
     @subscribers.each(&:call)
   end
 

--- a/app/models/output_aggregator.rb
+++ b/app/models/output_aggregator.rb
@@ -4,7 +4,7 @@ class OutputAggregator
     @output = output
   end
 
-  def to_s
+  def each
     scanner = TerminalOutputScanner.new(@output)
     log = []
 
@@ -13,8 +13,7 @@ class OutputAggregator
 
       log.pop if event == :replace
       log.push(data)
+      yield log.join
     end
-
-    log.join
   end
 end


### PR DESCRIPTION
…everything is persisted when job needs to be killed

@dragonfax for #80 

/fyi @steved @zendesk/runway 

this is a pretty bad approach since it produces a ton of queries, each printed line produces 8 updates since each line triggers 2 output calls and each job save triggers a touch against stage/deploy/project ... so not good ... but maybe a starting point ...


```
  SQL (0.4ms)  UPDATE `jobs` SET `output` = 'Beginning git repo setup\nCloning into \'/var/folders/b5/4n7zf5v10_lfwjqqlyvvy51w0000gp/T/d20150506-71600-gg6na7\'...\ndone.\nExecuting deploy\nhello\nbar\nhello', `updated_at` = '2015-05-06 21:16:01.191914' WHERE `jobs`.`id` = 178003113
  SQL (0.3ms)  UPDATE `deploys` SET `deploys`.`updated_at` = '2015-05-06 21:16:01.193363' WHERE `deploys`.`id` = 178003113
  SQL (0.3ms)  UPDATE `stages` SET `stages`.`updated_at` = '2015-05-06 21:16:01.194636' WHERE `stages`.`id` = 398743887
  SQL (0.3ms)  UPDATE `projects` SET `projects`.`updated_at` = '2015-05-06 21:16:01.196245' WHERE `projects`.`id` = 411008527
   (0.4ms)  COMMIT
   (0.2ms)  BEGIN
  SQL (0.4ms)  UPDATE `jobs` SET `output` = 'Beginning git repo setup\nCloning into \'/var/folders/b5/4n7zf5v10_lfwjqqlyvvy51w0000gp/T/d20150506-71600-gg6na7\'...\ndone.\nExecuting deploy\nhello\nbar\nhello\n', `updated_at` = '2015-05-06 21:16:01.199037' WHERE `jobs`.`id` = 178003113
  SQL (0.4ms)  UPDATE `deploys` SET `deploys`.`updated_at` = '2015-05-06 21:16:01.200578' WHERE `deploys`.`id` = 178003113
  SQL (0.4ms)  UPDATE `stages` SET `stages`.`updated_at` = '2015-05-06 21:16:01.202224' WHERE `stages`.`id` = 398743887
  SQL (0.3ms)  UPDATE `projects` SET `projects`.`updated_at` = '2015-05-06 21:16:01.203748' WHERE `projects`.`id` = 411008527
```

### Risks
 - None