### PR TITLE
use HTTPS to retrieve badges from img.shields.io

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -37,7 +37,7 @@ class StagesController < ApplicationController
 
         if stale?(etag: badge)
           expires_in 1.minute, public: true
-          image = open("http://img.shields.io/badge/#{badge}.svg").read
+          image = open("https://img.shields.io/badge/#{badge}.svg").read
           render text: image, content_type: Mime::SVG
         end
       end

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -17,7 +17,7 @@ describe StagesController do
     let(:deploy) { deploys(:succeeded_test) }
 
     it "renders" do
-      stub_request(:get, "http://img.shields.io/badge/Staging-staging-green.svg")
+      stub_request(:get, "https://img.shields.io/badge/Staging-staging-green.svg")
       get :show, valid_params
       assert_response :success
       response.content_type.must_equal Mime::SVG
@@ -31,7 +31,7 @@ describe StagesController do
 
     it "renders none without deploy" do
       deploy.destroy!
-      stub_request(:get, "http://img.shields.io/badge/Staging-None-red.svg")
+      stub_request(:get, "https://img.shields.io/badge/Staging-None-red.svg")
       get :show, valid_params
       assert_response :success
       response.content_type.must_equal Mime::SVG
@@ -39,7 +39,7 @@ describe StagesController do
 
     it "renders strange characters" do
       subject.update_column(:name, 'Foo & Bar 1-4')
-      stub_request(:get, "http://img.shields.io/badge/Foo%20%26%20Bar%201--4-staging-green.svg")
+      stub_request(:get, "https://img.shields.io/badge/Foo%20%26%20Bar%201--4-staging-green.svg")
       get :show, valid_params
       assert_response :success
       response.content_type.must_equal Mime::SVG


### PR DESCRIPTION
Requests to img.shields.io via HTTP get redirected to HTTPS, and that generates a `RuntimeError: redirection forbidden`

/cc @zendesk/samson 

### References
 - Airbrake: https://zendesk.airbrake.io/projects/95346/groups/1533483716423658788