### PR TITLE
make active deploy table behave like a normal link

### DIFF
--- a/app/assets/stylesheets/timeline.scss
+++ b/app/assets/stylesheets/timeline.scss
@@ -19,7 +19,6 @@
 }
 
 .timeline td {
-  cursor: pointer;
   border-bottom: 1px solid $samsonLight;
 }
 

--- a/app/assets/templates/deploys/_deploy_details.tmpl.html
+++ b/app/assets/templates/deploys/_deploy_details.tmpl.html
@@ -1,4 +1,4 @@
-<tr class="timeline-entry" data-url="{{deploy.url}}" ng-click="helper.jumpTo(deploy.url)">
+<tr class="timeline-entry">
   <td>
     <a class="timeline-project" ng-href="{{deploy.project.url}}">{{deploy.project.name}}</a>
   </td>
@@ -6,15 +6,12 @@
     {{deploy.user.name}}
   </td>
   <td class="timeline-summary">
-    {{deploy.summary}}
+    <a ng-href="{{deploy.url}}">{{deploy.summary}}</a>
   </td>
   <td>
     <span data-time="{{deploy.updated_at}}" class="timeline-time">{{deploy.updated_at_ago}}</span>
   </td>
   <td>
     <span class="label label-{{deploy.status | visualizeStatus}} timeline-deploy-status">{{deploy.status}}</span>
-  </td>
-  <td>
-    <i class="glyphicon glyphicon-log-out"></i>
   </td>
 </tr>

--- a/app/views/deploys/recent.html.erb
+++ b/app/views/deploys/recent.html.erb
@@ -35,7 +35,6 @@
         <th>DEPLOY</th>
         <th>LAST UPDATE</th>
         <th>STATUS</th>
-        <th></th>
       </tr>
       <tr deploy-details ng-repeat="deploy in deploys | projectUserFilter:search | userFilter:userType | stageFilter:stageType | statusFilter:deployStatus"></tr>
     </table>


### PR DESCRIPTION
@zendesk/runway 

 - can cmd+click / middle-mouse click to open multiple ones
 - no more cursor accross all of them
 - no more 'logout' button at the end

before:
![screen shot 2015-05-07 at 11 25 36 am](https://cloud.githubusercontent.com/assets/11367/7522797/6efe040c-f4ac-11e4-8259-a8bcdb43334a.png)


after:
![screen shot 2015-05-07 at 11 08 27 am](https://cloud.githubusercontent.com/assets/11367/7522794/6b90383a-f4ac-11e4-9a8a-eeb81abf54f4.png)



### Risks
 - None