### PR TITLE
Send access request as current user, cc manager

### DIFF
--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -5,14 +5,18 @@ class AccessRequestMailer < ApplicationMailer
     @manager_email = manager_email
     @reason = reason
     @projects = Project.order(:name).find(project_ids)
-    mail(to: build_recipients, subject: build_subject, body: build_body)
+    mail(from: @user.email, to: build_to, cc: build_cc, subject: build_subject, body: build_body)
   end
 
   private
 
-  def build_recipients
-    recipients = ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'].present? ? ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'].split : []
-    recipients << @manager_email
+  def build_to
+    # send to manager if no primary recipients configured
+    ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'].present? ? ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'].split : @manager_email
+  end
+
+  def build_cc
+    ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'].present? ? @manager_email : nil
   end
 
   def build_subject

--- a/test/controllers/access_requests_controller_test.rb
+++ b/test/controllers/access_requests_controller_test.rb
@@ -83,7 +83,7 @@ describe AccessRequestsController do
               post :create, request_params, session_params
             end
             access_request_email = ActionMailer::Base.deliveries.last
-            access_request_email.to.must_include manager_email
+            access_request_email.cc.must_equal [manager_email]
             access_request_email.body.to_s.must_match /#{reason}/
             Project.all.each { |project| access_request_email.body.to_s.must_match /#{project.name}/ }
           end

--- a/test/mailers/access_request_mailer_test.rb
+++ b/test/mailers/access_request_mailer_test.rb
@@ -26,12 +26,10 @@ describe AccessRequestMailer do
             hostname, user, manager_email, reason, Project.all.pluck(:id)).deliver_now
       end
 
-      it 'is from deploys@' do
-        subject.from.must_equal ['deploys@samson-deployment.com']
-      end
-
-      it 'sends to configured addresses' do
-        subject.to.must_equal(address_list.split << manager_email)
+      it 'has correct sender and recipients' do
+        subject.from.must_equal [user.email]
+        subject.to.must_equal address_list.split
+        subject.cc.must_equal [manager_email]
       end
 
       it 'has a correct subject' do
@@ -57,14 +55,16 @@ describe AccessRequestMailer do
       describe 'single address configured' do
         let(:address_list) { 'jira@example.com' }
         it 'handles single email address configured' do
-          subject.to.must_equal([address_list, manager_email])
+          subject.to.must_equal [address_list]
+          subject.cc.must_equal [manager_email]
         end
       end
 
       describe 'no address configured' do
         let(:address_list) { nil }
         it 'handles no configured email address' do
-          subject.to.must_equal([manager_email])
+          subject.to.must_equal [manager_email]
+          subject.cc.must_be_empty
         end
       end
     end


### PR DESCRIPTION
Use currently logged in user's email address as the sender for access request emails. It can then be used by tools like JIRA to properly set the ticket reporter.

Move manager email to CC field.

/cc @zendesk/samson @jonmoter 

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-99

### Risks
 - None