### PR TITLE
Dockerfile remove GEM_HOME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
 RUN echo 'deb https://deb.nodesource.com/node_0.12 jessie main' > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 
-ENV GEM_HOME=/bundle
 RUN gem update --system
 RUN gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
 RUN echo 'deb https://deb.nodesource.com/node_0.12 jessie main' > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs
 
-RUN gem update --system
-RUN gem install bundler
-
 WORKDIR /app
 
 # Mostly static


### PR DESCRIPTION
By creating /bundle and then installing a gem into it, it prevents zdi from mounting a docker volume to /bundle in development mode, which causes a repeated bundling that gets thrown away between runs. zendesk/docker-images#543 ensures that we have bundler installed even if we change with GEM_HOME, so this line should no longer be necessary.

/cc @zendesk/runway 