### PR TITLE
Allow deploys to determine what stage they are running from.

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -150,8 +150,10 @@ class JobExecution
       "cd #{dir}",
       *@job.commands
     ]
-    if @stage && group_names = @stage.deploy_groups.pluck(:env_value).sort.map!(&:shellescape).join(" ")
+    if @stage
+      group_names = @stage.deploy_groups.pluck(:env_value).sort.map!(&:shellescape).join(" ")
       commands.unshift("export DEPLOY_GROUPS='#{group_names}'") if group_names.presence
+      commands.unshift("export STAGE='#{@stage.permalink.shellescape}'")
     end
     commands
   end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -123,6 +123,7 @@ describe JobExecution do
     lines.must_include "DEPLOYER_NAME=John Doe"
     lines.must_include "REVISION=master"
     lines.must_include "TAG=v1"
+    lines.must_include "STAGE=stage4"
   end
 
   it 'works without a deploy' do


### PR DESCRIPTION
Mainly an internal request so that stages can create a local asset cache based on the stage name they are running inside while still being able to use a command command that's shared across stages.

Using the permalink instead of the name so that it can be dual purposed to allow creating URL to the stage as well.

/cc @zendesk/runway 

### References
 - Jira link:

### Risks
 - None