### PR TITLE
Use heading instead of legend in edit command form

### DIFF
--- a/app/views/admin/commands/edit.html.erb
+++ b/app/views/admin/commands/edit.html.erb
@@ -1,8 +1,8 @@
+<h1><%= command_form_legend %></h1>
+
 <section>
   <%= form_for [:admin, @command], html: { class: "form-horizontal" } do |form| %>
     <fieldset>
-      <legend><%= command_form_legend %></legend>
-
       <div class="form-group">
         <%= form.label :command, class: "col-lg-2 control-label" %>
         <div class="col-lg-6">


### PR DESCRIPTION
Across the Samson UI we consistently use headings as form titles. The new/edit command form is the only one that does this differently. This is a trivial PR which aims to fix the layout.

Before:

![screen shot 2015-10-01 at 13 21 14](https://cloud.githubusercontent.com/assets/4570601/10220535/32952830-6840-11e5-81bf-09447f01b855.png)

After:

![screen shot 2015-10-01 at 13 21 44](https://cloud.githubusercontent.com/assets/4570601/10220539/39d017b8-6840-11e5-8015-572e6cb26976.png)

/cc @zendesk/samson

### References
 - Jira link: N/A

### Risks
 - None