### PR TITLE
Do not override next_stage method in pipeline

### DIFF
--- a/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
+++ b/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
@@ -4,10 +4,6 @@ module SamsonPipelines::StageConcern
     super || next_stages.any?(&:production?)
   end
 
-  def next_stage
-    next_stage_ids.empty? ? super : Stage.find(next_stage_ids.first)
-  end
-
   def next_stages
     Stage.find(next_stage_ids)
   end

--- a/plugins/pipelines/test/models/stage_test.rb
+++ b/plugins/pipelines/test/models/stage_test.rb
@@ -13,17 +13,6 @@ describe Stage do
     project.stages = [stage1, stage2, stage3]
   end
 
-  describe '#next_stage' do
-    it 'returns next created stage if no pipeline set' do
-      stage2.next_stage.id.must_equal stage3.id
-    end
-
-    it 'returns next stage in pipeline if set' do
-      stage2.update!(next_stage_ids: [ stage1.id, stage3.id ])
-      stage2.next_stage.id.must_equal stage1.id
-    end
-  end
-
   describe '#production?' do
     it 'returns false if no pipeline set and not marked production' do
       stage1.deploy_groups = [ staging ]


### PR DESCRIPTION
/cc @zendesk/samson 

### Description
By redefining the ```next_stage``` method in pipeline, when deploying to a stage, the first stage listed in the pipeline will be displayed on the "Deploy to next stage" button. This is probably not what we want because the deploy is gonna happen automatically anyway.
Without this method redefined, the button will display the next stage in the list for this project.

### Steps to reproduce
 - have 3 stages, A, B and C in this order
 - have A pipeline deploy to C
 - deploy to stage A
 - when deploy is successful, you should have a button to deploy to stage B

### Steps to merge
* [x] :+1: from the team

### Risks
* None