### PR TITLE
user misconfiguration does not need to be reported to airbrake

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -56,7 +56,7 @@ class JobExecution
   def error!(exception)
     message = "JobExecution failed: #{exception.message}"
 
-    if defined?(Airbrake)
+    if defined?(Airbrake) && !exception.is_a?(Samson::Hooks::UserError)
       Airbrake.notify(exception,
         error_message: message,
         parameters: {

--- a/config/database.mysql.yml.example
+++ b/config/database.mysql.yml.example
@@ -1,4 +1,7 @@
-<% uri = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306/samson_development') %>
+<%
+  uri = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306/samson_development')
+  uri.scheme = 'mysql2'
+%>
 
 development:
   url: <%= uri %>

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -1,5 +1,8 @@
 module Samson
   module Hooks
+    class UserError < StandardError
+    end
+
     VIEW_HOOKS = [
       :stage_form,
       :project_form,

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -69,7 +69,7 @@ module SamsonEnv
       file = File.basename(file)
       keys = data.keys
       missing = required - keys
-      raise KeyError, "Missing env keys #{missing.join(", ")} for #{file}" if missing.any?
+      raise Samson::Hooks::UserError, "Missing env keys #{missing.join(", ")} for #{file}" if missing.any?
       ignored = keys - all
       Rails.logger.warn("Ignoring env keys #{ignored.join(", ")} for #{file}") if ignored.any?
       data.slice(*all)

--- a/plugins/env/test/hooks_test.rb
+++ b/plugins/env/test/hooks_test.rb
@@ -35,7 +35,7 @@ describe "env hooks" do
 
         it "fails when .env has an unsatisfied required key" do
           File.write(".env", "FOO=foo")
-          assert_raises KeyError do
+          assert_raises Samson::Hooks::UserError do
             Samson::Hooks.fire(:after_deploy_setup, Dir.pwd, stage)
           end
         end
@@ -73,7 +73,7 @@ describe "env hooks" do
       end
 
       it "fails when missing required keys" do
-        assert_raises KeyError do
+        assert_raises Samson::Hooks::UserError do
           fire
         end
       end


### PR DESCRIPTION
previous errors were mor of the mysql is broken / the app is failing kind,
but this is simply user error and does not need to be reported

@zendesk/runway 

### Risks
 - None