### PR TITLE
fix Project#github_repo so it can handle repos that don't end with ".git"

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -62,7 +62,7 @@ class Project < ActiveRecord::Base
   def github_repo
     # GitHub allows underscores, hyphens and dots in repo names
     # but only hyphens in user/organisation names (as well as alphanumeric).
-    repository_url.scan(/[:\/]([A-Za-z0-9-]+\/[\w.-]+)\.git$/).join
+    repository_url.scan(/[:\/]([A-Za-z0-9-]+\/[\w.-]+?)(?:\.git)?$/).join
   end
 
   def repository_directory

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -56,7 +56,7 @@ describe Project do
     end
   end
 
-  describe "#github_project" do
+  describe "#github_repo" do
     it "returns the user/repo part of the repository URL" do
       project = Project.new(repository_url: "git@github.com:foo/bar.git")
       project.github_repo.must_equal "foo/bar"
@@ -77,6 +77,11 @@ describe Project do
 
     it "handles https urls" do
       project = Project.new(repository_url: "https://github.com/foo/bar.git")
+      project.github_repo.must_equal "foo/bar"
+    end
+
+    it "works if '.git' is not at the end" do
+      project = Project.new(repository_url: "https://github.com/foo/bar")
       project.github_repo.must_equal "foo/bar"
     end
   end


### PR DESCRIPTION
This logic error was causing 500 errors on the staging page if the project's repo didn't end with ".git"

/cc @zendesk/runway 

### References
 - Airbrake: https://zendesk.airbrake.io/projects/95346/groups/1433509502896252640

### Risks
 - None