### PR TITLE
forgot macros and remove n+1 queries for every command

### DIFF
--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -1,6 +1,9 @@
 class Command < ActiveRecord::Base
   has_many :stage_command
   has_many :stages, through: :stage_command
+  has_many :macro_commands
+  has_many :macros, through: :macro_commands
+
   belongs_to :project
 
   validates :command, presence: true
@@ -15,5 +18,13 @@ class Command < ActiveRecord::Base
 
   def global?
     project_id.nil?
+  end
+
+  def usages
+    stages + macros
+  end
+
+  def self.usage_ids
+    MacroCommand.pluck(:command_id) + StageCommand.pluck(:command_id)
   end
 end

--- a/app/views/admin/commands/edit.html.erb
+++ b/app/views/admin/commands/edit.html.erb
@@ -20,8 +20,8 @@
       <div class="form-group">
         <div class="col-lg-offset-2 col-lg-10">
           <button type="submit" class="btn btn-default">Save</button>
-          <% if stages = @command.stages.to_a.presence %>
-            <%= "Used by #{stages.map { |s| link_to s.global_name, project_stage_path(s.project, s) }.join(", ") }".html_safe %>
+          <% if usages = @command.usages.presence %>
+            <%= "Used by #{usages.map { |s| link_to "#{s.class}: #{s.project.name} - #{s.name}", [s.project, s, action: :edit] }.join(", ") }".html_safe %>
           <% else %>
             <%= link_to_delete([:admin, @command]) %>
           <% end %>

--- a/app/views/admin/commands/index.html.erb
+++ b/app/views/admin/commands/index.html.erb
@@ -11,6 +11,7 @@
     </thead>
 
     <tbody>
+      <% usage_ids = Command.usage_ids %>
       <% @commands.each do |command| %>
         <tr>
           <td>
@@ -20,8 +21,9 @@
           <td>
             <%= link_to "Edit", edit_admin_command_path(command) %>
             |
-            <% if stages = command.stages.to_a.presence %>
-              <%= content_tag :span, "Used by #{pluralize stages.size, 'stage'}", title: "Click Edit to see usage details" %>
+            <% others = usage_ids.count(command.id) - 1 %>
+            <% if others > 0 %>
+              <%= content_tag :span, "Used by #{pluralize others, 'other'}", title: "Click Edit to see usage details" %>
             <% else %>
               <%= link_to_delete([:admin, command]) %>
             <% end %>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -68,12 +68,15 @@
   <p>Select the commands you want to run when executing this stage. Double click to edit commands.</p>
 
   <div id="commands">
+    <% usage_ids = Command.usage_ids %>
     <%= form.collection_check_boxes(:command_ids, form.object.all_commands, :id, :command) do |b| %>
       <% command = b.object %>
-      <% others = (command.stages - [@stage]).map(&:name) %>
-      <% others_warning = "#{others.size} other stages: #{others.join(", ")}" if others.any? %>
+      <% checked = b.value %>
+      <% others = usage_ids.count(command.id) - (checked ? 1 : 0) %>
+      <% others_warning = "#{others} others" if others > 0 %>
+
       <div class="row stage-bar bar">
-        <div data-id="<%= b.value %>" class="col-lg-offset-2 col-lg-2 command-checkbox">
+        <div data-id="<%= checked %>" class="col-lg-offset-2 col-lg-2 command-checkbox">
           <%= b.check_box %>
         </div>
         <div class="col-lg-8">
@@ -81,7 +84,7 @@
           <pre data-type="textarea" data-others-warning="<%= others_warning %>" data-url="<%= admin_command_path(b.value, format: :json) %>" class="<%= klass %>"><%= b.text %></pre>
         </div>
         <%= edit_command_link command %>
-        <%= content_tag :span, others.size, title: others_warning + " use this.", class: 'glyphicon glyphicon-lock' if others_warning %>
+        <%= content_tag :span, others, title: others_warning + " use this. Click edit for details.", class: 'glyphicon glyphicon-lock' if others_warning %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
@zendesk/runway

previous implementation did 1 query per command which gets nasty when there are 100 commands in 1 edit view ... reducing to a bare minimum and only showing details on the edit view

![screen shot 2015-06-26 at 7 58 35 am](https://cloud.githubusercontent.com/assets/11367/8381040/3de1cb3e-1bde-11e5-88dd-103e752a1def.png)
![screen shot 2015-06-26 at 8 00 50 am](https://cloud.githubusercontent.com/assets/11367/8381041/3de9738e-1bde-11e5-9f9f-9b90388e8b59.png)
![screen shot 2015-06-26 at 8 04 11 am](https://cloud.githubusercontent.com/assets/11367/8381047/4bbe97f0-1bde-11e5-92b9-a8cc1c3eb0f5.png)


### Risks
 - None