### PR TITLE
Fix to load plugin from Gem

### DIFF
--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -18,7 +18,7 @@ module Samson
       def initialize(path)
         @path = path
         @folder = File.expand_path('../../../', @path)
-        @name = File.basename(@folder)
+        @name = realname(File.basename(@folder))
       end
 
       def active?
@@ -52,6 +52,10 @@ module Samson
       end
 
       private
+
+      def realname(gemname)
+        gemname.sub(/-[^-]*\z/, '').sub(/\Asamson_/, "")
+      end
 
       def decorators_root
         @decorators_root ||= engine.config.root.join("app/decorators")

--- a/test/lib/samson/hooks_test.rb
+++ b/test/lib/samson/hooks_test.rb
@@ -46,6 +46,26 @@ describe Samson::Hooks do
         end
       end
     end
+
+    context 'when load via local plugin' do
+      let(:env) { 'other' }
+      let(:plugins) { 'all' }
+      let (:path) { '/path/to/samson/plugins/zendesk/lib/samson_zendesk/samson_plugin.rb' }
+
+      it 'return correct plugin name from folder' do
+        Samson::Hooks::Plugin.new(path).name.must_equal 'zendesk'
+      end
+    end
+
+    context 'when load via gem plugin' do
+      let(:env) { 'other' }
+      let(:plugins) { 'all' }
+      let (:path) { '/path/to/gems/ruby-2.2.2/gems/samson_hipchat-0.0.0/lib/samson_hipchat/samson_plugin.rb' }
+
+      it 'return correct plugin name from Gem' do
+        Samson::Hooks::Plugin.new(path).name.must_equal 'hipchat'
+      end
+    end
   end
 end
 


### PR DESCRIPTION
For issue #417 .

The way we currently calculate plugin name is based on directory name.

This leads to two issues:

1. The path include version
    
    Such as ```/Users/kureikain/.rvm/gems/ruby-2.2.2/gems/samson_hipchat-0.0.2```
    So the line `@engine ||= Kernel.const_get("::Samson#{@name.camelize}::Engine")` will have @name like `samson_hipchat-0.0.2`.

2. The classname is correct because the germane may different from classname. 

    Example, we hava gem samson_hipchat in
    Such as /Users/kureikain/.rvm/gems/ruby-2.2.2/gems/samson_hipchat-0.0.2

    The real class is `SamsonHipchat` but it became `SamsonSamsonHipchat`. 

So, I think we should have a convention for Samson plugin Gem starting with `samson_`. This PR implements that and fixs version issue.
