### PR TITLE
make the tests faster again

### DIFF
--- a/test/models/buddy_check_test.rb
+++ b/test/models/buddy_check_test.rb
@@ -65,6 +65,7 @@ describe BuddyCheck do
     before do
       stage.update_attribute(:production, true)
       job_execution.stubs(:execute!)
+      job_execution.stubs(:setup!).returns(true)
       JobExecution.expects(:start_job).returns(job_execution)
 
       BuddyCheck.stubs(:enabled?).returns(true)
@@ -97,6 +98,7 @@ describe BuddyCheck do
     before do
       job_execution.stubs(:execute!)
       JobExecution.expects(:start_job).returns(job_execution)
+      job_execution.stubs(:setup!).returns(true)
 
       BuddyCheck.stubs(:enabled?).returns(false)
     end

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -151,6 +151,7 @@ describe DeployService do
       stage.stubs(:create_deploy).returns(deploy)
       deploy.stubs(:persisted?).returns(true)
       job_execution.stubs(:execute!)
+      job_execution.stubs(:setup!).returns(true)
 
       JobExecution.stubs(:new).returns(job_execution)
     end


### PR DESCRIPTION
The change in https://github.com/zendesk/samson/pull/604 made the tests run dramatically slower. As an aside, I'd be strongly in favour of removing the conditional [here](https://github.com/zendesk/samson/blob/master/test/support/timeout.rb#L5) so this doesn't happen in future.

![screen shot 2015-10-29 at 5 16 07 pm](https://cloud.githubusercontent.com/assets/5535625/10811511/c751e63a-7e60-11e5-8093-e38d553c6373.png)

@zendesk/samson @steved @jonmoter 