### PR TITLE
Access rights request link on the profile page

### DIFF
--- a/app/helpers/access_request_helper.rb
+++ b/app/helpers/access_request_helper.rb
@@ -1,11 +1,13 @@
 module AccessRequestHelper
-  def display_access_request_link?(flash_type)
-    flash_type == :authorization_error && ENV['REQUEST_ACCESS_FEATURE'].present?
+  def display_access_request_link?(flash_type = :authorization_error)
+    flash_type == :authorization_error &&
+        ENV['REQUEST_ACCESS_FEATURE'].present? &&
+        !current_user.is_super_admin?
   end
 
   def link_to_request_access
     current_user.access_request_pending ?
         'Access request pending.' :
-        (link_to 'Request access.', new_access_request_path)
+        (link_to 'Request additional access rights', new_access_request_path)
   end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -30,6 +30,14 @@
         </div>
       </div>
 
+      <% if display_access_request_link? %>
+        <div class="form-group">
+          <div class="col-lg-offset-2 col-lg-10">
+            <%= link_to_request_access %>
+          </div>
+        </div>
+      <% end %>
+
       <div class="form-group">
         <div class="col-lg-offset-2 col-lg-10">
           <button type="submit" class="btn btn-default">Save</button>

--- a/test/helpers/access_request_helper_test.rb
+++ b/test/helpers/access_request_helper_test.rb
@@ -8,12 +8,28 @@ describe AccessRequestHelper do
     describe 'feature enabled' do
       before { ENV['REQUEST_ACCESS_FEATURE'] = '1' }
 
-      it 'returns true for authorization_error' do
-        assert(display_access_request_link? :authorization_error)
+      describe 'viewer user' do
+        let(:current_user) { users(:viewer) }
+
+        it 'returns true for authorization_error' do
+          assert(display_access_request_link? :authorization_error)
+        end
+
+        it 'returns true for default params' do
+          assert display_access_request_link?
+        end
+
+        it 'returns false for other flash types' do
+          refute(display_access_request_link? :success)
+        end
       end
 
-      it 'returns false for other flash types' do
-        refute(display_access_request_link? :success)
+      describe 'super_admin user' do
+        let(:current_user) { users(:super_admin) }
+
+        it 'returns false for super_admin' do
+          refute display_access_request_link?
+        end
       end
     end
 


### PR DESCRIPTION
This PR builds on #561

Viewers are instructed that they lack access rights when trying to view restricted content. Deployers have read access to everything so it's not possible for a deployer to request additional access rights from a popup. A link to request access rights is added in the profile page for every user except super_admin.

![screen_shot_2015-10-08_at_11_13_25](https://cloud.githubusercontent.com/assets/4570601/10363858/0101103a-6daf-11e5-997c-1d44e7f9c0fc.png)

/cc @zendesk/samson

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-99

### Risks
 - None