### PR TITLE
Ensure access request flag gets cleared for project level access updates

### DIFF
--- a/app/controllers/project_roles_controller.rb
+++ b/app/controllers/project_roles_controller.rb
@@ -14,7 +14,7 @@ class ProjectRolesController < ApplicationController
 
     if new_role.persisted?
       Rails.logger.info("#{current_user.name_and_email} granted the role of #{new_role.role.display_name} to #{new_role.user.name} on project #{current_project.name}")
-      reset_access_request_flag(new_role.user_id)
+      reset_access_request_flag(new_role.user)
       render status: :created, json: new_role
     else
       render status: :bad_request, json: {errors: new_role.errors.full_messages}
@@ -25,7 +25,7 @@ class ProjectRolesController < ApplicationController
     project_role = UserProjectRole.find(params[:id])
     if project_role.update(update_params)
       Rails.logger.info("#{current_user.name_and_email} granted the role of #{project_role.role.display_name} to #{project_role.user.name} on project #{current_project.name}")
-      reset_access_request_flag(project_role.user_id)
+      reset_access_request_flag(project_role.user)
       render status: :ok, json: project_role
     else
       render status: :bad_request, json: {errors: project_role.errors.full_messages}
@@ -42,7 +42,7 @@ class ProjectRolesController < ApplicationController
     params.require(:project_role).permit(:role_id)
   end
 
-  def reset_access_request_flag(user_id)
-    User.find(user_id).update!(access_request_pending: false)
+  def reset_access_request_flag(user)
+    user.update!(access_request_pending: false)
   end
 end

--- a/app/controllers/project_roles_controller.rb
+++ b/app/controllers/project_roles_controller.rb
@@ -14,6 +14,7 @@ class ProjectRolesController < ApplicationController
 
     if new_role.persisted?
       Rails.logger.info("#{current_user.name_and_email} granted the role of #{new_role.role.display_name} to #{new_role.user.name} on project #{current_project.name}")
+      reset_access_request_flag(new_role.user_id)
       render status: :created, json: new_role
     else
       render status: :bad_request, json: {errors: new_role.errors.full_messages}
@@ -24,6 +25,7 @@ class ProjectRolesController < ApplicationController
     project_role = UserProjectRole.find(params[:id])
     if project_role.update(update_params)
       Rails.logger.info("#{current_user.name_and_email} granted the role of #{project_role.role.display_name} to #{project_role.user.name} on project #{current_project.name}")
+      reset_access_request_flag(project_role.user_id)
       render status: :ok, json: project_role
     else
       render status: :bad_request, json: {errors: project_role.errors.full_messages}
@@ -38,5 +40,9 @@ class ProjectRolesController < ApplicationController
 
   def update_params
     params.require(:project_role).permit(:role_id)
+  end
+
+  def reset_access_request_flag(user_id)
+    User.find(user_id).update!(access_request_pending: false)
   end
 end

--- a/test/controllers/project_roles_controller_test.rb
+++ b/test/controllers/project_roles_controller_test.rb
@@ -51,6 +51,13 @@ describe ProjectRolesController do
         result['role_id'].must_equal user_project_role.role_id
       end
 
+      it 'clears the access request pending flag' do
+        check_pending_request_flag(new_admin) do
+          post :create, project_id: project.id, project_role: { user_id: new_admin.id, project_id: project.id, role_id: ProjectRole::ADMIN.id }, format: 'json'
+          assert_response :created
+        end
+      end
+
       it 'fails to create new project role' do
         post :create, project_id: project.id, project_role: { user_id: new_admin.id, project_id: project.id, role_id: 3 }, format: 'json'
 
@@ -84,6 +91,13 @@ describe ProjectRolesController do
         result['user_id'].must_equal user_project_role.user_id
         result['project_id'].must_equal user_project_role.project_id
         result['role_id'].must_equal user_project_role.role_id
+      end
+
+      it 'clears the access request pending flag' do
+        check_pending_request_flag(new_admin) do
+          post :create, project_id: project.id, project_role: { user_id: new_admin.id, project_id: project.id, role_id: ProjectRole::ADMIN.id }, format: 'json'
+          assert_response :created
+        end
       end
 
       it 'fails to create new project role' do
@@ -131,6 +145,13 @@ describe ProjectRolesController do
         result['role_id'].must_equal user_project_role.role_id
       end
 
+      it 'clears the access request pending flag' do
+        check_pending_request_flag(current_project_admin) do
+          put :update, project_id: project.id, id: current_project_admin_role.id, project_role: { role_id: ProjectRole::DEPLOYER.id }, format: 'json'
+          assert_response :success
+        end
+      end
+
       it 'fails to update project role' do
         put :update, project_id: project.id, id: current_project_admin_role.id, project_role: { role_id: 3 }, format: 'json'
 
@@ -164,6 +185,13 @@ describe ProjectRolesController do
         result['role_id'].must_equal user_project_role.role_id
       end
 
+      it 'clears the access request pending flag' do
+        check_pending_request_flag(current_project_admin) do
+          put :update, project_id: project.id, id: current_project_admin_role.id, project_role: { role_id: ProjectRole::DEPLOYER.id }, format: 'json'
+          assert_response :success
+        end
+      end
+
       it 'fails to update project role' do
         put :update, project_id: project.id, id: current_project_admin_role.id, project_role: { role_id: 3 }, format: 'json'
 
@@ -177,5 +205,15 @@ describe ProjectRolesController do
         result['errors'].wont_be_nil
       end
     end
+  end
+
+  private
+
+  def check_pending_request_flag(user)
+    user.update!(access_request_pending: true)
+    assert(user.access_request_pending)
+    yield
+    user.reload
+    refute(user.access_request_pending)
   end
 end


### PR DESCRIPTION
The flag was cleared only for global access rights changes. This prevented the user to request access rights for additional projects after the initial request got serviced.

/cc @zendesk/samson @sbrnunes 

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-99

### Risks
 - None