### PR TITLE
Respect RACK_ENV when choosing to load bootscale

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,2 +1,2 @@
 require 'bundler/setup'
-require 'bootscale/setup' if [nil, 'test', 'development'].include?(ENV['RAILS_ENV'])
+require 'bootscale/setup' if ['development', 'test'].include?(ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development')


### PR DESCRIPTION
`bundle --deployment --without development:test` then loading the rack app with `RACK_ENV=production` would fail because this line required the bootscale gem which is only in the development and test groups and was only checking `RAILS_ENV`.

This changes the logic to be the same as `Rails.env` (as of writing):

https://github.com/rails/rails/blob/0d216d1add9eaaddfc0b02813ccf08fd22910859/railties/lib/rails.rb#L70