### PR TITLE
env variable preview

### DIFF
--- a/plugins/env/app/controllers/admin/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/admin/environment_variable_groups_controller.rb
@@ -34,10 +34,10 @@ module Admin
     def preview
       @groups = if params[:group_id]
         @group = EnvironmentVariableGroup.find(params[:group_id])
-        SamsonEnv.env_groups(Project.new(environment_variable_groups: [@group]), DeployGroup.all)
+        SamsonEnv.env_groups(Project.new(environment_variable_groups: [@group]), DeployGroup.all, preview: true)
       else
         @project = Project.find(params[:project_id])
-        SamsonEnv.env_groups(@project, DeployGroup.all)
+        SamsonEnv.env_groups(@project, DeployGroup.all, preview: true)
       end
     end
 

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -5,7 +5,9 @@ class EnvironmentVariable < ActiveRecord::Base
   validates :scope_type, inclusion: ["Environment", "DeployGroup", nil]
 
   class << self
-    def env(project, deploy_group)
+    # preview parameter can be used to not raise an error,
+    # but return a value with a helpful message
+    def env(project, deploy_group, preview: false)
       variables = project.environment_variables + project.environment_variable_groups.flat_map(&:environment_variables)
       variables.sort_by! { |ev| ev.send :priority }
       env = variables.each_with_object({}) do |ev, all|

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -9,16 +9,16 @@ module SamsonEnv
         write_dotenv_file("#{dir}/.env", groups)
     end
 
-    def env_groups(project, deploy_groups)
+    def env_groups(project, deploy_groups, preview: false)
       groups = if deploy_groups.any?
         deploy_groups.map do |deploy_group|
           [
             ".#{deploy_group.name.parameterize}",
-            EnvironmentVariable.env(project, deploy_group)
+            EnvironmentVariable.env(project, deploy_group, preview: preview)
           ]
         end
       else
-        [["", EnvironmentVariable.env(project, nil)]]
+        [["", EnvironmentVariable.env(project, nil, preview: preview)]]
       end
       return groups if groups.any? { |_, data| data.present? }
     end

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -39,6 +39,12 @@ describe Admin::EnvironmentVariableGroupsController do
         get :preview, project_id: project.id
         assert_response :success
       end
+
+      it "calls env with preview" do
+        EnvironmentVariable.expects(:env).with(anything, anything, preview: true).times(3)
+        get :preview, group_id: env_group.id
+        assert_response :success
+      end
     end
 
     unauthorized :post, :create


### PR DESCRIPTION
in our private plugin we fail when unable to resolve some values, but would be nice to be able to show a helpful message so users can see if it only affects a certain group they might not care for / gives them a complete picture of the issue instead of failing at the first one

@zendesk/runway 

### Risks
 - None