### PR TITLE
Add headers to API for deploys

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -56,7 +56,7 @@ class DeploysController < ApplicationController
       end
 
       format.json do
-        render json: {}, status: @deploy.persisted? ? 200 : 422
+        render json: @deploy.to_json, status: @deploy.persisted? ? :created : 422, location: [current_project, @deploy]
       end
     end
   end

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -210,8 +210,8 @@ describe DeploysController do
       describe "as json" do
         let(:format) { :json }
 
-        it "responds ok" do
-          assert_response :ok
+        it "responds created" do
+          assert_response :created
         end
 
         it "creates a deploy" do
@@ -340,8 +340,8 @@ describe DeploysController do
       describe "as json" do
         let(:format) { :json }
 
-        it "responds ok" do
-          assert_response :ok
+        it "responds created" do
+          assert_response :created
         end
 
         it "creates a deploy" do


### PR DESCRIPTION
When creating a new deploy it is nice to know the location of the deploy as
well as getting a proper status code (201 Created) so API clients can more
easily be implemented.