### PR TITLE
fix not being able to click into text area

### DIFF
--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -191,7 +191,7 @@
   $(document).ready(function() {
     var $localCommands = $('#commands pre.local');
 
-    $('#commands').sortable({cancel: '.global'});
+    $('#commands').sortable();
     $.fn.editableform.buttons = <%= render('commands/buttons').inspect.html_safe %>;
 
     $localCommands.editable({


### PR DESCRIPTION
@sandlerr not sure what this cancel option was supposed to do, but it breaks editing ...
/cc @zendesk/runway 

### Risks
 - None