### PR TITLE
reduce size of indexed strings so indices created on MySQL [DBA-3014]

### DIFF
--- a/db/migrate/20150508140514_create_builds.rb
+++ b/db/migrate/20150508140514_create_builds.rb
@@ -1,10 +1,10 @@
-class CreateBuildArtifact < ActiveRecord::Migration
+class CreateBuilds < ActiveRecord::Migration
   def change
     create_table :builds do |t|
       t.belongs_to :project,    null: false, index: true
-      t.string :git_sha
+      t.string :git_sha,        limit: 128
       t.string :git_ref
-      t.string :container_sha,  index: true
+      t.string :container_sha,  limit: 128, index: true
       t.string :container_ref
       t.timestamps
 

--- a/db/migrate/20150508142111_add_build_references.rb
+++ b/db/migrate/20150508142111_add_build_references.rb
@@ -1,4 +1,4 @@
-class AddBuildArtifactReferences < ActiveRecord::Migration
+class AddBuildReferences < ActiveRecord::Migration
   def change
     change_table :deploys do |t|
       t.belongs_to :build, index: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,9 +28,9 @@ ActiveRecord::Schema.define(version: 20150530010900) do
 
   create_table "builds", force: :cascade do |t|
     t.integer "project_id",    null: false
-    t.string  "git_sha"
+    t.string  "git_sha",       limit: 128
     t.string  "git_ref"
-    t.string  "container_sha"
+    t.string  "container_sha", limit: 128
     t.string  "container_ref"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false


### PR DESCRIPTION
see https://github.com/rails/rails/issues/9855

Yes, I know it's bad form to change migrations that have already been merged. But deploys to staging are failing on these migrations, so the best option is to fix it.

/cc @zendesk/runway 

### References
 - Jira link: https://zendesk.atlassian.net/browse/DBA-3014

### Risks
 - None