### PR TITLE
allow plugins to define fixtures

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,7 @@ class ActiveSupport::TestCase
   #
   # Note: You'll currently still have to declare fixtures explicitly in integration tests
   # -- they do not yet inherit this setting
+  Samson::Hooks.plugin_test_setup
   fixtures :all
 
   before do


### PR DESCRIPTION
@zendesk/runway 
Had to do this a hacky symlink way - `ActiveSuport::TestCase` doesn't really make this easy. Overriding method missing and changing `ActiveSupport::TestCase.fixture_path` would be an option but I think it would get messy since fixtures in plugins will probably have a relation on core model fixtures like `Project`.