### PR TITLE
test for invalid git refs to avoid InvalidURI crash

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -70,6 +70,8 @@ class Changeset
   def find_comparison
     if empty?
       NullComparison.new(nil)
+    elsif !GitRepository.valid_ref_format?(commit)
+      NullComparison.new("Invalid git reference: '#{commit}'")
     else
       # for branches that need review we make sure to always get the correct cache, others might get an outdated changeset if they are reviewed with different shas
       if BRANCH_TAGS.include?(commit)

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -1,8 +1,8 @@
 class CommitStatus
   cattr_accessor(:token) { ENV['GITHUB_TOKEN'] }
 
-  def initialize(repo, sha)
-    @repo, @sha = repo, sha
+  def initialize(repo, ref)
+    @repo, @ref = repo, ref
   end
 
   def status
@@ -17,10 +17,14 @@ class CommitStatus
     @combined_status ||= load_status
   end
 
+  def valid_ref?
+    GitRepository.valid_ref_format?(@ref)
+  end
+
   private
 
   def load_status
-    GITHUB.combined_status(@repo, @sha)
+    valid_ref? ? GITHUB.combined_status(@repo, @ref) : {}
   rescue Octokit::NotFound
     {}
   end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -9,6 +9,11 @@ class GitRepository
     Rails.application.config.samson.cached_repos_dir
   end
 
+  def self.valid_ref_format?(reference)
+    IO.popen(['git', 'check-ref-format', "refs/head/#{reference}"]) { |_| }
+    $?.success?
+  end
+
   def initialize(repository_url:, repository_dir:, executor: nil)
     @repository_url = repository_url
     @repository_directory = repository_dir

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -43,6 +43,11 @@ describe Changeset do
         comparison.error.must_equal message
       end
     end
+
+    it 'handles an invalid commit' do
+      comparison = Changeset.new("foo/bar", "a", "invalid ref").comparison
+      comparison.error.must_include 'Invalid git reference'
+    end
   end
 
   describe "#github_url" do

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -219,4 +219,18 @@ describe GitRepository do
     end
   end
 
+  describe '.valid_ref_format?' do
+    it 'validates branches, tags, shas' do
+      assert GitRepository.valid_ref_format?('master')
+      assert GitRepository.valid_ref_format?('v123')
+      assert GitRepository.valid_ref_format?('user/branch-name')
+      assert GitRepository.valid_ref_format?('7f8568e386')
+    end
+
+    it 'catches invalid references' do
+      refute GitRepository.valid_ref_format?('string with spaces')
+      refute GitRepository.valid_ref_format?('double..dots')
+      refute GitRepository.valid_ref_format?('no-question-marks?')
+    end
+  end
 end


### PR DESCRIPTION
Fix a `URI::InvalidURIError` that was thrown in the `CommitStatusesController` or `JobExecution` if you specify an invalid reference, like `current_account['url']`

/cc @zendesk/samson
### References
- Error in CommitStatusesController: https://zendesk.airbrake.io/projects/95346/groups/1527665412157157182
- Error in JobExecution: https://zendesk.airbrake.io/projects/95346/groups/1563043716556859438
