### PR TITLE
Add extra hook to custom deployment

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -41,7 +41,7 @@ class DeploysController < ApplicationController
 
   def create
     deploy_service = DeployService.new(current_user)
-    @deploy = deploy_service.deploy!(stage, reference)
+    @deploy = deploy_service.deploy!(stage, deploy_params)
 
     respond_to do |format|
       format.html do
@@ -109,6 +109,10 @@ class DeploysController < ApplicationController
 
   protected
 
+  def deploy_permitted_params
+    [ :reference, :stage_id ] + Samson::Hooks.fire(:deploy_permitted_params)
+  end
+
   def reference
     deploy_params[:reference].strip
   end
@@ -118,7 +122,7 @@ class DeploysController < ApplicationController
   end
 
   def deploy_params
-    params.require(:deploy).permit(:reference, :stage_id)
+    params.require(:deploy).permit(deploy_permitted_params)
   end
 
   def find_project

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -30,7 +30,7 @@ class Integrations::BaseController < ApplicationController
     deploy_service = DeployService.new(user)
 
     stages.all? do |stage|
-      deploy_service.deploy!(stage, commit).persisted?
+      deploy_service.deploy!(stage, reference: commit).persisted?
     end
   end
 

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -5,8 +5,8 @@ class DeployService
     @user = user
   end
 
-  def deploy!(stage, reference)
-    deploy = stage.create_deploy(reference: reference, user: user)
+  def deploy!(stage, attributes)
+    deploy = stage.create_deploy(user, attributes)
     send_sse_deploy_update('new', deploy)
 
     if deploy.persisted? && (!stage.deploy_requires_approval? || release_approved?(deploy))

--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -20,7 +20,7 @@ class ReleaseService
     deploy_service = DeployService.new(release.author)
 
     @project.auto_release_stages.each do |stage|
-      deploy_service.deploy!(stage, release.version)
+      deploy_service.deploy!(stage, reference: release.version)
     end
   end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -94,11 +94,8 @@ class Stage < ActiveRecord::Base
     confirm
   end
 
-  def create_deploy(options = {})
-    user = options.fetch(:user)
-    reference = options.fetch(:reference)
-
-    deploys.create(reference: reference) do |deploy|
+  def create_deploy(user, attributes = {})
+    deploys.create(attributes) do |deploy|
       deploy.build_job(project: project, user: user, command: command)
     end
   end

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -31,6 +31,8 @@
         </div>
       </div>
 
+      <%= Samson::Hooks.render_views(:deploy_form, self, project: @project, form: form) %>
+
       <div class="form-group" id="new-deploy-buttons">
         <div class="col-lg-offset-2 col-lg-10">
           <%= form.submit "", class: "btn btn-primary", disabled: global_lock %>

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -8,6 +8,7 @@ module Samson
       :project_form,
       :deploys_header,
       :deploy_view,
+      :deploy_form, # for external plugin, so they can add extra form fields
       :admin_menu,
       :project_tabs_view
     ].freeze
@@ -15,6 +16,7 @@ module Samson
     EVENT_HOOKS = [
       :stage_clone,
       :stage_permitted_params,
+      :deploy_permitted_params, # for external plugin
       :project_permitted_params,
       :before_deploy,
       :after_deploy_setup,

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -124,7 +124,7 @@ describe DeploysController do
     end
 
     describe "#active_count" do
-      before { stage.create_deploy(reference: 'reference', user: admin) }
+      before { stage.create_deploy(admin, { reference: 'reference' }) }
 
       it "renders json" do
         get :active_count
@@ -199,7 +199,7 @@ describe DeploysController do
         end
 
         it "creates a deploy" do
-          assert_equal [[stage, "master"]], deploy_called
+          assert_equal [[stage, {"reference" => "master"}]], deploy_called
         end
       end
 
@@ -211,7 +211,7 @@ describe DeploysController do
         end
 
         it "creates a deploy" do
-          assert_equal [[stage, "master"]], deploy_called
+          assert_equal [[stage, {"reference" => "master"}]], deploy_called
         end
       end
     end

--- a/test/models/buddy_check_test.rb
+++ b/test/models/buddy_check_test.rb
@@ -13,14 +13,14 @@ describe BuddyCheck do
   let(:other_user) { users(:deployer_buddy) }
 
   it "start_time is set for buddy_checked deploy" do
-    deploy_rtn = stage.create_deploy(reference: reference, user: user)
+    deploy_rtn = stage.create_deploy(user, { reference: reference })
     deploy_rtn.confirm_buddy!(other_user)
 
     assert_equal true, deploy_rtn.start_time.to_i > 0
   end
 
   it "start_time is set for non-buddy_checked deploy" do
-    deploy_rtn = stage.create_deploy(reference: reference, user: user)
+    deploy_rtn = stage.create_deploy(user, { reference: reference })
 
     assert_equal true, deploy_rtn.start_time.to_i > 0
   end
@@ -31,7 +31,7 @@ describe BuddyCheck do
     stage.expects(:production?).returns(true)
     service.expects(:confirm_deploy!).never
 
-    service.deploy!(stage, reference)
+    service.deploy!(stage, reference: reference)
   end
 
   it "does deploy production if buddy check is not enabled" do
@@ -40,7 +40,7 @@ describe BuddyCheck do
     stage.stubs(:production?).returns(true)
     service.expects(:confirm_deploy!).once
 
-    service.deploy!(stage, reference)
+    service.deploy!(stage, reference: reference)
   end
 
   it "does deploy non-production if buddy check is enabled" do
@@ -49,7 +49,7 @@ describe BuddyCheck do
     stage.expects(:production?).returns(false)
     service.expects(:confirm_deploy!).once
 
-    service.deploy!(stage, reference)
+    service.deploy!(stage, reference: reference)
   end
 
   it "does deploy non-production if buddy check is not enabled" do
@@ -58,7 +58,7 @@ describe BuddyCheck do
     stage.stubs(:production?).returns(false)
     service.expects(:confirm_deploy!).once
 
-    service.deploy!(stage, reference)
+    service.deploy!(stage, reference: reference)
   end
 
   describe "before notifications, buddycheck enabled" do

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -21,7 +21,7 @@ describe DeployService do
       SseRailsEngine.expects(:send_event).twice
       assert_difference "Job.count", +1 do
         assert_difference "Deploy.count", +1 do
-          service.deploy!(stage, reference)
+          service.deploy!(stage, reference: reference)
         end
       end
     end
@@ -37,7 +37,7 @@ describe DeployService do
 
       it "does not start the deploy" do
         service.expects(:confirm_deploy!).never
-        service.deploy!(stage, reference)
+        service.deploy!(stage, reference: reference)
       end
 
       describe "if release is approved" do
@@ -45,13 +45,13 @@ describe DeployService do
 
         it "starts the deploy, if in grace period" do
           service.expects(:confirm_deploy!).once
-          service.deploy!(stage_production_2, ref1)
+          service.deploy!(stage_production_2, reference: ref1)
         end
 
         it "does not start the deploy, if past grace period" do
           service.expects(:confirm_deploy!).never
           travel (BuddyCheck.period).hour + 1.minute do
-            service.deploy!(stage_production_2, ref1)
+            service.deploy!(stage_production_2, reference: ref1)
           end
         end
 
@@ -62,7 +62,7 @@ describe DeployService do
         it "does not start the deploy" do
           service.expects(:release_approved?).once
           service.expects(:confirm_deploy!).never
-          service.deploy!(stage, reference)
+          service.deploy!(stage, reference: reference)
         end
       end
 
@@ -73,7 +73,7 @@ describe DeployService do
         end
         it "it starts the deploy" do
           service.expects(:confirm_deploy!).once
-          service.deploy!(stage, reference)
+          service.deploy!(stage, reference: reference)
         end
       end
 
@@ -86,13 +86,13 @@ describe DeployService do
         it 'should deploy because of prod deploy groups' do
           create_previous_deploy(ref1, stage_production_1)
           service.expects(:confirm_deploy!).once
-          service.deploy!(stage_production_2, ref1)
+          service.deploy!(stage_production_2, reference: ref1)
         end
 
         it 'should not deploy if previous deploy was not on prod' do
           create_previous_deploy(ref1, stages(:test_staging))
           service.expects(:confirm_deploy!).never
-          service.deploy!(stage_production_2, ref1)
+          service.deploy!(stage_production_2, reference: ref1)
         end
       end
     end
@@ -130,7 +130,7 @@ describe DeployService do
   describe "before notifications" do
     it "sends before_deploy hook" do
       record_hooks(:before_deploy) do
-        service.deploy!(stage, reference)
+        service.deploy!(stage, reference: reference)
       end.must_equal [[Deploy.first, nil]]
     end
 
@@ -142,7 +142,7 @@ describe DeployService do
       GithubDeployment.stubs(new: deployment)
       deployment.expects(:create_github_deployment)
 
-      service.deploy!(stage, reference)
+      service.deploy!(stage, reference: reference)
     end
   end
 
@@ -161,13 +161,13 @@ describe DeployService do
 
       DeployMailer.expects(:deploy_email).returns( stub("DeployMailer", deliver_now: true) )
 
-      service.deploy!(stage, reference)
+      service.deploy!(stage, reference: reference)
       job_execution.send(:run!)
     end
 
     it "sends after_deploy hook" do
       record_hooks(:after_deploy) do
-        service.deploy!(stage, reference)
+        service.deploy!(stage, reference: reference)
         job_execution.send(:run!)
       end.must_equal [[deploy, nil]]
     end
@@ -177,7 +177,7 @@ describe DeployService do
 
       DatadogNotification.any_instance.expects(:deliver)
 
-      service.deploy!(stage, reference)
+      service.deploy!(stage, reference: reference)
       job_execution.send(:run!)
     end
 
@@ -187,7 +187,7 @@ describe DeployService do
 
       GithubNotification.any_instance.expects(:deliver)
 
-      service.deploy!(stage, reference)
+      service.deploy!(stage, reference: reference)
       job_execution.send(:run!)
     end
 
@@ -197,7 +197,7 @@ describe DeployService do
 
       GithubNotification.any_instance.expects(:deliver).never
 
-      service.deploy!(stage, reference)
+      service.deploy!(stage, reference: reference)
       job_execution.send(:run!)
     end
 
@@ -209,7 +209,7 @@ describe DeployService do
       GithubDeployment.stubs(new: deployment)
       deployment.expects(:update_github_deployment_status)
 
-      service.deploy!(stage, reference)
+      service.deploy!(stage, reference: reference)
       job_execution.send(:run!)
     end
 
@@ -218,7 +218,7 @@ describe DeployService do
 
       DeployMailer.expects(:deploy_failed_email).returns( stub("DeployMailer", deliver_now: true) )
 
-      service.deploy!(stage, reference)
+      service.deploy!(stage, reference: reference)
       job_execution.send(:run!)
     end
   end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -127,18 +127,18 @@ describe Stage do
     let(:user) { users(:deployer) }
 
     it "creates a new deploy" do
-      deploy = subject.create_deploy(reference: "foo", user: user)
+      deploy = subject.create_deploy(user, {reference: "foo"})
       deploy.reference.must_equal "foo"
     end
 
     it "creates a new job" do
-      deploy = subject.create_deploy(reference: "foo", user: user)
+      deploy = subject.create_deploy(user, {reference: "foo"})
       deploy.job.user.must_equal user
     end
 
     it "creates neither job nor deploy if one fails to save" do
       assert_no_difference "Deploy.count + Job.count" do
-        subject.create_deploy(reference: "", user: user)
+        subject.create_deploy(user, {reference: ""})
       end
     end
   end
@@ -299,7 +299,7 @@ describe Stage do
   describe "#automated_failure_emails" do
     let(:user) { users(:super_admin) }
     let(:deploy) do
-      deploy = subject.create_deploy(user: user, reference: "commita")
+      deploy = subject.create_deploy(user, {reference: "commita"})
       deploy.job.fail!
       deploy
     end


### PR DESCRIPTION
This PR add some hooks so user can add custom fields for adding deployment.


## View hooks

* before_deploy_form
* after_deploy_form

So user can hook into to display content around deploy form. In my case, I want to add some extra fields.

## Even hooks

* after_deploy_create
* deploy_permitted_params

So user can permit custom field and save those extra fields after `deploy` is created.
