### PR TITLE
Select role when requesting additional access rights

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -8,7 +8,7 @@ class AccessRequestsController < ApplicationController
   def new
     session[:access_request_back_to] ||= request.referer
     @projects = Project.all.order(:name)
-    @roles = Role.all[1...-1] # ignore viewer (default) and super_admin (no such role per project)
+    @roles = ProjectRole.all
   end
 
   def create

--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -8,11 +8,14 @@ class AccessRequestsController < ApplicationController
   def new
     session[:access_request_back_to] ||= request.referer
     @projects = Project.all.order(:name)
+    @roles = Role.all[1...-1] # ignore viewer (default) and super_admin (no such role per project)
   end
 
   def create
     AccessRequestMailer.access_request_email(
-        request.base_url, current_user, params[:manager_email], params[:reason], params[:project_ids]).deliver_now
+        request.base_url, current_user,
+        params.require(:manager_email), params.require(:reason),
+        params.require(:project_ids), params.require(:role_id)).deliver_now
     current_user.update!(access_request_pending: true)
     flash[:success] = 'Access request email sent.'
     redirect_to session.delete(:access_request_back_to)

--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -1,10 +1,11 @@
 class AccessRequestMailer < ApplicationMailer
-  def access_request_email(host, user, manager_email, reason, project_ids)
+  def access_request_email(host, user, manager_email, reason, project_ids, role_id)
     @host = host
     @user = user
     @manager_email = manager_email
     @reason = reason
     @projects = Project.order(:name).find(project_ids)
+    @role = Role.find(role_id)
     mail(from: @user.email, to: build_to, cc: build_cc, subject: build_subject, body: build_body)
   end
 
@@ -22,7 +23,7 @@ class AccessRequestMailer < ApplicationMailer
   def build_subject
     subject = []
     subject << "[#{ENV['REQUEST_ACCESS_EMAIL_PREFIX']}]" if ENV['REQUEST_ACCESS_EMAIL_PREFIX'].present?
-    subject << "Grant #{desired_role} access rights to #{@user.name}"
+    subject << "Grant #{@role.display_name} access rights to #{@user.name}"
     subject.join ' '
   end
 
@@ -30,15 +31,11 @@ class AccessRequestMailer < ApplicationMailer
     message = []
     message << "Please bump access rights for user #{@user.name_and_email} on #{@host}."
     message << ''
-    message << "Desired role: #{desired_role}"
+    message << "Desired role: #{@role.display_name}"
     message << 'Target projects:'
     @projects.each { |project| message << "  - #{project.name}" }
     message << ''
     message << "Reason: #{@reason}"
     message.join "\n"
-  end
-
-  def desired_role
-    @user.is_super_admin? ? Role::SUPER_ADMIN.name : Role.find(@user.role_id + 1).name
   end
 end

--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -5,7 +5,7 @@ class AccessRequestMailer < ApplicationMailer
     @manager_email = manager_email
     @reason = reason
     @projects = Project.order(:name).find(project_ids)
-    @role = Role.find(role_id)
+    @role = ProjectRole.find(role_id)
     mail(from: @user.email, to: build_to, cc: build_cc, subject: build_subject, body: build_body)
   end
 

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -17,15 +17,23 @@
           <%= text_area_tag :reason, nil, class: 'form-control', rows: 4, required: 'required' %>
         </div>
       </div>
-    </fieldset>
 
-    <div class="form-group">
-      <label class="col-lg-2 control-label">Projects</label>
-      <div class="col-lg-4">
-        <%= select_tag :project_ids, options_from_collection_for_select(@projects, 'id', 'name'),
-                       class: 'form-control', multiple: true, required: 'required' %>
+      <div class="form-group">
+        <label class="col-lg-2 control-label">Projects</label>
+        <div class="col-lg-4">
+          <%= select_tag :project_ids, options_from_collection_for_select(@projects, 'id', 'name'),
+                         class: 'form-control', multiple: true, required: 'required' %>
+        </div>
       </div>
-    </div>
+
+      <div class="form-group">
+        <label class="col-lg-2 control-label">Role</label>
+        <div class="col-lg-4">
+          <%= select_tag :role_id, options_from_collection_for_select(@roles, 'id', 'display_name'),
+                         class: 'form-control', required: 'required' %>
+        </div>
+      </div>
+    </fieldset>
 
     <fieldset>
       <div class="form-group">

--- a/test/controllers/access_requests_controller_test.rb
+++ b/test/controllers/access_requests_controller_test.rb
@@ -55,7 +55,9 @@ describe AccessRequestsController do
       describe 'enabled' do
         let(:manager_email) { 'manager@example.com' }
         let(:reason) { 'Dummy reason.' }
-        let(:request_params) { {manager_email: manager_email, reason: reason, project_ids: Project.all.pluck(:id)} }
+        let(:role) { Role::DEPLOYER }
+        let(:request_params) {
+          {manager_email: manager_email, reason: reason, project_ids: Project.all.pluck(:id), role_id: role.id} }
         let(:session_params) { {access_request_back_to: root_path} }
         describe 'environment and user' do
           before { post :create, request_params, session_params }
@@ -85,6 +87,7 @@ describe AccessRequestsController do
             access_request_email = ActionMailer::Base.deliveries.last
             access_request_email.cc.must_equal [manager_email]
             access_request_email.body.to_s.must_match /#{reason}/
+            access_request_email.body.to_s.must_match /#{role.display_name}/
             Project.all.each { |project| access_request_email.body.to_s.must_match /#{project.name}/ }
           end
         end

--- a/test/controllers/access_requests_controller_test.rb
+++ b/test/controllers/access_requests_controller_test.rb
@@ -55,9 +55,10 @@ describe AccessRequestsController do
       describe 'enabled' do
         let(:manager_email) { 'manager@example.com' }
         let(:reason) { 'Dummy reason.' }
-        let(:role) { Role::DEPLOYER }
-        let(:request_params) {
-          {manager_email: manager_email, reason: reason, project_ids: Project.all.pluck(:id), role_id: role.id} }
+        let(:role) { ProjectRole::DEPLOYER }
+        let(:request_params) do
+          {manager_email: manager_email, reason: reason, project_ids: Project.all.pluck(:id), role_id: role.id}
+        end
         let(:session_params) { {access_request_back_to: root_path} }
         describe 'environment and user' do
           before { post :create, request_params, session_params }

--- a/test/mailers/access_request_mailer_test.rb
+++ b/test/mailers/access_request_mailer_test.rb
@@ -10,7 +10,7 @@ describe AccessRequestMailer do
     let(:hostname) { 'localhost' }
     let(:manager_email) { 'manager@example.com' }
     let(:reason) { 'Dummy reason.' }
-    let(:role) { Role::DEPLOYER }
+    let(:role) { ProjectRole::DEPLOYER }
     subject { ActionMailer::Base.deliveries.last }
 
     before do

--- a/test/mailers/previews/access_request_mailer_preview.rb
+++ b/test/mailers/previews/access_request_mailer_preview.rb
@@ -5,7 +5,8 @@ class AccessRequestMailerPreview < ActionMailer::Preview
   def access_request_email
     enable_access_request
     email = AccessRequestMailer.access_request_email(
-        'localhost', User.first, 'manager@example.com', 'Dummy reason.', Project.all.pluck(:id), Role::DEPLOYER.id)
+        'localhost', User.first, 'manager@example.com', 'Dummy reason.',
+        Project.all.pluck(:id), ProjectRole::DEPLOYER.id)
     restore_access_request_settings
     email
   end

--- a/test/mailers/previews/access_request_mailer_preview.rb
+++ b/test/mailers/previews/access_request_mailer_preview.rb
@@ -5,7 +5,7 @@ class AccessRequestMailerPreview < ActionMailer::Preview
   def access_request_email
     enable_access_request
     email = AccessRequestMailer.access_request_email(
-        'localhost', User.first, 'manager@example.com', 'Dummy reason.', Project.all.pluck(:id))
+        'localhost', User.first, 'manager@example.com', 'Dummy reason.', Project.all.pluck(:id), Role::DEPLOYER.id)
     restore_access_request_settings
     email
   end


### PR DESCRIPTION
Since we are now requesting roles per project, it makes sense to let the user specify which role they need.

![screen shot 2015-10-23 at 14 24 10](https://cloud.githubusercontent.com/assets/4570601/10693722/e4125620-7991-11e5-804f-a9009a1ebd2b.png)

/cc @zendesk/samson

### References
 - Jira link: https://zendesk.atlassian.net/browse/RUN-99

### Risks
 - None