### PR TITLE
send the job's commit to jenkins as a param

### DIFF
--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -16,7 +16,7 @@ module Samson
     def build
       opts = {'build_start_timeout' => 60}
       originated_from = deploy.project.name + '_' + deploy.stage.name + '_' + deploy.reference
-      client.job.build(job_name, {'buildStartedBy' => deploy.user.name, 'originatedFrom' => originated_from}, opts).to_i
+      client.job.build(job_name, {'buildStartedBy' => deploy.user.name, 'originatedFrom' => originated_from, 'commit' => deploy.job.commit}, opts).to_i
     rescue Timeout::Error => e
       "Jenkins '#{job_name}' build failed to start in a timely manner.  #{e.class} #{e}"
     rescue JenkinsApi::Exceptions::ApiException => e

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -13,7 +13,7 @@ describe Samson::Jenkins do
 
   def stub_build_with_parameters
     stub_request(:post, "http://user%40test.com:japikey@www.test-url.com/job/test_job/buildWithParameters").
-      with(body: {"buildStartedBy"=>"Super Admin", "originatedFrom"=>"Project_Staging_staging"}).
+      with(body: {"buildStartedBy"=>"Super Admin", "originatedFrom"=>"Project_Staging_staging", "commit" => "staging"}).
       to_return(status: 200, body: "", headers: {}).to_timeout
   end
 


### PR DESCRIPTION
We will need to know the `commit` (sha) of the deploy to know what version of the application to build on jenkins. We can't rely on the deploy's `reference` as sometimes it just sends `master` but that can be changing.

@rdhanoa 