### PR TITLE
Stop waiting 5 secs for dangling threads to finish

### DIFF
--- a/test/controllers/streams_controller_test.rb
+++ b/test/controllers/streams_controller_test.rb
@@ -6,6 +6,8 @@ describe StreamsController do
   let(:deployer) { users(:deployer) }
   let(:job) { jobs(:succeeded_test) }
 
+  after { kill_extra_threads } # SSE heartbeat never finishes
+
   as_a_deployer do
     describe "a GET to :show" do
       it "should have an initial :started SSE and a :finished SSE" do

--- a/test/models/event_streamer_test.rb
+++ b/test/models/event_streamer_test.rb
@@ -36,7 +36,7 @@ describe EventStreamer do
   let(:stream) { FakeStream.new }
   let(:streamer) { EventStreamer.new(stream) }
 
-  after { extra_threads.each(&:kill) } # heartbeat never finishes
+  after { kill_extra_threads } # heartbeat never finishes
 
   it "writes each message in the output into the stream" do
     streamer.start(output)


### PR DESCRIPTION
Rather than timing out after 5 seconds if there are dangling threads for a test, just fail out immediately and kill them.

/cc @zendesk/runway @zendesk/samson 

### References
 - Jira link:

### Risks
 - None