### PR TITLE
Fix display of variable numbers of environments.

### DIFF
--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -26,7 +26,7 @@
   <% if DeployGroup.enabled? %>
     <div class="form-group">
       <%= form.label :name, 'Deploy Groups', class: 'col-lg-2 control-label' %>
-      <div class="col-lg-5">
+      <div class=<%= "col-lg-#{2 + @environments.count}" %> >
         <% if @environments.count > 0 %>
           <%= hidden_field_tag "stage[deploy_group_ids][]" %>
           <table class="table table-condensed text-left deploy-groups">


### PR DESCRIPTION
Have a bit of flexibility when rendering variable numbers of environments.

## Before:
![screen shot 2015-05-08 at 15 32 01](https://cloud.githubusercontent.com/assets/515143/7538707/d3a5b48e-f599-11e4-8930-b0255d4e139f.png)
## After
![screen shot 2015-05-08 at 15 48 26](https://cloud.githubusercontent.com/assets/515143/7538709/d6ef8e94-f599-11e4-8fb9-bc1c45106668.png)


/cc @zendesk/runway @zendesk/samson 

### References
 - Jira link:

### Risks
 - None