### PR TITLE
A simplistic approach to pipelines.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,11 @@ PATH
       jenkins_api_client (~> 1.3)
 
 PATH
+  remote: plugins/pipelines/
+  specs:
+    samson_pipelines (0.0.0)
+
+PATH
   remote: plugins/slack/
   specs:
     samson_slack (0.0.0)
@@ -415,6 +420,7 @@ DEPENDENCIES
   samson_env!
   samson_flowdock!
   samson_jenkins!
+  samson_pipelines!
   samson_slack!
   samson_zendesk!
   sass-rails (~> 5.0)

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -120,7 +120,8 @@ class JobExecution
     ActiveSupport::Notifications.instrument("execute_shell.samson", payload) do
       payload[:success] = @executor.execute!(*cmds)
     end
-    Samson::Hooks.fire(:before_execute_finish_msg, @job, @output)
+    Samson::Hooks.fire(:after_job_execution, @job, payload[:success], @output)
+    payload[:success]
   end
 
   def setup!(dir)

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -120,6 +120,7 @@ class JobExecution
     ActiveSupport::Notifications.instrument("execute_shell.samson", payload) do
       payload[:success] = @executor.execute!(*cmds)
     end
+    Samson::Hooks.fire(:before_execute_finish_msg, @job, @output)
   end
 
   def setup!(dir)

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,6 +1,8 @@
 class Stage < ActiveRecord::Base
   include Permalinkable
 
+  puts "**** Stage Class is being eval'd"
+
   has_soft_deletion default_scope: true
 
   belongs_to :project, touch: true

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,8 +1,6 @@
 class Stage < ActiveRecord::Base
   include Permalinkable
 
-  puts "**** Stage Class is being eval'd"
-
   has_soft_deletion default_scope: true
 
   belongs_to :project, touch: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -273,6 +273,7 @@ ActiveRecord::Schema.define(version: 20150619170905) do
     t.string   "static_emails_on_automated_deploy_failure",    limit: 255
     t.string   "datadog_monitor_ids",                          limit: 255
     t.string   "jenkins_job_names",                            limit: 255
+    t.string   "next_stage_ids"
   end
 
   add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", length: {"project_id"=>nil, "permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -22,6 +22,7 @@ module Samson
       :after_deploy_setup,
       :after_deploy,
       :after_docker_build,
+      :before_execute_finish_msg
     ].freeze
 
     INTERNAL_HOOKS = [ :class_defined ]

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -22,7 +22,7 @@ module Samson
       :after_deploy_setup,
       :after_deploy,
       :after_docker_build,
-      :before_execute_finish_msg
+      :after_job_execution
     ].freeze
 
     INTERNAL_HOOKS = [ :class_defined ]

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -1,21 +1,6 @@
-module Stage::PipelineProductionEnhancer
-  # Return true if any stages in the pipeline are marked production
-  def production?(check_next: true)
-    super || (
-      check_next &&
-        next_stage_ids.any? &&
-        Stage.find(job.deploy.stage.next_stage_ids).any? { |s| s.production?(check_next: false) }
-    )
-  end
-end
-
 Stage.class_eval do
-  prepend Stage::PipelineProductionEnhancer
+  prepend SamsonPipelines::StageConcern
   serialize :next_stage_ids, Array
 
-  def next_stage
-    return Stage.find(next_stage_ids.first) unless next_stage_ids.empty?
-    stages = project.stages.to_a
-    stages[stages.index(self) + 1]
-  end
+  validate :valid_pipeline?
 end

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -1,0 +1,17 @@
+Stage.class_eval do
+  serialize :next_stage_ids, Array
+
+  puts "**** Stage Class Decorator is being eval'd"
+  def next_stage
+    return Stage.find(next_stage_ids.first) unless next_stage_ids.empty?
+    stages = project.stages.to_a
+    stages[stages.index(self) + 1]
+  end
+
+  # alias_method :old_production?, :production? if defined?(:production?)
+  # Return true if any stages in the pipeline are marked production
+  def production?
+    return old_production? if next_stage_ids.empty?
+    old_production? || Stage.find(job.deploy.stage.next_stage_ids).any?(:old_production?)
+  end
+end

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -8,7 +8,7 @@ Stage.class_eval do
     stages[stages.index(self) + 1]
   end
 
-  # alias_method :old_production?, :production? if defined?(:production?)
+  alias_method :old_production?, :production?
   # Return true if any stages in the pipeline are marked production
   def production?
     return old_production? if next_stage_ids.empty?

--- a/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
+++ b/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
@@ -1,0 +1,36 @@
+module SamsonPipelines::StageConcern
+  # Return true if any stages in the pipeline are marked production
+  def production?
+    super || next_stages.any?(&:production?)
+  end
+
+  def next_stage
+    next_stage_ids.empty? ? super : Stage.find(next_stage_ids.first)
+  end
+
+  def next_stages
+    Stage.find(next_stage_ids)
+  end
+
+  protected
+
+  # Ensure we don't have a circular pipeline:
+  #
+  # potential race-condition if 2 stages are saved at same time:
+  #   stageA saved with pipelines to stageB and stageC
+  #   stageC saved with pipeline to stageA   => will validate if stageA above hasn't been written to DB yet
+  def valid_pipeline?(origin_id = id)
+    if next_stage_ids.any? { |next_id| next_id.to_i == origin_id.to_i }
+      errors[:base] << "Stage #{name} causes a circular pipeline with this stage"
+      return false
+    end
+
+    next_stages.each do |stage|
+      unless stage.valid_pipeline?(origin_id)
+        errors[:base] << "Stage #{stage.name} causes a circular pipeline with this stage"
+        return false
+      end
+    end
+    true
+  end
+end

--- a/plugins/pipelines/app/views/samson_pipelines/_fields.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_fields.html.erb
@@ -1,0 +1,23 @@
+<fieldset>
+  <legend>Pipelining</legend>
+  <p class="col-lg-offset-2">Set the stage that will get automatically deployed after this one.</p>
+  <div class="col-lg-4 col-lg-offset-2">
+    <table>
+      <% (@project.stages - [@stage]).each do |next_stage| %>
+        <tr>
+          <td>
+            <%= label_tag do %>
+              <%= check_box_tag(
+                    'stage[next_stage_ids][]',
+                    next_stage.id,
+                    (@stage && @stage.next_stage_ids.include?(next_stage.id.to_s))
+                  )
+              %>
+              <%= next_stage.name %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</fieldset>

--- a/plugins/pipelines/app/views/samson_pipelines/_fields.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_fields.html.erb
@@ -1,6 +1,6 @@
 <fieldset>
   <legend>Pipelining</legend>
-  <p class="col-lg-offset-2">Set the stage that will get automatically deployed after this one.</p>
+  <p class="col-lg-offset-2">Set the stages that will get automatically deployed after this one.</p>
   <div class="col-lg-4 col-lg-offset-2">
     <table>
       <% (@project.stages - [@stage]).each do |next_stage| %>

--- a/plugins/pipelines/db/migrate/20150602113621_add_next_stage_to_stages.rb
+++ b/plugins/pipelines/db/migrate/20150602113621_add_next_stage_to_stages.rb
@@ -1,0 +1,7 @@
+class AddNextStageToStages < ActiveRecord::Migration
+  def change
+    change_table :stages do |t|
+      t.string :next_stage_ids
+    end
+  end
+end

--- a/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
+++ b/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
@@ -1,0 +1,27 @@
+module SamsonPipelines
+  class Engine < Rails::Engine
+  end
+
+  class << self
+    def start_pipelined_stages(job, output)
+      return if !job.deploy || job.deploy.stage.next_stage_ids.empty?
+
+      Stage.find(job.deploy.stage.next_stage_ids).each do |next_stage|
+        new_deploy = DeployService.new(job.deploy.user).deploy!(next_stage, reference: job.deploy.commit)
+        output.write("\n# Kicking off next stage: #{next_stage.name} - URL: #{new_deploy.url}\n")
+      end
+    rescue => ex
+      raise "Failed to start the next deploys in the pipeline: #{ex.message} - #{ex.backtrace}"
+    end
+  end
+end
+
+Samson::Hooks.view :stage_form, 'samson_pipelines/fields'
+
+Samson::Hooks.callback :stage_permitted_params do
+  { next_stage_ids: [] }
+end
+
+Samson::Hooks.callback :before_execute_finish_msg do |job, output|
+  SamsonPipelines.start_pipelined_stages(job, output)
+end

--- a/plugins/pipelines/samson_pipelines.gemspec
+++ b/plugins/pipelines/samson_pipelines.gemspec
@@ -1,0 +1,6 @@
+Gem::Specification.new 'samson_pipelines', '0.0.0' do |s|
+  s.summary = 'Samson Pipelines plugin'
+  s.authors = ['Shane Hender']
+  s.email = ['shender@zendesk.com']
+  s.files = Dir['{app,config,db,lib}/**/*']
+end

--- a/plugins/pipelines/test/lib/hooks_test.rb
+++ b/plugins/pipelines/test/lib/hooks_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_helper'
+
+describe 'zendesk hooks' do
+  let(:deploy) { deploys(:succeeded_test) }
+  let(:stage) { deploy.stage }
+  let(:next_stages) { [ stages(:test_production), stages(:test_production_pod) ] }
+  let(:fake_deploy) { Hashie::Mash.new(url: 'abc') }
+
+  describe :after_deploy do
+    it 'kicks off the next stages in the deploy' do
+      stage.update!(next_stage_ids: next_stages.map(&:id))
+      DeployService.any_instance.expects(:deploy!).returns(fake_deploy).twice
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
+    end
+
+    it 'does not deploy another if the next_stage_id is nil' do
+      DeployService.any_instance.expects(:new).never
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
+    end
+  end
+end

--- a/plugins/pipelines/test/lib/hooks_test.rb
+++ b/plugins/pipelines/test/lib/hooks_test.rb
@@ -2,20 +2,41 @@ require_relative '../test_helper'
 
 describe 'zendesk hooks' do
   let(:deploy) { deploys(:succeeded_test) }
+  let(:next_deploy) { deploys(:succeeded_production_test) }
   let(:stage) { deploy.stage }
   let(:next_stages) { [ stages(:test_production), stages(:test_production_pod) ] }
-  let(:fake_deploy) { Hashie::Mash.new(url: 'abc') }
+  let(:output) { StringIO.new }
+  let(:job) do
+    Job.create(
+      project: stage.project,
+      command: "echo hello world",
+      status: "running",
+      user: User.first,
+      deploy: deploy)
+  end
 
-  describe :after_deploy do
+  describe :after_job_execution do
     it 'kicks off the next stages in the deploy' do
       stage.update!(next_stage_ids: next_stages.map(&:id))
-      DeployService.any_instance.expects(:deploy!).returns(fake_deploy).twice
-      Samson::Hooks.fire(:after_deploy, deploy, nil)
+      DeployService.any_instance.expects(:deploy!).returns(next_deploy).twice
+      Samson::Hooks.fire(:after_job_execution, job, true, output)
+    end
+
+    it 'does not kick off the next stage in the pipeline if current stage failed' do
+      stage.update!(next_stage_ids: next_stages.map(&:id))
+      DeployService.any_instance.expects(:deploy!).never
+      Samson::Hooks.fire(:after_job_execution, job, false, output)
     end
 
     it 'does not deploy another if the next_stage_id is nil' do
-      DeployService.any_instance.expects(:new).never
-      Samson::Hooks.fire(:after_deploy, deploy, nil)
+      DeployService.any_instance.expects(:deploy!).never
+      Samson::Hooks.fire(:after_job_execution, job, true, output)
+    end
+
+    it 'does not deploy another if the deploy is nil' do
+      job = Job.create(project: stage.project, command: "echo", status: "running", user: User.first)
+      DeployService.any_instance.expects(:deploy!).never
+      Samson::Hooks.fire(:after_job_execution, job, true, output)
     end
   end
 end

--- a/plugins/pipelines/test/models/stage_test.rb
+++ b/plugins/pipelines/test/models/stage_test.rb
@@ -1,0 +1,23 @@
+require_relative '../test_helper'
+
+describe Stage do
+  describe '#next_stage' do
+    let(:project) { Project.new(name: 'foo') }
+    let(:stage1) { Stage.new(project: project, name: 'stage1') }
+    let(:stage2) { Stage.new(project: project, name: 'stage2') }
+    let(:stage3) { Stage.new(project: project, name: 'stage3') }
+
+    before do
+      project.stages = [stage1, stage2, stage3]
+    end
+
+    it 'should return next created stage if no pipeline set' do
+      stage2.next_stage.id.must_equal stage3.id
+    end
+
+    it 'should return next stage in pipeline if set' do
+      stage2.next_stage_ids = [ stage1.id, stage3.id ]
+      stage2.next_stage.id.must_equal stage1.id
+    end
+  end
+end

--- a/plugins/pipelines/test/models/stage_test.rb
+++ b/plugins/pipelines/test/models/stage_test.rb
@@ -1,23 +1,87 @@
 require_relative '../test_helper'
 
 describe Stage do
+  let(:project) { Project.create!(name: 'foo', repository_url: 'random') }
+  let(:stage1) { Stage.create!(project: project, name: 'stage1') }
+  let(:stage2) { Stage.create!(project: project, name: 'stage2') }
+  let(:stage3) { Stage.create!(project: project, name: 'stage3') }
+  let(:production) { deploy_groups(:pod1) }
+  let(:staging) { deploy_groups(:pod100) }
+
+  before do
+    Project.any_instance.stubs(:valid_repository_url).returns(true)
+    project.stages = [stage1, stage2, stage3]
+  end
+
   describe '#next_stage' do
-    let(:project) { Project.new(name: 'foo') }
-    let(:stage1) { Stage.new(project: project, name: 'stage1') }
-    let(:stage2) { Stage.new(project: project, name: 'stage2') }
-    let(:stage3) { Stage.new(project: project, name: 'stage3') }
-
-    before do
-      project.stages = [stage1, stage2, stage3]
-    end
-
-    it 'should return next created stage if no pipeline set' do
+    it 'returns next created stage if no pipeline set' do
       stage2.next_stage.id.must_equal stage3.id
     end
 
-    it 'should return next stage in pipeline if set' do
-      stage2.next_stage_ids = [ stage1.id, stage3.id ]
+    it 'returns next stage in pipeline if set' do
+      stage2.update!(next_stage_ids: [ stage1.id, stage3.id ])
       stage2.next_stage.id.must_equal stage1.id
+    end
+  end
+
+  describe '#production?' do
+    it 'returns false if no pipeline set and not marked production' do
+      stage1.deploy_groups = [ staging ]
+      stage1.production?.must_equal false
+    end
+
+    it 'returns true if no pipeline set and marked production' do
+      stage1.update(production: true)
+      stage1.production?.must_equal true
+    end
+
+    it 'returns false if pipeline set but none are marked as production' do
+      stage1.update!(next_stage_ids: [ stage3.id, stage2.id ])
+      stage1.production?.must_equal false
+    end
+
+    it 'returns true if pipeline set and self is marked production' do
+      stage1.update(production: true)
+      stage1.update!(next_stage_ids: [ stage3.id, stage2.id ])
+      stage1.production?.must_equal true
+    end
+
+    it 'returns true if pipeline set and later stage is marked production' do
+      stage2.update(production: true)
+      stage1.update!(next_stage_ids: [ stage3.id, stage2.id ])
+      stage1.production?.must_equal true
+    end
+  end
+
+  describe '#valid_pipeline?' do
+    it 'validates an empty pipeline' do
+      stage1.valid?.must_equal true
+    end
+
+    it 'validates a valid pipeline' do
+      stage1.update!(next_stage_ids: [ stage3.id, stage2.id ])
+      stage1.valid?.must_equal true
+    end
+
+    it 'invalidates a pipeline with itself in it' do
+      stage1.update(next_stage_ids: [ stage1.id ])
+      stage1.valid?.must_equal false
+      stage1.errors.messages.must_equal base: ["Stage stage1 causes a circular pipeline with this stage"]
+    end
+
+    it 'invalidates a circular pipeline' do
+      stage3.update!(next_stage_ids: [ stage1.id ])
+      stage1.update(next_stage_ids: [ stage3.id ])
+      stage1.valid?.must_equal false
+      stage1.errors.messages.must_equal base: ["Stage stage3 causes a circular pipeline with this stage"]
+    end
+
+    it 'invalidates a bigger circular pipeline' do
+      stage3.update!(next_stage_ids: [ stage1.id ])
+      stage2.update!(next_stage_ids: [ stage3.id ])
+      stage1.update(next_stage_ids: [ stage2.id ])
+      stage1.valid?.must_equal false
+      stage1.errors.messages.must_equal base: ["Stage stage2 causes a circular pipeline with this stage"]
     end
   end
 end

--- a/plugins/pipelines/test/test_helper.rb
+++ b/plugins/pipelines/test/test_helper.rb
@@ -1,0 +1,1 @@
+require_relative '../../../test/test_helper'

--- a/test/lib/samson/hooks_test.rb
+++ b/test/lib/samson/hooks_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../test_helper'
 
 describe Samson::Hooks do
-  let(:number_of_plugins) { 4 }
+  let(:number_of_plugins) { 5 }
   let(:plugins) { 'nope' }
 
   describe '.plugins' do

--- a/test/lib/samson/hooks_test.rb
+++ b/test/lib/samson/hooks_test.rb
@@ -1,7 +1,7 @@
 require_relative '../../test_helper'
 
 describe Samson::Hooks do
-  let(:number_of_plugins) { 5 }
+  let(:number_of_plugins) { Dir['plugins/*'].size }
   let(:plugins) { 'nope' }
 
   describe '.plugins' do
@@ -17,7 +17,7 @@ describe Samson::Hooks do
       let(:env) { 'test' }
 
       it 'returns all the plugins regardless of the PLUGINS env variable' do
-        Samson::Hooks.plugins.size.must_be :>, number_of_plugins
+        Samson::Hooks.plugins.size.must_equal number_of_plugins
       end
     end
 
@@ -34,7 +34,7 @@ describe Samson::Hooks do
         let(:plugins) { 'all' }
 
         it 'returns all the plugins' do
-          Samson::Hooks.plugins.size.must_be :>, number_of_plugins
+          Samson::Hooks.plugins.size.must_equal number_of_plugins
         end
       end
 


### PR DESCRIPTION
Add functionality to allow user to specify other stages to automatically deploy when a deploy finishes.
These deploys are kicked off in parallel.

This is the stage-edit Screenshot:
![screen shot 2015-06-02 at 12 58 31](https://cloud.githubusercontent.com/assets/515143/7936360/3dd17592-0930-11e5-93d8-7ad9e0f17041.png)


And we append the deploy links to the Deploy output:
![screen shot 2015-06-02 at 13 04 57](https://cloud.githubusercontent.com/assets/515143/7936372/5753215a-0930-11e5-868a-3bac6e80e1b4.png)


/cc @zendesk/runway @zendesk/samson 

### References
 - Jira link:

### Risks
 - None