### PR TITLE
fix exception thrown when X-Hub-Signature header missing

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -16,7 +16,7 @@ class Integrations::GithubController < Integrations::BaseController
       request.body.tap(&:rewind).read
     )
 
-    Rack::Utils.secure_compare(request.headers['X-Hub-Signature'], "sha1=#{hmac}")
+    Rack::Utils.secure_compare(request.headers['X-Hub-Signature'].to_s, "sha1=#{hmac}")
   end
 
   def valid_payload?


### PR DESCRIPTION
example error: https://zendesk.airbrake.io/projects/95346/groups/1415261459885533031

/cc @zendesk/runway

### Risks
 - None