### PR TITLE
Refactoring filters responsible for loading a project before actions get executed

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -1,17 +1,12 @@
 class BuildsController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_deployer!
 
   before_action :find_build, only: [:show, :build_docker_image, :edit, :update]
 
   def index
-    @builds = @project.builds.order('id desc').page(params[:page])
+    @builds = current_project.builds.order('id desc').page(params[:page])
 
     respond_to do |format|
       format.html
@@ -20,7 +15,7 @@ class BuildsController < ApplicationController
   end
 
   def new
-    @build = @project.builds.build
+    @build = current_project.builds.build
   end
 
   def create
@@ -33,7 +28,7 @@ class BuildsController < ApplicationController
     respond_to do |format|
       format.html do
         if @build.persisted?
-          redirect_to [@project, @build]
+          redirect_to [current_project, @build]
         else
           render :new, status: 422
         end
@@ -57,7 +52,7 @@ class BuildsController < ApplicationController
     respond_to do |format|
       format.html do
         if success
-          redirect_to [@project, @build]
+          redirect_to [current_project, @build]
         else
           render :edit, status: 422
         end
@@ -74,7 +69,7 @@ class BuildsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        redirect_to [@project, @build]
+        redirect_to [current_project, @build]
       end
 
       format.json do
@@ -102,15 +97,15 @@ class BuildsController < ApplicationController
   end
 
   def create_build
-    if old_build = @project.builds.where(git_sha: git_sha).last
+    if old_build = current_project.builds.where(git_sha: git_sha).last
       old_build.update_attributes(new_build_params)
       old_build
     else
-      @project.builds.build(new_build_params)
+      current_project.builds.build(new_build_params)
     end
   end
 
   def git_sha
-    @project.repository.commit_from_ref(new_build_params[:git_ref], length: nil)
+    current_project.repository.commit_from_ref(new_build_params[:git_ref], length: nil)
   end
 end

--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -2,15 +2,12 @@ class ChangelogsController < ApplicationController
   include CurrentProject
 
   before_action :check_params
-  before_action do
-    find_project(params[:project_id])
-  end
 
   def show
     @start_date = Date.strptime(params[:start_date], '%Y-%m-%d')
     @end_date = Date.strptime(params[:end_date], '%Y-%m-%d')
 
-    @changeset = Changeset.new(@project.github_repo, "master@{#{@start_date}}", "master@{#{@end_date}}")
+    @changeset = Changeset.new(current_project.github_repo, "master@{#{@start_date}}", "master@{#{@end_date}}")
   end
 
   private

--- a/app/controllers/commit_statuses_controller.rb
+++ b/app/controllers/commit_statuses_controller.rb
@@ -1,10 +1,5 @@
 class CommitStatusesController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_deployer!
 
@@ -15,6 +10,6 @@ class CommitStatusesController < ApplicationController
   private
 
   def commit_status
-    @commit_status ||= CommitStatus.new(@project.github_repo, params[:ref])
+    @commit_status ||= CommitStatus.new(current_project.github_repo, params[:ref])
   end
 end

--- a/app/controllers/concerns/current_project.rb
+++ b/app/controllers/concerns/current_project.rb
@@ -2,17 +2,19 @@ module CurrentProject
   extend ActiveSupport::Concern
 
   included do
+    before_action :require_project
+
     helper_method :current_project
   end
 
   def current_project
-    @project
+    @project ||= require_project
   end
 
   protected
 
-  def find_project(param)
-    # Will this return not found if project does not exist ?
-    @project = Project.find_by_param!(param)
+  def require_project
+    @project = (Project.find_by_param!(params[:project_id]) if params[:project_id])
   end
+
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,10 +1,8 @@
 class JobsController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
 
-  before_action except: [:enabled] do
-    find_project(params[:project_id])
-  end
+  skip_before_action :require_project, only: [:enabled]
+
   before_action :authorize_project_admin!, only: [:new, :create, :destroy]
   before_action :find_job, only: [:show, :destroy]
 
@@ -74,6 +72,6 @@ class JobsController < ApplicationController
   end
 
   def find_job
-    @job = @project.jobs.find(params[:id])
+    @job = current_project.jobs.find(params[:id])
   end
 end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -1,12 +1,10 @@
 class LocksController < ApplicationController
   include ProjectLevelAuthorization
 
-  before_action unless: :for_global_lock? do
-    find_project
-    authorize_project_deployer!
-  end
-
   before_action :authorize_admin!, if: :for_global_lock?
+
+  before_action :require_project, unless: :for_global_lock?
+  before_action :authorize_project_deployer!, unless: :for_global_lock?
 
   def create
     attributes = params.require(:lock).
@@ -38,7 +36,8 @@ class LocksController < ApplicationController
     @lock ||= Lock.find(params[:id])
   end
 
-  def find_project
+  #Overrides CurrentProject#require_project
+  def require_project
     case action_name
     when 'create' then
       @project = Stage.find(params[:lock][:stage_id]).project

--- a/app/controllers/macros_controller.rb
+++ b/app/controllers/macros_controller.rb
@@ -1,10 +1,6 @@
 class MacrosController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
 
-  before_action do
-    find_project(params[:project_id])
-  end
   before_action :authorize_project_deployer!
   before_action :authorize_project_admin!, only: [:new, :create, :edit, :update, :destroy]
   before_action :find_macro, only: [:edit, :update, :execute, :destroy]

--- a/app/controllers/new_relic_controller.rb
+++ b/app/controllers/new_relic_controller.rb
@@ -1,10 +1,5 @@
 class NewRelicController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_deployer!
   before_action :ensure_new_reclic_api_key

--- a/app/controllers/project_roles_controller.rb
+++ b/app/controllers/project_roles_controller.rb
@@ -1,10 +1,7 @@
 class ProjectRolesController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
 
-  before_action only: [:create, :update] do
-    find_project(params[:project_id])
-  end
+  skip_before_action :require_project, only: [:index]
 
   before_action :authorize_project_admin!, only: [:create, :update]
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,18 +1,16 @@
 class ProjectsController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
   include StagePermittedParams
 
-  attr_reader :project
-  
-  before_action except: [:index, :new, :create] do
-    find_project(params[:id])
-  end
+  skip_before_action :require_project, only: [:index, :new, :create]
+
   before_action :authorize_admin!, only: [:new, :create, :destroy]
   before_action :authorize_project_admin!, except: [:show, :index, :deploy_group_versions]
   before_action :get_environments, only: [:new, :create]
 
   helper_method :project
+
+  alias_method :project, :current_project
 
   def index
     respond_to do |format|
@@ -108,5 +106,10 @@ class ProjectsController < ApplicationController
 
   def get_environments
     @environments = Environment.all
+  end
+
+  # Overriding require_project from CurrentProject
+  def require_project
+    @project = (Project.find_by_param!(params[:id]) if params[:id])
   end
 end

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -1,10 +1,5 @@
 class ReferencesController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_deployer!
 

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,10 +1,5 @@
 class ReleasesController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_deployer!, except: [:show, :index]
 

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -1,15 +1,10 @@
 require 'open-uri' # needed to fetch from img.shields.io using open()
 
 class StagesController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
   include StagePermittedParams
 
   skip_before_action :login_users, if: :badge?
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_deployer!, unless: :badge?
   before_action :authorize_project_admin!, except: [:index, :show]
@@ -125,7 +120,7 @@ class StagesController < ApplicationController
   end
 
   def find_stage
-    @stage = @project.stages.find_by_param!(params[:id])
+    @stage = current_project.stages.find_by_param!(params[:id])
   end
 
   def get_environments

--- a/app/controllers/stars_controller.rb
+++ b/app/controllers/stars_controller.rb
@@ -1,10 +1,6 @@
 class StarsController < ApplicationController
   include CurrentProject
 
-  before_action do
-    find_project(params[:project_id])
-  end
-
   def create
     current_user.stars.create!(project: @project)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,32 +1,14 @@
 class UsersController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
-
-  helper_method :sort_column, :sort_direction
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_admin!
 
   def index
-    scope = User
-    scope = scope.search(params[:search]) if params[:search]
-    @users = scope.order("#{sort_column} #{sort_direction}").page(params[:page])
+    @users = User.search_by_criteria(params)
 
     respond_to do |format|
       format.html
       format.json { render json: @users }
     end
   end
-
-  def sort_column
-    User.column_names.include?(params[:sort]) ? params[:sort] : "created_at"
-  end
-
-  def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
-  end
-
 end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,39 +1,34 @@
 require 'samson/integration'
 
 class WebhooksController < ApplicationController
-  include CurrentProject
   include ProjectLevelAuthorization
-
-  before_action do
-    find_project(params[:project_id])
-  end
 
   before_action :authorize_project_deployer!
 
   def index
-    @webhooks = @project.webhooks
+    @webhooks = current_project.webhooks
     @sources = Samson::Integration.sources
   end
 
   def new
-    @webhooks = @project.webhooks
+    @webhooks = current_project.webhooks
   end
 
   def create
-    @project.webhooks.create!(webhook_params)
+    current_project.webhooks.create!(webhook_params)
 
-    redirect_to project_webhooks_path(@project)
+    redirect_to project_webhooks_path(current_project)
   end
 
   def destroy
-    webhook = @project.webhooks.find(params[:id])
+    webhook = current_project.webhooks.find(params[:id])
     webhook.soft_delete!
 
-    redirect_to project_webhooks_path(@project)
+    redirect_to project_webhooks_path(current_project)
   end
 
   def show
-    @webhook = @project.webhooks.find(params[:id])
+    @webhook = current_project.webhooks.find(params[:id])
   end
 
   private


### PR DESCRIPTION
Following the code review from pull request [#553](https://github.com/zendesk/samson/pull/553), before_action filters loading the "current project" have been removed and the "current project" is now a lazily initialised attribute, accessible through the helper method `current_project`, which has been defined in the module `CurrentProject`.

/cc @zendesk/samson 

### References
Related to (or consequence of):
- [SAMSON-169](https://zendesk.atlassian.net/browse/SAMSON-169)

### Risks
- Changes to the behaviour regarding how the current project is loaded on several controllers (make sure all tests are passing and no functionality has been broken)
