### PR TITLE
Only display the build project tab if the deploy flag is set in the p…

### DIFF
--- a/app/views/shared/_project_tabs.html.erb
+++ b/app/views/shared/_project_tabs.html.erb
@@ -7,9 +7,11 @@
       <%= link_to "Releases", project_releases_path(project) %>
     </li>
   <% end %>
-  <li class="<%= 'active' if active == 'builds' %>">
-    <%= link_to "Builds", project_builds_path(project) %>
-  </li>
+  <% if project.deploy_with_docker? %>
+    <li class="<%= 'active' if active == 'builds' %>">
+      <%= link_to "Builds", project_builds_path(project) %>
+    </li>
+  <% end %>
   <li class="<%= 'active' if active == 'deploys' %>">
     <%= link_to "Deploys", project_deploys_path(project) %>
   </li>


### PR DESCRIPTION
Only display the "Builds" project tab if the docker
 flag is set in the project settings.


![project0](https://cloud.githubusercontent.com/assets/515143/8745612/7194bc92-2c79-11e5-9dd9-ce638a6cccd8.png)



![samson](https://cloud.githubusercontent.com/assets/515143/8745687/46d988ec-2c7a-11e5-8f22-4d4f459b338e.png)



/cc @zendesk/runway 

### References
 - Jira link:

### Risks
 - None