### PR TITLE
Add @team mention in the default Flowdock message

### DIFF
--- a/plugins/flowdock/app/helpers/flowdock_helper.rb
+++ b/plugins/flowdock/app/helpers/flowdock_helper.rb
@@ -1,5 +1,5 @@
 module FlowdockHelper
   def default_flowdock_message(deploy)
-    ":pray: #{deploy.user.name} is requesting approval to deploy **#{deploy.reference}** to production. [Approve this deploy](#{project_deploy_url(deploy.project, deploy)})."
+    ":pray: @team #{deploy.user.name} is requesting approval to deploy **#{deploy.reference}** to production. [Approve this deploy](#{project_deploy_url(deploy.project, deploy)})."
   end
 end


### PR DESCRIPTION
I found myself to always change the default Flowdock message, in order to mention the @team and get more attention.

I wonder if this is a general felt need - in that case, this PR will fix that.

@zendesk/samson 

#### Risks
 * none