### PR TITLE
better_errors TRUSTED_IP env variable

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,4 +37,6 @@ Samson::Application.configure do
 
   # config.lograge.enabled = true
   # config.lograge.formatter = Lograge::Formatters::Logstash.new
+
+  BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
 end


### PR DESCRIPTION
ENV-basede IP whitelisting. This is recommended in the https://github.com/charliesome/better_errors README.

Augments #443

/cc @zendesk/runway 