### PR TITLE
Don't show stop button on job output view if no @deploy there. Otherw…

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -87,6 +87,7 @@ module DeploysHelper
   end
 
   def stop_button(options = {})
+    return unless @project && @deploy
     link_to "Stop", [@project, @deploy], options.merge({ method: :delete, class: options.fetch(:class, 'btn btn-danger btn-xl') })
   end
 


### PR DESCRIPTION
Don't show stop button on job output view if no @deploy exists. Otherwise it'll delete the project! :)

![project1_deploy__running_](https://cloud.githubusercontent.com/assets/515143/10221427/4a418676-6846-11e5-95b1-3727758ccd4c.png)


/cc @zendesk/samson @zendesk/runway 

### References
 - Jira link:

### Risks
 - None