### PR TITLE
Add Zendesk Samson webhook hidden inside travis ENV var.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ env:
     - DB=postgresql TASK=rake
     - DB=sqlite TASK=rake
 script: script/ci.rb
+notifications:
+  webhooks:
+    urls:
+      - $SAMSON_WEBHOOK
+    on_failure: never


### PR DESCRIPTION
This is to see if Webhooks can be hidden inside env vars so that external users don't see our Samson server URL.

/cc @zendesk/runway 

### References
 - Jira link:

### Risks
 - None