### PR TITLE
longer docker timeout for slower ops like compiling native node modules

### DIFF
--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -2,6 +2,7 @@ require 'docker'
 
 if ENV['DOCKER_URL'].present? && !Rails.env.test? && !ENV['PRECOMPILE']
   Docker.url = ENV['DOCKER_URL']
+  Docker.options = { read_timeout: 600 }
 
   # Confirm the Docker daemon is a recent enough version
   Docker.validate_version!


### PR DESCRIPTION
@zendesk/runway @jonmoter 
I had this timeout several times on my laptop. The default is 60 sec iirc. Sometimes there is no output for quite a while. 10 minutes is probably a bit too long - what should we use?