### PR TITLE
save 40 character sha for job's commit

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -161,7 +161,7 @@ class JobExecution
   def setup!(dir)
     locked = lock_project do
       return false unless @repository.setup!(dir, @reference)
-      commit = @repository.commit_from_ref(@reference)
+      commit = @repository.commit_from_ref(@reference, length: 40)
       tag = @repository.tag_from_ref(@reference)
       @job.update_git_references!(commit: commit, tag: tag)
     end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -84,7 +84,7 @@ describe JobExecution do
     assert job.succeeded?
     assert_equal 'mantis shrimp', last_line_of_output
     assert job.commit.present?, "Expected #{job} to record the commit"
-    assert_includes commit, job.commit
+    assert_equal commit, job.commit
     assert_includes 'annotated_tag', job.tag
   end
 


### PR DESCRIPTION
When saving the commit for a job - we were saving the shortened. (7 character sha).

However, some of the github endpoint require the long 40 character sha such as creating a status: https://developer.github.com/v3/repos/statuses/#create-a-status

If you want to use the shortened sha - you can still use the `short_reference` from a job: https://github.com/zendesk/samson/blob/master/app/models/job.rb#L145

@zendesk/samson 