### PR TITLE
Change DeployGroup links to use PermaLinks to user-friendliness

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -94,6 +94,6 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   def deploy_group
-    @deploy_group ||= DeployGroup.find(params[:id])
+    @deploy_group ||= DeployGroup.find_by_param!(params[:id])
   end
 end

--- a/app/controllers/deploy_groups_controller.rb
+++ b/app/controllers/deploy_groups_controller.rb
@@ -15,6 +15,6 @@ class DeployGroupsController < ApplicationController
   private
 
   def find_deploy_group
-    @deploy_group = DeployGroup.find(params[:id])
+    @deploy_group = DeployGroup.find_by_param!(params[:id])
   end
 end

--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -1,4 +1,6 @@
 class DeployGroup < ActiveRecord::Base
+  include Permalinkable
+
   has_soft_deletion default_scope: true
 
   belongs_to :environment
@@ -27,6 +29,10 @@ class DeployGroup < ActiveRecord::Base
   end
 
   private
+
+  def permalink_base
+    name
+  end
 
   def touch_stages
     stages.update_all(updated_at: Time.now)

--- a/db/migrate/20151201104205_add_permalink_to_deploy_groups.rb
+++ b/db/migrate/20151201104205_add_permalink_to_deploy_groups.rb
@@ -1,0 +1,17 @@
+class AddPermalinkToDeployGroups < ActiveRecord::Migration
+  def change
+    add_column :deploy_groups, :permalink, :string
+    add_index :deploy_groups, :permalink, unique: true
+
+    DeployGroup.reset_column_information
+
+    DeployGroup.with_deleted do
+      DeployGroup.find_each do |deploy_group|
+        deploy_group.send(:generate_permalink)
+        deploy_group.update_column(:permalink, deploy_group.permalink)
+      end
+    end
+
+    change_column :deploy_groups, :permalink, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116174240) do
+ActiveRecord::Schema.define(version: 20151201104205) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -60,9 +60,11 @@ ActiveRecord::Schema.define(version: 20151116174240) do
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
     t.string   "env_value",      limit: 255, null: false
+    t.string   "permalink",      null: false
   end
 
   add_index "deploy_groups", ["environment_id"], name: "index_deploy_groups_on_environment_id", using: :btree
+  add_index "deploy_groups", ["permalink"], name: "index_deploy_groups_on_permalink", unique: true
 
   create_table "deploy_groups_stages", id: false, force: :cascade do |t|
     t.integer "deploy_group_id", limit: 4

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -55,7 +55,7 @@ describe Admin::DeployGroupsController do
         deploy_group_count = DeployGroup.count
         post :create, deploy_group: {name: nil}
         assert_template :edit
-        flash[:error].must_equal ["Name can't be blank", "Environment can't be blank"]
+        flash[:error].must_equal ["Permalink can't be blank", "Name can't be blank", "Environment can't be blank"]
         DeployGroup.count.must_equal deploy_group_count
       end
     end

--- a/test/fixtures/deploy_groups.yml
+++ b/test/fixtures/deploy_groups.yml
@@ -2,13 +2,16 @@ pod1:
   name: Pod1
   env_value: pod1
   environment: production
+  permalink: pod1
 
 pod2:
   name: Pod2
   env_value: pod2
   environment: production
+  permalink: pod2
 
 pod100:
   name: Pod 100
   env_value: pod100
   environment: staging
+  permalink: pod100


### PR DESCRIPTION
This PR makes URLs dealing with Deploy Groups friendlier like projects and stages.
![samson](https://cloud.githubusercontent.com/assets/515143/11499698/dda1f820-981f-11e5-8a40-325b0262301a.png)


/cc @pswadi-zendesk @zendesk/samson @sbrnunes @msufa 

### References
 - Jira link: 

### Risks
 - None