### PR TITLE
Hide delete link when creating new command

### DIFF
--- a/app/views/admin/commands/edit.html.erb
+++ b/app/views/admin/commands/edit.html.erb
@@ -23,7 +23,7 @@
           <% if usages = @command.usages.presence %>
             <%= "Used by #{usages.map { |s| link_to "#{s.class}: #{s.project.name} - #{s.name}", [s.project, s, action: :edit] }.join(", ") }".html_safe %>
           <% else %>
-            <%= link_to_delete([:admin, @command]) %>
+            <%= link_to_delete([:admin, @command]) unless @command.new_record? %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
The "Delete" link is currently displayed when creating a new command. Clicking it results in a routing error (can't delete something that hasn't been created yet).

This PR hides the link when creating new commands.

Before:

![screen shot 2015-10-01 at 13 43 00](https://cloud.githubusercontent.com/assets/4570601/10221307/8169c5ce-6845-11e5-898c-75a7e9fdea02.png)

After:

![screen shot 2015-10-01 at 13 43 30](https://cloud.githubusercontent.com/assets/4570601/10221317/8967b952-6845-11e5-9fcf-06ed4f1e7c14.png)

/cc @zendesk/samson

### References
 - Jira link: N/A

### Risks
 - None