### PR TITLE
Fix for environment variables

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,8 +96,6 @@ Samson::Application.routes.draw do
     resources :commands, except: [:show]
     resources :environments, except: [:show]
     resources :deploy_groups
-
-    get '/:action', to: 'admin#:action', :defaults => { :format => 'json' }
   end
 
   namespace :integrations do


### PR DESCRIPTION
Environment Variables, in the Admin menu, was broken due to an obsolete route config that was mapping to an non-existing controller.

/cc @zendesk/samson 
