### PR TITLE
show shared commands, prevent edits of shared commands and show unuse…

### DIFF
--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -1,6 +1,6 @@
 class Command < ActiveRecord::Base
   has_many :stage_command
-  has_many :stages, through: :stage_commands
+  has_many :stages, through: :stage_command
   belongs_to :project
 
   validates :command, presence: true

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -116,14 +116,19 @@
 
   <div id="commands">
     <%= form.collection_check_boxes(:command_ids, form.object.all_commands, :id, :command) do |b| %>
+      <% command = b.object %>
+      <% others = (command.stages - [@stage]).map(&:name) %>
+      <% others_warning = "#{others.size} other stages: #{others.join(", ")}" if others.any? %>
       <div class="row stage-bar bar">
         <div data-id="<%= b.value %>" class="col-lg-offset-2 col-lg-2 command-checkbox">
           <%= b.check_box %>
         </div>
         <div class="col-lg-8">
-          <pre data-type="textarea" data-url="<%= admin_command_path(b.value, format: :json) %>" class="pre-command pre-inline <%= b.object.global? ? 'global' : 'local' %>"><%= b.text %></pre>
+          <% klass = "pre-command pre-inline #{command.global? ? 'global' : 'local'} #{'others' if others_warning}" %>
+          <pre data-type="textarea" data-others-warning="<%= others_warning %>" data-url="<%= admin_command_path(b.value, format: :json) %>" class="<%= klass %>"><%= b.text %></pre>
         </div>
-        <%= edit_command_link(b.object) %>
+        <%= edit_command_link command %>
+        <%= content_tag :span, others.size, title: others_warning + " use this.", class: 'glyphicon glyphicon-lock' if others_warning %>
       </div>
     <% end %>
   </div>
@@ -229,10 +234,12 @@
 
 <script>
   $(document).ready(function() {
-    $('#commands').sortable();
+    var $localCommands = $('#commands pre.local');
+
+    $localCommands.sortable();
     $.fn.editableform.buttons = <%= render('commands/buttons').inspect.html_safe %>;
 
-    $('#commands pre.local').editable({
+    $localCommands.editable({
       mode: 'inline',
       send: 'always',
       toggle: 'dblclick',
@@ -244,6 +251,10 @@
         type: 'PATCH',
         dataType: 'json'
       }
+    });
+
+    $localCommands.filter(".others").dblclick(function(){
+      alert("Editing for " + $(this).data('others-warning') + ". If you do not want this, make a copy.");
     });
 
     $('#commands pre.global').dblclick(function(){


### PR DESCRIPTION
…d commands

@zendesk/runway 

 - lock -> shared -> think about editing + big warning in your face when you edit
 - no lock + unchecked -> unused -> can be deleted
 - no lock + checked -> 1-off command ... might be something fishy .. should use shared command

![screen shot 2015-06-25 at 2 18 40 pm](https://cloud.githubusercontent.com/assets/11367/8365919/72a18362-1b45-11e5-902f-03b54f2d5905.png)

![screen shot 2015-06-25 at 2 18 46 pm](https://cloud.githubusercontent.com/assets/11367/8365974/d434e2b8-1b45-11e5-9b74-6c447b8260db.png)


### Risks
 - None