### PR TITLE
Allow creation of build with an existing git_sha

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -17,7 +17,7 @@ class BuildsController < ApplicationController
   end
 
   def create
-    @build = @project.builds.build(new_build_params)
+    @build = create_build
     @build.creator = current_user
     @build.save
 
@@ -96,5 +96,18 @@ class BuildsController < ApplicationController
 
   def start_docker_build
     DockerBuilderService.new(@build).run!(push: true)
+  end
+
+  def create_build
+    if old_build = @project.builds.where(git_sha: git_sha).last
+      old_build.update_attributes(new_build_params)
+      old_build
+    else
+      @project.builds.build(new_build_params)
+    end
+  end
+
+  def git_sha
+    @project.repository.commit_from_ref(new_build_params[:git_ref], length: nil)
   end
 end


### PR DESCRIPTION
At moment it throws a 500 error in Samson if you try to create a 'build' with the same git_sha as last time.
This will just overwrite the build with the updated values as if you edited it.

This allows the docker image to be rebuilt.

/cc @zendesk/samson @zendesk/runway @fneves 

### References
 - Jira link:

### Risks
 - None