### PR TITLE
dont error out if the manifest is not used for the samson env plugin

### DIFF
--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -49,6 +49,10 @@ module SamsonEnv
       # manifest.json includes required keys and other things we copy
       manifest = JSON.load(File.read(manifest_json))
       settings = manifest.delete("settings")
+
+      # hackaround to support projects that have a manifest.json for
+      # a completely different purpose such as github.com/zendesk/mailchimp_activity_app
+      return false if settings.nil?
       json.reverse_merge!(manifest)
       required_keys, optional_keys = settings.keys.partition do |key|
         settings[key].fetch("required", true)

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -51,7 +51,7 @@ module SamsonEnv
       settings = manifest.delete("settings")
 
       # hackaround to support projects that have a manifest.json for
-      # a completely different purpose such as github.com/zendesk/mailchimp_activity_app
+      # a completely different purpose such as github.com/zendesk/timetracking_app
       return false if settings.nil?
       json.reverse_merge!(manifest)
       required_keys, optional_keys = settings.keys.partition do |key|


### PR DESCRIPTION
We need to use a `manifest.json` because its part of the spec of a Zendesk Apps Marketplace app, but we don't need the SamsonEnv plugin to parse it at all. This is a quick fix.

@zendesk/quokka 