### PR TITLE
When using Pipeline, deploy the reference rather than the SHA to the next stage

### DIFF
--- a/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
+++ b/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
@@ -17,7 +17,7 @@ module SamsonPipelines
     private
 
     def start_next_stage(next_stage, current_job, deploy_service, output)
-      deploy = deploy_service.deploy!(next_stage, reference: current_job.deploy.commit)
+      deploy = deploy_service.deploy!(next_stage, reference: current_job.deploy.reference)
       if !deploy.persisted?
         output.puts "# Pipeline: Failed to start the next stage '#{next_stage.name}': #{deploy.errors.full_messages}\n"
       elsif next_stage.deploy_requires_approval?

--- a/plugins/pipelines/test/lib/hooks_test.rb
+++ b/plugins/pipelines/test/lib/hooks_test.rb
@@ -18,7 +18,8 @@ describe 'zendesk hooks' do
   describe :after_job_execution do
     it 'kicks off the next stages in the deploy' do
       stage.update!(next_stage_ids: next_stages.map(&:id))
-      DeployService.any_instance.expects(:deploy!).returns(next_deploy).twice
+      DeployService.any_instance.expects(:deploy!).with(stages(:test_production),     reference: 'staging')
+      DeployService.any_instance.expects(:deploy!).with(stages(:test_production_pod), reference: 'staging')
       Samson::Hooks.fire(:after_job_execution, job, true, output)
     end
 


### PR DESCRIPTION
/cc @zendesk/samson 

### Description
At the moment when you configure pipeline deployments, it will try to deploy the SHA of the commit to the next stage. For one it is a bit ugly and confusion when seing all stages but also some of our stages prevent to deploy a SHA and you have to deploy a TAG so the deploy is failing. This will try to deploy the reference rather than the SHA.

### Steps to reproduce
 - setup pipeline
 - deploy "master" to the first stage
 - see that "master" was deployed to the next stage

### Steps to merge
* [x] :+1: from the team

### Risks
* Low: pipeline deploy failing because there is no reference?