### PR TITLE
Fix heroku incompatibility.

### DIFF
--- a/config/initializers/revision.rb
+++ b/config/initializers/revision.rb
@@ -3,5 +3,5 @@ file = Rails.root.join('REVISION')
 Rails.application.config.samson.revision = if File.exists?(file)
   File.read(file).chomp
 else
-  `git rev-parse HEAD`.chomp.presence || raise("No #{file} found and not a git repository ... something is wrong")
+  `git rev-parse HEAD`.chomp.presence
 end


### PR DESCRIPTION
Heroku strips git metadata when creating its deploy slugs. So just removing the exception that prevents startup.

/cc @zendesk/runway @zendesk/samson 
