### PR TITLE
Refactor and clean up some GitRepository code

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -29,14 +29,16 @@ class GitRepository
     executor.execute!("cd #{repo_cache_dir}", 'git fetch -p')
   end
 
-  def commit_from_ref(git_reference)
-    description = Dir.chdir(repo_cache_dir) do
-      IO.popen(['git', 'describe', '--long', '--tags', '--all', git_reference]) do |io|
+  def commit_from_ref(git_reference, length: 7)
+    Dir.chdir(repo_cache_dir) do
+      description = IO.popen(['git', 'describe', '--long', '--tags', '--all', "--abbrev=#{length || 40}", git_reference], err: [:child, :out]) do |io|
         io.read.strip
       end
-    end
 
-    description.split('-').last.sub(/^g/, '')
+      return nil unless $?.success?
+
+      description.split('-').last.sub(/^g/, '')
+    end
   end
 
   def tag_from_ref(git_reference)

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -1,6 +1,7 @@
 require_relative '../test_helper'
 
 describe JobExecution do
+  include GitRepoTestHelper
 
   let(:repository_url) { Dir.mktmpdir }
   let(:repo_dir) { File.join(GitRepository.cached_repos_dir, project.repository_directory) }
@@ -17,15 +18,7 @@ describe JobExecution do
 
   before do
     Project.any_instance.stubs(:valid_repository_url).returns(true)
-    execute_on_remote_repo <<-SHELL
-      git init
-      git config user.email "test@example.com"
-      git config user.name "Test User"
-      echo monkey > foo
-      git add foo
-      git commit -m "initial commit"
-      git tag v1
-    SHELL
+    create_repo_with_tags('v1')
     user.name = 'John Doe'
     user.email = 'jdoe@test.com'
     project.repository.clone!(mirror: true)

--- a/test/support/git_repo_test_support.rb
+++ b/test/support/git_repo_test_support.rb
@@ -1,0 +1,63 @@
+module GitRepoTestHelper
+  def repo_temp_dir
+    @repo_temp_dir ||= Dir.mktmpdir
+  end
+
+  def execute_on_remote_repo(cmds)
+    `exec 2> /dev/null; cd #{repo_temp_dir}; #{cmds}`
+  end
+
+  def create_repo_without_tags
+    execute_on_remote_repo <<-SHELL
+      git init
+      git config user.email "test@example.com"
+      git config user.name "Test User"
+      echo monkey > foo
+      git add foo
+      git commit -m "initial commit"
+    SHELL
+  end
+
+  def create_repo_with_tags(tag_name = 'v1')
+    create_repo_without_tags
+    execute_on_remote_repo <<-SHELL
+      git tag #{tag_name}
+    SHELL
+  end
+
+  def create_repo_with_an_additional_branch(branch_name = 'test_user/test_branch')
+    create_repo_without_tags
+    execute_on_remote_repo <<-SHELL
+      git checkout -b #{branch_name}
+      echo monkey > foo2
+      git add foo2
+      git commit -m "branch commit"
+      git checkout master
+    SHELL
+  end
+
+  def create_repo_with_second_commit
+    create_repo_without_tags
+    execute_on_remote_repo <<-SHELL
+      echo more-monkey >> foo
+      git add foo
+      git commit -m "added more monkey"
+    SHELL
+  end
+
+  def current_branch
+    `git rev-parse --abbrev-ref HEAD`.strip
+  end
+
+  def current_commit
+    `git rev-parse HEAD`.strip
+  end
+
+  def number_of_commits
+    `git rev-list HEAD --count`.strip.to_i
+  end
+
+  def update_workspace
+    `git pull`.strip
+  end
+end


### PR DESCRIPTION
DRY up some test support code related to GitRepository.
Allow GitRepository#commit_from_ref to return the full SHA, and handle errors.
More tests for GitRepository#commit_from_ref.

/cc @zendesk/runway 

### Risks
 - None