### PR TITLE
persist full output when an exception happens

### DIFF
--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -22,7 +22,7 @@ class DeployService
     job_execution = JobExecution.start_job(deploy.reference, deploy.job)
     send_sse_deploy_update('start', deploy)
 
-    job_execution.subscribe do
+    job_execution.on_complete do
       send_after_notifications(deploy)
     end
   end

--- a/app/models/output_buffer.rb
+++ b/app/models/output_buffer.rb
@@ -37,6 +37,7 @@ class OutputBuffer
   end
 
   def close
+    return if closed?
     @closed = true
     write(nil, :close)
   end

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -100,7 +100,7 @@ describe DeployService do
 
   describe "#confirm_deploy!" do
     it "starts a job execution" do
-      JobExecution.expects(:start_job).returns(mock(subscribe: true)).once
+      JobExecution.expects(:start_job).returns(mock(on_complete:true)).once
       service.confirm_deploy!(deploy)
     end
 
@@ -111,7 +111,7 @@ describe DeployService do
 
       it "starts a job execution" do
         stub_request(:get, "https://api.github.com/repos/bar/foo/compare/staging...staging")
-        JobExecution.expects(:start_job).returns(mock(subscribe: true)).once
+        JobExecution.expects(:start_job).returns(mock(on_complete:true)).once
         DeployMailer.expects(:bypass_email).never
         deploy.buddy = other_user
         service.confirm_deploy!(deploy)
@@ -119,7 +119,7 @@ describe DeployService do
 
       it "reports bypass via mail" do
         stub_request(:get, "https://api.github.com/repos/bar/foo/compare/staging...staging")
-        JobExecution.expects(:start_job).returns(mock(subscribe: true)).once
+        JobExecution.expects(:start_job).returns(mock(on_complete:true)).once
         DeployMailer.expects(bypass_email: stub(deliver_now: true))
         deploy.buddy = user
         service.confirm_deploy!(deploy)

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -191,6 +191,25 @@ describe JobExecution do
     end
   end
 
+  describe "#start!" do
+    let(:execution) { JobExecution.new('master', job) }
+
+    it "runs a job" do
+      execution.start!
+      execution.wait!
+      execution.output.to_s.must_include "cat foo"
+      job.reload.output.must_include "cat foo"
+    end
+
+    it "records exceptions" do
+      job.expects(:run!).raises("Oh boy")
+      execution.start!
+      execution.wait!
+      execution.output.to_s.must_include "JobExecution failed: Oh boy"
+      job.reload.output.must_include "JobExecution failed: Oh boy"
+    end
+  end
+
   def execute_job(branch = 'master')
     execution = JobExecution.new(branch, job)
     execution.send(:run!)


### PR DESCRIPTION
atm when for example an env variable is missing an exception is raised that is only visible to the deployer and is not stored ... lets fix that :)

@zendesk/runway 

### Risks
 - None