### PR TITLE
[WIP] native support for Samson building Docker Images [RUN-122]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'sse-rails-engine'
 gem 'lograge'
 gem 'logstash-event'
 
+# Docker
+gem 'docker-api'
+
 group :production, :staging do
   gem 'rails_12factor'
   gem 'airbrake', '~> 4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,9 @@ GEM
     dalli (2.7.4)
     debug_inspector (0.0.2)
     docile (1.1.5)
+    docker-api (1.21.4)
+      excon (>= 0.38.0)
+      json
     dogapi (1.17.0)
       multi_json
     dogstatsd-ruby (1.4.1)
@@ -116,6 +119,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.7)
     eventmachine (1.0.7-java)
+    excon (0.45.3)
     execjs (2.5.2)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
@@ -356,6 +360,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   coderay (~> 1.1.0)
   dalli (~> 2.7.0)
+  docker-api
   dogapi (~> 1.9)
   dogstatsd-ruby (~> 1.4.0)
   dotenv-rails (~> 0.9)

--- a/app/models/docker_builder.rb
+++ b/app/models/docker_builder.rb
@@ -1,0 +1,43 @@
+
+class DockerImageBuilder
+  attr_reader :build
+
+  def initialize(build)
+    @build = build
+  end
+
+  def build!(image_name: nil, push: true)
+    image = build_image
+
+    build.container_sha = image.id
+    build.container_ref = image_name || build.git_ref || 'master'
+    build.save!
+
+    image.tag(tag: build.container_ref)
+
+    # TODO: figure out how to authenticate with the Docker registry
+    image.push if push
+
+    image
+  end
+
+  private
+
+  def build_image
+    Dir.mktmpdir do |tmp_dir|
+      repository.setup!(TerminalExecutor.new(output, verbose: true), tmp_dir, build.git_sha)
+
+      Docker::Image.build_from_dir(tmp_dir) do |build_output_chunk|
+        output.write(build_output_chunk)
+      end
+    end
+  end
+
+  def repository
+    @repository ||= @build.project.repository
+  end
+
+  def output
+    @output ||= OutputBuffer.new
+  end
+end


### PR DESCRIPTION
Not ready to merge yet. Still need to:
1. save build output to table
2. trigger builds automatically (possibly when a `Release` is currently made?)
3. figure out image naming

/cc @zendesk/runway, @zendesk/zendesk-meatballs 

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-122

### Risks
 - None