### PR TITLE
user must specify project when requesting access rights

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -7,7 +7,7 @@ class AccessRequestsController < ApplicationController
 
   def create
     AccessRequestMailer.access_request_email(
-        request.base_url, current_user, params[:manager_email], params[:reason]).deliver_now
+        request.base_url, current_user, params[:manager_email], params[:reason], params[:project_id]).deliver_now
     current_user.update!(access_request_pending: true)
     flash[:success] = 'Access request email sent.'
     redirect_to session.delete(:access_request_back_to)

--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -7,7 +7,7 @@ class AccessRequestsController < ApplicationController
 
   def create
     AccessRequestMailer.access_request_email(
-        request.base_url, current_user, params[:manager_email], params[:reason], params[:project_id]).deliver_now
+        request.base_url, current_user, params[:manager_email], params[:reason], params[:project_ids]).deliver_now
     current_user.update!(access_request_pending: true)
     flash[:success] = 'Access request email sent.'
     redirect_to session.delete(:access_request_back_to)

--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -1,9 +1,10 @@
 class AccessRequestMailer < ApplicationMailer
-  def access_request_email(host, user, manager_email, reason)
+  def access_request_email(host, user, manager_email, reason, project_id)
     @host = host
     @user = user
     @manager_email = manager_email
     @reason = reason
+    @project = Project.find(project_id)
     mail(to: build_recipients, subject: build_subject, body: build_body)
   end
 
@@ -14,14 +15,21 @@ class AccessRequestMailer < ApplicationMailer
   end
 
   def build_subject
-    "[#{ENV['REQUEST_ACCESS_EMAIL_PREFIX']}] Grant #{desired_role} access rights to #{@user.name}"
+    "[#{ENV['REQUEST_ACCESS_EMAIL_PREFIX']}] Grant #{desired_role} access rights for #{@project.name} to #{@user.name}"
   end
 
   def build_body
-    "Please bump access rights to #{desired_role} on #{@host} for #{@user.name_and_email}\n\nReason:\n#{@reason}"
+    message = []
+    message << "Please bump access rights for user #{@user.name_and_email} on #{@host}."
+    message << ''
+    message << "Desired role: #{desired_role}"
+    message << "Target project: #{@project.name}"
+    message << ''
+    message << "Reason: #{@reason}"
+    message.join "\n"
   end
 
   def desired_role
-    Role.find(@user.role_id + 1).name
+    @user.is_super_admin? ? Role::SUPER_ADMIN.name : Role.find(@user.role_id + 1).name
   end
 end

--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -1,10 +1,10 @@
 class AccessRequestMailer < ApplicationMailer
-  def access_request_email(host, user, manager_email, reason, project_id)
+  def access_request_email(host, user, manager_email, reason, project_ids)
     @host = host
     @user = user
     @manager_email = manager_email
     @reason = reason
-    @project = Project.find(project_id)
+    @projects = Project.order(:name).find(project_ids)
     mail(to: build_recipients, subject: build_subject, body: build_body)
   end
 
@@ -15,7 +15,7 @@ class AccessRequestMailer < ApplicationMailer
   end
 
   def build_subject
-    "[#{ENV['REQUEST_ACCESS_EMAIL_PREFIX']}] Grant #{desired_role} access rights for #{@project.name} to #{@user.name}"
+    "[#{ENV['REQUEST_ACCESS_EMAIL_PREFIX']}] Grant #{desired_role} access rights to #{@user.name}"
   end
 
   def build_body
@@ -23,7 +23,8 @@ class AccessRequestMailer < ApplicationMailer
     message << "Please bump access rights for user #{@user.name_and_email} on #{@host}."
     message << ''
     message << "Desired role: #{desired_role}"
-    message << "Target project: #{@project.name}"
+    message << 'Target projects:'
+    @projects.each { |project| message << "  - #{project.name}" }
     message << ''
     message << "Reason: #{@reason}"
     message.join "\n"

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -20,10 +20,10 @@
     </fieldset>
 
     <div class="form-group">
-      <label class="col-lg-2 control-label">Project</label>
+      <label class="col-lg-2 control-label">Projects</label>
       <div class="col-lg-4">
-        <%= select_tag :project_id, options_from_collection_for_select(Project.all.order(:name), 'id', 'name'),
-                       class: 'form-control', include_blank: true, required: 'required' %>
+        <%= select_tag :project_ids, options_from_collection_for_select(Project.all.order(:name), 'id', 'name'),
+                       class: 'form-control', multiple: true, required: 'required' %>
       </div>
     </div>
 

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -19,6 +19,14 @@
       </div>
     </fieldset>
 
+    <div class="form-group">
+      <label class="col-lg-2 control-label">Project</label>
+      <div class="col-lg-4">
+        <%= select_tag :project_id, options_from_collection_for_select(Project.all.order(:name), 'id', 'name'),
+                       class: 'form-control', include_blank: true, required: 'required' %>
+      </div>
+    </div>
+
     <fieldset>
       <div class="form-group">
         <div class="col-lg-offset-2 col-lg-10">

--- a/test/controllers/access_requests_controller_test.rb
+++ b/test/controllers/access_requests_controller_test.rb
@@ -53,7 +53,7 @@ describe AccessRequestsController do
       describe 'enabled' do
         let(:manager_email) { 'manager@example.com' }
         let(:reason) { 'Dummy reason.' }
-        let(:request_params) { {manager_email: manager_email, reason: reason, project_id: projects(:test).id} }
+        let(:request_params) { {manager_email: manager_email, reason: reason, project_ids: Project.all.map(&:id)} }
         let(:session_params) { {access_request_back_to: root_path} }
         describe 'environment and user' do
           before { post :create, request_params, session_params }
@@ -83,7 +83,7 @@ describe AccessRequestsController do
             access_request_email = ActionMailer::Base.deliveries.last
             access_request_email.to.must_include manager_email
             access_request_email.body.to_s.must_match /#{reason}/
-            access_request_email.body.to_s.must_match /#{projects(:test).name}/
+            Project.all.each { |project| access_request_email.body.to_s.must_match /#{project.name}/ }
           end
         end
       end

--- a/test/controllers/access_requests_controller_test.rb
+++ b/test/controllers/access_requests_controller_test.rb
@@ -53,7 +53,7 @@ describe AccessRequestsController do
       describe 'enabled' do
         let(:manager_email) { 'manager@example.com' }
         let(:reason) { 'Dummy reason.' }
-        let(:request_params) { {manager_email: manager_email, reason: reason} }
+        let(:request_params) { {manager_email: manager_email, reason: reason, project_id: projects(:test).id} }
         let(:session_params) { {access_request_back_to: root_path} }
         describe 'environment and user' do
           before { post :create, request_params, session_params }
@@ -83,6 +83,7 @@ describe AccessRequestsController do
             access_request_email = ActionMailer::Base.deliveries.last
             access_request_email.to.must_include manager_email
             access_request_email.body.to_s.must_match /#{reason}/
+            access_request_email.body.to_s.must_match /#{projects(:test).name}/
           end
         end
       end

--- a/test/mailers/access_request_mailer_test.rb
+++ b/test/mailers/access_request_mailer_test.rb
@@ -3,7 +3,6 @@ require_relative '../test_helper'
 describe AccessRequestMailer do
   describe 'sends email' do
     let(:user) { users(:viewer) }
-    let(:project) { projects(:test) }
     let(:address_list) { 'jira@example.com watchers@example.com' }
     let(:prefix) { 'SAMSON ACCESS' }
     let(:hostname) { 'localhost' }
@@ -16,8 +15,6 @@ describe AccessRequestMailer do
       @original_prefix = ENV['REQUEST_ACCESS_EMAIL_PREFIX']
       ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'] = address_list
       ENV['REQUEST_ACCESS_EMAIL_PREFIX'] = prefix
-
-      AccessRequestMailer.access_request_email(hostname, user, manager_email, reason, project.id).deliver_now
     end
 
     after do
@@ -25,41 +22,58 @@ describe AccessRequestMailer do
       ENV['REQUEST_ACCESS_EMAIL_PREFIX'] = @original_prefix
     end
 
-    it 'is from deploys@' do
-      subject.from.must_equal ['deploys@samson-deployment.com']
+    describe 'multiple projects' do
+      before do
+        Project.any_instance.stubs(:valid_repository_url).returns(true)
+        Project.create!(name: 'Second project', repository_url: 'git://foo.com:hello/world.git')
+        AccessRequestMailer.access_request_email(
+          hostname, user, manager_email, reason, Project.all.map(&:id)).deliver_now
+      end
+
+      it 'is from deploys@' do
+        subject.from.must_equal ['deploys@samson-deployment.com']
+      end
+
+      it 'sends to configured addresses' do
+        subject.to.must_equal(address_list.split << manager_email)
+      end
+
+      it 'includes name in subject' do
+        subject.subject.must_match /#{user.name}/
+      end
+
+      it 'includes proper role in subject' do
+        subject.subject.must_match /#{Role.find(user.role_id + 1).name}/
+      end
+
+      it 'includes email in body' do
+        subject.body.to_s.must_match /#{user.email}/
+      end
+
+      it 'includes proper role in body' do
+        subject.body.to_s.must_match /#{Role.find(user.role_id + 1).name}/
+      end
+
+      it 'includes host in body' do
+        subject.body.to_s.must_match /#{hostname}/
+      end
+
+      it 'includes reason in body' do
+        subject.body.to_s.must_match /#{reason}/
+      end
+
+      it 'includes target project names in body' do
+        Project.all.each { |project| subject.body.to_s.must_match /#{project.name}/ }
+      end
     end
 
+    describe 'single project' do
+      before { AccessRequestMailer.access_request_email(
+          hostname, user, manager_email, reason, [projects(:test).id]).deliver_now }
 
-    it 'sends to configured addresses' do
-      subject.to.must_equal(address_list.split << manager_email)
-    end
-
-    it 'includes name in subject' do
-      subject.subject.must_match /#{user.name}/
-    end
-
-    it 'includes proper role in subject' do
-      subject.subject.must_match /#{Role.find(user.role_id + 1).name}/
-    end
-
-    it 'includes email in body' do
-      subject.body.to_s.must_match /#{user.email}/
-    end
-
-    it 'includes proper role in body' do
-      subject.body.to_s.must_match /#{Role.find(user.role_id + 1).name}/
-    end
-
-    it 'includes host in body' do
-      subject.body.to_s.must_match /#{hostname}/
-    end
-
-    it 'includes reason in body' do
-      subject.body.to_s.must_match /#{reason}/
-    end
-
-    it 'includes target project in body' do
-      subject.body.to_s.must_match /#{project.name}/
+      it 'includes target project name in body' do
+        subject.body.to_s.must_match /#{projects(:test).name}/
+      end
     end
   end
 end

--- a/test/mailers/access_request_mailer_test.rb
+++ b/test/mailers/access_request_mailer_test.rb
@@ -3,6 +3,7 @@ require_relative '../test_helper'
 describe AccessRequestMailer do
   describe 'sends email' do
     let(:user) { users(:viewer) }
+    let(:project) { projects(:test) }
     let(:address_list) { 'jira@example.com watchers@example.com' }
     let(:prefix) { 'SAMSON ACCESS' }
     let(:hostname) { 'localhost' }
@@ -16,7 +17,7 @@ describe AccessRequestMailer do
       ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'] = address_list
       ENV['REQUEST_ACCESS_EMAIL_PREFIX'] = prefix
 
-      AccessRequestMailer.access_request_email(hostname, user, manager_email, reason).deliver_now
+      AccessRequestMailer.access_request_email(hostname, user, manager_email, reason, project.id).deliver_now
     end
 
     after do
@@ -55,6 +56,10 @@ describe AccessRequestMailer do
 
     it 'includes reason in body' do
       subject.body.to_s.must_match /#{reason}/
+    end
+
+    it 'includes target project in body' do
+      subject.body.to_s.must_match /#{project.name}/
     end
   end
 end

--- a/test/mailers/previews/access_request_mailer_preview.rb
+++ b/test/mailers/previews/access_request_mailer_preview.rb
@@ -3,7 +3,7 @@ class AccessRequestMailerPreview < ActionMailer::Preview
   def access_request_email
     before
     email = AccessRequestMailer.access_request_email(
-        'localhost', User.first, 'manager@example.com', 'Dummy reason.', Project.first.id)
+        'localhost', User.first, 'manager@example.com', 'Dummy reason.', Project.all.map(&:id))
     after
     email
   end

--- a/test/mailers/previews/access_request_mailer_preview.rb
+++ b/test/mailers/previews/access_request_mailer_preview.rb
@@ -1,9 +1,9 @@
-# Preview all emails at http://localhost:3000/rails/mailers/request_access_mailer
+# Preview all emails at http://localhost:3000/rails/mailers/access_request_mailer
 class AccessRequestMailerPreview < ActionMailer::Preview
   def access_request_email
     before
-    user = User.new(name: 'Dummy User', email: 'dummy@example.com', )
-    email = AccessRequestMailer.access_request_email('localhost', user, 'manager@example.com', 'Dummy reason.')
+    email = AccessRequestMailer.access_request_email(
+        'localhost', User.first, 'manager@example.com', 'Dummy reason.', Project.first.id)
     after
     email
   end


### PR DESCRIPTION
This PR is building on #561.

The user needs to choose projects for which the additional access rights should be granted. Project names will be added to the email request. This functionality is added to align the feature with #560 

![screen shot 2015-10-09 at 11 19 24](https://cloud.githubusercontent.com/assets/4570601/10391670/5fb65882-6e78-11e5-81b7-f47b7cc5bd97.png)

Sample email:

![screen shot 2015-10-09 at 11 20 41](https://cloud.githubusercontent.com/assets/4570601/10391673/66fddb2e-6e78-11e5-9367-939e82bc7054.png)

/cc @zendesk/samson

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-99

### Risks
 - None