### PR TITLE
Shender/fix project and stage caching

### DIFF
--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -2,7 +2,8 @@ class DeployGroup < ActiveRecord::Base
   has_soft_deletion default_scope: true
 
   belongs_to :environment
-  has_and_belongs_to_many :stages
+  has_many :deploy_groups_stages
+  has_many :stages, through: :deploy_groups_stages
 
   validates_presence_of :name, :environment_id
   validates_uniqueness_of :name, :env_value

--- a/app/models/deploy_groups_stage.rb
+++ b/app/models/deploy_groups_stage.rb
@@ -1,0 +1,4 @@
+class DeployGroupsStage < ActiveRecord::Base
+  belongs_to :stage, touch: true
+  belongs_to :deploy_group
+end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -16,10 +16,8 @@ class Stage < ActiveRecord::Base
     -> { order('stage_commands.position ASC') },
     through: :stage_commands, auto_include: false
 
-  # Force a dirty stage even if only the deploy_groups have changed.
-  has_and_belongs_to_many :deploy_groups,
-                          after_add: ->(stage, _) { stage.updated_at = Time.now },
-                          after_remove: ->(stage, _) { stage.updated_at = Time.now }
+  has_many :deploy_groups_stages
+  has_many :deploy_groups, through: :deploy_groups_stages
 
   default_scope { order(:order) }
 

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -16,7 +16,10 @@ class Stage < ActiveRecord::Base
     -> { order('stage_commands.position ASC') },
     through: :stage_commands, auto_include: false
 
-  has_and_belongs_to_many :deploy_groups
+  # Force a dirty stage even if only the deploy_groups have changed.
+  has_and_belongs_to_many :deploy_groups,
+                          after_add: ->(stage, _) { stage.updated_at = Time.now },
+                          after_remove: ->(stage, _) { stage.updated_at = Time.now }
 
   default_scope { order(:order) }
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -419,4 +419,14 @@ describe Stage do
     end
   end
 
+  describe '#save' do
+    it 'touches the stage and project when only changing deploy_groups for cache invalidation' do
+      stage_updated_at = stage.updated_at
+      project_updated_at = stage.project.updated_at
+      stage.deploy_groups << deploy_groups(:pod1)
+      stage.save
+      stage_updated_at.wont_equal stage.updated_at
+      project_updated_at.wont_equal stage.project.updated_at
+    end
+  end
 end


### PR DESCRIPTION
Cache wasn't taking into account changes to deploy group memberships for stages. So made it part of the cache_key.

![project0](https://cloud.githubusercontent.com/assets/515143/8549017/4e78ae0a-24c0-11e5-9e03-53dc3790f05e.png)

==================================================

![editing_pods__project0_](https://cloud.githubusercontent.com/assets/515143/8549018/508eb3ce-24c0-11e5-9af8-8435b1195888.png)

/cc @zendesk/runway @zendesk/samson 

### References
 - Jira link:

### Risks
 - None