### PR TITLE
RUN-162 Fixed datadog tags striping semicolon bug

### DIFF
--- a/app/models/datadog_notification.rb
+++ b/app/models/datadog_notification.rb
@@ -19,7 +19,7 @@ class DatadogNotification
       alert_type: status,
       source_type_name: "samson",
       date_happened: @deploy.updated_at,
-      tags: @stage.datadog_tags + ["deploy"]
+      tags: @stage.datadog_tags_as_array + ["deploy"]
     )
 
     client = Dogapi::Client.new(api_key, nil, "")

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -141,12 +141,12 @@ class Stage < ActiveRecord::Base
     commands + command_scope
   end
 
-  def datadog_tags
-    super.to_s.split(";").map(&:strip)
+  def datadog_tags_as_array
+    datadog_tags.to_s.split(";").map(&:strip)
   end
 
   def send_datadog_notifications?
-    datadog_tags.any?
+    datadog_tags_as_array.any?
   end
 
   def send_github_notifications?

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -267,15 +267,20 @@ describe Stage do
     end
   end
 
-  describe "#datadog_tags" do
+  describe "#datadog_tags_as_array" do
     it "returns an array of the tags" do
       subject.datadog_tags = " foo; bar; baz "
-      subject.datadog_tags.must_equal ["foo", "bar", "baz"]
+      subject.datadog_tags_as_array.must_equal ["foo", "bar", "baz"]
+    end
+
+    it "uses only semicolon as separate" do
+      subject.datadog_tags = " foo bar: baz "
+      subject.datadog_tags_as_array.must_equal ["foo bar: baz"]
     end
 
     it "returns an empty array if no tags have been configured" do
       subject.datadog_tags = nil
-      subject.datadog_tags.must_equal []
+      subject.datadog_tags_as_array.must_equal []
     end
   end
 


### PR DESCRIPTION
Instead of overriding the ```datadog_tags``` field to return an array, we keep it and rename the method to ```datadog_tags_as_array```.

/cc @zendesk/samson 

I will be on a two-week leave since tomorrow. Feel free to update and merge when it looks good to you guys.

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-162

### Risks
 - None