### PR TITLE
pending label should match timeline.js

### DIFF
--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -7,8 +7,7 @@ module StatusHelper
   }
 
   LABEL_STATUS_MAPPING = ALERT_STATUS_MAPPING.merge(
-    "running" => "primary",
-    "pending" => "default"
+    "running" => "primary"
   )
 
   def status_alert(key)


### PR DESCRIPTION
@zendesk/samson 

The default is info.

https://github.com/zendesk/samson/blob/master/app/assets/javascripts/timeline.js#L30-L40