### PR TITLE
Fix create Deploy Group when Kubernetes is not enabled

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -9,7 +9,7 @@ class Admin::DeployGroupsController < ApplicationController
 
   def new
     @deploy_group = DeployGroup.new
-    @deploy_group.build_cluster_deploy_group if allow_kuber_cluster_assignment?
+    Samson::Hooks.fire(:edit_deploy_group, @deploy_group)
     render 'edit'
   end
 
@@ -25,9 +25,7 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   def edit
-    if allow_kuber_cluster_assignment?
-      @deploy_group.build_cluster_deploy_group unless @deploy_group.cluster_deploy_group
-    end
+    Samson::Hooks.fire(:edit_deploy_group, @deploy_group)
   end
 
   def update
@@ -49,24 +47,14 @@ class Admin::DeployGroupsController < ApplicationController
   private
 
   def deploy_group_params
-    allowed_params = [:name, :environment_id, :env_value]
-    if allow_kuber_cluster_assignment?
-      allowed_params << { cluster_deploy_group_attributes: [:id, :kubernetes_cluster_id, :namespace] }
-    end
-    dg_params = params.require(:deploy_group).permit(*allowed_params)
-    if allow_kuber_cluster_assignment?
-      if dg_params[:cluster_deploy_group_attributes] && dg_params[:cluster_deploy_group_attributes][:kubernetes_cluster_id].blank?
-        dg_params[:cluster_deploy_group_attributes]['_destroy'] = '1'
-      end
-    end
-    dg_params
+    params.require(:deploy_group).permit(*allowed_deploy_group_params)
+  end
+
+  def allowed_deploy_group_params
+    ([:name, :environment_id, :env_value] + Samson::Hooks.fire(:deploy_group_permitted_params)).freeze
   end
 
   def deploy_group
     @deploy_group ||= DeployGroup.find(params[:id])
-  end
-
-  def allow_kuber_cluster_assignment?
-    Samson::Hooks.active_plugin?('kubernetes')
   end
 end

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -66,10 +66,6 @@ class Admin::DeployGroupsController < ApplicationController
     @deploy_group ||= DeployGroup.find(params[:id])
   end
 
-  def build_kuber_cluster
-    @deploy_group.build_cluster_deploy_group unless @deploy_group.cluster_deploy_group
-  end
-
   def allow_kuber_cluster_assignment?
     Samson::Hooks.active_plugin?('kubernetes')
   end

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -9,9 +9,7 @@ class Admin::DeployGroupsController < ApplicationController
 
   def new
     @deploy_group = DeployGroup.new
-    if allow_kuber_cluster_assignment?
-      @deploy_group.build_cluster_deploy_group
-    end
+    @deploy_group.build_cluster_deploy_group if allow_kuber_cluster_assignment?
     render 'edit'
   end
 
@@ -27,9 +25,7 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   def edit
-    if allow_kuber_cluster_assignment?
       @deploy_group.build_cluster_deploy_group unless @deploy_group.cluster_deploy_group
-    end
   end
 
   def update

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -25,7 +25,9 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   def edit
+    if allow_kuber_cluster_assignment?
       @deploy_group.build_cluster_deploy_group unless @deploy_group.cluster_deploy_group
+    end
   end
 
   def update

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -24,7 +24,9 @@ module Samson
       :before_docker_build,
       :after_docker_build,
       :after_job_execution,
-      :job_additional_vars
+      :job_additional_vars,
+      :deploy_group_permitted_params,
+      :edit_deploy_group
     ].freeze
 
     INTERNAL_HOOKS = [ :class_defined ]

--- a/plugins/kubernetes/app/decorators/admin/deploy_groups_controller_decorator.rb
+++ b/plugins/kubernetes/app/decorators/admin/deploy_groups_controller_decorator.rb
@@ -1,0 +1,4 @@
+Admin::DeployGroupsController.class_eval do
+  prepend Kubernetes::DeployGroupPermittedParams
+
+end

--- a/plugins/kubernetes/app/models/concerns/kubernetes/deploy_group_permitted_params.rb
+++ b/plugins/kubernetes/app/models/concerns/kubernetes/deploy_group_permitted_params.rb
@@ -1,0 +1,15 @@
+module Kubernetes::DeployGroupPermittedParams
+
+  def deploy_group_params
+    dg_params = super
+    dg_params[:cluster_deploy_group_attributes]['_destroy'] = '1' if kubernetes_cluster_empty?(dg_params)
+    dg_params
+  end
+
+  private
+
+  def kubernetes_cluster_empty?(dg_params)
+    dg_params[:cluster_deploy_group_attributes] && dg_params[:cluster_deploy_group_attributes][:kubernetes_cluster_id].blank?
+  end
+
+end

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -7,3 +7,12 @@ end
 
 Samson::Hooks.view :project_tabs_view, 'kubernetes_project/project_tab'
 Samson::Hooks.view :admin_menu, 'kubernetes_project/admin_menu'
+
+Samson::Hooks.callback :deploy_group_permitted_params do
+  { cluster_deploy_group_attributes: [:id, :kubernetes_cluster_id, :namespace] }
+end
+
+Samson::Hooks.callback :edit_deploy_group do |deploy_group|
+  deploy_group.build_cluster_deploy_group unless deploy_group.cluster_deploy_group
+end
+


### PR DESCRIPTION
When the Kubernetes plugin is disabled, an error is displayed when we try to access the page that allows us to create a new Deploy Group.

/cc @zendesk/samson