### PR TITLE
Increasing API version to make the cache compatible with the api 20

### DIFF
--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -84,7 +84,7 @@ class BinaryBuilder
     api_version_major, api_version_minor = docker_api_version.scan(/(\d+)\.(\d+)/).flatten.map(&:to_i)
     if api_version_major == 0 || (api_version_major == 1 && api_version_minor <= 14)
       fail "Unsupported Docker api version '#{docker_api_version}', use at least v1.15"
-    elsif api_version_major == 1 && api_version_minor <= 19
+    elsif api_version_major == 1 && api_version_minor <= 20
       options.merge!(
         {
           'Volumes' => {


### PR DESCRIPTION
@henders @andreionut 

Cache in the docker binary plugin is restricted to work with docker api version 19. There are no changes around this [version 20](https://docs.docker.com/engine/reference/api/docker_remote_api/#v1-20-api-changes).
Just bumping the version to make the mounts work with version 20.

