### PR TITLE
Downcase the docker image name

### DIFF
--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -116,7 +116,7 @@ class BinaryBuilder
   end
 
   def image_name
-    "#{@project.send(:permalink_base)}_build:#{@git_reference}"
+    "#{@project.send(:permalink_base)}_build:#{@git_reference}".downcase
   end
 
   def create_build_image

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -4,7 +4,7 @@ describe BinaryBuilder do
   describe '#build' do
     let(:project) { projects(:test) }
     let(:dir) { '/tmp' }
-    let(:reference) { 'abc' }
+    let(:reference) { 'aBc-19F' }
     let(:output) { StringIO.new }
     let(:builder) { BinaryBuilder.new(dir, project, reference, output) }
     let(:fake_image) { stub(remove: true) }
@@ -47,7 +47,7 @@ describe BinaryBuilder do
       builder.send(:create_container_options).must_equal(
         {
           'Cmd' => ['/app/build.sh'],
-          'Image' => 'foo_build:abc',
+          'Image' => 'foo_build:abc-19f',
           'Volumes' => { '/opt/samson_build_cache' => {} },
           'HostConfig' => {
             'Binds' => ['/opt/samson_build_cache:/build/cache'],
@@ -62,7 +62,7 @@ describe BinaryBuilder do
       builder.send(:create_container_options).must_equal(
         {
           'Cmd' => ['/app/build.sh'],
-          'Image' => 'foo_build:abc',
+          'Image' => 'foo_build:abc-19f',
           'Mounts' => [
             {
               'Source' => '/opt/samson_build_cache',
@@ -81,6 +81,11 @@ describe BinaryBuilder do
     it 'throws exception with api < 1.15' do
       Docker.stubs(:version).returns({ 'ApiVersion' => '1.14' })
       proc { builder.send(:create_container_options) }.must_raise RuntimeError
+    end
+
+    it 'downcases the image name' do
+      image_name = builder.send(:image_name)
+      image_name.must_equal(image_name.downcase)
     end
   end
 end


### PR DESCRIPTION
:globe_with_meridians: :fuelpump: :cloud: 

/cc @henders @fneves @stubotnik  @zendesk/samson 

Docker does not like uppercase in the image name and it uses this regex to validate the name: `[a-z0-9]+(?:[._-][a-z0-9]+)*`. In the cases where we have upper case characters in our git branch (e.g.: Jira tasks) we can't deploy.

### Risks
- Level: Low
- Notes for Support: None
- Notes for QA: None