### PR TITLE
Add support for project level deployer role [SAMSON-169]

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,13 +1,9 @@
 class Admin::UsersController < ApplicationController
   before_action :authorize_admin!
   before_action :authorize_super_admin!, only: [ :update, :destroy ]
-  helper_method :sort_column, :sort_direction
 
   def index
-    scope = User
-    scope = scope.search(params[:search]) if params[:search]
-    @users = scope.order(sort_column + ' ' + sort_direction).page(params[:page])
-
+    @users = User.search_by_criteria(params)
     respond_to do |format|
       format.html
       format.json { render json: @users }
@@ -16,10 +12,7 @@ class Admin::UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-
-    scope = Project
-    scope = scope.search(params[:search]) if params[:search]
-    @projects = scope.order("#{sort_column} #{sort_direction}").page(params[:page])
+    @projects = Project.search_by_criteria(params)
   end
 
   def update
@@ -46,13 +39,5 @@ class Admin::UsersController < ApplicationController
   def user_params
     # also reset pending access request, so the user can request further access rights
     params.require(:user).permit(:role_id).merge(access_request_pending: false)
-  end
-
-  def sort_column
-    User.column_names.include?(params[:sort]) ? params[:sort] : "created_at"
-  end
-
-  def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
   end
 end

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -1,6 +1,13 @@
 class BuildsController < ApplicationController
-  before_action :authorize_deployer!
-  before_action :find_project
+  include CurrentProject
+  include ProjectLevelAuthorization
+
+  before_action do
+    find_project(params[:project_id])
+  end
+
+  before_action :authorize_project_deployer!
+
   before_action :find_build, only: [:show, :build_docker_image, :edit, :update]
 
   def index
@@ -77,10 +84,6 @@ class BuildsController < ApplicationController
   end
 
   private
-
-  def find_project
-    @project = Project.find_by_param!(params[:project_id])
-  end
 
   def find_build
     @build = Build.find(params[:id])

--- a/app/controllers/commit_statuses_controller.rb
+++ b/app/controllers/commit_statuses_controller.rb
@@ -1,5 +1,12 @@
 class CommitStatusesController < ApplicationController
-  before_action :authorize_deployer!
+  include CurrentProject
+  include ProjectLevelAuthorization
+
+  before_action do
+    find_project(params[:project_id])
+  end
+
+  before_action :authorize_project_deployer!
 
   def show
     render json: { status: commit_status.status, status_list: commit_status.status_list }
@@ -8,10 +15,6 @@ class CommitStatusesController < ApplicationController
   private
 
   def commit_status
-    @commit_status ||= CommitStatus.new(project.github_repo, params[:ref])
-  end
-
-  def project
-    @project ||= Project.find_by_param!(params[:project_id])
+    @commit_status ||= CommitStatus.new(@project.github_repo, params[:ref])
   end
 end

--- a/app/controllers/concerns/current_project.rb
+++ b/app/controllers/concerns/current_project.rb
@@ -12,6 +12,7 @@ module CurrentProject
   protected
 
   def find_project(param)
+    # Will this return not found if project does not exist ?
     @project = Project.find_by_param!(param)
   end
 end

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -1,10 +1,14 @@
 class DeploysController < ApplicationController
   include CurrentProject
+  include ProjectLevelAuthorization
 
-  before_action :authorize_deployer!, only: [:new, :create, :confirm, :update, :destroy, :buddy_check, :pending_start]
+
   before_action except: [:active, :active_count, :recent, :changeset] do
     find_project(params[:project_id])
   end
+
+  before_action :authorize_project_deployer!, only: [:new, :create, :confirm, :buddy_check, :pending_start, :destroy]
+
   before_action :find_deploy, except: [:index, :recent, :active, :active_count, :new, :create, :confirm]
   before_action :stage, only: :new
 

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -1,5 +1,11 @@
 class LocksController < ApplicationController
-  before_action :authorize_deployer!
+  include ProjectLevelAuthorization
+
+  before_action unless: :for_global_lock? do
+    find_project
+    authorize_project_deployer!
+  end
+
   before_action :authorize_admin!, if: :for_global_lock?
 
   def create
@@ -7,26 +13,39 @@ class LocksController < ApplicationController
       permit(:description, :stage_id, :warning).
       merge(user: current_user)
     Lock.create!(attributes)
-    redirect_to :back, notice: "Locked"
+    redirect_to :back, notice: 'Locked'
   end
 
   def destroy
     lock.try(:soft_delete)
-    redirect_to :back, notice: "Unlocked"
+    redirect_to :back, notice: 'Unlocked'
   end
 
   protected
 
   def for_global_lock?
     case action_name
-    when "create" then !params[:lock].try(:[], :stage_id)
-    when "destroy" then !lock.stage_id
+    when 'create' then
+      !params[:lock].try(:[], :stage_id) || !params[:lock][:stage_id].present?
+    when 'destroy' then
+      !lock.stage_id
     else
-      raise "Unsupported action"
+      raise 'Unsupported action'
     end
   end
 
   def lock
     @lock ||= Lock.find(params[:id])
+  end
+
+  def find_project
+    case action_name
+    when 'create' then
+      @project = Stage.find(params[:lock][:stage_id]).project
+    when 'destroy' then
+      @project = lock.stage.project
+    else
+      raise 'Unsupported action'
+    end
   end
 end

--- a/app/controllers/macros_controller.rb
+++ b/app/controllers/macros_controller.rb
@@ -2,10 +2,10 @@ class MacrosController < ApplicationController
   include CurrentProject
   include ProjectLevelAuthorization
 
-  before_action :authorize_deployer!
   before_action do
     find_project(params[:project_id])
   end
+  before_action :authorize_project_deployer!
   before_action :authorize_project_admin!, only: [:new, :create, :edit, :update, :destroy]
   before_action :find_macro, only: [:edit, :update, :execute, :destroy]
 

--- a/app/controllers/new_relic_controller.rb
+++ b/app/controllers/new_relic_controller.rb
@@ -1,5 +1,12 @@
 class NewRelicController < ApplicationController
-  before_action :authorize_deployer!
+  include CurrentProject
+  include ProjectLevelAuthorization
+
+  before_action do
+    find_project(params[:project_id])
+  end
+
+  before_action :authorize_project_deployer!
   before_action :ensure_new_reclic_api_key
 
   def show
@@ -14,7 +21,7 @@ class NewRelicController < ApplicationController
   end
 
   def stage
-    Stage.where(project_id: Project.find_by_param!(params[:project_id])).find(params[:id])
+    Stage.where(project_id: @project).find(params[:id])
   end
 
   def ensure_new_reclic_api_key

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,7 @@ class ProjectsController < ApplicationController
   include StagePermittedParams
 
   attr_reader :project
-
+  
   before_action except: [:index, :new, :create] do
     find_project(params[:id])
   end

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -1,10 +1,12 @@
 class ReferencesController < ApplicationController
   include CurrentProject
+  include ProjectLevelAuthorization
 
-  before_action :authorize_deployer!
   before_action do
     find_project(params[:project_id])
   end
+
+  before_action :authorize_project_deployer!
 
   def index
     @references = ReferencesService.new(@project).find_git_references

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,10 +1,12 @@
 class ReleasesController < ApplicationController
   include CurrentProject
+  include ProjectLevelAuthorization
 
-  before_action :authorize_deployer!, except: [:show, :index]
   before_action do
     find_project(params[:project_id])
   end
+
+  before_action :authorize_project_deployer!, except: [:show, :index]
 
   def show
     @release = @project.releases.find_by_version!(params[:id])

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -7,10 +7,11 @@ class StagesController < ApplicationController
 
   skip_before_action :login_users, if: :badge?
 
-  before_action :authorize_deployer!, unless: :badge?
   before_action do
     find_project(params[:project_id])
   end
+
+  before_action :authorize_project_deployer!, unless: :badge?
   before_action :authorize_project_admin!, except: [:index, :show]
   before_action :check_token, if: :badge?
   before_action :find_stage, only: [:show, :edit, :update, :destroy, :clone]

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -2,11 +2,13 @@ require 'samson/integration'
 
 class WebhooksController < ApplicationController
   include CurrentProject
+  include ProjectLevelAuthorization
 
-  before_action :authorize_deployer!
   before_action do
     find_project(params[:project_id])
   end
+
+  before_action :authorize_project_deployer!
 
   def index
     @webhooks = @project.webhooks

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
 
   def sortable(column, title = nil)
     title ||= column.titleize
-    direction = (column == sort_column && sort_direction == "asc") ? "desc" : "asc"
+    direction = (column == params[:sort] && params[:direction] == "asc") ? "desc" : "asc"
     link_to title, sort: column, direction: direction
   end
 

--- a/app/models/concerns/has_project_role.rb
+++ b/app/models/concerns/has_project_role.rb
@@ -4,9 +4,12 @@ module HasProjectRole
     ProjectRole.find(role_id)
   end
 
-  ProjectRole.all.each do |role|
-    define_method "is_project_#{role.name}?" do
-      role_id >= role.id
-    end
+  def is_deployer?
+    role_id >= ProjectRole::DEPLOYER.id
   end
+
+  def is_admin?
+    role_id >= ProjectRole::ADMIN.id
+  end
+
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,0 +1,21 @@
+module Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    def self.search_by_criteria(criteria)
+      scope = self
+      scope = scope.search(criteria[:search]) if criteria[:search]
+      scope.order("#{sort_column(criteria[:sort])} #{sort_direction(criteria[:direction])}").page(criteria[:page])
+    end
+
+    private
+
+    def self.sort_column(column)
+      column_names.include?(column) ? column : 'created_at'
+    end
+
+    def self.sort_direction(direction)
+      %w[asc desc].include?(direction) ? direction : 'asc'
+    end
+  end
+end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,8 +1,8 @@
 module Searchable
   extend ActiveSupport::Concern
 
-  included do
-    def self.search_by_criteria(criteria)
+  module ClassMethods
+    def search_by_criteria(criteria)
       scope = self
       scope = scope.search(criteria[:search]) if criteria[:search]
       scope.order("#{sort_column(criteria[:sort])} #{sort_direction(criteria[:direction])}").page(criteria[:page])
@@ -10,11 +10,11 @@ module Searchable
 
     private
 
-    def self.sort_column(column)
+    def sort_column(column)
       column_names.include?(column) ? column : 'created_at'
     end
 
-    def self.sort_direction(direction)
+    def sort_direction(direction)
       %w[asc desc].include?(direction) ? direction : 'asc'
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,6 @@
 class Project < ActiveRecord::Base
   include Permalinkable
+  include Searchable
 
   has_soft_deletion default_scope: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ require 'digest/md5'
 
 class User < ActiveRecord::Base
   include HasRole
+  include Searchable
 
   has_soft_deletion default_scope: true
 
@@ -60,11 +61,11 @@ class User < ActiveRecord::Base
   end
 
   def is_admin_for?(project)
-    project_role_for(project).try(:is_project_admin?)
+    project_role_for(project).try(:is_admin?)
   end
 
   def is_deployer_for?(project)
-    project_role_for(project).try(:is_project_deployer?)
+    project_role_for(project).try(:is_deployer?)
   end
 
   def project_role_for(project)

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -23,11 +23,11 @@
     </thead>
     <tbody>
     <% if @projects.empty? %>
-        <tr>
-          <td>No project was found!</td>
-        </tr>
+      <tr>
+        <td>No project was found!</td>
+      </tr>
     <% else %>
-        <%= render partial: 'project', collection: @projects, as: :project, locals: {user: @user} %>
+      <%= render partial: 'project', collection: @projects, as: :project, locals: {user: @user} %>
     <% end %>
     </tbody>
   </table>

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -9,3 +9,17 @@ Viewer | Can view all deploys.
 Deployer | Viewer + ability to deploy projects.
 Admin | Deployer + can setup and configure projects.
 Super Admin | Admin + management of user roles.
+
+# Project Roles
+
+A User with system-level role 'Admin' or 'Super Admin' is able to manage the access rights for other Users on specific
+projects, including assigning other Users as admins for those projects. This project level access control can be managed
+through the 'Admin' -> 'Users' menu, after clicking on a specific User.
+
+A User that has been given 'Admin' rights for a specific project can also manage the access rights for another Users on
+that same project. This is done through the "Users" tab on the Project settings screen.
+
+Project Role | Description
+--- | ---
+Deployer | Can deploy a project, regardless if his system level role.
+Admin | Deployer + can setup and configure the project, regardless of his system level role.

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -111,4 +111,85 @@ describe BuildsController do
       end
     end
   end
+
+  as_a_project_deployer do
+    describe '#index' do
+      it 'works with no builds' do
+        get :index, project_id: project.to_param
+        assert_response :ok
+      end
+
+      it 'displays basic build info' do
+        project.builds.create!(label: 'test branch', git_ref: 'test_branch')
+        project.builds.create!(label: 'master branch', git_ref: 'master')
+        get :index, project_id: project.to_param
+        assert_response :ok
+        @response.body.must_include 'test branch'
+        @response.body.must_include 'master branch'
+      end
+    end
+
+    describe '#show' do
+      before { default_build }
+
+      it 'displays information about the build' do
+        get :show, project_id: project.to_param, id: default_build.id
+        assert_response :ok
+        @response.body.must_include default_build.label
+      end
+    end
+
+    describe 'creating a new build' do
+      it 'displays the #new page' do
+        get :new, project_id: project.to_param
+        assert_response :ok
+      end
+
+      it 'can create a build' do
+        git_sha = '0123456789012345678901234567890123456789'
+        stub_git_reference_check(returns: git_sha)
+
+        post :create, project_id: project.to_param, build: { label: 'Test creation', git_ref: 'master', description: 'hi there' }
+        assert_response :redirect
+
+        new_build = Build.last
+        assert_equal('Test creation', new_build.label)
+        assert_equal(git_sha, new_build.git_sha)
+        assert_redirected_to project_build_path(project, new_build)
+      end
+
+      it 'handles errors' do
+        stub_git_reference_check(returns: false)
+        post :create, project_id: project.to_param, build: { label: 'Test creation', git_ref: 'INVALID REF' }
+        assert_response 422
+      end
+    end
+
+    describe 'editing a build' do
+      before { default_build }
+
+      it 'displays the #edit page' do
+        get :edit, project_id: project.to_param, id: default_build.id
+        assert_response :ok
+        @response.body.must_include default_build.label
+      end
+
+      it 'updates the build' do
+        put :update, project_id: project.to_param, id: default_build.id, build: { label: 'New updated label!' }
+        assert_response :redirect
+        default_build.reload
+        assert_equal('New updated label!', default_build.label)
+      end
+
+      it 'prevents changing the git ref or sha' do
+        assert_raises ActionController::UnpermittedParameters do
+          put :update, project_id: project.to_param, id: default_build.id, build: { git_ref: 'test_branch' }
+        end
+
+        assert_raises ActionController::UnpermittedParameters do
+          put :update, project_id: project.to_param, id: default_build.id, build: { git_sha: '0123456789012345678901234567890123456789' }
+        end
+      end
+    end
+  end
 end

--- a/test/controllers/commit_statuses_controller_test.rb
+++ b/test/controllers/commit_statuses_controller_test.rb
@@ -2,10 +2,41 @@ require_relative '../test_helper'
 
 describe CommitStatusesController do
   as_a_viewer do
-    unauthorized :get, :show, project_id: 1, id: 'test/test'
+    unauthorized :get, :show, project_id: :foo, id: 'test/test'
   end
 
   as_a_deployer do
+    describe 'a GET to #show' do
+      it "fails with unknown project" do
+        assert_raises ActiveRecord::RecordNotFound do
+          get :show, project_id: 123123, id: 'test/test'
+        end
+      end
+
+      describe 'valid' do
+        let(:commit_status_data) {
+          {
+            status: 'pending',
+            status_list: [{ status: 'pending', description: 'the Travis build is still running' }]
+          }
+        }
+        setup do
+          CommitStatus.stubs(new: stub(commit_status_data))
+          get :show, project_id: projects(:test), id: 'test/test'
+        end
+
+        it 'responds ok' do
+          response.status.must_equal(200)
+        end
+
+        it 'responds with the status' do
+          response.body.must_equal(JSON.dump(commit_status_data))
+        end
+      end
+    end
+  end
+
+  as_a_project_deployer do
     describe 'a GET to #show' do
       it "fails with unknown project" do
         assert_raises ActiveRecord::RecordNotFound do

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -4,20 +4,12 @@ describe DeploysController do
   let(:project) { job.project }
   let(:stage) { deploy.stage }
   let(:admin) { users(:admin) }
-  let(:deployer) { users(:deployer) }
   let(:command) { job.command }
   let(:job) { jobs(:succeeded_test) }
   let(:deploy) { deploys(:succeeded_test) }
   let(:deploy_service) { stub(deploy!: nil, stop!: nil) }
   let(:deploy_called) { [] }
   let(:changeset) { stub_everything(commits: [], files: [], pull_requests: [], jira_issues: []) }
-
-  setup do
-    DeployService.stubs(:new).with(deployer).returns(deploy_service)
-    deploy_service.stubs(:deploy!).capture(deploy_called).returns(deploy)
-
-    Deploy.any_instance.stubs(:changeset).returns(changeset)
-  end
 
   it "routes" do
     assert_routing "/projects/1/stages/2/deploys/new", controller: "deploys", action: "new", project_id: "1", stage_id: "2"
@@ -26,6 +18,8 @@ describe DeploysController do
   end
 
   as_a_viewer do
+    let(:deployer) { users(:viewer) }
+
     describe "a GET to :index" do
       it "renders html" do
         get :index, project_id: project
@@ -169,13 +163,153 @@ describe DeploysController do
       end
     end
 
-    unauthorized :get, :new, project_id: 1, stage_id: 2
-    unauthorized :post, :create, project_id: 1, stage_id: 2
-    unauthorized :post, :buddy_check, project_id: 1, id: 1
-    unauthorized :delete, :destroy, project_id: 1, id: 1
+    unauthorized :get, :new, project_id: :foo, stage_id: 2
+    unauthorized :post, :create, project_id: :foo, stage_id: 2
+    unauthorized :post, :buddy_check, project_id: :foo, id: 1
+    unauthorized :delete, :destroy, project_id: :foo, id: 1
   end
 
   as_a_deployer do
+    let(:deployer) { users(:deployer) }
+
+    setup do
+      DeployService.stubs(:new).with(deployer).returns(deploy_service)
+      deploy_service.stubs(:deploy!).capture(deploy_called).returns(deploy)
+
+      Deploy.any_instance.stubs(:changeset).returns(changeset)
+    end
+
+    describe "a GET to :new" do
+      it "sets stage and reference" do
+        get :new, project_id: project.to_param, stage_id: stage.to_param, reference: "abcd"
+        deploy = assigns(:deploy)
+        deploy.reference.must_equal "abcd"
+      end
+    end
+
+    describe "a POST to :create" do
+
+      setup do
+        post :create, params.merge(project_id: project.to_param, stage_id: stage.to_param, format: format)
+      end
+
+      let(:params) {{ deploy: { reference: "master" }}}
+
+      describe "as html" do
+        let(:format) { :html }
+
+        it "redirects to the job path" do
+          assert_redirected_to project_deploy_path(project, deploy)
+        end
+
+        it "creates a deploy" do
+          assert_equal [[stage, {"reference" => "master"}]], deploy_called
+        end
+      end
+
+      describe "as json" do
+        let(:format) { :json }
+
+        it "responds ok" do
+          assert_response :ok
+        end
+
+        it "creates a deploy" do
+          assert_equal [[stage, {"reference" => "master"}]], deploy_called
+        end
+      end
+    end
+
+    describe "a POST to :confirm" do
+      setup do
+        Deploy.delete_all # triggers more callbacks
+
+        post :confirm, project_id: project.to_param, stage_id: stage.to_param, deploy: { reference: "master" }
+      end
+
+      it "renders the template" do
+        assert_template :changeset
+      end
+    end
+
+    describe "a POST to :buddy_check" do
+      let(:deploy) { deploys(:succeeded_test) }
+      before { deploy.job.update_column(:status, 'pending') }
+
+      it "confirms and redirects to the deploy" do
+        DeployService.stubs(:new).with(deploy.user).returns(deploy_service)
+        deploy_service.expects(:confirm_deploy!)
+        refute deploy.buddy
+
+        post :buddy_check, project_id: project.to_param, id: deploy.id
+
+        assert_redirected_to project_deploy_path(project, deploy)
+        deploy.reload.buddy.must_equal deployer
+      end
+    end
+
+    describe "a DELETE to :destroy" do
+      describe "with a deploy owned by the deployer" do
+        setup do
+          DeployService.stubs(:new).with(deployer).returns(deploy_service)
+          Job.any_instance.stubs(:started_by?).returns(true)
+          deploy_service.expects(:stop!).once
+
+          delete :destroy, project_id: project.to_param, id: deploy.to_param
+        end
+
+        it "cancels a deploy" do
+          flash[:error].must_be_nil
+        end
+      end
+
+      describe "with a deploy not owned by the deployer" do
+        setup do
+          deploy_service.expects(:stop!).never
+          Deploy.any_instance.stubs(:started_by?).returns(false)
+          User.any_instance.stubs(:is_admin?).returns(false)
+
+          delete :destroy, project_id: project.to_param, id: deploy.to_param
+        end
+
+        it "doesn't cancel the deloy" do
+          flash[:error].wont_be_nil
+        end
+      end
+    end
+  end
+
+  as_a_admin do
+    let(:deployer) { users(:admin) }
+
+    setup do
+      DeployService.stubs(:new).with(deployer).returns(deploy_service)
+    end
+
+    describe "a DELETE to :destroy" do
+      describe "with a valid deploy" do
+        setup do
+          deploy_service.expects(:stop!).once
+          delete :destroy, project_id: project.to_param, id: deploy.to_param
+        end
+
+        it "cancels the deploy" do
+          flash[:error].must_be_nil
+        end
+      end
+    end
+  end
+
+  as_a_project_deployer do
+    let(:deployer) { users(:project_deployer) }
+
+    setup do
+      DeployService.stubs(:new).with(deployer).returns(deploy_service)
+      deploy_service.stubs(:deploy!).capture(deploy_called).returns(deploy)
+
+      Deploy.any_instance.stubs(:changeset).returns(changeset)
+    end
+
     describe "a GET to :new" do
       it "sets stage and reference" do
         get :new, project_id: project.to_param, stage_id: stage.to_param, reference: "abcd"
@@ -270,22 +404,6 @@ describe DeploysController do
 
         it "doesn't cancel the deloy" do
           flash[:error].wont_be_nil
-        end
-      end
-    end
-  end
-
-  as_a_admin do
-    describe "a DELETE to :destroy" do
-      describe "with a valid deploy" do
-        setup do
-          DeployService.stubs(:new).with(admin).returns(deploy_service)
-          deploy_service.expects(:stop!).once
-          delete :destroy, project_id: project.to_param, id: deploy.to_param
-        end
-
-        it "cancels the deploy" do
-          flash[:error].must_be_nil
         end
       end
     end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -109,8 +109,8 @@ describe JobsController do
     end
   end
 
-  as_a_deployer_project_admin do
-    let(:project_admin) { users(:deployer_project_admin) }
+  as_a_project_admin do
+    let(:project_admin) { users(:project_admin) }
     let(:job) { Job.create!(command: command, project: project, user: project_admin) }
 
     setup do

--- a/test/controllers/locks_controller_test.rb
+++ b/test/controllers/locks_controller_test.rb
@@ -1,54 +1,70 @@
 require_relative '../test_helper'
 
 describe LocksController do
+  let(:stage) { stages(:test_staging) }
+  let(:lock) { stage.create_lock! user: users(:deployer) }
   let(:global_lock) { Lock.create! user: users(:deployer) }
 
   before { request.headers['HTTP_REFERER'] = '/back' }
 
   as_a_viewer do
     unauthorized :post, :create
-    unauthorized :post, :create, lock: {stage_id: 1}
-    unauthorized :delete, :destroy, id: 1
+
+    it 'responds with unauthorized when doing a post to create a local lock' do
+      post :create, lock: {stage_id: stage.id}
+      @unauthorized.must_equal true, 'Request was not marked unauthorized'
+    end
+
+    it 'is unauthorized when doing a delete to destroy a local lock' do
+      delete :destroy, id: lock.id
+      @unauthorized.must_equal true, 'Request was not marked unauthorized'
+    end
+
+    it 'is unauthorized when doing a delete to destroy a global lock' do
+      delete :destroy, id: global_lock.id
+    end
   end
 
   as_a_deployer do
     unauthorized :post, :create
-    it("unauthorized") { post :create, id: global_lock.id }
 
-    let(:stage) { stages(:test_staging) }
+    it 'responds with unauthorized when doing a post to create a global lock' do
+      post :create, lock: {stage_id: '', description: 'DESC'}
+      @unauthorized.must_equal true, 'Request was not marked unauthorized'
+    end
 
     describe 'POST to #create' do
-      it "creates a lock" do
-        post :create, lock: {stage_id: stage.id, description: "DESC"}
-        assert_redirected_to "/back"
+      it 'creates a lock' do
+        post :create, lock: {stage_id: stage.id, description: 'DESC'}
+        assert_redirected_to '/back'
         assert flash[:notice]
 
         stage.reload
 
         stage.warning?.must_equal(false)
         stage.locked?.must_equal(true)
-        stage.lock.description.must_equal "DESC"
+        stage.lock.description.must_equal 'DESC'
       end
 
-      it "creates a warning" do
-        post :create, lock: {stage_id: stage.id, description: "DESC", warning: true}
-        assert_redirected_to "/back"
+      it 'creates a warning' do
+        post :create, lock: {stage_id: stage.id, description: 'DESC', warning: true}
+        assert_redirected_to '/back'
         assert flash[:notice]
 
         stage.reload
 
         stage.warning?.must_equal(true)
         stage.locked?.must_equal(false)
-        stage.lock.description.must_equal "DESC"
+        stage.lock.description.must_equal 'DESC'
       end
     end
 
     describe 'DELETE to #destroy' do
-      it "destroys the lock" do
+      it 'destroys the lock' do
         lock = stage.create_lock!(user: users(:deployer))
         delete :destroy, id: lock.id
 
-        assert_redirected_to "/back"
+        assert_redirected_to '/back'
         assert flash[:notice]
 
         stage.reload
@@ -61,23 +77,73 @@ describe LocksController do
 
   as_a_admin do
     describe 'POST to #create' do
-      it "creates a global lock" do
-        post :create, lock: {description: "DESC"}
-        assert_redirected_to "/back"
+      it 'creates a global lock' do
+        post :create, lock: {stage_id: '', description: 'DESC'}
+        assert_redirected_to '/back'
         assert flash[:notice]
 
         lock = Lock.global.first
-        lock.description.must_equal "DESC"
+        lock.description.must_equal 'DESC'
       end
     end
 
     describe 'DELETE to #destroy' do
-      it "destroys a global lock" do
+      it 'destroys a global lock' do
         delete :destroy, id: global_lock.id
 
-        assert_redirected_to "/back"
+        assert_redirected_to '/back'
         assert flash[:notice]
 
+        Lock.count.must_equal 0
+      end
+    end
+  end
+
+  as_a_project_deployer do
+    unauthorized :post, :create
+
+    it 'responds with unauthorized when doing a post to create a global lock' do
+      post :create, lock: {stage_id: '', description: 'DESC'}
+      @unauthorized.must_equal true, 'Request was not marked unauthorized'
+    end
+
+    describe 'POST to #create' do
+      it 'creates a lock' do
+        post :create, lock: {stage_id: stage.id, description: 'DESC'}
+        assert_redirected_to '/back'
+        assert flash[:notice]
+
+        stage.reload
+
+        stage.warning?.must_equal(false)
+        stage.locked?.must_equal(true)
+        stage.lock.description.must_equal 'DESC'
+      end
+
+      it 'creates a warning' do
+        post :create, lock: {stage_id: stage.id, description: 'DESC', warning: true}
+        assert_redirected_to '/back'
+        assert flash[:notice]
+
+        stage.reload
+
+        stage.warning?.must_equal(true)
+        stage.locked?.must_equal(false)
+        stage.lock.description.must_equal 'DESC'
+      end
+    end
+
+    describe 'DELETE to #destroy' do
+      it 'destroys the lock' do
+        lock = stage.create_lock!(user: users(:deployer))
+        delete :destroy, id: lock.id
+
+        assert_redirected_to '/back'
+        assert flash[:notice]
+
+        stage.reload
+
+        stage.locked?.must_equal(false)
         Lock.count.must_equal 0
       end
     end

--- a/test/controllers/macros_controller_test.rb
+++ b/test/controllers/macros_controller_test.rb
@@ -2,7 +2,6 @@ require_relative '../test_helper'
 
 describe MacrosController do
   let(:project) { projects(:test) }
-  let(:deployer) { users(:deployer) }
   let(:macro) { macros(:test) }
   let(:macro_service) { stub(execute!: nil) }
   let(:execute_called) { [] }
@@ -14,6 +13,8 @@ describe MacrosController do
   end
 
   as_a_viewer do
+    let(:deployer) { users(:viewer) }
+
     unauthorized :get, :index, project_id: :foo
     unauthorized :get, :new, project_id: :foo
     unauthorized :get, :edit, project_id: :foo, id: 1
@@ -24,6 +25,8 @@ describe MacrosController do
   end
 
   as_a_deployer do
+    let(:deployer) { users(:deployer) }
+
     describe "a GET to :index" do
       setup { get :index, project_id: project.to_param }
 
@@ -63,6 +66,8 @@ describe MacrosController do
   end
 
   as_a_admin do
+    let(:deployer) { users(:admin) }
+
     describe 'a GET to #new' do
       setup { get :new, project_id: project.to_param }
 
@@ -177,6 +182,8 @@ describe MacrosController do
   end
 
   as_a_super_admin do
+    let(:deployer) { users(:super_admin) }
+
     describe 'a DELETE to #destroy' do
       setup do
         delete :destroy, project_id: project.to_param, id: macro.id
@@ -193,7 +200,50 @@ describe MacrosController do
     end
   end
 
-  as_a_deployer_project_admin do
+  as_a_project_deployer do
+    let(:deployer) { users(:project_deployer) }
+
+    describe "a GET to :index" do
+      setup { get :index, project_id: project.to_param }
+
+      it "renders the template" do
+        assert_template :index
+      end
+    end
+
+    describe 'a POST to #execute' do
+      describe 'with a macro' do
+        setup do
+          JobExecution.stubs(:start_job)
+          post :execute, project_id: project.to_param, id: macro.id
+        end
+
+        it "redirects to the job path" do
+          assert_redirected_to project_job_path(project, job)
+        end
+
+        it "creates a job" do
+          assert_equal [[macro]], execute_called
+        end
+      end
+
+      it 'fails for non-existent macro' do
+        assert_raises ActiveRecord::RecordNotFound do
+          post :execute, project_id: project.to_param, id: 123123123
+        end
+      end
+    end
+
+    unauthorized :get, :new, project_id: :foo
+    unauthorized :get, :edit, project_id: :foo, id: 1
+    unauthorized :post, :create, project_id: :foo
+    unauthorized :put, :update, project_id: :foo, id: 1
+    unauthorized :delete, :destroy, project_id: :foo, id: 1
+  end
+
+  as_a_project_admin do
+    let(:deployer) { users(:project_admin) }
+
     describe 'a GET to #new' do
       setup { get :new, project_id: project.to_param }
 
@@ -281,7 +331,7 @@ describe MacrosController do
     describe 'a DELETE to #destroy' do
       describe 'with the macro creator being project admin' do
         setup do
-          macro.update_attributes!(user: users(:deployer_project_admin))
+          macro.update_attributes!(user: users(:project_admin))
           delete :destroy, project_id: project.to_param, id: macro.id
         end
 

--- a/test/controllers/new_relic_controller_test.rb
+++ b/test/controllers/new_relic_controller_test.rb
@@ -64,4 +64,64 @@ describe NewRelicController do
       end
     end
   end
+
+  as_a_project_deployer do
+    it "requires a project" do
+      assert_raises(ActiveRecord::RecordNotFound) do
+        get :show, project_id: 123123, id: 123123
+      end
+    end
+
+    it "requires a stage" do
+      assert_raises(ActiveRecord::RecordNotFound) do
+        get :show, project_id: projects(:test), id: 123123
+      end
+    end
+
+    it "requires a NewReclic api key" do
+      begin
+        old, NewRelicApi.api_key = NewRelicApi.api_key, ""
+        get :show, project_id: projects(:test), id: 123123
+      ensure
+        NewRelicApi.api_key = old
+      end
+      assert_response :precondition_failed
+    end
+
+    describe "success" do
+      setup do
+        NewRelic.expects(:metrics).
+            with([new_relic_applications(:production).name], initial).
+            returns('test_project' => true)
+
+        get :show, project_id: projects(:test),
+            id: stages(:test_staging).id,
+            initial: initial ? 'true' : nil
+      end
+
+      describe 'initial' do
+        let(:initial) { true }
+
+        it 'responds 200' do
+          response.status.must_equal(200)
+        end
+
+        it 'renders json representation' do
+          response.body.must_equal(JSON.dump('test_project' => true))
+        end
+      end
+
+      describe 'not initial' do
+        let(:initial) { false }
+
+        it 'responds 200' do
+          response.status.must_equal(200)
+        end
+
+        it 'renders json representation' do
+          response.body.must_equal(JSON.dump('test_project' => true))
+        end
+      end
+    end
+  end
 end

--- a/test/controllers/project_roles_controller_test.rb
+++ b/test/controllers/project_roles_controller_test.rb
@@ -64,7 +64,7 @@ describe ProjectRolesController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       let(:new_admin) { users(:deployer) }
 
       it 'creates new project role' do
@@ -101,7 +101,7 @@ describe ProjectRolesController do
   end
 
   describe "a PUT to #update" do
-    let(:current_project_admin) { users(:deployer_project_admin) }
+    let(:current_project_admin) { users(:project_admin) }
     let(:current_project_admin_role) { user_project_roles(:project_admin) }
 
     as_a_viewer do
@@ -145,7 +145,7 @@ describe ProjectRolesController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       it 'updates the project role' do
         put :update, project_id: project.id, id: current_project_admin_role.id, project_role: { role_id: ProjectRole::DEPLOYER.id }, format: 'json'
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -86,7 +86,7 @@ describe ProjectsController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       unauthorized :get, :new
     end
   end
@@ -156,7 +156,7 @@ describe ProjectsController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       unauthorized :post, :create
     end
   end
@@ -189,7 +189,7 @@ describe ProjectsController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       unauthorized :delete, :destroy, id: :foo
     end
   end
@@ -242,7 +242,7 @@ describe ProjectsController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       it "does not find soft deleted" do
         project.soft_delete!
         assert_raises ActiveRecord::RecordNotFound do
@@ -305,7 +305,7 @@ describe ProjectsController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       it "renders" do
         get :edit, id: project.to_param
         assert_template :edit

--- a/test/controllers/references_controller_test.rb
+++ b/test/controllers/references_controller_test.rb
@@ -17,6 +17,15 @@ describe ReferencesController do
           response.content_type.must_equal 'application/json'
           assigns(:references).must_equal %w(master test_user/test_branch)
         end
+      end
+
+      as_a_project_deployer do
+
+        it 'returns the git references for the project test' do
+          get :index, project_id: projects(:test).to_param, format: :json
+          response.content_type.must_equal 'application/json'
+          assigns(:references).must_equal %w(master test_user/test_branch)
+        end
 
       end
     end

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -5,8 +5,8 @@ describe ReleasesController do
   let(:release) { releases(:test) }
 
   as_a_viewer do
-    unauthorized :get, :new, project_id: 1
-    unauthorized :post, :create, project_id: 1
+    unauthorized :get, :new, project_id: :foo
+    unauthorized :post, :create, project_id: :foo
 
     describe "#show" do
       it "renders" do
@@ -30,6 +30,27 @@ describe ReleasesController do
   end
 
   as_a_deployer do
+    describe "#create" do
+      let(:release_params) { { commit: "abcd" } }
+      before { GITHUB.stubs(:create_release) }
+
+      it "creates a new release" do
+        assert_difference "Release.count", +1 do
+          post :create, project_id: project.to_param, release: release_params
+          assert_redirected_to "/projects/foo/releases/v124"
+        end
+      end
+    end
+
+    describe "#new" do
+      it "renders" do
+        get :new, project_id: project.to_param
+        assert_response :success
+      end
+    end
+  end
+
+  as_a_project_deployer do
     describe "#create" do
       let(:release_params) { { commit: "abcd" } }
       before { GITHUB.stubs(:create_release) }

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -294,7 +294,53 @@ describe StagesController do
     end
   end
 
-  as_a_deployer_project_admin do
+  as_a_project_deployer do
+    describe 'GET to :show' do
+      describe 'valid' do
+        before do
+          Deploy.delete_all # triggers more github requests
+        end
+
+        it 'renders the template' do
+          get :show, project_id: subject.project.to_param, id: subject.to_param
+          assert_template :show
+        end
+
+        it 'displays a sanitized dashboard' do
+          subject.update_attribute :dashboard,
+                                   'START_OF_TEXT<p>PARAGRAPH_TEXT</p><img src="foo.jpg"/><iframe src="http://localhost/foo.txt"></iframe><script>alert("hi there");</script>END_OF_TEXT'
+
+          get :show, project_id: subject.project.to_param, id: subject.to_param
+
+          response.body.to_s[/START_OF_TEXT.*END_OF_TEXT/].must_equal(
+              'START_OF_TEXT<p>PARAGRAPH_TEXT</p><img src="foo.jpg"><iframe src="http://localhost/foo.txt"></iframe>alert("hi there");END_OF_TEXT'
+          )
+        end
+      end
+
+      it "fails with invalid stage" do
+        assert_raises ActiveRecord::RecordNotFound do
+          get :show, project_id: 123123, id: subject.to_param
+        end
+      end
+
+      it "fails with invalid stage" do
+        assert_raises ActiveRecord::RecordNotFound do
+          get :show, project_id: subject.project.to_param, id: 123123
+        end
+      end
+    end
+
+    unauthorized :get, :new, project_id: :foo
+    unauthorized :post, :create, project_id: :foo
+    unauthorized :get, :edit, project_id: :foo, id: 1
+    unauthorized :patch, :update, project_id: :foo, id: 1
+    unauthorized :delete, :destroy, project_id: :foo, id: 1
+    unauthorized :patch, :reorder, project_id: :foo, id: 1
+    unauthorized :get, :clone, project_id: :foo, id: 1
+  end
+
+  as_a_project_admin do
     describe 'GET to #new' do
       describe 'valid' do
         before { get :new, project_id: subject.project.to_param }

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -48,7 +48,7 @@ describe UsersController do
       end
     end
 
-    as_a_deployer_project_admin do
+    as_a_project_admin do
       it 'responds successfully' do
         get :index, project_id: project.to_param
         users = User.all

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -3,41 +3,80 @@ require_relative '../test_helper'
 describe WebhooksController do
   let(:project) { projects(:test) }
   let(:stage) { stages(:test_staging) }
-  let(:user) { users(:admin) }
 
-  setup do
-    request.env['warden'].set_user(user)
+  as_a_viewer do
+    unauthorized :get, :index, project_id: :foo
+    unauthorized :post, :create, project_id: :foo
+    unauthorized :delete, :destroy, project_id: :foo, id: 1
   end
 
-  describe 'GET :index' do
-    it 'renders :index template' do
-      get :index, project_id: project.to_param
-      assert_template :index
-    end
-  end
-
-  describe 'POST :create' do
-    let(:params) { { branch: "master", stage_id: stage.id, source: 'any' } }
-    setup do
-      post :create, project_id: project.to_param, webhook: params
-    end
-
-    describe 'with valid params' do
-      it 'redirects to :index' do
-        assert_redirected_to project_webhooks_path(project)
-      end
-    end
-
-    describe 'handles stage deletion' do
-      setup do
-        stage.soft_delete!
-        project.reload
-      end
-
-      it "renders :index" do
+  as_a_deployer do
+    describe 'GET :index' do
+      it 'renders :index template' do
         get :index, project_id: project.to_param
         assert_template :index
       end
     end
+
+    describe 'POST :create' do
+      let(:params) { { branch: "master", stage_id: stage.id, source: 'any' } }
+      setup do
+        post :create, project_id: project.to_param, webhook: params
+      end
+
+      describe 'with valid params' do
+        it 'redirects to :index' do
+          assert_redirected_to project_webhooks_path(project)
+        end
+      end
+
+      describe 'handles stage deletion' do
+        setup do
+          stage.soft_delete!
+          project.reload
+        end
+
+        it "renders :index" do
+          get :index, project_id: project.to_param
+          assert_template :index
+        end
+      end
+    end
   end
+
+  as_a_project_deployer do
+    describe 'GET :index' do
+      it 'renders :index template' do
+        get :index, project_id: project.to_param
+        assert_template :index
+      end
+    end
+
+    describe 'POST :create' do
+      let(:params) { { branch: "master", stage_id: stage.id, source: 'any' } }
+      setup do
+        post :create, project_id: project.to_param, webhook: params
+      end
+
+      describe 'with valid params' do
+        it 'redirects to :index' do
+          assert_redirected_to project_webhooks_path(project)
+        end
+      end
+
+      describe 'handles stage deletion' do
+        setup do
+          stage.soft_delete!
+          project.reload
+        end
+
+        it "renders :index" do
+          get :index, project_id: project.to_param
+          assert_template :index
+        end
+      end
+    end
+  end
+
+
 end

--- a/test/fixtures/user_project_roles.yml
+++ b/test/fixtures/user_project_roles.yml
@@ -1,9 +1,9 @@
 project_admin:
-  user: deployer_project_admin
+  user: project_admin
   project: test
   role_id: <%= ProjectRole::ADMIN.id %>
 
 project_deployer:
-  user: viewer_project_deployer
+  user: project_deployer
   project: test
   role_id: <%= ProjectRole::DEPLOYER.id %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -35,13 +35,13 @@ github_viewer:
   role_id: <%= Role::VIEWER.id %>
   external_id: 'github-3'
 
-deployer_project_admin:
+project_admin:
   name: "Deployer Project Admin"
   email: "deployer_admin@example.com"
   role_id: <%= Role::DEPLOYER.id %>
   external_id: 'github-4'
 
-viewer_project_deployer:
+project_deployer:
   name: "Project Deployer"
   email: "viewer_deployer@example.com"
   role_id: <%= Role::VIEWER.id %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -243,7 +243,7 @@ describe User do
 
   describe "#admin_for_project?" do
     it "is true for a user that has been granted the role of project admin" do
-      users(:deployer_project_admin).is_admin_for?(projects(:test)).must_equal(true)
+      users(:project_admin).is_admin_for?(projects(:test)).must_equal(true)
     end
 
     it "is false for users that have not been granted the role of project admin" do
@@ -256,11 +256,11 @@ describe User do
 
   describe "#deployer_for_project?" do
     it "is true for a user that has been granted the role of project deployer" do
-      users(:viewer_project_deployer).is_deployer_for?(projects(:test)).must_equal(true)
+      users(:project_deployer).is_deployer_for?(projects(:test)).must_equal(true)
     end
 
     it "is true for a user that has been granted the role of project admin" do
-      users(:deployer_project_admin).is_deployer_for?(projects(:test)).must_equal(true)
+      users(:project_admin).is_deployer_for?(projects(:test)).must_equal(true)
     end
 
     it "is false for users that have not been granted the roles of project deployer or project admin" do
@@ -273,7 +273,7 @@ describe User do
 
   describe "#project_role_for" do
     it "returns the project role for the given project" do
-      users(:deployer_project_admin).project_role_for(projects(:test)).must_equal user_project_roles(:project_admin)
+      users(:project_admin).project_role_for(projects(:test)).must_equal user_project_roles(:project_admin)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -155,7 +155,7 @@ class ActionController::TestCase
       end
     end
 
-    %w{deployer_project_admin}.each do |user|
+    %w{project_admin project_deployer}.each do |user|
       define_method "as_a_#{user}" do |&block|
         describe "as a #{user}" do
           setup { request.env['warden'].set_user(users(user)) }


### PR DESCRIPTION
Adding support to allow an User with project role 'Deployer' to have deployer access to a project regardless of his system level role.

(This is effectively the same PR as #566, but merging to `master` instead of a different branch.)

/cc @zendesk/samson 

### References
- [SAMSON-169](https://zendesk.atlassian.net/browse/SAMSON-169)

### Risks
- Changes to the behaviour of authorisation filters (confirm no security holes were added)
