### PR TITLE
Add audit trail of config changes to projects [SAMSON-176]

### DIFF
--- a/app/controllers/concerns/samson_audit.rb
+++ b/app/controllers/concerns/samson_audit.rb
@@ -1,0 +1,57 @@
+module SamsonAudit
+  extend ActiveSupport::Concern
+  include CurrentUser
+
+  mattr_accessor :original_attributes
+
+  def prepare_audit(subject)
+    self.original_attributes = subject.to_auditable_json if is_auditable(subject)
+  end
+
+  def audit(subject)
+    case action_name
+    when 'create' then
+      audit_create(action_name, subject)
+    when 'destroy' then
+      audit_destroy(action_name, subject)
+    when 'update' then
+      audit_update(action_name, subject)
+    else
+      raise "Unsupported action: #{action_name}"
+    end
+  end
+
+  private
+
+  def audit_create(action, subject)
+    audit_action(action, subject, after: subject.to_auditable_json) if is_auditable(subject)
+  end
+
+  def audit_destroy(action, subject)
+    audit_action(action, subject, before: subject.to_auditable_json) if is_auditable(subject)
+  end
+
+  def audit_update(action, subject)
+    audit_action(action, subject, before: original_attributes, after: subject.to_auditable_json) if is_auditable(subject)
+  end
+
+  def audit_action(action, subject, before: {}, after: {})
+    Rails.logger.info(JSON.pretty_generate(audit_object(action, after, before, subject)))
+  end
+
+  def is_auditable(subject)
+    subject.respond_to? :to_auditable_json
+  end
+
+  def audit_object(action, after, before, subject)
+    {
+      logtype: 'AUDIT',
+      logged_at: "#{Time.now.getutc}",
+      user: "#{current_user.name_and_email}",
+      object: "#{subject.class.name}",
+      action: "#{action}",
+      before: "#{before}",
+      after: "#{after}"
+    }
+  end
+end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -2,6 +2,7 @@ require 'open-uri' # needed to fetch from img.shields.io using open()
 
 class StagesController < ApplicationController
   include StagePermittedParams
+  include SamsonAudit
 
   skip_before_action :login_users, if: :badge?
   before_action :authorize_admin!, except: [:index, :show]
@@ -10,6 +11,14 @@ class StagesController < ApplicationController
   before_action :find_project
   before_action :find_stage, only: [:show, :edit, :update, :destroy, :clone]
   before_action :get_environments, only: [:new, :create, :edit, :update, :clone]
+
+  #Audit
+  before_action only: :update do
+    prepare_audit(@stage)
+  end
+  after_action only: :update do
+    audit(@stage)
+  end
 
   def index
     @stages = @project.stages

--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -27,4 +27,12 @@ class Command < ActiveRecord::Base
   def self.usage_ids
     MacroCommand.pluck(:command_id) + StageCommand.pluck(:command_id)
   end
+
+  def to_auditable_json
+    to_json(
+      only: [:id, :command, :project_id],
+      include: [
+        stages: { only: [:id] }
+      ])
+  end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -44,7 +44,7 @@ class Stage < ActiveRecord::Base
 
   def self.unlocked_for(user)
     where("locks.id IS NULL OR locks.user_id = ?", user.id).
-    joins("LEFT OUTER JOIN locks ON \
+      joins("LEFT OUTER JOIN locks ON \
           locks.deleted_at IS NULL AND \
           locks.stage_id = stages.id")
   end
@@ -190,6 +190,14 @@ class Stage < ActiveRecord::Base
 
   def datadog_monitors
     datadog_monitor_ids.to_s.split(/, ?/).map { |id| DatadogMonitor.new(id) }
+  end
+
+  def to_auditable_json
+    to_json(only: [:id, :name, :project_id, :webhooks],
+      include: [
+        { commands: { only: [:id, :command, :project_id] } },
+        { stage_commands: { only: [:id, :command_id] } }
+      ])
   end
 
   private

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,6 +1,6 @@
 class Webhook < ActiveRecord::Base
   has_soft_deletion default_scope: true
-  validates :branch, uniqueness: { scope: [ :stage ], conditions: -> { where("deleted_at IS NULL") }, message: "one webhook per (stage, branch) combination." }
+  validates :branch, uniqueness: { scope: [:stage], conditions: -> { where("deleted_at IS NULL") }, message: "one webhook per (stage, branch) combination." }
 
   belongs_to :project
   belongs_to :stage
@@ -10,6 +10,10 @@ class Webhook < ActiveRecord::Base
   end
 
   def self.for_source(service_type, service_name)
-    where(source: [ 'any', "any_#{service_type}", service_name ])
+    where(source: ['any', "any_#{service_type}", service_name])
+  end
+
+  def to_auditable_json
+    to_json(only: [:id, :project_id, :stage_id])
   end
 end

--- a/test/controllers/admin/commands_controller_test.rb
+++ b/test/controllers/admin/commands_controller_test.rb
@@ -20,6 +20,8 @@ describe Admin::CommandsController do
 
     describe 'POST to #create' do
       before do
+        @controller.expects(:audit).times(1)
+
         post :create, command: attributes
       end
 
@@ -57,6 +59,9 @@ describe Admin::CommandsController do
 
     describe 'PATCH to #update' do
       before do
+        @controller.expects(:prepare_audit).times(1)
+        @controller.expects(:audit).times(1)
+
         patch :update, id: commands(:echo).id,
           command: attributes, format: format
       end
@@ -105,6 +110,8 @@ describe Admin::CommandsController do
     end
 
     describe 'DELETE to #destroy' do
+
+
       it "fails with unknown id" do
         assert_raises ActiveRecord::RecordNotFound do
           delete :destroy, id: 123123
@@ -112,7 +119,11 @@ describe Admin::CommandsController do
       end
 
       describe 'valid' do
-        before { delete :destroy, id: commands(:echo).id, format: format }
+        before do
+          @controller.expects(:audit).times(1)
+
+          delete :destroy, id: commands(:echo).id, format: format
+        end
 
         describe 'html' do
           let(:format) { 'html' }

--- a/test/controllers/concerns/samson_audit_test.rb
+++ b/test/controllers/concerns/samson_audit_test.rb
@@ -1,0 +1,155 @@
+require_relative '../../test_helper'
+
+describe SamsonAudit do
+  let(:user) { users(:viewer) }
+  let(:project) { projects(:test) }
+  let(:stage) { stages(:test_staging) }
+
+  setup do
+    @object = Object.new
+    @object.extend(SamsonAudit)
+    @object.stubs(:current_user).returns(user)
+  end
+
+  def audit_object(user, action, object, before, after)
+    {
+      logtype: 'AUDIT',
+      logged_at: "#{Time.now.getutc}",
+      user: "#{user.name_and_email}",
+      object: "#{object.class.name}",
+      action: "#{action}",
+      before: "#{before}",
+      after: "#{after}"
+    }
+  end
+
+  describe 'given a Webhook object' do
+    let(:webhook) { project.webhooks.create!({ branch: 'some branch', stage_id: stage.id, source: 'some source' }) }
+
+    describe 'auditing a create action' do
+      let(:action_name) { 'create' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+      end
+
+      it('should log the operation using the application logger') do
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, webhook, {}, { id: webhook.id, project_id: project.id, stage_id: stage.id }.to_json)))
+        @object.audit(webhook)
+      end
+    end
+
+    describe 'auditing a destroy action' do
+      let(:action_name) { 'destroy' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+      end
+
+      it('should log the operation using the application logger') do
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, webhook, { id: webhook.id, project_id: project.id, stage_id: stage.id }.to_json, {})))
+        @object.audit(webhook)
+      end
+    end
+  end
+
+  describe 'given a Command object' do
+    let(:command) { Command.create({ command: 'some command', project_id: project.id }) }
+
+    describe 'auditing a create action' do
+      let(:action_name) { 'create' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+      end
+
+      it('should log the operation using the application logger') do
+        expected_after = { id: command.id, command: command.command, project_id: project.id, stages: [] }.to_json
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, command, {}, expected_after)))
+        @object.audit(command)
+      end
+    end
+
+    describe 'auditing a destroy action' do
+      let(:action_name) { 'destroy' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+      end
+
+      it('should log the operation using the application logger') do
+        expected_before = { id: command.id, command: command.command, project_id: project.id, stages: [] }.to_json
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, command, expected_before, {})))
+        @object.audit(command)
+      end
+    end
+
+    describe 'auditing an update action' do
+      let(:action_name) { 'update' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+        @object.prepare_audit(command)
+        command.update_attributes({ command: 'editted command', project_id: project.id })
+      end
+
+      it('should log the operation using the application logger') do
+        expected_before = { id: command.id, command: 'some command', project_id: project.id, stages: [] }.to_json
+        expected_after = { id: command.id, command: 'editted command', project_id: project.id, stages: [] }.to_json
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, command, expected_before, expected_after)))
+        @object.audit(command)
+      end
+    end
+  end
+
+  describe 'given a Stage object' do
+    let(:stage) { project.stages.create({ name: 'test' }) }
+
+    describe 'auditing a create action' do
+      let(:action_name) { 'create' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+      end
+
+      it('should log the operation using the application logger') do
+        expected_after = { id: stage.id, name: stage.name, project_id: project.id, commands: [], stage_commands: [] }.to_json
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, stage, {}, expected_after)))
+        @object.audit(stage)
+      end
+    end
+
+    describe 'auditing a destroy action' do
+      let(:action_name) { 'destroy' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+      end
+
+      it('should log the operation using the application logger') do
+        expected_before = { id: stage.id, name: stage.name, project_id: project.id, commands: [], stage_commands: [] }.to_json
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, stage, expected_before, {})))
+        @object.audit(stage)
+      end
+    end
+
+    describe 'auditing an update action' do
+      let(:action_name) { 'update' }
+
+      setup do
+        @object.stubs(:action_name).returns(action_name)
+        @object.prepare_audit(stage)
+
+        stage.update_attributes({ command: 'stage command' })
+      end
+
+      it('should log the operation using the application logger') do
+        expected_before = { id: stage.id, name: stage.name, project_id: project.id, commands: [], stage_commands: [] }.to_json
+        expected_after = { id: stage.id, name: stage.name, project_id: project.id, commands: [], stage_commands: [{ id: stage.stage_commands[0].id, command_id: stage.stage_commands[0].command_id }] }.to_json
+        Rails.logger.expects(:info).with(JSON.pretty_generate(audit_object(user, action_name, stage, expected_before, expected_after)))
+        @object.audit(stage)
+      end
+    end
+  end
+end
+

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -193,6 +193,11 @@ describe StagesController do
 
     describe 'PATCH to #update' do
       describe 'valid id' do
+        setup do
+          @controller.expects(:prepare_audit).times(1)
+          @controller.expects(:audit).times(1)
+        end
+
         before do
           patch :update, project_id: subject.project.to_param, id: subject.to_param,
             stage: attributes

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -19,6 +19,8 @@ describe WebhooksController do
   describe 'POST :create' do
     let(:params) { { branch: "master", stage_id: stage.id, source: 'any' } }
     setup do
+      @controller.expects(:audit).times(1)
+
       post :create, project_id: project.to_param, webhook: params
     end
 


### PR DESCRIPTION
Adding support for auditing config changes on projects. At the moment, only the following changes will be audited:
- Adding/removing Webhooks on a Project
- Adding/removing commands on a Stage
- Editing a command, on a Stage or through the admin menu

/cc @zendesk/samson 

### Steps to reproduce
When one of the above operations take place, the audit log will be written into the stdout with the following format:
```
{
  "logtype": "AUDIT",
  "logged_at": <some timestamp>,
  "user": <user name and email>,
  "object": <object type: Stage | Command | Webhook>,
  "action": <action type: create | update | destroy>,
  "before": <json string with the previous state of the object>,
  "after": <json string with the new state of the object>
}
```

### References
 - [SAMSON 176](https://zendesk.atlassian.net/browse/SAMSON-176)

### Risks
 - Logging sensitive information (make sure to filter out any sensitive data or to log only what's relevant for auditing purposes)
