### PR TITLE
Update status of Kubernetes release objects based on watching API

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151013181500) do
+ActiveRecord::Schema.define(version: 20151014205641) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -177,12 +177,13 @@ ActiveRecord::Schema.define(version: 20151013181500) do
   end
 
   create_table "kubernetes_release_docs", force: :cascade do |t|
-    t.integer  "kubernetes_role_id",          limit: 4,     null: false
-    t.integer  "kubernetes_release_id",       limit: 4,     null: false
-    t.integer  "replica_count",               limit: 4,     null: false
+    t.integer  "kubernetes_role_id",          limit: 4,                         null: false
+    t.integer  "kubernetes_release_id",       limit: 4,                         null: false
+    t.integer  "replica_target",              limit: 4,                         null: false
+    t.integer  "replicas_live",               limit: 4,     default: 0,         null: false
     t.string   "replication_controller_name", limit: 255
     t.text     "replication_controller_doc",  limit: 65535
-    t.string   "status",                      limit: 255
+    t.string   "status",                      limit: 255,   default: "created"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -201,9 +202,9 @@ ActiveRecord::Schema.define(version: 20151013181500) do
   add_index "kubernetes_release_groups", ["build_id"], name: "index_kubernetes_release_groups_on_build_id", using: :btree
 
   create_table "kubernetes_releases", force: :cascade do |t|
-    t.integer  "kubernetes_release_group_id", limit: 4,   null: false
-    t.integer  "deploy_group_id",             limit: 4,   null: false
-    t.string   "status",                      limit: 255
+    t.integer  "kubernetes_release_group_id", limit: 4,                       null: false
+    t.integer  "deploy_group_id",             limit: 4,                       null: false
+    t.string   "status",                      limit: 255, default: "created"
     t.datetime "deploy_finished_at"
     t.datetime "destroyed_at"
     t.datetime "created_at"

--- a/plugins/kubernetes/app/controllers/kubernetes_release_groups_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_release_groups_controller.rb
@@ -11,7 +11,7 @@ class KubernetesReleaseGroupsController < ApplicationController
 
     @release_group.releases.each do |release|
       params[:replicas].each do |role_id, replica_count|
-        release.release_docs.build(kubernetes_role_id: role_id, replica_count: replica_count.to_i)
+        release.release_docs.build(kubernetes_role_id: role_id, replica_target: replica_count.to_i)
       end
     end
 

--- a/plugins/kubernetes/app/models/kuber_deploy_service.rb
+++ b/plugins/kubernetes/app/models/kuber_deploy_service.rb
@@ -44,13 +44,48 @@ class KuberDeployService
     # TODO: hunt down this issue and fix it properly
     Watchers::PodWatcher ; Watchers::ReplicationControllerWatcher ; Watchers::EventWatcher
 
-    # Commented out for now, to avoid creating threads without ever destroying them
-    # Thread.new { kuber_release.watch_pods }
-    # Thread.new { kuber_release.watch_rcs }
+    Thread.new do
+      kuber_release.watch_pods(&method(:handle_pod_notice))
+    end
+
     # Thread.new { sleep(5) ; kuber_release.watch_pod_events }
   end
 
   private
+
+  def handle_pod_notice(notice, watcher)
+    release_doc = kuber_release.docs_by_role[notice.role]
+
+    if release_doc.nil?
+      Kubernetes::Util.log "ERROR: could not find role", role: notice.role, available_roles: kuber_release.docs_by_role.keys
+      return
+    end
+
+    ready_count = watcher.num_ready
+    if ready_count > release_doc.replicas_live
+      release_doc.update_replica_count(ready_count)
+      release_doc.save!
+      update_release_status
+      log 'Another replica is live', role: notice.role, count: ready_count, r_status: kuber_release.status, r_doc_status: release_doc.status
+    end
+  end
+
+  def update_release_status
+    statuses = kuber_release.release_docs.map(&:status)
+
+    if statuses.all? { |s| s == 'live' }
+      deploy_is_live
+    elsif statuses.include?('spinning_up')
+      kuber_release.update_attribute(:status, 'spinning_up') unless kuber_release.status == 'spinning_up'
+    end
+  end
+
+  def deploy_is_live
+    kuber_release.release_is_live
+    kuber_release.save!
+
+    kuber_release.stop_watching   # this should kill the #watch_pods Thread spawned above
+  end
 
   def log(msg, extra_info = {})
     extra_info.merge!(

--- a/plugins/kubernetes/app/models/kuber_deploy_service.rb
+++ b/plugins/kubernetes/app/models/kuber_deploy_service.rb
@@ -71,12 +71,10 @@ class KuberDeployService
   end
 
   def update_release_status
-    statuses = kuber_release.release_docs.map(&:status)
-
-    if statuses.all? { |s| s == 'live' }
+    if kuber_release.release_docs.all?(&:live?)
       deploy_is_live
-    elsif statuses.include?('spinning_up')
-      kuber_release.update_attribute(:status, 'spinning_up') unless kuber_release.status == 'spinning_up'
+    elsif kuber_release.release_docs.any?(&:spinning_up?)
+      kuber_release.update_attribute(:status, 'spinning_up') unless kuber_release.spinning_up?
     end
   end
 

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -12,7 +12,9 @@ module Kubernetes
     validates :deploy_group, presence: true
     validates :status, inclusion: STATUSES
 
-    after_initialize :set_default_status, on: :create
+    STATUSES.each do |s|
+      define_method("#{s}?") { status == s }
+    end
 
     def release_is_live
       self.status = 'live'
@@ -29,8 +31,6 @@ module Kubernetes
         release_id: id.to_s
       }
     end
-
-    # TODO: define state machine for 'status' field
 
     def nested_error_messages
       errors.full_messages + release_docs.flat_map(&:nested_error_messages)
@@ -89,12 +89,6 @@ module Kubernetes
       @docs_by_role ||= release_docs.each_with_object({}) do |rel_doc, hash|
         hash[rel_doc.kubernetes_role.label_name] = rel_doc
       end
-    end
-
-    private
-
-    def set_default_status
-      self.status ||= 'created'
     end
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -13,6 +13,10 @@ module Kubernetes
 
     after_create :save_rc_info    # do this after create, so id has been generated
 
+    Kubernetes::Release::STATUSES.each do |s|
+      define_method("#{s}?") { status == s }
+    end
+
     # Definition of the ReplicationController, based on the rc_template, but
     # updated with the image and metadata for this deploy.
     #

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -6,7 +6,9 @@ module Kubernetes
 
     validates :kubernetes_role, presence: true
     validates :kubernetes_release, presence: true
-    validates :replica_count, presence: true, numericality: { greater_than: 0 }
+    validates :replica_target, presence: true, numericality: { greater_than: 0 }
+    validates :replicas_live, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :status, presence: true, inclusion: Kubernetes::Release::STATUSES
     validate :validate_config_file, on: :create
 
     after_create :save_rc_info    # do this after create, so id has been generated
@@ -79,6 +81,16 @@ module Kubernetes
       @watcher.stop_watching if @watcher
     end
 
+    def update_replica_count(new_count)
+      self.replicas_live = new_count
+
+      if replicas_live >= replica_target
+        self.status ='live'
+      elsif replicas_live > 0
+        self.status ='spinning_up'
+      end
+    end
+
     private
 
     def save_rc_info
@@ -98,7 +110,7 @@ module Kubernetes
 
     def build_rc_hash
       @rc_hash = rc_template.dup.with_indifferent_access
-      @rc_hash[:spec][:replicas] = replica_count
+      @rc_hash[:spec][:replicas] = replica_target
 
       pod_hash = @rc_hash[:spec][:template]
 

--- a/plugins/kubernetes/app/models/watchers/base_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/base_watcher.rb
@@ -3,8 +3,11 @@ module Watchers
   # objects via their API.  Expects an instance of Kubeclient::Common::WatchStream
   # to be passed in.
   class BaseWatcher
+    attr_reader :start_time
+
     def initialize(watch_stream, log: true)
       @watch_stream, @log, = watch_stream, log
+      @start_time = Time.now
     end
 
     def start_watching(&block)
@@ -18,6 +21,10 @@ module Watchers
         @watch_stream.finish
         @watch_stream = nil
       end
+    end
+
+    def time_watching
+      Time.now - start_time
     end
 
     protected

--- a/plugins/kubernetes/app/models/watchers/pod_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/pod_watcher.rb
@@ -44,10 +44,11 @@ module Watchers
     def handle_notice(notice, &block)
       return if handle_error(notice)
       notice.extend(PWrapper)
-      yield(notice, self) if block_given?
 
       # keep track of the state of all pods
       @pod_info[notice.pod_name] = notice
+
+      yield(notice, self) if block_given?
 
       log "Received Pod notice", watcher: 'pod', notice_type: notice.type, phase: notice.phase, ready: notice.ready?, status_counts: status_counts
     end

--- a/plugins/kubernetes/app/models/watchers/replication_controller_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/replication_controller_watcher.rb
@@ -10,18 +10,22 @@ module Watchers
       @rc_info = {}
     end
 
+    def rc_names
+      @rc_info.keys
+    end
+
     protected
 
     def handle_notice(notice, &block)
       return if handle_error(notice)
 
       notice.extend(RCWrapper)
-      yield(notice, self) if block_given?
 
       log "RC notice received", watcher: 'rc', notice_type: notice.type, rc_name: notice.rc_name, replicas: notice.replica_count
 
       # keep track of the state of all pods
       @rc_info[notice.rc_name] = notice
+      yield(notice, self) if block_given?
     end
 
     # Decorator class for the Replication Controller data that is returned

--- a/plugins/kubernetes/app/views/kubernetes_clusters/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_clusters/_form.html.erb
@@ -25,7 +25,7 @@
       <%= form.label :config_context, 'Context', class: "col-lg-2 control-label" %>
       <div class="col-lg-2">
         <% if @context_options.any? %>
-          <%= form.select :config_context, @context_options %>
+          <%= form.select :config_context, @context_options, {}, { class: 'form-control' } %>
         <% else %>
           <%= form.text_field :config_context, class: "form-control" %>
         <% end %>

--- a/plugins/kubernetes/app/views/kubernetes_release_doc/_release_doc_row.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_release_doc/_release_doc_row.html.erb
@@ -6,16 +6,23 @@
 </div>
 
 <div class="form-group">
+  <label class="col-lg-2 control-label">Status</label>
+  <div class="col-lg-4">
+    <p class="form-control-static"><%= release_doc.status %></p>
+  </div>
+</div>
+
+<div class="form-group">
   <label class="col-lg-2 control-label">Num Replicas</label>
   <div class="col-lg-4">
-    <p class="form-control-static"><%= release_doc.replica_count %></p>
+    <p class="form-control-static"><%= release_doc.replicas_live %> / <%= release_doc.replica_target %></p>
   </div>
 </div>
 
 <div class="form-group">
   <label class="col-lg-2 control-label">Controller Doc</label>
   <div class="col-lg-10">
-    <pre><%= release_doc.pretty_rc_doc %></pre>
+    <pre style="height: 10pc; overflow-y: scroll;"><%= release_doc.pretty_rc_doc %></pre>
   </div>
 </div>
 

--- a/plugins/kubernetes/app/views/kubernetes_release_groups/new.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_release_groups/new.html.erb
@@ -37,7 +37,7 @@
               <%= build.project.name %> - <%= build.label %>
             </p>
           <% elsif @project.builds.any? %>
-            <%= form.select :build_id, @project.builds.order('id desc').limit(20).map { |b| [b.label, b.id] } %>
+            <%= form.select :build_id, @project.builds.order('id desc').limit(20).map { |b| [b.label, b.id] }, {}, { class: 'form-control' } %>
           <% else %>
             <p class="form-control-static">
               You must create a <%= link_to 'Build', new_project_build_path(@project) %> before deploying.

--- a/plugins/kubernetes/db/migrate/20151014202234_add_live_replicas_to_kuber_release_doc.rb
+++ b/plugins/kubernetes/db/migrate/20151014202234_add_live_replicas_to_kuber_release_doc.rb
@@ -1,0 +1,8 @@
+class AddLiveReplicasToKuberReleaseDoc < ActiveRecord::Migration
+  def change
+    change_table :kubernetes_release_docs do |t|
+      t.rename :replica_count, :replica_target
+      t.integer :replicas_live, after: :replica_target, null: false, default: 0
+    end
+  end
+end

--- a/plugins/kubernetes/db/migrate/20151014205641_set_kuber_release_default_status.rb
+++ b/plugins/kubernetes/db/migrate/20151014205641_set_kuber_release_default_status.rb
@@ -1,0 +1,6 @@
+class SetKuberReleaseDefaultStatus < ActiveRecord::Migration
+  def change
+    change_column :kubernetes_releases, :status, :string, default: 'created'
+    change_column :kubernetes_release_docs, :status, :string, default: 'created'
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -9,7 +9,7 @@ describe Kubernetes::Release do
     end
 
     it 'test validity of status' do
-      Kubernetes::Release::VALID_STATUSES.each do |status|
+      Kubernetes::Release::STATUSES.each do |status|
         assert_valid(release.tap { |kr| kr.status = status })
       end
       refute_valid(release.tap { |kr| kr.status = 'foo' })


### PR DESCRIPTION
After ReplicationControllers are crated in Kubernetes, watch the status of the Pods until they're in a "Ready" state, and update the status of the `Kubernetes::Release*` objects.

We still need to add logic to watch the `Events` stream for failures to schedule pods.
This also needs tests.  The Kubernetes plugin code is definitely under-tested.

/cc @msufa, @sbrnunes, @henders 

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-39

### Risks
 - Minimal risk, since logic is all localized to Kubernetes plugin.