### PR TITLE
Added support for the releases list page in AngularJS.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,7 @@ require 'github/markdown'
 
 module ApplicationHelper
   include Ansible
+  include DateTimeHelper
 
   cattr_reader(:github_status_cache_key) { 'github-status-ok' }
 
@@ -47,10 +48,6 @@ module ApplicationHelper
 
   def relative_time(time)
     content_tag(:span, time.rfc822, data: { time: datetime_to_js_ms(time) }, class: "mouseover")
-  end
-
-  def datetime_to_js_ms(utc_string)
-    utc_string.to_i * 1000
   end
 
   def sortable(column, title = nil)

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -1,0 +1,7 @@
+module DateTimeHelper
+
+  def datetime_to_js_ms(utc_string)
+    utc_string.to_i * 1000
+  end
+
+end

--- a/app/serializers/build_serializer.rb
+++ b/app/serializers/build_serializer.rb
@@ -1,5 +1,7 @@
 class BuildSerializer < ActiveModel::Serializer
-  attributes :id, :git_sha, :git_ref, :docker_image_id, :docker_ref, :docker_repo_digest, :docker_status, :created_at
+  include DateTimeHelper
+
+  attributes :id, :label, :git_sha, :git_ref, :docker_image_id, :docker_ref, :docker_repo_digest, :docker_status, :created_at
 
   has_one :project
 

--- a/app/serializers/deploy_group_serializer.rb
+++ b/app/serializers/deploy_group_serializer.rb
@@ -1,0 +1,3 @@
+class DeployGroupSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_release_groups_ctrl.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_release_groups_ctrl.js
@@ -1,5 +1,15 @@
-samson.controller('KubernetesReleaseGroupsCtrl', function($state, $stateParams) {
+samson.controller('KubernetesReleaseGroupsCtrl', function($scope, $stateParams, kubernetesService, kubernetesReleaseGroupFactory) {
+  $scope.project_id = $stateParams.project_id;
 
-//TODO: Load release groups asynchronously
+  function loadKubernetesReleaseGroups() {
+    kubernetesService.loadKubernetesReleaseGroups($scope.project_id).then(function(data) {
+        $scope.release_groups = data.map(function(item) {
+          return kubernetesReleaseGroupFactory.build(item);
+        });
+      }
+    );
+  }
+
+  loadKubernetesReleaseGroups();
 
 });

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_roles_ctrl.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_roles_ctrl.js
@@ -1,8 +1,6 @@
 samson.controller('KubernetesRolesCtrl', function($scope, $stateParams, kubernetesService, kubernetesRoleFactory) {
   $scope.project_id = $stateParams.project_id;
 
-  $scope.roles = [];
-
   function loadRoles() {
     kubernetesService.loadRoles($scope.project_id).then(function(data) {
         $scope.roles = data.map(function(item) {

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/factories/build_factory.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/factories/build_factory.js
@@ -1,0 +1,16 @@
+samson.factory('buildFactory', function() {
+
+  function Build(id, label) {
+    this.id = id;
+    this.label = label;
+  }
+
+  Build.build = function(data) {
+    return new Build(
+      data.id,
+      data.label
+    );
+  };
+
+  return Build;
+});

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/factories/kubernetes_release_group_factory.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/factories/kubernetes_release_group_factory.js
@@ -1,0 +1,28 @@
+samson.factory('kubernetesReleaseGroupFactory', function(buildFactory) {
+
+  function KubernetesReleaseGroup(id, created_at, created_by, build, deploy_groups) {
+    this.id = id;
+    this.created_at = created_at;
+    this.created_by = created_by;
+    this.build = build;
+    this.deploy_groups = deploy_groups;
+  }
+
+  KubernetesReleaseGroup.build = function(data) {
+    var build = buildFactory.build(data.build);
+
+    var deploy_groups = data.deploy_groups.map(function(deploy_group){
+      return deploy_group.name;
+    });
+
+    return new KubernetesReleaseGroup(
+      data.id,
+      data.created_at,
+      data.user.name,
+      build,
+      deploy_groups
+    );
+  };
+
+  return KubernetesReleaseGroup;
+});

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/services/kubernetes_service.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/services/kubernetes_service.js
@@ -6,6 +6,10 @@ samson.service('kubernetesService', function($http, $q) {
     }
   };
 
+  /*********************************************************************
+    Kubernetes Roles
+   *********************************************************************/
+
   this.loadRoles = function(project_id) {
     var deferred = $q.defer();
 
@@ -71,6 +75,26 @@ samson.service('kubernetesService', function($http, $q) {
     );
     return deferred.promise;
   };
+
+  /*********************************************************************
+   Kubernetes Release Groups
+   *********************************************************************/
+
+  this.loadKubernetesReleaseGroups = function(project_id) {
+    var deferred = $q.defer();
+
+    $http.get('/projects/' + project_id + '/kubernetes_release_groups', config).then(
+      function(response) {
+        deferred.resolve(response.data);
+      }
+    );
+
+    return deferred.promise;
+  };
+
+  /*********************************************************************
+   Other functions
+   *********************************************************************/
 
   function handleError(response, deferred) {
     if (!_.isUndefined(response.data) && !_.isUndefined(response.data.errors)) {

--- a/plugins/kubernetes/app/assets/stylesheets/kubernetes/application.css
+++ b/plugins/kubernetes/app/assets/stylesheets/kubernetes/application.css
@@ -7,14 +7,31 @@
   color: rgb(255,205,210);
 }
 
-/*.kubernetes .md-tabs {*/
-  /*transition: none;*/
-/*}*/
-
-.kubernetes [role="tabpanel"] {
-  transition: none;
+.kubernetes [role="progressbar"] {
+  transform: scale(0.4) !important;
+  margin: 50px auto !important;
 }
 
-.kubernetes [role="tablist"] {
-  transition: none;
+.kubernetes [role="progressbar"]::after {
+  position: absolute;
+  font-size: 14px;
+  transform: scale(2) !important;
+  width: 150px;
+  text-align: center;
+  top: 140px;
+  left: -20px;
 }
+
+.kubernetes-roles [role="progressbar"]::after {
+  content: "Loading Kubernetes Roles";
+}
+
+.kubernetes-release-groups [role="progressbar"]::after {
+  content: "Loading Kubernetes Releases";
+}
+
+.kubernetes-release-groups span.label-info {
+  margin: 0 5px;
+}
+
+

--- a/plugins/kubernetes/app/controllers/kubernetes_release_groups_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_release_groups_controller.rb
@@ -1,9 +1,31 @@
 class KubernetesReleaseGroupsController < ApplicationController
+  include ProjectLevelAuthorization
   helper ProjectsHelper
 
-  before_action :project
-  before_action :authorize_deployer!
+  before_action :authorize_project_deployer!
   before_action :load_environments, only: [:new, :create]
+
+  def index
+    render json: current_project.kubernetes_release_groups.order('id desc'), root: false
+  end
+
+  def show
+    @release_group = Kubernetes::ReleaseGroup.find(params[:id])
+
+    respond_to do |format|
+      format.html
+      format.json { render @release_group, root:false }
+    end
+  end
+
+  def new
+    @release_group = Kubernetes::ReleaseGroup.new(user: current_user, build_id: params[:build_id])
+
+    respond_to do |format|
+      format.html
+      format.json {render @release_group, root:false }
+    end
+  end
 
   def create
     @release_group = Kubernetes::ReleaseGroup.new(create_params)
@@ -27,29 +49,28 @@ class KubernetesReleaseGroupsController < ApplicationController
     redirect_to project_kubernetes_release_group_path(@project, @release_group)
   end
 
-  def index
-    @release_group_list = project.kubernetes_release_groups.order('id desc')
-  end
-
-  def new
-    @release_group = Kubernetes::ReleaseGroup.new(user: current_user, build_id: params[:build_id])
-  end
-
-  def show
-    @release_group = Kubernetes::ReleaseGroup.find(params[:id])
-  end
-
-  def build
-    @build = Build.find(params[:build_id])
-    @release_group_list = @build.kubernetes_release_groups.order('id desc')
-  end
+  # def create
+  #   release_group = Kubernetes::ReleaseGroup.new(create_params)
+  #   release_group.user = current_user
+  #
+  #   release_group.releases.each do |release|
+  #     params[:replicas].each do |role_id, replica_count|
+  #       release.release_docs.build(kubernetes_role_id: role_id, replica_target: replica_count.to_i)
+  #     end
+  #   end
+  #
+  #   if release_group.save
+  #     release_group.releases.each do |release|
+  #       KuberDeployService.new(release).deploy!
+  #     end
+  #
+  #     render :created, json: release_group, root: false
+  #   else
+  #     render :bad_request, json: {errors: release_group.errors.full_messages}
+  #   end
+  # end
 
   private
-
-  def project
-    @project ||= Project.find_by_param!(params[:project_id])
-  end
-  helper_method :project
 
   def create_params
     params.require(:kubernetes_release_group).permit(:build_id, { deploy_group_ids: [] })

--- a/plugins/kubernetes/app/controllers/kubernetes_release_groups_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_release_groups_controller.rb
@@ -49,27 +49,6 @@ class KubernetesReleaseGroupsController < ApplicationController
     redirect_to project_kubernetes_release_group_path(@project, @release_group)
   end
 
-  # def create
-  #   release_group = Kubernetes::ReleaseGroup.new(create_params)
-  #   release_group.user = current_user
-  #
-  #   release_group.releases.each do |release|
-  #     params[:replicas].each do |role_id, replica_count|
-  #       release.release_docs.build(kubernetes_role_id: role_id, replica_target: replica_count.to_i)
-  #     end
-  #   end
-  #
-  #   if release_group.save
-  #     release_group.releases.each do |release|
-  #       KuberDeployService.new(release).deploy!
-  #     end
-  #
-  #     render :created, json: release_group, root: false
-  #   else
-  #     render :bad_request, json: {errors: release_group.errors.full_messages}
-  #   end
-  # end
-
   private
 
   def create_params

--- a/plugins/kubernetes/app/serializers/kubernetes/release_group_serializer.rb
+++ b/plugins/kubernetes/app/serializers/kubernetes/release_group_serializer.rb
@@ -1,0 +1,22 @@
+module Kubernetes
+  class ReleaseGroupSerializer < ActiveModel::Serializer
+    include DateTimeHelper
+
+    attributes :id, :created_at
+
+    has_one :user
+    has_one :build
+    has_many :deploy_groups
+
+    def deploy_groups
+      object.releases.map { |release| release.deploy_group}
+    end
+
+    def created_at
+      datetime_to_js_ms(object.created_at)
+    end
+
+  end
+end
+
+

--- a/plugins/kubernetes/app/serializers/kubernetes/release_serializer.rb
+++ b/plugins/kubernetes/app/serializers/kubernetes/release_serializer.rb
@@ -1,0 +1,7 @@
+module Kubernetes
+  class ReleaseSerializer < ActiveModel::Serializer
+    attributes :id, :created_at
+
+    has_one :deploy_group
+  end
+end

--- a/plugins/kubernetes/app/views/kubernetes_release_groups/_release_groups_list.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_release_groups/_release_groups_list.html.erb
@@ -1,33 +1,38 @@
 <script type="text/ng-template" id="kubernetes/kubernetes_release_groups.tmpl.html">
-  <div>
-    <table class="table table-condensed">
-      <tr>
-        <th>Id</th>
-        <th>Build</th>
-        <th>Deploy Groups</th>
-        <th>Created</th>
-        <th>Created By</th>
-      </tr>
-
-      <% if @release_group_list.any? %>
-        <% @release_group_list.each do |release_group| %>
-          <tr>
-            <td><%= link_to release_group.id, project_kubernetes_release_group_path(@project, release_group) %></td>
-            <td><%= link_to release_group.build.label, project_build_path(@project, release_group.build) %></td>
-            <td><%= release_group.releases.map { |r| r.deploy_group.name }.join(', ') %></td>
-            <td><%= release_group.created_at.to_s %></td>
-            <td><%= release_group.user.name %></td>
-          </tr>
-        <% end %>
-      <% else %>
+  <div class="kubernetes-release-groups">
+    <md-progress-circular md-mode="indeterminate" ng-if="!release_groups"></md-progress-circular>
+    <div ng-if="release_groups">
+      <table class="table table-condensed">
+        <thead>
         <tr>
-          <td colspan="5">None</td>
+          <th>Id</th>
+          <th>Build</th>
+          <th>Deploy Groups</th>
+          <th>Created</th>
+          <th>Created By</th>
         </tr>
-      <% end %>
-    </table>
+        </thead>
+        <tbody>
+        <tr ng-show="!release_groups.length" ng-hide="release_groups.length">
+          <td colspan="5">No releases have been created yet.</td>
+        </tr>
+        <tr ng-repeat="release_group in release_groups" ng-show="release_groups.length" ng-hide="!release_groups.length">
+          <td>{{release_group.id}}</td>
+          <td>
+            <a href="/projects/{{project_id}}/builds/{{release_group.build.id}}">{{release_group.build.label}}</a>
+          </td>
+          <td>
+            <span ng-repeat="deploy_group in release_group.deploy_groups" class="label label-info">{{deploy_group}}</span>
+          </td>
+          <td>{{release_group.created_at | date: 'yyyy-MM-dd HH:mm:ss'}} UTC</td>
+          <td>{{release_group.created_by}}</td>
+        </tr>
+        </tbody>
+      </table>
+      <p class="pull-right">
+        <%= link_to 'Create Release', new_project_kubernetes_release_group_path(@project), class: "btn btn-default" %>
+        <!--<a ui-sref="kubernetes.releases.create" class="btn btn-default">Create Release</a>-->
+      </p>
+    </div>
   </div>
-
-  <p class="pull-right">
-    <%= link_to "Create Release", new_project_kubernetes_release_group_path(@project), class: "btn btn-default" %>
-  </p>
 </script>

--- a/plugins/kubernetes/app/views/kubernetes_roles/_roles_list.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_roles/_roles_list.html.erb
@@ -1,40 +1,41 @@
 <script type="text/ng-template" id="kubernetes/kubernetes_roles.tmpl.html">
-  <div>
-    <table class="table table-condensed">
-      <thead>
-      <tr>
-        <th>Role</th>
-        <th>Config File</th>
-        <th>Service Name</th>
-        <th>RAM</th>
-        <th>CPU</th>
-        <th>Replicas</th>
-        <th>Actions</th>
-      </tr>
-      </thead>
-
-      <tbody>
-      <tr ng-show="!roles.length" ng-hide="roles.length">
-        <td colspan="7">No project roles have been created yet.</td>
-      </tr>
-      <tr ng-repeat="role in roles" ng-show="roles.length" ng-hide="!roles.length">
-        <td>{{role.name}}</td>
-        <td>{{role.config_file}}</td>
-        <td>{{role.service_name}}</td>
-        <td>{{role.ram}}MB</td>
-        <td>{{role.cpu.to_s}} cores</td>
-        <td>{{role.replicas}}</td>
-        <td>
-          <a ui-sref="kubernetes.roles.edit({ role_id: role.id })">Edit</a>
-        </td>
-      </tr>
-      </tbody>
-    </table>
+  <div class="kubernetes-roles">
+    <md-progress-circular md-mode="indeterminate" ng-if="!roles"></md-progress-circular>
+    <div ng-if="roles">
+      <table class="table table-condensed">
+        <thead>
+          <tr>
+            <th>Role</th>
+            <th>Config File</th>
+            <th>Service Name</th>
+            <th>RAM</th>
+            <th>CPU</th>
+            <th>Replicas</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-show="!roles.length" ng-hide="roles.length">
+            <td colspan="7">No project roles have been created yet.</td>
+          </tr>
+          <tr ng-repeat="role in roles" ng-show="roles.length" ng-hide="!roles.length">
+            <td>{{role.name}}</td>
+            <td>{{role.config_file}}</td>
+            <td>{{role.service_name}}</td>
+            <td>{{role.ram}}MB</td>
+            <td>{{role.cpu.to_s}} cores</td>
+            <td>{{role.replicas}}</td>
+            <td>
+              <a ui-sref="kubernetes.roles.edit({ role_id: role.id })">Edit</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="pull-right">
+        <a ui-sref="kubernetes.roles.create" class="btn btn-default">Create New Role</a>
+      </p>
+    </div>
   </div>
-
-  <p class="pull-right">
-    <a ui-sref="kubernetes.roles.create" class="btn btn-default">Create New Role</a>
-  </p>
 </script>
 
 <%= render 'kubernetes_roles/role_create_form' %>


### PR DESCRIPTION
PR following #625, supporting the list of Kubernetes releases in the client side in AngularJS.

/cc @zendesk/samson

Tasks
 - [x] Initial framework and setup for AngularJS with ui-router
 - [x] Support for existing functionality (list, create, edit Kubernetes Releases and Kubernetes Roles) 
 - [x] Implement Kubernetes Roles functionality on the client-side with AngularJS
 - [ ] Implement Kubernetes Releases functionality on the client-side with AngularJS
 - [ ] Implement dashboard tab
 - [ ] Write tests for the client side Javascript code
 - [ ] Finish styling

### References
 - [PAAS-80](https://zendesk.atlassian.net/browse/PAAS-80)

### Risks
 - There shouldn't be any risks regarding production
 - Breaking existing Kubernetes functionality

![screenshot 2015-11-05 17 00 15](https://cloud.githubusercontent.com/assets/2833020/10975259/eaad86ca-83dd-11e5-95fd-537e7e245fcd.png)

![screenshot 2015-11-05 17 01 03](https://cloud.githubusercontent.com/assets/2833020/10975285/09a4f95a-83de-11e5-905d-a9ce9854dc0a.png)
