### PR TITLE
use process groups and kill

### DIFF
--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -139,7 +139,7 @@ describe JobExecution do
     execute_job
     lines = job.output.split "\n"
     lines.must_include "# Deploy URL: #{deploy.url}"
-    lines.must_include 'DEPLOY_GROUPS=\;\|sudo\ make-sandwich\ / pod1 pod2'
+    lines.must_include 'DEPLOY_GROUPS=;|sudo make-sandwich / pod1 pod2'
   end
 
   it 'does not export deploy_group information if no deploy groups present' do
@@ -234,7 +234,7 @@ describe JobExecution do
 
     it "stops the execution with kill if job has already been interrupted" do
       begin
-        old, JobExecution.stop_timeout = JobExecution.stop_timeout, 1
+        old, JobExecution.stop_timeout = JobExecution.stop_timeout, 0
         execution.start!
         TerminalExecutor.any_instance.expects(:stop!).with('INT')
         TerminalExecutor.any_instance.expects(:stop!).with('KILL')

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -46,26 +46,21 @@ describe TerminalExecutor do
   describe '#stop!' do
     def execute_and_stop(command, signal)
       thread = Thread.new(subject) do |shell|
-        sleep(0.1) until shell.pid
-        shell.stop! signal
+        sleep(0.1) until shell.pgid
+        shell.stop!(signal)
       end
 
       result = subject.execute!(command)
-
       thread.join
       result
     end
 
-    # does not kill properly on OSX with default pkill, and causes interrupts
-    # with homebrew pkill 0.4.pre1
-    before { skip if RbConfig::CONFIG["target_os"].start_with? "darwin" }
-
     it 'properly kills the execution' do
-      execute_and_stop('sleep 100', 'INT').must_equal(false)
+      execute_and_stop('sleep 100', 'INT').must_equal(nil)
     end
 
     it 'terminates hanging processes with -9' do
-      execute_and_stop('trap "sleep 100" 2; sleep 100', 'KILL').must_equal(false)
+      execute_and_stop('trap "sleep 100" 2; sleep 100', 'KILL').must_equal(nil)
     end
   end
 end


### PR DESCRIPTION
pkill with a parent id doesn't work for single processes (i.e. sleep infinity).
Find out the pgid, and then use kill on that.

This stuff still doesn't work as well as I'd like, let's try a new tactic.

@zendesk/samson 