### PR TITLE
Fix loading commit when comparing to master

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -1,5 +1,6 @@
 class Changeset
   attr_reader :repo, :previous_commit, :commit
+  BRANCH_TAGS = ["master", "develop"]
 
   def initialize(repo, previous_commit, commit)
     @repo, @commit = repo, commit
@@ -70,6 +71,11 @@ class Changeset
     if empty?
       NullComparison.new(nil)
     else
+      # for branches that need review we make sure to always get the correct cache, others might get an outdated changeset if they are reviewed with different shas
+      if BRANCH_TAGS.include?(commit)
+        @commit = GITHUB.branch(repo, commit).commit[:sha]
+      end
+
       Rails.cache.fetch(cache_key) do
         GITHUB.compare(repo, previous_commit, commit)
       end

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -11,11 +11,25 @@ describe Changeset do
       Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
     end
 
-    it "caches" do
-      stub_github_api("repos/foo/bar/compare/a...b", "x" => "y")
-      Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
-      stub_github_api("repos/foo/bar/compare/a...b", "x" => "z")
-      Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
+    describe "with a specificed SHA" do
+      it "caches" do
+        stub_github_api("repos/foo/bar/compare/a...b", "x" => "y")
+        Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
+        stub_github_api("repos/foo/bar/compare/a...b", "x" => "z")
+        Changeset.new("foo/bar", "a", "b").comparison.to_h.must_equal :x => "y"
+      end
+    end
+
+    describe "with master" do
+      it "doesn't cache" do
+        stub_github_api("repos/foo/bar/branches/master", {:commit => { sha: "foo"}})
+        stub_github_api("repos/foo/bar/compare/a...foo", "x" => "y")
+        Changeset.new("foo/bar", "a", "master").comparison.to_h.must_equal :x => "y"
+
+        stub_github_api("repos/foo/bar/branches/master", {:commit => { sha: "bar"}})
+        stub_github_api("repos/foo/bar/compare/a...bar", "x" => "z")
+        Changeset.new("foo/bar", "a", "master").comparison.to_h.must_equal :x => "z"
+      end
     end
 
     {


### PR DESCRIPTION
@grosser 
The changeset is cached with cache key is based on previous commit
and the tag when deploying. If the tag is a branch name, such as
`master`, the cache key is same leads to us seeing old data. If we
push more commit to the branch, new changeset won't be updated.

I ran into this issue when demoing Samson today to the team :(.
Someone try to push more commit and changeset still shows nothing