### PR TITLE
Allow airbrakes to be output to log when in development mode.

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -56,7 +56,7 @@ class JobExecution
   def error!(exception)
     message = "JobExecution failed: #{exception.message}"
 
-    if defined?(Airbrake) && !exception.is_a?(Samson::Hooks::UserError)
+    if !exception.is_a?(Samson::Hooks::UserError)
       Airbrake.notify(exception,
         error_message: message,
         parameters: {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -170,14 +170,12 @@ class Project < ActiveRecord::Base
   def alert_clone_error!(exception)
     message = "Could not clone git repository #{repository_url} for project #{name}"
     log.error("#{message} - #{exception.message}")
-    if defined?(Airbrake)
-      Airbrake.notify(exception,
-        error_message: message,
-        parameters: {
-          project_id: id
-        }
-      )
-    end
+    Airbrake.notify(exception,
+      error_message: message,
+      parameters: {
+        project_id: id
+      }
+    )
   end
 
   def valid_repository_url

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,7 +1,17 @@
-if !defined?(Rails) || Rails.env.staging? || Rails.env.production?
-  require 'airbrake'
+require 'airbrake'
 
+if !defined?(Rails) || Rails.env.staging? || Rails.env.production?
   Airbrake.configure do |config|
     config.api_key = ENV['AIRBRAKE_API_KEY']
+  end
+else
+  module Airbrake
+    def self.notify(ex, *args)
+      logger.error "AIRBRAKE: #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
+    end
+
+    def self.notify_or_ignore(ex, *args)
+      notify(ex)
+    end
   end
 end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,16 +1,15 @@
-require 'airbrake'
-
 if !defined?(Rails) || Rails.env.staging? || Rails.env.production?
+  require 'airbrake'
   Airbrake.configure do |config|
     config.api_key = ENV['AIRBRAKE_API_KEY']
   end
 else
   module Airbrake
-    def self.notify(ex, *args)
-      logger.error "AIRBRAKE: #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
+    def self.notify(ex, *_args)
+      Rails.logger.error "AIRBRAKE: #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
     end
 
-    def self.notify_or_ignore(ex, *args)
+    def self.notify_or_ignore(ex, *_args)
       notify(ex)
     end
   end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -170,6 +170,7 @@ describe Project do
       project.repository.expects(:clone!).raises(error)
       expected_message = "Could not clone git repository #{project.repository_url} for project #{project.name} - #{error}"
       Rails.logger.expects(:error).with(expected_message)
+      Airbrake.expects(:notify).once
       clone_repository(project)
     end
 


### PR DESCRIPTION
There are a few places in the code (especially Plugins) that don't log the error, and only send an Airbrake if it's defined.

This will allow developer to see when an airbrake is going to be sent when in development mode.
It just prints the error and a section of the backtrace.

/cc @zendesk/runway @zendesk/samson 

### References
 - Jira link:

### Risks
 - None