### PR TITLE
handle invalid UTF-8 characters in terminal output

### DIFF
--- a/app/models/terminal_output_scanner.rb
+++ b/app/models/terminal_output_scanner.rb
@@ -26,8 +26,10 @@ class TerminalOutputScanner
   private
 
   def write(data)
-    data.scan(/\r?[^\r]*/).each do |part|
-      next if part == ""
+    data
+      .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      .scan(/\r?[^\r]*/).each do |part|
+        next if part == ''
       write_part(part)
     end
   end

--- a/test/models/terminal_output_scanner_test.rb
+++ b/test/models/terminal_output_scanner_test.rb
@@ -41,4 +41,9 @@ describe TerminalOutputScanner do
     output("bar\n")
     tokens.must_equal [[:append, "foobar\n"]]
   end
+
+  it 'can handle an invalid UTF-8 character' do
+    output("invalid char\255\n")
+    tokens.must_equal [[:append, "invalid char\n"]]
+  end
 end


### PR DESCRIPTION
Fix airbrake error we see when output contains an invalid UTF-8 character.

```
ArgumentError: JobExecutionSubscriber failed: invalid byte sequence in UTF-8
app/models/terminal_output_scanner.rb:29 in scan
app/models/terminal_output_scanner.rb:29 in write
app/models/terminal_output_scanner.rb:16 in block in each
app/models/output_buffer.rb:60 in each
...
```

/cc @zendesk/samson

### References
 - Airbrake error: https://zendesk.airbrake.io/projects/95346/groups/1539486345310184431
 - Inspiration for fix: https://robots.thoughtbot.com/fight-back-utf-8-invalid-byte-sequences

### Risks
 - Minimal risk, one-line change to output parsing code.