### PR TITLE
add REVISION to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN gem install bundler
 RUN mkdir /app
 WORKDIR /app
 
+ADD REVISION /REVISION
+
 # Mostly static
 ADD config.ru /app/
 ADD Rakefile /app/


### PR DESCRIPTION
REVISION file is necessary for ZDI to push a release. Its creation is managed by the ZDI build process.

/cc @zendesk/runway 