### PR TITLE
Create Kubernetes Services as part of deploy

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -19,5 +19,13 @@ module Kubernetes
     def ram_with_units
       "#{ram}Mi" if ram.present?
     end
+
+    def has_service?
+      service_name.present?
+    end
+
+    def service_for(deploy_group)
+      Kubernetes::Service.new(role: self, deploy_group: deploy_group) if has_service?
+    end
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/service.rb
+++ b/plugins/kubernetes/app/models/kubernetes/service.rb
@@ -1,0 +1,95 @@
+module Kubernetes
+  # Convenience wrapper around the 'Service' object we can get from the K8S API
+  class Service
+    attr_reader :deploy_group, :role, :name, :ip_address, :port_info
+
+    def initialize(deploy_group: nil, role: nil)
+      @deploy_group = deploy_group
+      @role = role
+      @port_info = []
+      @name = role.try(:service_name)
+    end
+
+    def namespace
+      deploy_group.kubernetes_namespace
+    end
+
+    def running?
+      service_object.present?
+    end
+
+    def proxy_address
+      "#{example_node_ip}:#{node_ports.first}" if running?
+    end
+
+    def example_node_ip
+      node = client.get_nodes.first
+      node.spec.externalID if node
+    end
+
+    # The set of ports that are exposed on each Kubernetes minion. Traffic sent
+    # to this port on any minion will be proxied to the Pods in this service.
+    def node_ports
+      fetch_service if @service_object.nil?
+      @port_info.map(&:nodePort)
+    end
+
+    # Returns an array of OpenStructs containing the list of Pods that this
+    # service routes traffic to. Each object return has the following attributes:
+    #   `pod_ip` : IP address of the Pod
+    #   `pod_name` : name of the Pod
+    #   `ready?` : true if the Pod is ready and accepting traffic
+    def endpoints
+      return [] if endpoint_object.nil?
+
+      results = []
+
+      # https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_endpoints
+      endpoint_object.subsets.each do |subset|
+        [:addresses, :notReadyAddresses].each do |attr|
+          next if subset[attr].blank?
+
+          subset[attr].each do |address|
+            if address.targetRef.kind == 'Pod'
+              results << OpenStruct.new(pod_ip: address.ip,
+                                        pod_name: address.targetRef.name,
+                                        ready?: (attr == :addresses))
+            end
+          end
+        end
+      end
+
+      results
+    end
+
+    def service_object
+      @service_object || fetch_service
+    end
+
+    def endpoint_object
+      @endpoint_object || fetch_endpoint
+    end
+
+    private
+
+    def fetch_service
+      @service_object = client.get_service(name, namespace)
+      @name = @service_object.metadata.name
+      @ip_address = @service_object.spec.clusterIP
+      @port_info = @service_object.spec.ports || []
+      @service_object
+    rescue KubeException => e
+      raise e unless e.error_code == 404
+      nil
+    end
+
+    def fetch_endpoint
+      @endpoint_object = client.get_endpoints(namespace: namespace,
+                                              field_selector: "metadata.name=#{name}").first
+    end
+
+    def client
+      deploy_group.kubernetes_cluster.client
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/service.rb
+++ b/plugins/kubernetes/app/models/kubernetes/service.rb
@@ -1,13 +1,19 @@
 module Kubernetes
   # Convenience wrapper around the 'Service' object we can get from the K8S API
   class Service
-    attr_reader :deploy_group, :role, :name, :ip_address, :port_info
+    attr_reader :deploy_group, :role
 
-    def initialize(deploy_group: nil, role: nil)
+    def initialize(deploy_group:, role:)
       @deploy_group = deploy_group
       @role = role
-      @port_info = []
-      @name = role.try(:service_name)
+    end
+
+    def name
+      if defined?(@service_object)
+        service_object.metadata.name
+      else
+        role.try(:service_name)
+      end
     end
 
     def namespace
@@ -18,24 +24,35 @@ module Kubernetes
       service_object.present?
     end
 
+    def ip_address
+      service_object.spec.clusterIP if running?
+    end
+
+    def port_info
+      (service_object.spec.ports if running?) || []
+    end
+
     def proxy_address
       "#{example_node_ip}:#{node_ports.first}" if running?
     end
 
+    # In Kubernetes, each minion acts as a proxy. So there's no single server
+    # that acts as a proxy/load-balancer. This method returns the IP address
+    # of one of the nodes that could act as a proxy.
     def example_node_ip
       node = client.get_nodes.first
       node.spec.externalID if node
     end
 
     # The set of ports that are exposed on each Kubernetes minion. Traffic sent
-    # to this port on any minion will be proxied to the Pods in this service.
+    # to these ports on any minion will be proxied to the Pods in this service.
     def node_ports
-      fetch_service if @service_object.nil?
-      @port_info.map(&:nodePort)
+      fetch_service
+      port_info.map(&:nodePort)
     end
 
     # Returns an array of OpenStructs containing the list of Pods that this
-    # service routes traffic to. Each object return has the following attributes:
+    # service routes traffic to. Each object returned has the following attributes:
     #   `pod_ip` : IP address of the Pod
     #   `pod_name` : name of the Pod
     #   `ready?` : true if the Pod is ready and accepting traffic
@@ -46,14 +63,14 @@ module Kubernetes
 
       # https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/HEAD/docs/api-reference/v1/definitions.html#_v1_endpoints
       endpoint_object.subsets.each do |subset|
-        [:addresses, :notReadyAddresses].each do |attr|
-          next if subset[attr].blank?
+        [:addresses, :notReadyAddresses].each do |key|
+          next if subset[key].blank?
 
-          subset[attr].each do |address|
+          subset[key].each do |address|
             if address.targetRef.kind == 'Pod'
               results << OpenStruct.new(pod_ip: address.ip,
                                         pod_name: address.targetRef.name,
-                                        ready?: (attr == :addresses))
+                                        ready?: (key == :addresses))
             end
           end
         end
@@ -63,21 +80,17 @@ module Kubernetes
     end
 
     def service_object
-      @service_object || fetch_service
+      defined?(@service_object) ? @service_object : fetch_service
     end
 
     def endpoint_object
-      @endpoint_object || fetch_endpoint
+      defined?(@endpoint_object) ? @endpoint_object : fetch_endpoint
     end
 
     private
 
     def fetch_service
       @service_object = client.get_service(name, namespace)
-      @name = @service_object.metadata.name
-      @ip_address = @service_object.spec.clusterIP
-      @port_info = @service_object.spec.ports || []
-      @service_object
     rescue KubeException => e
       raise e unless e.error_code == 404
       nil

--- a/plugins/kubernetes/app/views/kubernetes_release_doc/_release_doc_row.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_release_doc/_release_doc_row.html.erb
@@ -13,6 +13,20 @@
 </div>
 
 <div class="form-group">
+  <label class="col-lg-2 control-label">Proxy Address</label>
+  <div class="col-lg-10">
+    <% if address = release_doc.service.try(:proxy_address) %>
+      <p class="form-control-static" style="font-family:monospace;">
+        <%= link_to address, "http://#{address}" %>
+      </p>
+      <p class="form-control-static">Note this address will only work if you have direct access to the minions.</p>
+    <% else %>
+      <p class="form-control-static">None</p>
+  <% end %>
+  </div>
+</div>
+
+<div class="form-group">
   <label class="col-lg-2 control-label">Controller Doc</label>
   <div class="col-lg-10">
     <pre><%= release_doc.pretty_rc_doc %></pre>


### PR DESCRIPTION
When a project is deployed to Kubernetes for the first time, a Service should be created for every `Role` that defines a service.

This PR creates a `Kubernetes::Service` object that wraps some functionality of the Service abstraction. Right now it's just a ruby class, but I'm considering adding a table in the DB to keep track of them. I need to give that a little more thought.

It also adds logic to `KuberDeployService` to create the Service as part of deployment.

Sadly, this is still lacking in tests. I need to give some thought on how to make all this code more testable. I think we'll need some kind of Kubernetes testing framework, and maybe some integration tests.

/cc @henders, @msufa, @sbrnunes 

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-36

### Risks
 - Only affects Kubernetes plugin code, so minimal risk to primary Samson functionality.