### PR TITLE
Git branches without columns

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -80,7 +80,7 @@ class GitRepository
   end
 
   def branches
-    cmd = 'git branch --no-color --list'
+    cmd = 'git branch --list --no-color --no-column'
     success, output = run_single_command(cmd) { |line| line.sub('*', '').strip }
     success ? output : []
   end


### PR DESCRIPTION
On my local dev environment when running the tests I am getting failures like:

```
  1) Failure:
ReferencesService#test_0001_returns a sorted set of tags and branches [./test/lib/references_service_test.rb:27]:
--- expected
+++ actual
@@ -1 +1 @@
-["v1", "master", "test_user/test_branch"]
+["v1", "master  test_user/test_branch"]

  2) Failure:
ReferencesService#test_0002_returns a sorted set of tags and branches from cached repo [./test/lib/references_service_test.rb:31]:
--- expected
+++ actual
@@ -1 +1 @@
-["v1", "master", "test_user/test_branch"]
+["v1", "master  test_user/test_branch"]
```

Because I have:

```
$ git config --list | grep column
column.ui=auto,dense
```

Which enables:

```
       --column[=<options>], --no-column
           Display branch listing in columns. See configuration variable column.branch for option
           syntax.--column and --no-column without options are equivalent to always and never
           respectively.

           This option is only applicable in non-verbose mode.
```

This just makes sure it's off when listing branches. :-)