### PR TITLE
Allow binaries to be compiled in separate docker image to reduce size…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,9 @@
 PATH
+  remote: plugins/docker_binary_builder/
+  specs:
+    samson_docker_binary_builder (0.0.0)
+
+PATH
   remote: plugins/dockerb/
   specs:
     samson_dockerb (0.0.0)
@@ -416,6 +421,7 @@ DEPENDENCIES
   rails-assets-vis!
   rails-assets-x-editable!
   rails_12factor
+  samson_docker_binary_builder!
   samson_dockerb!
   samson_env!
   samson_flowdock!

--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -30,6 +30,7 @@ class DockerBuilderService
 
   def build_image(tmp_dir)
     repository.setup!(tmp_dir, build.git_sha)
+    Samson::Hooks.fire(:before_docker_build, tmp_dir, build, output_buffer)
 
     File.write("#{tmp_dir}/REVISION", build.git_sha)
 

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -110,6 +110,10 @@ class GitRepository
     @executor ||= TerminalExecutor.new(StringIO.new)
   end
 
+  def file_changed?(sha1, sha2, file)
+    executor.execute!("cd #{pwd}", "git diff --quiet --name-only #{sha1}..#{sha2} #{file}")
+  end
+
   private
 
   def checkout!(git_reference, pwd: repo_cache_dir)

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -98,7 +98,7 @@ class JobExecution
 
   def execute!(dir)
     if setup!(dir)
-      Samson::Hooks.fire(:after_deploy_setup, dir, stage) if stage
+      Samson::Hooks.fire(:after_deploy_setup, dir, stage, @output, @reference) if stage
     else
       @job.error!
       return

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -21,6 +21,7 @@ module Samson
       :before_deploy,
       :after_deploy_setup,
       :after_deploy,
+      :before_docker_build,
       :after_docker_build,
       :after_job_execution
     ].freeze

--- a/plugins/docker_binary_builder/README.md
+++ b/plugins/docker_binary_builder/README.md
@@ -1,0 +1,63 @@
+# Docker Builder for Binaries
+
+This plugin is useful when your projects are based on compiled languages and you don't want to base
+your deployment docker images on images that have all the tools/libs/compilers installed.
+
+Advantages to separating your docker images include:
+- Smaller deployment docker images.
+- Better security in your docker images to not be able to recompile code.
+
+## Getting Started
+
+This plugin makes a few assumptions:
+- You have 2 dockerfiles:
+ - 'Dockerfile' used to generate your main deployment docker image
+ - 'Dockerfile.build' used to create a temporary image to build any binaries you want to package into the former.
+- You have a build script 'build.sh' that can be executed to compile the needed binaries
+  - This is packaged inside the Dockerfile.build image and executed
+  - After binaries are compiled the build.sh script finishes by tar'ing all necessary files into an 'artifacts.tar' file.
+  
+If you want to share caches between builds, e.g. all your projects are Java and use Maven to build, then sharing the .m2 
+directory will be a huge time saving tactic to share all downloaded dependencies.
+
+If the directory '/opt/samson_build_cache' exists on the Docker host, it will mount it to '/build/cache' inside the 
+docker build image. That way you could then instruct Maven to use '/build/cache/.m2' as the cache directory for all your 
+projects.
+
+## Example Setup
+
+'Dockerfile' contents
+```
+# We only need the JRE base image now
+FROM java:8u45-jre
+
+# These jars will be built in the other Dockerfile.build image and then copied into here.
+ADD target/scala-2.11/myproject-*.jar
+```
+
+
+'Dockerfile.build' contents
+```
+FROM scala_sbt:2.11.7
+
+# create cache directory in case it couldn't be mounted correctly
+RUN mkdir -p /build/cache
+# '/app' will be the main directory in this image
+RUN mkdir -p /app/src
+
+# Add the scala build config files
+ADD project /app/project
+# Add the source directory into this image 
+ADD src/main /app/src/main
+# Add our main build script into the image
+ADD build.sh /app/build.sh
+
+WORKDIR /app
+```
+
+'build.sh' contents:
+```
+#!/usr/bin/env bash
+sbt -ivy /build/cache/.ivy2 clean compile assembly
+cd /app && tar -cvf /app/artifacts.tar target/scala-2.11/*.jar
+```

--- a/plugins/docker_binary_builder/lib/samson_docker_binary_builder/samson_plugin.rb
+++ b/plugins/docker_binary_builder/lib/samson_docker_binary_builder/samson_plugin.rb
@@ -1,0 +1,12 @@
+module SamsonDockerBinaryBuilder
+  class Engine < Rails::Engine
+  end
+end
+
+Samson::Hooks.callback :before_docker_build do |dir, build, output|
+  BinaryBuilder.new(dir, build.project, build.git_ref, output).build
+end
+
+Samson::Hooks.callback :after_deploy_setup do |dir, stage, output, reference|
+  BinaryBuilder.new(dir, stage.project, reference, output).build
+end

--- a/plugins/docker_binary_builder/samson_docker_binary_builder.gemspec
+++ b/plugins/docker_binary_builder/samson_docker_binary_builder.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new 'samson_docker_binary_builder', '0.0.0' do |s|
   s.summary = 'Samson DockerBinaryBuilder plugin'
-  s.authors = ['Shane Hender']
-  s.email = ['henders@gmail.com']
+  s.authors = ['Shane Hender', 'Fabio Neves', 'Stuart Gray', 'Andrei Balcanasu']
+  s.email = ['henders@gmail.com' ]
   s.files = Dir['{app,config,db,lib}/**/*']
 end

--- a/plugins/docker_binary_builder/samson_docker_binary_builder.gemspec
+++ b/plugins/docker_binary_builder/samson_docker_binary_builder.gemspec
@@ -1,0 +1,6 @@
+Gem::Specification.new 'samson_docker_binary_builder', '0.0.0' do |s|
+  s.summary = 'Samson DockerBinaryBuilder plugin'
+  s.authors = ['Shane Hender']
+  s.email = ['henders@gmail.com']
+  s.files = Dir['{app,config,db,lib}/**/*']
+end

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -1,0 +1,86 @@
+require_relative '../test_helper'
+
+describe BinaryBuilder do
+  describe '#build' do
+    let(:project) { projects(:test) }
+    let(:dir) { '/tmp' }
+    let(:reference) { 'abc' }
+    let(:output) { StringIO.new }
+    let(:builder) { BinaryBuilder.new(dir, project, reference, output) }
+    let(:fake_image) { stub(remove: true) }
+    let(:fake_container) { stub(delete: true, start: true, attach: true, copy: true) }
+
+    before do
+      Docker.stubs(:version).returns({ 'ApiVersion' => '1.19' })
+      Docker::Container.stubs(:create).returns(fake_container)
+      Docker::Image.stubs(:build_from_dir).returns(fake_image)
+      builder.stubs(:untar).returns(true)
+    end
+
+    it 'does nothing if docker flag is not set for project' do
+      builder.expects(:create_image).never
+      builder.build
+    end
+
+    it 'does nothing if docker flag is set for project but no dockerfile.build exists' do
+      File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_FILE)).returns(false)
+      project.update_attributes(deploy_with_docker: true)
+      builder.expects(:create_image).never
+      builder.build
+    end
+
+    it 'builds image if docker flag is set for project and dockerfile.build exists' do
+      File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_FILE)).returns(true)
+      project.update_attributes(deploy_with_docker: true)
+      builder.build
+      output.string.must_equal [
+        "Connecting to Docker host with Api version: 1.19 ...\n",
+        "Now building the build container...\n",
+        "Now starting Build container...\n",
+        "Grabbing '/app/artifacts.tar' from build container...\n",
+        "Continuing docker build...\n",
+        "Cleaning up docker build image and container...\n"].join
+    end
+
+    it 'uses the old style of mounting directories with api v1.19' do
+      Docker.stubs(:version).returns({ 'ApiVersion' => '1.19' })
+      builder.send(:create_container_options).must_equal(
+        {
+          'Cmd' => ['/app/build.sh'],
+          'Image' => 'foo_build:abc',
+          'Volumes' => { '/opt/samson_build_cache' => {} },
+          'HostConfig' => {
+            'Binds' => ['/opt/samson_build_cache:/build/cache'],
+            'NetworkMode' => 'host'
+          }
+        }
+      )
+    end
+
+    it 'uses the new style of mounting directories with api v1.20' do
+      Docker.stubs(:version).returns({ 'ApiVersion' => '1.20' })
+      builder.send(:create_container_options).must_equal(
+        {
+          'Cmd' => ['/app/build.sh'],
+          'Image' => 'foo_build:abc',
+          'Mounts' => [
+            {
+              'Source' => '/opt/samson_build_cache',
+              'Destination' => '/build/cache',
+              'Mode' => 'rw,Z',
+              'RW' => true
+            }
+          ],
+          'HostConfig' => {
+            'NetworkMode' => 'host'
+          }
+        }
+      )
+    end
+
+    it 'throws exception with api < 1.15' do
+      Docker.stubs(:version).returns({ 'ApiVersion' => '1.14' })
+      proc { builder.send(:create_container_options) }.must_raise RuntimeError
+    end
+  end
+end

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -18,19 +18,19 @@ describe BinaryBuilder do
     end
 
     it 'does nothing if docker flag is not set for project' do
-      builder.expects(:create_image).never
+      builder.expects(:create_build_image).never
       builder.build
     end
 
     it 'does nothing if docker flag is set for project but no dockerfile.build exists' do
-      File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_FILE)).returns(false)
+      File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_BUILD_FILE)).returns(false)
       project.update_attributes(deploy_with_docker: true)
-      builder.expects(:create_image).never
+      builder.expects(:create_build_image).never
       builder.build
     end
 
     it 'builds image if docker flag is set for project and dockerfile.build exists' do
-      File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_FILE)).returns(true)
+      File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_BUILD_FILE)).returns(true)
       project.update_attributes(deploy_with_docker: true)
       builder.build
       output.string.must_equal [

--- a/plugins/docker_binary_builder/test/test_helper.rb
+++ b/plugins/docker_binary_builder/test/test_helper.rb
@@ -1,0 +1,1 @@
+require_relative '../../../test/test_helper'

--- a/plugins/dockerb/test/hooks_test.rb
+++ b/plugins/dockerb/test/hooks_test.rb
@@ -5,7 +5,7 @@ describe "env hooks" do
 
   describe :after_deploy_setup do
     def fire
-      Samson::Hooks.fire(:after_deploy_setup, "repo", stage)
+      Samson::Hooks.fire(:after_deploy_setup, "repo", stage, StringIO.new, 'abc')
     end
 
     around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir) { test.call } } }

--- a/plugins/env/test/hooks_test.rb
+++ b/plugins/env/test/hooks_test.rb
@@ -7,7 +7,7 @@ describe "env hooks" do
 
   describe :after_deploy_setup do
     def fire
-      Samson::Hooks.fire(:after_deploy_setup, Dir.pwd, stage)
+      Samson::Hooks.fire(:after_deploy_setup, Dir.pwd, stage, StringIO.new, 'abc')
     end
 
     around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir) { test.call } } }
@@ -47,7 +47,7 @@ describe "env hooks" do
 
       describe "with deploy groups" do
         it "deletes the base file" do
-          Samson::Hooks.fire(:after_deploy_setup, Dir.pwd, stage)
+          Samson::Hooks.fire(:after_deploy_setup, Dir.pwd, stage, StringIO.new, 'abc')
           File.read(".env.pod-100").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
           refute File.exist?(".env")
         end


### PR DESCRIPTION
This plugin basically allows apps that deal with compiled languages to not have bloated docker deployment images.

At moment projects deal with deploying apps with compiled binaries in 2 ways:
- Compile the binaries locally and checkin to the github repo.
- Have the docker image contain all the tools/compilers/libraries necessary to compile the binaries and build it all into the deployment image.

With a Scala app, this can lead to 1.5GB docker images.

To solve this we split building into the docker image into 2 phases:
- 1: Build and spin up a temporary build container that has all the tools/libs necessary to compile the binaries. A script inside this compiles the binaries, and Samson retrieves those binaries that are zipped into a tarball
- 2: The main Dockerfile is then used to build the docker image which now has all the binaries available but only needs the runtime libs in the actual image for deployment.

/cc @zendesk/runway @stubotnik @fneves @andreionut 

### References
 - Jira link:

### Risks
 - None