### PR TITLE
Fixing typeahead display problems

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -66,6 +66,7 @@ $(function () {
     engine.initialize();
 
     $reference.typeahead(null, {
+      display: 'value',
       source: engine.ttAdapter()
     });
   }

--- a/app/assets/stylesheets/typeahead.scss
+++ b/app/assets/stylesheets/typeahead.scss
@@ -1,29 +1,25 @@
 span.twitter-typeahead {
   width: 100%;
 
-  .tt-dropdown-menu {
+  .tt-menu {
     @extend .dropdown-menu;
     width: 100%;
   }
 
   .tt-suggestion {
+    padding: 8px 15px;
+    line-height: $line-height-base;
+    color: $dropdown-link-color;
+
     &.tt-cursor {
       background-color: $dropdown-link-hover-bg;
-    }
-
-    > p {
-      padding: 8px 15px;
-      line-height: $line-height-base;
-      color: $dropdown-link-color;
     }
   }
 }
 
 #scrollable-dropdown-menu {
-
   .tt-dropdown-menu {
     max-height: 180px;
     overflow-y: auto;
   }
-
 }


### PR DESCRIPTION
Samson is incorrectly displaying the auto complete suggestions in the deploys page.
![bad_autocomplete](https://cloud.githubusercontent.com/assets/647255/7933531/991ef596-0917-11e5-904b-c6dc206dee2e.png)

This is caused by the version of the typeahead that we are now using. Since we updated to the rails assets gem we started using the latest version of the typeahead plugin. This version removes the attribute ```value``` as the default key that will be used and changes the plugin generated html.

I've just set the correct key and fixed the styles.

![fixed_autocomplete](https://cloud.githubusercontent.com/assets/647255/7933592/255ea812-0918-11e5-9257-3a77d2d18a20.png)

/cc @zendesk/samson @pswadi-zendesk 

### References
 - Jira link: [RUN-134](https://zendesk.atlassian.net/browse/RUN-134)

### Risks
 - None