### PR TITLE
Create models to represent Builds

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -2,10 +2,15 @@ class Build < ActiveRecord::Base
   SHA1_REGEX = /\A[0-9a-f]{40}/i
 
   belongs_to :project
+  has_many :statuses, class: 'BuildStatus'
   has_many :deploys
   has_many :releases
 
   validates :project, presence: true
   validates :git_sha, format: SHA1_REGEX, allow_nil: true
   validates :container_sha, format: SHA1_REGEX, allow_nil: true
+
+  def successful?
+    statuses.successful.all?
+  end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -1,8 +1,8 @@
 class Build < ActiveRecord::Base
-  SHA1_REGEX = /\A[0-9a-f]{40}/i
+  SHA1_REGEX = /\A[0-9a-f]{40}\Z/i
 
   belongs_to :project
-  has_many :statuses, class: 'BuildStatus'
+  has_many :statuses, class_name: 'BuildStatus'
   has_many :deploys
   has_many :releases
 
@@ -11,6 +11,6 @@ class Build < ActiveRecord::Base
   validates :container_sha, format: SHA1_REGEX, allow_nil: true
 
   def successful?
-    statuses.successful.all?
+    statuses.all?(&:successful?)
   end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -1,0 +1,11 @@
+class Build < ActiveRecord::Base
+  SHA1_REGEX = /\A[0-9a-f]{40}/i
+
+  belongs_to :project
+  has_many :deploys
+  has_many :releases
+
+  validates :project, presence: true
+  validates :git_sha, format: SHA1_REGEX, allow_nil: true
+  validates :container_sha, format: SHA1_REGEX, allow_nil: true
+end

--- a/app/models/build_status.rb
+++ b/app/models/build_status.rb
@@ -1,0 +1,22 @@
+class BuildStatus < ActiveRecord::Base
+  SUCCESSFUL = 'successful'.freeze
+  PENDING    = 'pending'.freeze
+  FAILED     = 'failed'.freeze
+
+  VALID_STATUSES = [SUCCESSFUL, PENDING, FAILED]
+
+  belongs_to :build
+
+  validates :build, presence: true
+  validates :status, presence: true, inclusion: VALID_STATUSES
+
+  VALID_STATUSES.each do |s|
+    define_singleton_method s do
+      where(status: s)
+    end
+
+    define_method "#{s}?" do
+      self.status == s
+    end
+  end
+end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -2,6 +2,7 @@ class Deploy < ActiveRecord::Base
   has_soft_deletion default_scope: true
 
   belongs_to :stage, touch: true
+  belongs_to :build
   belongs_to :job
   belongs_to :buddy, class_name: 'User'
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,6 +10,7 @@ class Project < ActiveRecord::Base
   before_update :clean_old_repository, if: :repository_url_changed?
   after_soft_delete :clean_repository
 
+  has_many :builds
   has_many :releases
   has_many :stages, dependent: :destroy
   has_many :deploys, through: :stages

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,6 +1,7 @@
 class Release < ActiveRecord::Base
   belongs_to :project, touch: true
   belongs_to :author, polymorphic: true
+  belongs_to :build
 
   before_create :assign_release_number
 

--- a/db/migrate/20150508140514_create_build_artifact.rb
+++ b/db/migrate/20150508140514_create_build_artifact.rb
@@ -2,11 +2,13 @@ class CreateBuildArtifact < ActiveRecord::Migration
   def change
     create_table :builds do |t|
       t.belongs_to :project,    null: false, index: true
-      t.string :git_sha,        index: true
+      t.string :git_sha
       t.string :git_ref
       t.string :container_sha,  index: true
       t.string :container_ref
       t.timestamps
+
+      t.index :git_sha, unique: true
     end
   end
 end

--- a/db/migrate/20150508140514_create_build_artifact.rb
+++ b/db/migrate/20150508140514_create_build_artifact.rb
@@ -1,0 +1,12 @@
+class CreateBuildArtifact < ActiveRecord::Migration
+  def change
+    create_table :builds do |t|
+      t.belongs_to :project,    null: false, index: true
+      t.string :git_sha,        index: true
+      t.string :git_ref
+      t.string :container_sha,  index: true
+      t.string :container_ref
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150508142111_add_build_artifact_references.rb
+++ b/db/migrate/20150508142111_add_build_artifact_references.rb
@@ -1,0 +1,11 @@
+class AddBuildArtifactReferences < ActiveRecord::Migration
+  def change
+    change_table :deploys do |t|
+      t.belongs_to :build, index: true
+    end
+
+    change_table :releases do |t|
+      t.belongs_to :build, index: true
+    end
+  end
+end

--- a/db/migrate/20150520210103_create_build_statuses.rb
+++ b/db/migrate/20150520210103_create_build_statuses.rb
@@ -2,7 +2,7 @@ class CreateBuildStatuses < ActiveRecord::Migration
   def change
     create_table :build_statuses do |t|
       t.belongs_to :build,    null: false, index: true
-      t.string :type
+      t.string :source
       t.string :status,       null: false, default: 'pending'
       t.string :url
       t.string :summary,      limit: 512

--- a/db/migrate/20150520210103_create_build_statuses.rb
+++ b/db/migrate/20150520210103_create_build_statuses.rb
@@ -1,0 +1,13 @@
+class CreateBuildStatuses < ActiveRecord::Migration
+  def change
+    create_table :build_statuses do |t|
+      t.belongs_to :build,    null: false, index: true
+      t.string :type
+      t.string :status,       null: false, default: 'pending'
+      t.string :url
+      t.string :summary,      limit: 512
+      t.text :data
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,6 +27,19 @@ ActiveRecord::Schema.define(version: 20150520210103) do
   add_index "builds", ["git_sha"], name: "index_builds_on_git_sha", using: :btree
   add_index "builds", ["project_id"], name: "index_builds_on_project_id", using: :btree
 
+  create_table "build_statuses", force: :cascade do |t|
+    t.integer  "build_id",   null: false
+    t.string   "type",
+    t.string   "status",     null: false, default: "pending"
+    t.string   "url"
+    t.string   "summary",    limit: 512
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "build_statuses", ["build_id"], name: "index_build_statuses_on_build_id", using: :btree
+
   create_table "commands", force: :cascade do |t|
     t.text     "command",    limit: 10485760
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,19 @@
 
 ActiveRecord::Schema.define(version: 20150520210103) do
 
+  create_table "build_statuses", force: :cascade do |t|
+    t.integer  "build_id",   null: false
+    t.string   "source"
+    t.string   "status",     null: false, default: "pending"
+    t.string   "url"
+    t.string   "summary",    limit: 512
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "build_statuses", ["build_id"], name: "index_build_statuses_on_build_id", using: :btree
+
   create_table "builds", force: :cascade do |t|
     t.integer "project_id",    null: false
     t.string  "git_sha"
@@ -24,21 +37,8 @@ ActiveRecord::Schema.define(version: 20150520210103) do
   end
 
   add_index "builds", ["container_sha"], name: "index_builds_on_container_sha", using: :btree
-  add_index "builds", ["git_sha"], name: "index_builds_on_git_sha", using: :btree
+  add_index "builds", ["git_sha"], name: "index_builds_on_git_sha", unique: true, using: :btree
   add_index "builds", ["project_id"], name: "index_builds_on_project_id", using: :btree
-
-  create_table "build_statuses", force: :cascade do |t|
-    t.integer  "build_id",   null: false
-    t.string   "type",
-    t.string   "status",     null: false, default: "pending"
-    t.string   "url"
-    t.string   "summary",    limit: 512
-    t.text     "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "build_statuses", ["build_id"], name: "index_build_statuses_on_build_id", using: :btree
 
   create_table "commands", force: :cascade do |t|
     t.text     "command",    limit: 10485760

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150519000042) do
+ActiveRecord::Schema.define(version: 20150520210103) do
+
+  create_table "builds", force: :cascade do |t|
+    t.integer "project_id",    null: false
+    t.string  "git_sha"
+    t.string  "git_ref"
+    t.string  "container_sha"
+    t.string  "container_ref"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "builds", ["container_sha"], name: "index_builds_on_container_sha", using: :btree
+  add_index "builds", ["git_sha"], name: "index_builds_on_git_sha", using: :btree
+  add_index "builds", ["project_id"], name: "index_builds_on_project_id", using: :btree
 
   create_table "commands", force: :cascade do |t|
     t.text     "command",    limit: 10485760
@@ -47,8 +61,10 @@ ActiveRecord::Schema.define(version: 20150519000042) do
     t.integer  "buddy_id"
     t.datetime "started_at"
     t.datetime "deleted_at"
+    t.integer  "build_id"
   end
 
+  add_index "deploys", ["build_id"], name: "index_deploys_on_build_id", using: :btree
   add_index "deploys", ["deleted_at"], name: "index_deploys_on_deleted_at"
   add_index "deploys", ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
   add_index "deploys", ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at"
@@ -166,8 +182,10 @@ ActiveRecord::Schema.define(version: 20150519000042) do
     t.string   "author_type",             null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "build_id"
   end
 
+  add_index "releases", ["build_id"], name: "index_releases_on_build_id", using: :btree
   add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
 
   create_table "slack_channels", force: :cascade do |t|

--- a/test/fixtures/builds.yml
+++ b/test/fixtures/builds.yml
@@ -1,0 +1,16 @@
+staging:
+  project: test
+  git_sha: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+  git_ref: 'staging'
+
+v1_tag:
+  project: test
+  git_sha: '0fbc33a0bfe9dcb5a17e26b9c319cce9d86ede14'
+  git_ref: 'v1.0'
+
+docker_build:
+  project: test
+  git_sha: '1a6f551a2ffa6d88e15eef5461384da0bfb1c194'
+  git_ref: 'v123'
+  container_sha: '7e46d621322a5601274228f1f7b0c03d216ba790'
+  container_ref: 'v123'

--- a/test/models/build_status_test.rb
+++ b/test/models/build_status_test.rb
@@ -1,0 +1,48 @@
+require_relative '../test_helper'
+
+describe BuildStatus do
+  let(:build) { builds(:docker_build) }
+
+  def valid_build_status options = {}
+    BuildStatus.new(options.reverse_merge(build: build, status: 'pending'))
+  end
+
+  describe 'validations' do
+    it 'should validate presence of build' do
+      assert_valid(valid_build_status)
+      refute_valid(valid_build_status(build: nil))
+    end
+
+    it 'should validate the status' do
+      BuildStatus::VALID_STATUSES.each do |s|
+        assert_valid(valid_build_status(status: s))
+      end
+      refute_valid(valid_build_status(status: nil))
+      refute_valid(valid_build_status(status: 'not a valid status'))
+      refute_valid(valid_build_status(status: 123))
+    end
+  end
+
+  describe 'status helpers' do
+    it 'should have inquriry methods defined' do
+      status = valid_build_status
+      BuildStatus::VALID_STATUSES.each do |s|
+        assert_respond_to(status, "#{s}?")
+      end
+    end
+
+    it 'should work for each status' do
+      assert valid_build_status(status: 'pending').pending?
+      refute valid_build_status(status: 'pending').successful?
+      refute valid_build_status(status: 'pending').failed?
+
+      refute valid_build_status(status: 'successful').pending?
+      assert valid_build_status(status: 'successful').successful?
+      refute valid_build_status(status: 'successful').failed?
+
+      refute valid_build_status(status: 'failed').pending?
+      refute valid_build_status(status: 'failed').successful?
+      assert valid_build_status(status: 'failed').failed?
+    end
+  end
+end

--- a/test/models/build_status_test.rb
+++ b/test/models/build_status_test.rb
@@ -8,12 +8,12 @@ describe BuildStatus do
   end
 
   describe 'validations' do
-    it 'should validate presence of build' do
+    it 'validates presence of build' do
       assert_valid(valid_build_status)
       refute_valid(valid_build_status(build: nil))
     end
 
-    it 'should validate the status' do
+    it 'validates the status' do
       BuildStatus::VALID_STATUSES.each do |s|
         assert_valid(valid_build_status(status: s))
       end
@@ -24,14 +24,14 @@ describe BuildStatus do
   end
 
   describe 'status helpers' do
-    it 'should have inquriry methods defined' do
+    it 'has inquriry methods defined' do
       status = valid_build_status
       BuildStatus::VALID_STATUSES.each do |s|
         assert_respond_to(status, "#{s}?")
       end
     end
 
-    it 'should work for each status' do
+    it 'works for each status' do
       assert valid_build_status(status: 'pending').pending?
       refute valid_build_status(status: 'pending').successful?
       refute valid_build_status(status: 'pending').failed?

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -16,4 +16,26 @@ describe Build do
       refute_valid(Build.new(project: project, container_sha: 'abc'))
     end
   end
+
+  describe 'successful?' do
+    let(:build) { builds(:staging) }
+
+    it 'returns true when all successful' do
+      build.statuses.create!(source: 'Jenkins', status: BuildStatus::SUCCESSFUL)
+      build.statuses.create!(source: 'Travis',  status: BuildStatus::SUCCESSFUL)
+      assert build.successful?
+    end
+
+    it 'returns false when there is a failure' do
+      build.statuses.create!(source: 'Jenkins', status: BuildStatus::SUCCESSFUL)
+      build.statuses.create!(source: 'Travis',  status: BuildStatus::FAILED)
+      refute build.successful?
+    end
+
+    it 'returns false when there is a pending status' do
+      build.statuses.create!(source: 'Jenkins', status: BuildStatus::SUCCESSFUL)
+      build.statuses.create!(source: 'Travis',  status: BuildStatus::PENDING)
+      refute build.successful?
+    end
+  end
 end

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -1,0 +1,19 @@
+require_relative '../test_helper'
+
+describe Build do
+  let(:project) { projects(:test) }
+
+  describe 'validations' do
+    it 'should validate git sha' do
+      assert_valid(Build.new(project: project, git_sha: '0fbc33a0bfe9dcb5a17e26b9c319cce9d86ede14'))
+      refute_valid(Build.new(project: project, git_sha: 'This is a string of 40 characters.......'))
+      refute_valid(Build.new(project: project, git_sha: 'abc'))
+    end
+
+    it 'should validate container sha' do
+      assert_valid(Build.new(project: project, container_sha: '0fbc33a0bfe9dcb5a17e26b9c319cce9d86ede14'))
+      refute_valid(Build.new(project: project, container_sha: 'This is a string of 40 characters.......'))
+      refute_valid(Build.new(project: project, container_sha: 'abc'))
+    end
+  end
+end


### PR DESCRIPTION
The Build models will be used to associate Docker builds with a given Github SHA.
The BuildStatus class will be used when running tests or analysis on that build, such as Code Climate, Travis, Jenkins, and possibly Canary runs.

/cc @zendesk/runway 

### Risks
 - new code, minimal risk