### PR TITLE
Allow viewer to access project overview

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,7 +2,6 @@ class ProjectsController < ApplicationController
   include StagePermittedParams
 
   before_action :authorize_admin!, except: [:show, :index, :deploy_group_versions]
-  before_action :redirect_viewers!, only: [:show]
   before_action :project, only: [:show, :edit, :update, :deploy_group_versions]
   before_action :get_environments, only: [:new, :create]
 
@@ -95,12 +94,6 @@ class ProjectsController < ApplicationController
   def project
     @project ||= Project.find_by_param!(params[:id]).tap do |project|
       project.current_user = current_user
-    end
-  end
-
-  def redirect_viewers!
-    unless current_user.is_deployer?
-      redirect_to project_deploys_path(project)
     end
   end
 

--- a/app/views/projects/_stage.html.erb
+++ b/app/views/projects/_stage.html.erb
@@ -16,6 +16,10 @@
     <% else %>
       <td>-</td>
     <% end %>
-    <td align="right"><%= deploy_link @project, stage %></td>
+    <td align="right">
+      <% if current_user.is_deployer? %>
+        <%= deploy_link @project, stage %>
+      <% end %>
+    </td>
   </tr>
 <% end %>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -20,7 +20,9 @@
     <% end %>
   </td>
   <td>
-    <%= render 'deploy_to_button', release: release, stages: @stages %>
+    <% if current_user.is_deployer? %>
+      <%= render 'deploy_to_button', release: release, stages: @stages %>
+    <% end %>
   </td>
 </tr>
 <tr class="release-info collapse">

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -238,9 +238,9 @@ describe ProjectsController do
 
   describe "a GET to #show" do
     as_a_viewer do
-      it "redirects to the deploys page" do
+      it "does not redirect to the deploys page" do
         get :show, id: project.to_param
-        assert_redirected_to project_deploys_path(project)
+        assert_response :success
       end
     end
 


### PR DESCRIPTION
Currently the Viewer is redirected straight to the Deploys page when opening a project. This is done without any notification, while when clicking on other restricted tabs the user gets a popup informing that they're not authorised to view the page.

This PR lifts that restriction. The "Deploy" buttons will be hidden from Viewer in both the Overview and Releases pages.

/cc @henders @fneves @grosser 

### References
 - Jira link:

### Risks
 - None