### PR TITLE
show error on deploy page if reference does not exist

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -110,6 +110,11 @@ $(function () {
             $tag_form_group.addClass("has-error");
             show_status_problems(data.status_list);
             break;
+          case null:
+            $ref_status_label.removeClass("hidden");
+            $tag_form_group.addClass("has-error");
+            show_status_problems([{"state": "Tag or SHA", description: "'" + ref + "' does not exist"}])
+            break;
         }
       }
     });


### PR DESCRIPTION
Displays an error message if you try deploying a reference that doesn't exist.

/cc @zendesk/samson

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-195

### Risks
 - Minimal risk, small change to JS when validating reference on deploy page

![samson](https://cloud.githubusercontent.com/assets/1056506/10650696/a5920820-77ff-11e5-91dc-bc6c945f9e97.jpg)
