### PR TITLE
Project#current_user accessor for permissions in plugin hooks

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,12 +22,14 @@ class ProjectsController < ApplicationController
 
   def new
     @project = Project.new
+    @project.current_user = current_user
     stage = @project.stages.build(name: "Production")
     stage.new_relic_applications.build
   end
 
   def create
     @project = Project.new(project_params)
+    @project.current_user = current_user
 
     if @project.save
       if ENV['PROJECT_CREATED_NOTIFY_ADDRESS']
@@ -90,7 +92,9 @@ class ProjectsController < ApplicationController
   end
 
   def project
-    @project ||= Project.find_by_param!(params[:id])
+    @project ||= Project.find_by_param!(params[:id]).tap do |project|
+      project.current_user = current_user
+    end
   end
 
   def redirect_viewers!

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -19,6 +19,9 @@ class Project < ActiveRecord::Base
   has_many :commands
   has_many :macros
 
+  # For permission checks on callbacks. Currently used in private plugins.
+  attr_accessor :current_user
+
   accepts_nested_attributes_for :stages
 
   scope :alphabetical, -> { order('name') }


### PR DESCRIPTION
I have a plugin that needs to enforce permissions based on the user's role, e.g. only all super users to manage docker assignments in production. Normally I'd use a service object for this, but we don't have that luxury with plugins.

/cc @zendesk/runway 