### PR TITLE
Fix socket shutdown in pod watcher

### DIFF
--- a/plugins/kubernetes/app/models/watchers/cluster_pod_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/cluster_pod_watcher.rb
@@ -10,7 +10,6 @@ module Watchers
     finalizer :stop_watching
 
     def initialize(client)
-      @started = false
       @client = client
       @watch_stream = nil
       async :start_watching
@@ -18,7 +17,6 @@ module Watchers
 
     def start_watching
       info 'watcher started'
-      @started = true
       @watch_stream = @client.watch_pods
       @watch_stream.each do |notice|
         handle_notice notice
@@ -27,7 +25,6 @@ module Watchers
 
     def stop_watching
       info 'watcher stopped'
-      @started = false
       if @watch_stream
         @watch_stream.finish
         @watch_stream = nil

--- a/plugins/kubernetes/config/initializers/watchers.rb
+++ b/plugins/kubernetes/config/initializers/watchers.rb
@@ -17,7 +17,7 @@ module Kubeclient
           fail KubeException.new(response.code, response.reason, response)
         end
         read_stream(response.body, &block)
-      rescue Errno::EBADF
+      rescue IOError
         raise unless @finished
       end
 


### PR DESCRIPTION
System IO raises an EOFError when reading from a closed socket, which happens when we close a long running connection listening for pod events. Celluloid transforms EOFError into MailboxShutdown and terminates the actor quietly. We ned to rescue EOFError before it gets to Celluloid.

/cc @zendesk/samson @henders @sbrnunes 

### References
 - Jira link: 

### Risks
 - None