### PR TITLE
Trim the Git reference for the Deploy model

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -16,6 +16,8 @@ class Deploy < ActiveRecord::Base
   delegate :finished?, :errored?, :failed?, to: :job
   delegate :production?, :project, to: :stage
 
+  before_validation :trim_reference
+
   def cache_key
     [super, commit]
   end
@@ -163,5 +165,9 @@ class Deploy < ActiveRecord::Base
     else
       "(with #{buddy.name})"
     end
+  end
+
+  def trim_reference
+    self.reference.strip! if self.reference.presence
   end
 end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -148,6 +148,13 @@ describe Deploy do
     end
   end
 
+  describe "trim_reference" do
+    it "trims the Git reference" do
+      deploy = create_deploy!({reference: " master "})
+      deploy.reference.must_equal "master"
+    end
+  end
+
   def create_deploy!(attrs = {})
     default_attrs = {
       reference: "baz",


### PR DESCRIPTION
@zendesk/samson 

The Git reference is not trimmed and can result in user confusion.

![screenshot 2015-10-15 10 29 15](https://cloud.githubusercontent.com/assets/1051275/10509867/a0ad3f82-7327-11e5-8105-efc9d709aa2e.png)
