### PR TITLE
timeout

### DIFF
--- a/test/support/timeout.rb
+++ b/test/support/timeout.rb
@@ -1,17 +1,8 @@
 # tests sometimes hang locally or on ci and with this we can actually debug the cause instead of just hanging forever
 module TimeoutEveryTestCase
-  # travis randomly fails on some tests with this enabled
-  def timeout_for_test
-    ENV["CI"] ? false : 5
-  end
-
   def capture_exceptions(*args, &block)
-    if timeout_for_test == false
-      super
-    else
-      super do
-        Timeout.timeout(timeout_for_test, &block)
-      end
+    super do
+      Timeout.timeout(5, &block)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,12 +65,10 @@ class ActiveSupport::TestCase
     create_default_stubs
   end
 
-  unless ENV['SKIP_TIMEOUT']
-    after { fail_if_dangling_threads }
-  end
+  after { fail_if_dangling_threads }
 
   def fail_if_dangling_threads
-    max_threads = ENV['CI'] ? 0 : 1
+    max_threads = 1 # Timeout.timeout adds a thread
     raise "Test left dangling threads: #{extra_threads}" if extra_threads.count > max_threads
   ensure
     kill_extra_threads


### PR DESCRIPTION
@sandlerr let's see if that works ...
alternative approach would be to use forking_test_runner to at least see what file was hanging ... or running with `-v`

### Risks
 - None