### PR TITLE
allow selective disabling of plugins via ENV variable

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,4 +1,4 @@
-### Plugins
+# Plugins
 
 Samson now supports writing plugins to add functionality to the core app keeping the core isolated and simpler. You can
 thus add UI elements to pages that support it, and hook into events such as before and after deploys.
@@ -19,3 +19,21 @@ Current Plugins:
 * Jenkins
 * Pipelines
 * Slack
+
+## Enabling Plugins
+
+To specify which plugins you want to run, Samson looks at the `PLUGINS` environment
+variable. Through this mechanism, you can enable and disable plugins.
+
+To selectively enable plugins, you can pass a comma-separated list:
+
+`PLUGINS="flowdock,env,slack"`
+
+To enable all plugins, use a value of "all":
+
+`PLUGINS="all"`
+
+To selectively disable plugins, use "all", and then a comma-separated list of
+plugins, with a minus sign in front of each:
+
+`PLUGINS="all,-flowdock,-slack"`

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -40,7 +40,7 @@ module Samson
       end
 
       def active?
-        Rails.env.test? || ENV["PLUGINS"] == "all" || ENV["PLUGINS"].to_s.split(',').map(&:strip).include?(@name)
+        Hooks.active_plugin?(@name)
       end
 
       def load
@@ -94,6 +94,16 @@ module Samson
         end
       end
 
+      def active_plugin?(plugin_name)
+        if Rails.env.test?
+          true
+        elsif @all_plugins_enabled
+          !@disabled_plugins.include?(plugin_name)
+        else
+          @enabled_plugins.include?(plugin_name)
+        end
+      end
+
       # configure
       def callback(name, &block)
         hooks(name) << block
@@ -131,6 +141,7 @@ module Samson
       end
 
       def plugin_setup
+        parse_env_var
         Samson::Hooks.plugins.
           each(&:load).
           each(&:add_migrations).
@@ -167,11 +178,35 @@ module Samson
         nil
       end
 
+      def reset_plugins!
+        @plugins = nil
+        parse_env_var
+      end
+
       private
 
       def hooks(*args)
         raise "Using unsupported hook #{args.inspect}" unless KNOWN.include?(args.first)
         (@@hooks[args] ||= [])
+      end
+
+      # Loads the PLUGINS environment variable. See docs/plugins.md for more info.
+      def parse_env_var
+        @enabled_plugins = []
+        @disabled_plugins = []
+        @all_plugins_enabled = false
+
+        values = (ENV['PLUGINS'] || '').split(',').map(&:strip)
+
+        @all_plugins_enabled = true if values.delete('all')
+
+        values.each do |v|
+          if v.starts_with?('-')
+            @disabled_plugins << v[1..-1]
+          else
+            @enabled_plugins << v
+          end
+        end
       end
     end
   end

--- a/test/lib/samson/hooks_test.rb
+++ b/test/lib/samson/hooks_test.rb
@@ -10,7 +10,7 @@ describe Samson::Hooks do
       ENV['PLUGINS'] = plugins
 
       # Clear cached plugins
-      Samson::Hooks.instance_variable_set('@plugins', nil)
+      Samson::Hooks.reset_plugins!
     end
 
     context 'when in the test environment' do
@@ -38,11 +38,25 @@ describe Samson::Hooks do
         end
       end
 
+       context 'when the plugins env is set to all' do
+        let(:plugins) { 'all,-slack,-zendesk' }
+
+        it 'returns the plugins that were not disabled' do
+          Samson::Hooks.plugins.size.must_equal (number_of_plugins - 2)
+          refute Samson::Hooks.active_plugin?('slack')
+          refute Samson::Hooks.active_plugin?('zendesk')
+          assert Samson::Hooks.active_plugin?('env')
+        end
+      end
+
       context 'when the plugins env is set to include some plugins' do
         let(:plugins) { 'slack, zendesk' }
 
         it 'only returns those plugins' do
           Samson::Hooks.plugins.size.must_equal 2
+          assert Samson::Hooks.active_plugin?('slack')
+          assert Samson::Hooks.active_plugin?('zendesk')
+          refute Samson::Hooks.active_plugin?('env')
         end
       end
     end


### PR DESCRIPTION
Adds the capability to say "all plugins except A, B, and C" via a syntax like:

`PLUGINS="all,-slack,-env"`

/cc @zendesk/samson

### Risks
 - Minimal. No change to current behavior. Only adds new functionality.