### PR TITLE
fix sporadic runtime errors seen in production due to MRI bug

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -123,7 +123,7 @@ class Deploy < ActiveRecord::Base
   end
 
   def url
-    Rails.application.routes.url_helpers.project_deploy_path(project, self)
+    AppRoutes.url_helpers.project_deploy_path(project, self)
   end
 
   private

--- a/app/models/github_deployment.rb
+++ b/app/models/github_deployment.rb
@@ -52,10 +52,6 @@ class GithubDeployment
   end
 
   def url
-    url_helpers.project_deploy_url(@project, @deploy)
-  end
-
-  def url_helpers
-    Rails.application.routes.url_helpers
+    AppRoutes.url_helpers.project_deploy_url(@project, @deploy)
   end
 end

--- a/app/models/github_notification.rb
+++ b/app/models/github_notification.rb
@@ -29,7 +29,7 @@ class GithubNotification
   private
 
   def body
-    url = url_helpers.project_deploy_url(@project, @deploy)
+    url = AppRoutes.url_helpers.project_deploy_url(@project, @deploy)
     short_reference_link = "<a href='#{url}' target='_blank'>#{@deploy.short_reference}</a>"
     "This PR was deployed to #{@stage.name}. Reference: #{short_reference_link}"
   end
@@ -45,9 +45,4 @@ class GithubNotification
       end
     end.each(&:join)
   end
-
-  def url_helpers
-    Rails.application.routes.url_helpers
-  end
-
 end

--- a/config/initializers/app_routes.rb
+++ b/config/initializers/app_routes.rb
@@ -1,0 +1,7 @@
+module AppRoutes
+  # memoize this due to a bug in MRI that shows up in multi-threaded code
+  # see https://github.com/puma/puma/issues/647, search for "bug in MRI"
+  def self.url_helpers
+    @@routes_url_helpers ||= Rails.application.routes.url_helpers
+  end
+end

--- a/plugins/flowdock/app/models/flowdock_notification.rb
+++ b/plugins/flowdock/app/models/flowdock_notification.rb
@@ -2,7 +2,7 @@ require 'flowdock'
 
 class FlowdockNotification
   delegate :project, :stage, :user, to: :@deploy
-  delegate :project_deploy_url, to: 'Rails.application.routes.url_helpers'
+  delegate :project_deploy_url, to: 'AppRoutes.url_helpers'
 
   def initialize(deploy)
     @deploy = deploy

--- a/plugins/zendesk/app/models/zendesk_notification_renderer.rb
+++ b/plugins/zendesk/app/models/zendesk_notification_renderer.rb
@@ -9,6 +9,6 @@ class ZendeskNotificationRenderer
   private
 
   def self.url(deploy)
-    Rails.application.routes.url_helpers.project_deploy_url(deploy.project, deploy)
+    AppRoutes.url_helpers.project_deploy_url(deploy.project, deploy)
   end
 end


### PR DESCRIPTION
see explanation at https://github.com/puma/puma/issues/647
example error: https://zendesk.airbrake.io/projects/95346/groups/1338411361327591219
```
NoMethodError: undefined method `url_options' for #<Module:0x007f029d1080c8>`
```

/cc @zendesk/runway

### Risks
 - None