### PR TITLE
remove unneeded statement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV GEM_HOME=/bundle
 RUN gem update --system
 RUN gem install bundler
 
-RUN mkdir /app && touch -t 201501010000 /app
 WORKDIR /app
 
 # Mostly static


### PR DESCRIPTION
From the docs for [ADD](https://docs.docker.com/reference/builder/):

> If \<dest\> doesn’t exist, it is created along with all missing directories in its path.

This builds and caches fine.

@zendesk/runway @zendesk/samson @grosser @princemaple 