### PR TITLE
Don't append to FETCH_HEAD when fetching

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -26,7 +26,7 @@ class GitRepository
   end
 
   def update!(executor: TerminalExecutor.new(StringIO.new))
-    executor.execute!("cd #{repo_cache_dir}", 'git fetch -ap')
+    executor.execute!("cd #{repo_cache_dir}", 'git fetch -p')
   end
 
   def commit_from_ref(git_reference)


### PR DESCRIPTION
The -a flag will make the FETCH_HEAD file grow forever
for no reason.

/cc @steved @grosser