### PR TITLE
aditional exports hook

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -185,6 +185,8 @@ class JobExecution
       CACHE_DIR: artifact_cache_dir
     }.merge(@env)
 
+    env.merge!(Hash[*Samson::Hooks.fire(:additional_exports, @job)])
+
     commands = env.map do |key, value|
       "export #{key}=#{value.shellescape}"
     end

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -185,7 +185,7 @@ class JobExecution
       CACHE_DIR: artifact_cache_dir
     }.merge(@env)
 
-    env.merge!(Hash[*Samson::Hooks.fire(:additional_exports, @job)])
+    env.merge!(Hash[*Samson::Hooks.fire(:job_additional_vars, @job)])
 
     commands = env.map do |key, value|
       "export #{key}=#{value.shellescape}"

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -24,7 +24,7 @@ module Samson
       :before_docker_build,
       :after_docker_build,
       :after_job_execution,
-      :additional_exports
+      :job_additional_vars
     ].freeze
 
     INTERNAL_HOOKS = [ :class_defined ]

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -23,7 +23,8 @@ module Samson
       :after_deploy,
       :before_docker_build,
       :after_docker_build,
-      :after_job_execution
+      :after_job_execution,
+      :additional_exports
     ].freeze
 
     INTERNAL_HOOKS = [ :class_defined ]

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -117,7 +117,7 @@ describe JobExecution do
   it "tests additional exports hook" do
     job.update(command: 'env | sort')
 
-    Samson::Hooks.callback :additional_exports do |job|
+    Samson::Hooks.callback :job_additional_vars do |job|
       { ADDITIONAL_EXPORT: "yes" }
     end
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -114,6 +114,18 @@ describe JobExecution do
     assert_equal 'zebra', last_line_of_output
   end
 
+  it "tests additional exports hook" do
+    job.update(command: 'env | sort')
+
+    Samson::Hooks.callback :additional_exports do |job|
+      { ADDITIONAL_EXPORT: "yes" }
+    end
+
+    execute_job
+    lines = job.output.split "\n"
+    lines.must_include "ADDITIONAL_EXPORT=yes"
+  end
+
   it "exports deploy information as environment variables" do
     job.update(command: 'env | sort')
     execute_job('master', FOO: 'bar')


### PR DESCRIPTION
Hello,

We're using Samson here for deployment (512 deploys until now) and it's running pretty well. But we also want to run ansible playbooks, database migrations and blue&green deploys on it.

This PR aims to let you export additional variables (through plugins) during deployment. We're using it on an ansible plugin here to handle different tags for each deploy. Thanks :)