### PR TITLE
force ssl except for ping

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  force_ssl if: :force_ssl?
+
   # CurrentUser must be after protect_from_forgery,
   # so that authenticate! is called
   include CurrentUser
@@ -11,6 +14,10 @@ class ApplicationController < ActionController::Base
   helper :flash
 
   protected
+
+  def force_ssl?
+    ENV['FORCE_SSL'] == '1'
+  end
 
   def verified_request?
     warden.winning_strategy || super

--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -4,4 +4,9 @@ class PingController < ApplicationController
   def show
     head :ok
   end
+
+  private
+  def force_ssl?
+    false
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,9 +39,6 @@ Samson::Application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ENV['FORCE_SSL'] == '1'
-
   # Set to :debug to see everything in the log.
   config.log_level = :info
 


### PR DESCRIPTION
@zendesk/runway @zendesk/samson @babbottscott 
https://zendesk.atlassian.net/browse/OP-12730

The problem is to use SSL means we need to access not just the Rails app but also nginx and friends. So the ping controller should be accessible without using ssl.

Alternative solution by @adammw would be for the health check to pass `X-Forwarded-Proto: https` header