### PR TITLE
show plugin source in backtraces

### DIFF
--- a/test/support/show_plugin_backtrace.rb
+++ b/test/support/show_plugin_backtrace.rb
@@ -1,0 +1,6 @@
+# by default backtrace from plugins is hidden
+# to update: add a error into a file inside a plugin and run the test
+# backtrace should show the exact line of the error
+old = Rails::BacktraceCleaner::APP_DIRS_PATTERN
+Rails::BacktraceCleaner.send(:remove_const, :APP_DIRS_PATTERN)
+Rails::BacktraceCleaner::APP_DIRS_PATTERN = Regexp.union(old, /^\/?plugin/)


### PR DESCRIPTION
@zendesk/runway 

before:

```
ActiveRecord::StatementInvalid
    test/support/timeout.rb:13:in `block in capture_exceptions'
    test/support/timeout.rb:12:in `capture_exceptions'
```

after:

```
ActiveRecord::StatementInvalid
    plugins/env/app/models/environment_variable.rb:8:in `env'
    plugins/env/test/models/environment_variable_test.rb:28:in `block (3 levels) in <main>'
    test/support/timeout.rb:13:in `block in capture_exceptions'
    test/support/timeout.rb:12:in `capture_exceptions'
```

PSA: with `-v` the full backtrace is show (maxitest feature)

### Risks
 - None