### PR TITLE
Fix a few small bugs that occurred running tests locally

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,7 @@ require File.expand_path('../config/application', __FILE__)
 Samson::Application.load_tasks
 
 Rake::Task["default"].clear
-
-Rails::TestTask.new(:default) do |t|
-  t.pattern = "{test,plugins/*/test}/**/*_test.rb"
-end
+task default: :test
 
 namespace :plugins do
   Rails::TestTask.new(:test) do |t|
@@ -18,6 +15,10 @@ namespace :plugins do
 end
 
 namespace :test do
+  Rails::TestTask.new(:default) do |t|
+    t.pattern = "{test,plugins/*/test}/**/*_test.rb"
+  end
+
   task js: :environment do
     with_tmp_karma_config do |config|
       sh "./node_modules/karma/bin/karma start #{config} --single-run"

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -160,6 +160,10 @@ module Samson
             File.symlink(fixture, new_path) unless File.exist?(new_path)
             Minitest.after_run { File.delete(new_path) if File.symlink?(new_path) }
           end
+
+          # Load test_helper.rb if it exists
+          test_helper_file = File.join(plugin.folder, 'test', 'test_helper.rb')
+          require test_helper_file if File.exists?(test_helper_file)
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,7 +79,11 @@ class ActiveSupport::TestCase
   end
 
   def extra_threads
-    Thread.list - @before_threads
+    if @before_threads
+      Thread.list - @before_threads
+    else
+      []
+    end
   end
 
   def assert_valid(record)


### PR DESCRIPTION
A few small fixes related to automated tests:

* Updates Rakefile so that `rake` and `rake test` now do the same thing
* Fixes fixtures problem where running `mtest` on a single test would trigger an error like:

```
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'user' in 'field list': INSERT INTO `kubernetes_release_groups` (`user`, `build`) VALUES ('deployer', 'docker_build')
    test/support/timeout.rb:13:in `block in capture_exceptions'
    test/support/timeout.rb:12:in `capture_exceptions'
```

* Fixes a problem that if there was an error loading fixtures, each test would also spit out an error like:

```
TypeError: no implicit conversion of nil into Array
    test/test_helper.rb:83:in `extra_threads'
    test/test_helper.rb:79:in `kill_extra_threads'
    test/test_helper.rb:75:in `ensure in fail_if_dangling_threads'
    test/test_helper.rb:75:in `fail_if_dangling_threads'
    test/test_helper.rb:69:in `block in <class:TestCase>'
```

/cc @zendesk/samson, @msufa, @sbrnunes