### PR TITLE
SAMSON-170: add simple JIRA issue key matching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,16 @@ GITHUB_TOKEN={fill me in}
 # FLOWDOCK_API_TOKEN={ required for the flowdock integration }
 
 # FORCE_SSL={optional, set to 1 to require SSL}
+
+## JIRA_BASE_URL, if set, would enable the auto-detection of JIRA issue keys
+## (e.g., KEY-123, SAMSON-456) in the titles and bodies of the pull requests
+## associated with a deploy. The auto-detected JIRA issues will be displayed
+## and linked (by prepending JIRA_BASE_URL) in the "JIRA Issues" tab of a deploy
+##
+## Full absolute JIRA URLs will still be detected, and they will take precedence
+## over generated ones (i.e., if JIRA_BASE_URL is https://a.atlassian.net/browse/
+## and both "KEY-123" and "http://z.atlassian.net/browse/KEY-123" appear in a
+## pull request's title and body, only "http://z.atlassian.net/browse/KEY-123"
+## would appear in the "JIRA Issues" tab).
+##
+# JIRA_BASE_URL={optional, eg. https://jira.atlassian.net/browse/}

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -1,13 +1,19 @@
 class Changeset::PullRequest
+  # Common patterns
+  CODE_ONLY = "[A-Z][A-Z\\d]+-\\d+"  # e.g., S4MS0N-123, SAM-456
+  PUNCT = "\\s|\\p{Punct}|~|="
+
   # Matches a section heading named "Risks".
   RISKS_SECTION = /#+\s+Risks.*\n/i
 
   # Matches URLs to JIRA issues.
-  JIRA_ISSUE = %r[https://\w+\.atlassian\.net/browse/[\w-]+]
+  JIRA_ISSUE_URL = %r[https?:\/\/[\da-z\.\-]+\.[a-z\.]{2,6}\/browse\/#{CODE_ONLY}(?=#{PUNCT}|$)]
 
   # Matches "VOICE-1234" or "[VOICE-1234]"
-  JIRA_CODE = %r[(\[)*([a-zA-Z]+)-((\d)+)(\])*]
+  JIRA_CODE_TITLE = %r[(\[)*(#{CODE_ONLY})(\])*]
 
+  # Matches "VOICE-1234" only
+  JIRA_CODE = %r[(?<=#{PUNCT}|^)(#{CODE_ONLY})(?=#{PUNCT}|$)]
   # Finds the pull request with the given number.
   #
   # repo   - The String repository name, e.g. "zendesk/samson".
@@ -34,7 +40,7 @@ class Changeset::PullRequest
   delegate :number, :title, :additions, :deletions, to: :@data
 
   def title_without_jira
-    title.gsub(JIRA_CODE, "").strip
+    title.gsub(JIRA_CODE_TITLE, "").strip
   end
 
   def url
@@ -62,15 +68,25 @@ class Changeset::PullRequest
   end
 
   def jira_issues
-    @jira_issues ||= parse_jira_issues!
+    @jira_issues ||= parse_jira_issues
   end
 
   private
 
-  def parse_jira_issues!
-    body.scan(JIRA_ISSUE).map do |match|
-      Changeset::JiraIssue.new(match)
+  def parse_jira_issues
+    custom_jira_url = ENV['JIRA_BASE_URL']
+    title_and_body = "#{title} #{body}"
+    jira_issue_map = {}
+    if custom_jira_url
+      title_and_body.scan(JIRA_CODE).each do |match|
+        jira_issue_map[match[0]] = custom_jira_url + match[0]
+      end
     end
+    # explicit URLs should take precedence for issue links
+    title_and_body.scan(JIRA_ISSUE_URL).each do |match|
+      jira_issue_map[match.match(JIRA_CODE)[0]] = match
+    end
+    jira_issue_map.values.map { |x| Changeset::JiraIssue.new(x) }
   end
 
   def body

--- a/docs/extra_features.md
+++ b/docs/extra_features.md
@@ -25,3 +25,11 @@ Admin screens  | Dashboard screens
 ------------- | -------------
 <img src="/docs/images/deploy_group_admin2.png?raw=true" width="300" /> | <img src="/docs/images/deploy_group_dash1.png?raw=true" width="300" />
 <img src="/docs/images/deploy_group_admin.png?raw=true" width="300"> | <img src="/docs/images/deploy_group_dash2.png?raw=true" width="300">
+
+## Auto JIRA issue key detection
+
+Enable by setting JIRA_BASE_URL to a default JIRA instance e.g., `JIRA_BASE_URL=http://jira.example.com/browse/`
+
+This would enable the auto-detection of JIRA issue keys (e.g., KEY-123, SAMSON-456) in the titles and bodies of the pull requests associated with a deploy. The auto-detected JIRA issues will be displayed and linked in the "JIRA Issues" tab of a deploy.
+
+Full absolute JIRA URLs will still be detected when JIRA_BASE_URL is set, and they will take precedence over generated ones (i.e., if JIRA_BASE_URL is https://a.atlassian.net/browse/ and both "KEY-123" and "http://z.atlassian.net/browse/KEY-123" appear in a pull request's title and body, only "http://z.atlassian.net/browse/KEY-123" would appear in the "JIRA Issues" tab). Use full URLs if you need to reference issues of non-default JIRA instances.

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -66,8 +66,18 @@ describe Changeset::PullRequest do
   end
 
   describe "#jira_issues" do
-    let(:data_nil_body) { stub("data", user: user, body: nil) }
+    let(:data_nil_body) { stub("data", user: user, body: nil, title: nil) }
     let(:pr_no_body) { Changeset::PullRequest.new("xxx", data_nil_body) }
+    let(:jira_url) { "https://jira.zendesk.com/browse/" }
+
+    before do
+      @original_jira_url_env = ENV['JIRA_BASE_URL']
+      ENV['JIRA_BASE_URL'] = nil  # delete for consistent test environment
+    end
+
+    after do
+      ENV['JIRA_BASE_URL'] = @original_jira_url_env
+    end
 
     it "returns a list of JIRA issues referenced in the PR body" do
       body.replace(<<-BODY)
@@ -87,6 +97,174 @@ describe Changeset::PullRequest do
 
     it "returns an empty array if body is missing" do
       pr_no_body.jira_issues.must_equal []
+    end
+
+    it "returns a list of JIRA urls using JIRA_BASE_URL ENV var given JIRA codes" do
+      ENV['JIRA_BASE_URL'] = 'https://foo.atlassian.net/browse/'
+      body.replace(<<-BODY)
+        Fixes XY-123 and AB-666
+      BODY
+
+      pr.jira_issues.must_equal [
+        Changeset::JiraIssue.new("https://foo.atlassian.net/browse/XY-123"),
+        Changeset::JiraIssue.new("https://foo.atlassian.net/browse/AB-666")
+      ]
+    end
+
+    it "returns JIRA URLs from both title and body" do
+      ENV['JIRA_BASE_URL'] = 'https://foo.atlassian.net/browse/'
+      body.replace(<<-BODY)
+        Fixes issue in title and AB-666
+      BODY
+      data.title = "XY-123: Make it bigger!"
+
+      pr.jira_issues.must_equal [
+        Changeset::JiraIssue.new("https://foo.atlassian.net/browse/XY-123"),
+        Changeset::JiraIssue.new("https://foo.atlassian.net/browse/AB-666")
+      ]
+    end
+
+    it "returns an empty array if JIRA_BASE_URL ENV var is not set when given JIRA codes" do
+      ENV['JIRA_BASE_URL'] = nil
+      body.replace(<<-BODY)
+        Fixes XY-123 and AB-666
+      BODY
+
+      pr.jira_issues.must_equal []
+    end
+
+    it "returns an empty array if invalid URLs are given" do
+      body.replace(<<-BODY)
+        Fixes https://foobar.atlassian.net/browse/XY-123k
+      BODY
+
+      pr.jira_issues.must_equal []
+    end
+
+    it "should use full JIRA urls when given, falling back to JIRA_BASE_URL" do
+      ENV['JIRA_BASE_URL'] = 'https://foo.atlassian.net/browse/'
+      body.replace(<<-BODY)
+        Fixes https://foobar.atlassian.net/browse/XY-123 and AB-666
+      BODY
+
+      pr.jira_issues.must_equal [
+        Changeset::JiraIssue.new("https://foobar.atlassian.net/browse/XY-123"),
+        Changeset::JiraIssue.new("https://foo.atlassian.net/browse/AB-666")
+      ]
+    end
+
+    it "should use full URL if given and not auto-generate even when JIRA_BASE_URL is set" do
+      ENV['JIRA_BASE_URL'] = 'https://foo.atlassian.net/browse/'
+      body.replace(<<-BODY)
+        Fixes XY-123, see https://foobar.atlassian.net/browse/XY-123
+      BODY
+
+      pr.jira_issues.must_equal [
+        Changeset::JiraIssue.new("https://foobar.atlassian.net/browse/XY-123")
+      ]
+    end
+
+    single_key_cases = [
+      ["ABC-123",                "ABC-123"], # exactly the key
+      ["ABC-124 text",           "ABC-124"], # starting line with key
+      ["message ABC-123",        "ABC-123"], # ending line with key
+      ["message ABC-123 text",   "ABC-123"], # separated by whitespaces
+      ["message\nABC-123\ntext", "ABC-123"], # separated by newlines
+      ["message\rABC-123\rtext", "ABC-123"], # separated by carriage returns
+      ["message.ABC-123.text",   "ABC-123"], # separated by dots
+      ["message:ABC-123:text",   "ABC-123"], # separated by colons
+      ["message,ABC-123,text",   "ABC-123"], # separated by commas
+      ["message;ABC-123;text",   "ABC-123"], # separated by semicolons
+      ["message&ABC-123&text",   "ABC-123"], # separated by ampersands
+      ["message=ABC-123=text",   "ABC-123"], # separated by equal signs
+      ["message?ABC-123?text",   "ABC-123"], # separated by question marks
+      ["message!ABC-123!text",   "ABC-123"], # separated by exclamation marks
+      ["message/ABC-123/text",   "ABC-123"], # separated by slashes
+      ["message\\ABC-123\\text", "ABC-123"], # separated by back slashes
+      ["message~ABC-123~text",   "ABC-123"], # separated by tildas
+    ]
+    single_key_cases.each do |casebody, key|
+      it "returns #{key} when given \"#{casebody}\"" do
+        ENV['JIRA_BASE_URL'] = jira_url
+        full_url = jira_url + key
+        body.replace(casebody)
+        pr.jira_issues.must_equal [Changeset::JiraIssue.new(full_url)]
+      end
+    end
+
+    keys_with_number_cases = [
+      ["A1BC-123",                "A1BC-123"], # exactly the key
+      ["AB8C-123 text",           "AB8C-123"], # starting line with key
+      ["message A7BC-123",        "A7BC-123"], # ending line with key
+      ["message A7BC-123\r\n",    "A7BC-123"], # ending line with key
+      ["message AB9C-123 text",   "AB9C-123"], # separated by whitespaces
+      ["message\nA2BC-123\ntext", "A2BC-123"], # separated by newlines
+      ["message\rABC0-123\rtext", "ABC0-123"], # separated by carriage returns
+      ["mes\r\nABC0-123\r\ntext", "ABC0-123"], # separated by CRLF
+      ["mssge.ABC789-123.text", "ABC789-123"], # separated by dots
+      ["message:A1BC-123:text",   "A1BC-123"], # separated by colons
+      ["message,A1BC-123,text",   "A1BC-123"], # separated by commas
+      ["message;A1BC-123;text",   "A1BC-123"], # separated by semicolons
+      ["message&AB1C-123&text",   "AB1C-123"], # separated by ampersands
+      ["message=A1BC-123=text",   "A1BC-123"], # separated by equal signs
+      ["message?A1BC-123?text",   "A1BC-123"], # separated by question marks
+      ["message!AB1C-123!text",   "AB1C-123"], # separated by exclamation marks
+      ["message/AB1C-123/text",   "AB1C-123"], # separated by slashes
+      ["message\\A1BC-123\\text", "A1BC-123"], # separated by back slashes
+      ["message~A1BC-123~text",   "A1BC-123"]  # separated by tildas
+    ]
+    keys_with_number_cases.each do |casebody, key|
+      it "returns #{key} when given \"#{casebody}\"" do
+        ENV['JIRA_BASE_URL'] = jira_url
+        full_url = jira_url + key
+        body.replace(casebody)
+        pr.jira_issues.must_equal [Changeset::JiraIssue.new(full_url)]
+      end
+    end
+
+    multiple_keys_cases = [
+      ["ABC-123 DEF-456",                 ["ABC-123", "DEF-456"]], # exactly the keys
+      ["message ABD-123 DEF-456 text",    ["ABD-123", "DEF-456"]], # separated by whitespaces
+      ["message\nABC-123\nDEF-456\ntext", ["ABC-123", "DEF-456"]], # separated by newlines
+      ["message\rABC-123\rDEF-457\rtext", ["ABC-123", "DEF-457"]], # separated by carriage returns
+      ["message.ABC-123.DEF-456.text",    ["ABC-123", "DEF-456"]], # separated by dots
+      ["message:ABC-123:DEF-456:text",    ["ABC-123", "DEF-456"]], # separated by colons
+      ["message,ABC-123,DEF-456,text",    ["ABC-123", "DEF-456"]], # separated by commas
+      ["message;ABC-123;DEF-456;text",    ["ABC-123", "DEF-456"]], # separated by semicolons
+      ["message&ABC-123&DEF-456&text",    ["ABC-123", "DEF-456"]], # separated by ampersands
+      ["message=ABC-123=DEF-456=text",    ["ABC-123", "DEF-456"]], # separated by equal signs
+      ["message?ABC-123?DEF-456?text",    ["ABC-123", "DEF-456"]], # separated by question marks
+      ["message!ABC-123!DEF-456!text",    ["ABC-123", "DEF-456"]], # separated by exclamation marks
+      ["message/ABC-123/DEF-456/text",    ["ABC-123", "DEF-456"]], # separated by slashes
+      ["message\\ABC-123\\DEF-456\\text", ["ABC-123", "DEF-456"]], # separated by back slashes
+      ["message~ABC-123~DEF-456~text",    ["ABC-123", "DEF-456"]], # separated by tildas
+    ]
+    multiple_keys_cases.each do |casebody, keys|
+      it "returns #{keys} when given \"#{casebody}\"" do
+        ENV['JIRA_BASE_URL'] = jira_url
+        body.replace(casebody)
+        pr.jira_issues.must_equal keys.map { |x| Changeset::JiraIssue.new(jira_url + x) }
+      end
+    end
+
+    no_key_cases = [
+      "message without key",
+      "message ABC-A text",
+      "message M-123 invalid key",
+      "message MES- invalid key",
+      "message -123 invalid key",
+      "message 1ABC-123 invalid key",
+      "message 123-123 invalid key",
+      "should not parse key0MES-123",
+      "should not parse MES-123key",
+      "MES-123k invalid char",
+      "invalid char MES-123k"
+    ]
+    no_key_cases.each do |casebody|
+      it "returns [] when given \"#{casebody}\"" do
+        body.replace(casebody)
+        pr.jira_issues.must_equal []
+      end
     end
   end
 


### PR DESCRIPTION
Requires an environment variable `JIRA_URL` to be set.
Format should be a URL including the trailing slash.
Example: https://jira.zendesk.com/browse/

If `JIRA_URL` is not set, behaviour reverts to a more general case of the current behaviour.
It will match generic URLs with a /browse/ISSUE-KEY format instead of just Atlassian ones.

If `JIRA_URL` is set, plain issue keys (e.g., ABC-123) will have full URLs generated.
e.g., https://jira.zendesk.com/browse/ABC-123

Works for issue keys in both title and body of the PR.