### PR TITLE
Revert "add an incrementing per-project number to Build"

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -15,8 +15,6 @@ class Build < ActiveRecord::Base
 
   validate :validate_git_reference, on: :create
 
-  before_create :assign_number
-
   def nice_name
     "Build #{label.presence || id}"
   end
@@ -86,10 +84,5 @@ class Build < ActiveRecord::Base
         errors.add(:git_sha, 'is not a valid SHA for this project')
       end
     end
-  end
-
-  def assign_number
-    biggest_number = project.builds.maximum(:number) || 0
-    self.number = biggest_number + 1
   end
 end

--- a/db/migrate/20150903201829_add_number_to_builds.rb
+++ b/db/migrate/20150903201829_add_number_to_builds.rb
@@ -1,9 +1,0 @@
-class AddNumberToBuilds < ActiveRecord::Migration
-  def change
-    change_table :builds do |t|
-      t.integer :number, after: :project_id
-    end
-
-    Release.joins(:build).update_all('builds.number = releases.number')
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150903201829) do
+ActiveRecord::Schema.define(version: 20150720121725) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 20150903201829) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                       null: false
-    t.integer  "number",              limit: 4
     t.string   "git_sha",             limit: 255
     t.string   "git_ref",             limit: 255
     t.string   "docker_image_id",     limit: 255

--- a/test/fixtures/builds.yml
+++ b/test/fixtures/builds.yml
@@ -1,18 +1,15 @@
 staging:
   project: test
-  number: 1
   git_sha: 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
   git_ref: 'staging'
 
 v1_tag:
   project: test
-  number: 2
   git_sha: '0fbc33a0bfe9dcb5a17e26b9c319cce9d86ede14'
   git_ref: 'v1.0'
 
 docker_build:
   project: test
-  number: 3
   git_sha: '1a6f551a2ffa6d88e15eef5461384da0bfb1c194'
   git_ref: 'v123'
   docker_image_id: '2d2b0b3204b0166435c3d96d0b27d0ad2083e5e040192632c58eeb9491d6bfaa'

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -51,22 +51,6 @@ describe Build do
     end
   end
 
-  describe 'create' do
-    let(:project) { projects(:test) }
-
-    before do
-      create_repo_without_tags
-      project.repository_url = repo_temp_dir
-    end
-
-    it 'increments the build number' do
-      biggest_build_num = project.builds.maximum(:number) || 0
-      build = project.builds.create!(git_ref: 'master')
-      assert_valid(build)
-      assert_equal(biggest_build_num + 1, build.number)
-    end
-  end
-
   describe 'successful?' do
     let(:build) { builds(:staging) }
 


### PR DESCRIPTION
Reverts zendesk/samson#545

Still confused about the intent with the 1-to-many relationship with the 'releases' table. So just reverting it since it breaks SQLite migrations.


Describe your PR

/cc @zendesk/samson @zendesk/runway @jonmoter 

### References
 - Jira link:

### Risks
 - None