### PR TITLE
env vars improvements

### DIFF
--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -5,11 +5,17 @@ class EnvironmentVariable < ActiveRecord::Base
 
   def self.env(stage, deploy_group_id)
     variables = stage.environment_variables + stage.environment_variable_groups.flat_map(&:environment_variables)
-    variables.each_with_object({}) do |ev, all|
+    env = variables.each_with_object({}) do |ev, all|
       if !ev.deploy_group_id
         all[ev.name] ||= ev.value
       elsif ev.deploy_group_id == deploy_group_id
         all[ev.name] = ev.value
+      end
+    end
+
+    env.each_value do |value|
+      value.gsub!(/\$\{(\w+)\}|\$(\w+)/) do |original|
+        env[$1 || $2] || original
       end
     end
   end

--- a/plugins/env/app/views/admin/environment_variable_groups/form.html.erb
+++ b/plugins/env/app/views/admin/environment_variable_groups/form.html.erb
@@ -17,7 +17,10 @@
     </fieldset>
 
     <fieldset>
-      <legend>Environment variables</legend>
+      <legend>
+        Environment variables
+        <i class="glyphicon glyphicon-info-sign" title="$VAR / ${VAR} replacements supported&#13;Priority is DeployGroup, Environment, All"></i>
+      </legend>
       <%= render "samson_env/environment_variables", form: form %>
 
       <hr>

--- a/plugins/env/app/views/samson_env/_environment_variables.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables.html.erb
@@ -2,24 +2,26 @@
 <% form.object.environment_variables.build %>
 <%= form.fields_for :environment_variables do |fields| %>
   <div class="form-group">
-    <div class="col-lg-2">
+    <div class="col-lg-3">
       <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
     </div>
 
-    <div class="col-lg-4">
-      <%= fields.text_field :value, class: "form-control", placeholder: "Value" %>
+    <div class="col-lg-7">
+      <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
     </div>
 
     <% if DeployGroup.enabled? %>
-      <div class="col-lg-2">
+      <div class="col-lg-1">
         <%= fields.select :deploy_group_id, deploy_groups, class: "form-control", placeholder: "Deploy group" %>
       </div>
     <% end %>
 
     <% if fields.object.persisted? %>
       <div class="col-lg-1 checkbox">
-        <%= fields.check_box :_destroy if fields.object.persisted? %>
-        <%= fields.label :_destroy, "Delete" %>
+        <%= fields.label :_destroy do %>
+          <%= fields.check_box :_destroy if fields.object.persisted? %>
+          Delete
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/plugins/env/app/views/samson_env/_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_fields.html.erb
@@ -1,5 +1,8 @@
 <fieldset>
-  <legend>Env variables written to .env before deploy</legend>
+  <legend>
+    Env variables written to .env before deploy
+    <i class="glyphicon glyphicon-info-sign" title="$VAR / ${VAR} replacements supported&#13;Priority is Stage,EnvironmentGroup then DeployGroup, Environment, All"></i>
+  </legend>
   <%= render "samson_env/environment_variables", form: form %>
 
   <h4>Groups</h4>

--- a/plugins/env/samson_env.gemspec
+++ b/plugins/env/samson_env.gemspec
@@ -1,5 +1,6 @@
 Gem::Specification.new "samson_env", "0.0.0" do |s|
   s.summary = "Generate a .env file via stages ui for all deploy groups, validate it against the checked in .env keys, and ignores unwanted env keys"
+  s.description = "Variables are prioritized by Stage, EnvironmentGroup then DeployGroup, EnvironmentGroup, All\n.env.deploy-group-name files are generated when there are deploy groups assigned to the stage"
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
   s.add_runtime_dependency "dotenv"

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -53,6 +53,12 @@ describe EnvironmentVariable do
           groups.each { |deploy_group| EnvironmentVariable.env(stage, deploy_group.id) }
         end
       end
+
+      it "can resolve references" do
+        stage.environment_variables.last.update_column(:value, "STAGE--$POD_ID--$POD_ID_NOT--${POD_ID}")
+        stage.environment_variables.create!(name: "POD_ID", value: "1")
+        EnvironmentVariable.env(stage, nil).must_equal("STAGE"=>"STAGE--1--$POD_ID_NOT--1", "POD_ID"=>"1", "X"=>"Y", "Y"=>"Z")
+      end
     end
   end
 end


### PR DESCRIPTION
more screen space and reusing other env vars, so we can have NEWRELIC_APP_NAME="Zendesk $SERVICE_NAME pod $ZENDESK_POD_ID" instead of repeating it a bunch of times

![screen shot 2015-06-03 at 12 04 17 pm](https://cloud.githubusercontent.com/assets/11367/7971475/d87025ca-09f9-11e5-991b-d4caa3e52952.png)

@zendesk/runway 

### Risks
 - None
