### PR TITLE
turn off debug assets in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,7 +27,7 @@ Samson::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Lograge
   # For testing purposes, you need to have something like this in your asl.conf (Mac OS X):


### PR DESCRIPTION
cc @zendesk/runway dev site is quite slow and needs a lot of requests to load each page, this helps a lot.