### PR TITLE
add command_name to deploy groups so they can be different from the u…

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -42,7 +42,7 @@ class Admin::DeployGroupsController < ApplicationController
   private
 
   def deploy_group_params
-    params.require(:deploy_group).permit(:name, :environment_id)
+    params.require(:deploy_group).permit(:name, :environment_id, :env_value)
   end
 
   def deploy_group

--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -5,7 +5,8 @@ class DeployGroup < ActiveRecord::Base
   has_and_belongs_to_many :stages
 
   validates_presence_of :name, :environment_id
-  validates_uniqueness_of :name
+  validates_uniqueness_of :name, :env_value
+  before_validation :initialize_env_value, on: :create
 
   default_scope { order(:name) }
 
@@ -19,5 +20,11 @@ class DeployGroup < ActiveRecord::Base
 
   def long_name
     "#{name} (#{environment.name})"
+  end
+
+  private
+
+  def initialize_env_value
+    self.env_value = name if env_value.blank?
   end
 end

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -150,7 +150,7 @@ class JobExecution
       "cd #{dir}",
       *@job.commands
     ]
-    if @stage && group_names = @stage.deploy_groups.pluck(:name).sort.map!(&:shellescape).join(" ")
+    if @stage && group_names = @stage.deploy_groups.pluck(:env_value).sort.map!(&:shellescape).join(" ")
       commands.unshift("export DEPLOY_GROUPS='#{group_names}'") if group_names.presence
     end
     commands

--- a/app/views/admin/deploy_groups/_fields.html.erb
+++ b/app/views/admin/deploy_groups/_fields.html.erb
@@ -7,6 +7,13 @@
   </div>
 
   <div class="form-group">
+    <%= form.label :env_value, "Value in $DEPLOY_GROUPS", class: "col-lg-2 control-label" %>
+    <div class="col-lg-4">
+      <%= form.text_field :env_value, class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="form-group">
     <%= form.label :name, "Environment", class: "col-lg-2 control-label" %>
     <div class="col-lg-4">
       <%= form.collection_select(:environment_id, Environment.all, :id, :name, {}, { class: 'form-control' }) %>

--- a/db/migrate/20150618182108_add_env_value_to_deploy_group.rb
+++ b/db/migrate/20150618182108_add_env_value_to_deploy_group.rb
@@ -1,0 +1,7 @@
+class AddEnvValueToDeployGroup < ActiveRecord::Migration
+  def change
+    add_column :deploy_groups, :env_value, :string
+    DeployGroup.update_all('env_value = name')
+    change_column_null :deploy_groups, :env_value, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150611013506) do
+ActiveRecord::Schema.define(version: 20150618182108) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20150611013506) do
     t.datetime "deleted_at"
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+    t.string   "env_value",      limit: 255, null: false
   end
 
   add_index "deploy_groups", ["environment_id"], name: "index_deploy_groups_on_environment_id", using: :btree

--- a/test/fixtures/deploy_groups.yml
+++ b/test/fixtures/deploy_groups.yml
@@ -1,11 +1,14 @@
 pod1:
   name: Pod1
+  env_value: pod1
   environment: production
 
 pod2:
   name: Pod2
+  env_value: pod2
   environment: production
 
 pod100:
   name: Pod 100
+  env_value: pod100
   environment: staging

--- a/test/models/deploy_group_test.rb
+++ b/test/models/deploy_group_test.rb
@@ -34,4 +34,14 @@ describe DeployGroup do
     DeployGroup.create!(name: 'Pod668', environment: prod_env)
     env.deploy_groups.must_equal [dg1, dg2]
   end
+
+  describe "#initialize_env_value" do
+    it 'prefils env_value' do
+      DeployGroup.create!(name: 'Pod666 - the best', environment: prod_env).env_value.must_equal 'Pod666 - the best'
+    end
+
+    it 'can set env_value' do
+      DeployGroup.create!(name: 'Pod666 - the best', env_value: 'pod:666', environment: prod_env).env_value.must_equal 'pod:666'
+    end
+  end
 end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -138,7 +138,7 @@ describe JobExecution do
     execute_job
     lines = job.output.split "\n"
     lines.must_include "# Deploy URL: #{deploy.url}"
-    lines.must_include 'DEPLOY_GROUPS=\;\|sudo\ make-sandwich\ / Pod1 Pod2'
+    lines.must_include 'DEPLOY_GROUPS=\;\|sudo\ make-sandwich\ / pod1 pod2'
   end
 
   it 'does not export deploy_group information if no deploy groups present' do


### PR DESCRIPTION
…i name

atm we are not using $DEPLOY_GROUPS because they poorly map to some stages like master/staging/gamma servers, this should make this easier and we can finally start exclusively using $DEPLOY_GROUPS

@craig-day @jcheatham @zendesk/runway 

### Risks
 - None