### PR TITLE
make sure to lock on git setup for Build

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -68,7 +68,9 @@ class Build < ActiveRecord::Base
 
     return if errors.include?(:git_ref) || errors.include?(:git_sha)
 
-    project.repository.setup_local_cache!
+    project.with_lock(holder: 'Build reference validation') do
+      project.repository.setup_local_cache!
+    end
 
     if git_ref.present?
       commit = project.repository.commit_from_ref(git_ref, length: nil)


### PR DESCRIPTION
@zendesk/samson 

Why are we creating build records without Docker deploys?
https://github.com/zendesk/samson/blob/master/app/controllers/integrations/base_controller.rb#L8