### PR TITLE
add project 'deploy with docker' checkbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ GITHUB_TOKEN={fill me in}
 
 # DEPLOY_GROUP_FEATURE={optional, set to 1 to enable Environments and DeployGroups}
 
+# DOCKER_FEATURE={optional, set to 1 for experimental docker support}
+
 # SLACK_TOKEN={ required for the slack integration }
 
 # FLOWDOCK_API_TOKEN={ required for the flowdock integration }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -83,6 +83,7 @@ class ProjectsController < ApplicationController
         :owner,
         :permalink,
         :release_branch,
+        :deploy_with_docker,
         stages_attributes: stage_permitted_params
       ] + Samson::Hooks.fire(:project_permitted_params)
     )

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -47,6 +47,17 @@
       </div>
     </div>
 
+    <% if ENV['DOCKER_FEATURE'] %>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10">
+        <div class="checkbox">
+          <%= form.check_box :deploy_with_docker %>
+          <%= form.label :deploy_with_docker, 'Deploy with Docker' %>
+        </div>
+      </div>
+    </div>
+    <% end %>
+
     <%= Samson::Hooks.render_views(:project_form, self, form: form) %>
 
     <% unless project.persisted? %>

--- a/db/migrate/20150619170905_projects_add_deploy_with_docker.rb
+++ b/db/migrate/20150619170905_projects_add_deploy_with_docker.rb
@@ -1,0 +1,5 @@
+class ProjectsAddDeployWithDocker < ActiveRecord::Migration
+  def change
+    add_column :projects, :deploy_with_docker, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150618182108) do
+ActiveRecord::Schema.define(version: 20150619170905) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -204,16 +204,17 @@ ActiveRecord::Schema.define(version: 20150618182108) do
   add_index "project_environment_variable_groups", ["project_id", "environment_variable_group_id"], name: "project_environment_variable_groups_unique_group_id", unique: true, using: :btree
 
   create_table "projects", force: :cascade do |t|
-    t.string   "name",           limit: 255,   null: false
-    t.string   "repository_url", limit: 255,   null: false
+    t.string   "name",               limit: 255,                   null: false
+    t.string   "repository_url",     limit: 255,                   null: false
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "token",          limit: 255
-    t.string   "release_branch", limit: 255
-    t.string   "permalink",      limit: 255,   null: false
-    t.text     "description",    limit: 65535
-    t.string   "owner",          limit: 255
+    t.string   "token",              limit: 255
+    t.string   "release_branch",     limit: 255
+    t.string   "permalink",          limit: 255,                   null: false
+    t.text     "description",        limit: 65535
+    t.string   "owner",              limit: 255
+    t.boolean  "deploy_with_docker", limit: 1,     default: false, null: false
   end
 
   add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at", length: {"permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -214,7 +214,7 @@ ActiveRecord::Schema.define(version: 20150619170905) do
     t.string   "permalink",          limit: 255,                   null: false
     t.text     "description",        limit: 65535
     t.string   "owner",              limit: 255
-    t.boolean  "deploy_with_docker", limit: 1,     default: false, null: false
+    t.boolean  "deploy_with_docker",               default: false, null: false
   end
 
   add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at", length: {"permalink"=>191, "deleted_at"=>nil}, using: :btree


### PR DESCRIPTION
Adds an explicit flag for whether we should apply any docker-specific behavior to this project, e.g. building images or presenting UI for host assignment.

We could alternately infer this from the presence of a `Dockerfile` in the repo, but until we're further down the road I'd rather not surprise anyone with behavior.

/cc @zendesk/runway 