### PR TITLE
fix "cancelled" deploy status panel view

### DIFF
--- a/app/helpers/deploy_status_helper.rb
+++ b/app/helpers/deploy_status_helper.rb
@@ -1,5 +1,4 @@
 module DeployStatusHelper
-
   STATUS_MAPPING = {
     "running" => "primary",
     "succeeded" => "success",

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -42,7 +42,10 @@ module DeploysHelper
   end
 
   def deploy_status_panel(deploy)
-    deploy_status_panel_common(deploy, BuddyCheck.enabled?)
+    content = content_no_buddy_check(deploy)
+    content ||= h deploy.summary
+
+    content_tag :div, content.html_safe, class: "alert #{deploy_status(deploy.status, 'alert')}"
   end
 
   def buddy_check_button(project, deploy)
@@ -93,28 +96,11 @@ module DeploysHelper
 
   private
 
-    def deploy_status_panel_common(deploy, enabled, hash = { "cancelled" => "danger" } )
-      mapping = {
-        "succeeded" => "success",
-        "failed"    => "danger",
-        "errored"   => "warning",
-      }
-
-      mapping = mapping.merge(hash) if enabled
-
-      content, status = content_no_buddy_check(deploy)
-
-      content ||= h deploy.summary
-      status ||= mapping.fetch(deploy.status, "info")
-
-      content_tag :div, content.html_safe, class: "alert alert-#{status}"
+  def content_no_buddy_check(deploy)
+    if deploy.finished?
+      content = h "#{deploy.summary} "
+      content << relative_time(deploy.start_time)
+      content << ", it took #{duration_text(deploy)}."
     end
-
-    def content_no_buddy_check(deploy)
-      if deploy.finished?
-        content = h "#{deploy.summary} "
-        content << relative_time(deploy.start_time)
-        content << ", it took #{duration_text(deploy)}."
-      end
-    end
+  end
 end

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -1,7 +1,7 @@
 <h1>
   <%= @project.name %>
-  <div class="pull-right">
 
+  <div class="pull-right">
     <% if current_user.is_deployer? %>
       <% unless @deploy.succeeded? || @deploy.active? %>
         <%= link_to "Redeploy", project_stage_deploys_path(@project, @deploy.stage, deploy: { reference: @deploy.reference }), method: :post, class: "btn btn-danger" %>


### PR DESCRIPTION
@zendesk/samson 

I don't really understand why we need a separate mapping if the buddy check is enabled...