### PR TITLE
Run on_completed hooks after updating the log

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -86,12 +86,12 @@ class JobExecution
       @job.fail!
     end
 
-    @subscribers.each(&:call)
   rescue => e
     error!(e)
   ensure
     @output.close
     @job.update_output!(OutputAggregator.new(@output).to_s)
+    @subscribers.each(&:call)
     ActiveRecord::Base.clear_active_connections!
     JobExecution.finished_job(@job)
   end


### PR DESCRIPTION
Hi,

Currently the `on_completed` hook is invoke before the output is stored. Therefore, it makes subscribers have no way to access the log, such as emailing it out(nicer than viewer it in the app). This change move it down after we store log output.

cc @zendesk/runway