### PR TITLE
add row duplicator for environment variables

### DIFF
--- a/plugins/env/app/assets/javascripts/env/application.js
+++ b/plugins/env/app/assets/javascripts/env/application.js
@@ -1,0 +1,9 @@
+$(function(){
+  $(".duplicate_previous_row").click(function(e){
+    e.preventDefault();
+    var $row = $(this).prev();
+    var $new_row = $row.clone();
+    $new_row.find('input').val('');
+    $row.after($new_row);
+  });
+});

--- a/plugins/env/app/views/samson_env/_environment_variables.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables.html.erb
@@ -1,5 +1,5 @@
 <% deploy_groups = [["All", nil]] + DeployGroup.all.map{ |dg| [dg.name, dg.id] } %>
-<% [deploy_groups.size, 2].max.times { form.object.environment_variables.build } %>
+<% form.object.environment_variables.build %>
 <%= form.fields_for :environment_variables do |fields| %>
   <div class="form-group">
     <div class="col-lg-2">
@@ -24,3 +24,4 @@
     <% end %>
   </div>
 <% end %>
+<%= link_to "Add row", "#", class: "duplicate_previous_row" %>

--- a/plugins/env/app/views/samson_env/_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_fields.html.erb
@@ -4,7 +4,7 @@
 
   <h4>Groups</h4>
   <% stage = form.object %>
-  <% ids = stage.environment_variable_group_ids + [nil, nil] %>
+  <% ids = stage.environment_variable_group_ids + [nil] %>
   <% environment_variable_groups = EnvironmentVariableGroup.all.map { |g| [g.name, g.id] } %>
   <% if environment_variable_groups.any? %>
     <% ids.each do |id| %>
@@ -15,5 +15,6 @@
       </div>
     <% end %>
   <% end %>
+  <%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
   <%= link_to "Group overview", [:admin, EnvironmentVariableGroup] %>
 </fieldset>


### PR DESCRIPTION
staging looks silly with all these extra rows ... now uses less space and offers more functionality ...

@zendesk/runway 

![screen shot 2015-06-01 at 11 28 12 am](https://cloud.githubusercontent.com/assets/11367/7920070/5505c27a-0851-11e5-84fe-d27696092819.png)


### Risks
 - None