### PR TITLE
Allow 'bundle install' to be run inside subdirectories without screwi…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :no_preload do
   gem 'coderay', '~> 1.1.0'
   gem 'dogapi', '~> 1.9'
   gem 'net-http-persistent'
-  Dir["plugins/*/"].each { |f| gemspec path: f, require: false } # treat included plugins like gems
+  Dir[File.join(Bundler.root, 'plugins/*/')].each { |f| gemspec path: f, require: false } # treat included plugins like gems
 end
 
 group :development, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,10 +340,10 @@ GEM
       rails-assets-angular (= 1.4.7)
     rails-assets-angular-scenario (1.4.7)
       rails-assets-angular (= 1.4.7)
-    rails-assets-angular-ui-bootstrap-bower (0.14.3)
-      rails-assets-angular (>= 1.3.0)
     rails-assets-angular-truncate-2 (0.4.1)
       rails-assets-angular (>= 1.2.0, < 2)
+    rails-assets-angular-ui-bootstrap-bower (0.14.3)
+      rails-assets-angular (>= 1.3.0)
     rails-assets-angular-ui-router (0.2.15)
       rails-assets-angular (>= 1.0.8)
     rails-assets-bootstrap-select (1.7.4)
@@ -521,8 +521,8 @@ DEPENDENCIES
   rails-assets-angular-material!
   rails-assets-angular-mocks!
   rails-assets-angular-scenario!
-  rails-assets-angular-ui-bootstrap-bower!
   rails-assets-angular-truncate-2!
+  rails-assets-angular-ui-bootstrap-bower!
   rails-assets-angular-ui-router!
   rails-assets-bootstrap-select!
   rails-assets-font-awesome (~> 4.3.0)!


### PR DESCRIPTION
Allow 'bundle install' to be run inside subdirectories without screwing up plugin deps.
Sometimes a dev (possibly me) doesn't realize they're in a subdirectory while executing bundle install and wonder why various gems are getting deleted from vendor/cache.

/cc @zendesk/samson @sbrnunes @msufa 

### References
 - Jira link: 

### Risks
 - None