### PR TITLE
Trigger docker build creation when webhooks are triggered.

### DIFF
--- a/app/assets/javascripts/projects.js
+++ b/app/assets/javascripts/projects.js
@@ -3,4 +3,8 @@ $(function() {
   $('.star a').bind('ajax:complete', function() {
     window.location.reload();
   });
+
+  $('#project_deploy_with_docker').change(function(){
+    $('#docker_release_push').toggle($(this).prop('checked'));
+  }).triggerHandler('change');
 });

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -3,7 +3,7 @@ class Integrations::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
-    return head(:ok) if !deploy?
+    return head(:ok) unless deploy?
     if project.create_releases_for_branch?(branch)
       create_build_record
       create_docker_image if project.deploy_with_docker? && project.auto_release_docker_image?

--- a/app/controllers/integrations/buildkite_controller.rb
+++ b/app/controllers/integrations/buildkite_controller.rb
@@ -10,7 +10,7 @@ class Integrations::BuildkiteController < Integrations::BaseController
   end
 
   def no_skip_token_present?
-    !contains_skip_token?(build_param[:message])
+    !contains_skip_token?(message)
   end
 
   def commit
@@ -23,5 +23,9 @@ class Integrations::BuildkiteController < Integrations::BaseController
 
   def build_param
     @build_param ||= params.fetch(:build, { })
+  end
+
+  def message
+    build_param[:message]
   end
 end

--- a/app/controllers/integrations/semaphore_controller.rb
+++ b/app/controllers/integrations/semaphore_controller.rb
@@ -7,7 +7,7 @@ class Integrations::SemaphoreController < Integrations::BaseController
   end
 
   def skip?
-    contains_skip_token?(params[:commit][:message])
+    contains_skip_token?(message)
   end
 
   def commit
@@ -16,5 +16,9 @@ class Integrations::SemaphoreController < Integrations::BaseController
 
   def branch
     params[:branch_name]
+  end
+
+  def message
+    params[:commit][:message]
   end
 end

--- a/app/controllers/integrations/travis_controller.rb
+++ b/app/controllers/integrations/travis_controller.rb
@@ -19,7 +19,7 @@ class Integrations::TravisController < Integrations::BaseController
   end
 
   def skip?
-    contains_skip_token?(payload['message'])
+    contains_skip_token?(message)
   end
 
   def branch
@@ -28,5 +28,9 @@ class Integrations::TravisController < Integrations::BaseController
 
   def commit
     payload['commit']
+  end
+
+  def message
+    payload['message']
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -86,6 +86,7 @@ class ProjectsController < ApplicationController
         :permalink,
         :release_branch,
         :deploy_with_docker,
+        :auto_release_docker_image,
         stages_attributes: stage_permitted_params
       ] + Samson::Hooks.fire(:project_permitted_params)
     )

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -10,7 +10,7 @@ class Build < ActiveRecord::Base
   has_many :releases
 
   validates :project, presence: true
-  validates :git_sha, format: SHA1_REGEX, allow_nil: true
+  validates :git_sha, format: SHA1_REGEX, allow_nil: true, uniqueness: true
   validates :docker_image_id, format: SHA256_REGEX, allow_nil: true
 
   validate :validate_git_reference, on: :create
@@ -73,7 +73,7 @@ class Build < ActiveRecord::Base
     if git_ref.present?
       commit = project.repository.commit_from_ref(git_ref, length: nil)
       if commit
-        self.git_sha = commit
+        self.git_sha = commit unless git_sha.present?
       else
         errors.add(:git_ref, 'is not a valid reference')
       end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,11 +43,11 @@ class Project < ActiveRecord::Base
     @docker_repo ||= begin
       registry = Rails.application.config.samson.docker.registry
       if Rails.env.production?
-        registry
+        "#{registry}/#{permalink_base}"
       else
         host, namespace = registry.split '/'
         namespace ||= 'samson'
-        "#{host}/#{namespace}_non_prod"
+        "#{host}/#{namespace}_non_prod/#{permalink_base}"
       end
     end
   end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -43,6 +43,11 @@
       <%= form.label :release_branch, class: "col-lg-2 control-label" %>
       <div class="col-lg-4">
         <%= form.text_field :release_branch, class: "form-control" %>
+        <div id="docker_release_push">
+          <%= form.check_box :auto_release_docker_image  %>
+          <%= form.label :auto_release_docker_image, 'Auto push docker images' %>
+        </div>
+
         <p class="help-block">New commits on this branch will cause a release.</p>
       </div>
     </div>

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -7,3 +7,9 @@ if ENV['DOCKER_URL'].present? && !Rails.env.test? && !ENV['PRECOMPILE']
   # Confirm the Docker daemon is a recent enough version
   Docker.validate_version!
 end
+
+
+if ENV['DOCKER_FEATURE'] && !ENV['DOCKER_REGISTRY'].present?
+  puts '*** DOCKER_REGISTRY environment variable must be configured when DOCKER_FEATURE is enabled ***'
+  exit(1)
+end

--- a/db/migrate/20150720121725_add_auto_build_docker_image_to_projects.rb
+++ b/db/migrate/20150720121725_add_auto_build_docker_image_to_projects.rb
@@ -1,0 +1,7 @@
+class AddAutoBuildDockerImageToProjects < ActiveRecord::Migration
+  def change
+    change_table :projects do |t|
+      t.boolean :auto_release_docker_image, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150619170905) do
+ActiveRecord::Schema.define(version: 20150720121725) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -215,6 +215,7 @@ ActiveRecord::Schema.define(version: 20150619170905) do
     t.text     "description",        limit: 65535
     t.string   "owner",              limit: 255
     t.boolean  "deploy_with_docker",               default: false, null: false
+    t.boolean  "auto_release_docker_image",        default: false, null: false
   end
 
   add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at", length: {"permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -1,0 +1,48 @@
+require_relative '../../test_helper'
+
+describe Integrations::BaseController do
+  let(:sha) { "dc395381e650f3bac18457909880829fc20e34ba" }
+  let(:project) { projects(:test) }
+  let(:stage) { stages(:test_staging) }
+  let(:base_controller) { Integrations::BaseController.new }
+
+  before do
+    project.releases.destroy_all
+    project.builds.destroy_all
+    Integrations::BaseController.any_instance.stubs(:deploy?).returns(true)
+    Integrations::BaseController.any_instance.stubs(:project).returns(project)
+    Integrations::BaseController.any_instance.stubs(:commit).returns(sha)
+    Integrations::BaseController.any_instance.stubs(:branch).returns('master')
+    Project.any_instance.stubs(:create_releases_for_branch?).returns(true)
+    Build.any_instance.stubs(:validate_git_reference).returns(true)
+    stub_request(:post, "https://api.github.com/repos/bar/foo/releases").
+      to_return(:status => 200, :body => "", :headers => {})
+  end
+
+  describe "#create" do
+    it 'creates release and build' do
+      base_controller.expects(:head).with(:ok)
+      base_controller.create
+      project.releases.count.must_equal 1
+      project.builds.count.must_equal 1
+    end
+
+    it 'returns :ok if this is not a merge' do
+      Integrations::BaseController.any_instance.stubs(:deploy?).returns(false)
+      base_controller.expects(:head).with(:ok)
+      base_controller.create
+      project.releases.count.must_equal 0
+      project.builds.count.must_equal 0
+    end
+
+    it 're-uses last release if commit already present' do
+      base_controller.expects(:head).with(:ok).twice
+      base_controller.create
+
+      base_controller.expects(:latest_release).once
+      base_controller.create
+      project.releases.count.must_equal 1
+      project.builds.count.must_equal 1
+    end
+  end
+end

--- a/test/controllers/integrations/travis_controller_test.rb
+++ b/test/controllers/integrations/travis_controller_test.rb
@@ -4,13 +4,11 @@ describe Integrations::TravisController do
   let(:sha) { "123abc" }
   let(:project) { projects(:test) }
   let(:stage) { stages(:test_staging) }
-  let(:release_service) { stub("release_service") }
 
   setup do
     Deploy.delete_all
     @orig_token, ENV["TRAVIS_TOKEN"] = ENV["TRAVIS_TOKEN"], "TOKEN"
     project.webhooks.create!(stage: stages(:test_staging), branch: "master", source: 'travis')
-    Project.any_instance.stubs(releases: stub("releases", create!: nil))
   end
 
   teardown do


### PR DESCRIPTION
Workflow now is:
- Webhook gets fired
- Build + Release records are built if project.release_branch is set
- Docker image is created + pushed if project.deploy_with_docker + project.auto_release_docker_image are set
- Commit is deployed if the branch matches any webhook mappings to stages.

I'll leave the actual hooking up to appropriate docker image reference when kicking off the deploys to another PR when we get staging/production up to actually test docker image creation first.


Screenshot with docker feature enabled for project:
![samson](https://cloud.githubusercontent.com/assets/515143/8780090/af4c8bf0-2efe-11e5-88ff-3507812ef4c4.png)

Screenshot with docker feature disabled for project:
![samson1](https://cloud.githubusercontent.com/assets/515143/8780100/b6da50be-2efe-11e5-86a1-eac1ca14251b.png)


/cc @zendesk/runway 

### References
 - Jira link:

### Risks
 - None