### PR TITLE
Use the Github API to check if last release already contains a new commit

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -66,7 +66,8 @@ class Project < ActiveRecord::Base
 
   def last_release_contains_commit?(commit)
     last_release = releases.order(:id).last
-    last_release && repository.downstream_commit?(last_release.commit, commit)
+    # status values documented here: http://stackoverflow.com/questions/23943855/github-api-to-compare-commits-response-status-is-diverged
+    last_release && %w(behind identical).include?(GITHUB.compare(github_repo, last_release.commit, commit).status)
   end
 
   def auto_release_stages

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -68,6 +68,9 @@ class Project < ActiveRecord::Base
     last_release = releases.order(:id).last
     # status values documented here: http://stackoverflow.com/questions/23943855/github-api-to-compare-commits-response-status-is-diverged
     last_release && %w(behind identical).include?(GITHUB.compare(github_repo, last_release.commit, commit).status)
+  rescue Octokit::Error => e
+    Airbrake.notify(e, parameters: { github_repo: github_repo, last_commit: last_release.commit, commit: commit })
+    false # Err on side of caution and cause a new release to be created.
   end
 
   def auto_release_stages

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -36,6 +36,7 @@ describe Integrations::BaseController do
     end
 
     it 're-uses last release if commit already present' do
+      stub_github_api("repos/bar/foo/compare/#{sha}...#{sha}", { status: 'identical' })
       base_controller.expects(:head).with(:ok).twice
       base_controller.create
 


### PR DESCRIPTION
There are cases where webhooks cause many Releases/tags to be created because the samson cached_repo isn't updated often enough, so Samson believes there hasn't been a release created for commits that have already been processed.

As a result you get releases with no associated commits showing up. Plus their tags are pushed to Github.
![](https://dl.dropboxusercontent.com/u/2227779/Screenshots/T1O8Fj9WE78XXlq8EWeF.png)

This fix is just a proposal. Alternates were:
- Configure Github to send Samson notifications when commits occur which are picked up by a background thread in Samson and updates the cached_repo. This would keep the cached_repo up-to-date but would be a hog with resources.
- Sync the cached_repo whenever a webhook is processed. This also will heavily affect the resource usage of the Samson process, though not as much as the above.

/cc @bquorning @jonmoter @grosser @sandlerr @msufa @sbrnunes @zendesk/samson 

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-190

### Risks
 - Breaks any bitbucket/gitlab support for webhooks