### PR TITLE
fix starring projects

### DIFF
--- a/app/controllers/concerns/current_project.rb
+++ b/app/controllers/concerns/current_project.rb
@@ -15,6 +15,7 @@ module CurrentProject
 
   def require_project
     @project = (Project.find_by_param!(params[:project_id]) if params[:project_id])
+    @project ||= (Project.find_by_param!(params[:id]) if params[:id])
   end
 
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -2,14 +2,14 @@ module ProjectsHelper
   def star_for_project(project)
     content_tag :span, class: 'star' do
       if current_user.starred_project?(project)
-        path = star_path(project_id: project)
+        path = star_path(id: project)
         options = {
           class: 'glyphicon glyphicon-star',
           method: :delete,
           title: 'Unstar this project'
         }
       else
-        path = stars_path(project_id: project)
+        path = stars_path(id: project)
         options = {
           class: 'glyphicon glyphicon-star-empty',
           method: :post,

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -2,14 +2,14 @@ module ProjectsHelper
   def star_for_project(project)
     content_tag :span, class: 'star' do
       if current_user.starred_project?(project)
-        path = star_path(id: project)
+        path = star_path(project_id: project)
         options = {
           class: 'glyphicon glyphicon-star',
           method: :delete,
           title: 'Unstar this project'
         }
       else
-        path = stars_path(id: project)
+        path = stars_path(project_id: project)
         options = {
           class: 'glyphicon glyphicon-star-empty',
           method: :post,


### PR DESCRIPTION
The `CurrentProject` concern used in the `StarsController` pulls out the `project_id` param, not the `id` param.

@zendesk/samson @miogalang @ryanseddon 