### PR TITLE
Make compatible with main docker hub registry.

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -53,7 +53,7 @@ class DockerBuilderService
 
     output_buffer.puts("### Pushing Docker image to #{project.docker_repo}:#{build.docker_ref}")
 
-    result = build.docker_image.push(registry_credentials) do |output_chunk|
+    build.docker_image.push(registry_credentials) do |output_chunk|
       parsed_chunk = handle_output_chunk(output_chunk)
 
       status = parsed_chunk.fetch('status', '')
@@ -61,12 +61,8 @@ class DockerBuilderService
         build.docker_repo_digest = "#{project.docker_repo}@#{matches[1]}"
       end
     end
-    # Fallbacks if registry did not send us back a digest
-    build.docker_repo_digest ||= result.info['RepoDigests'].first if result.info['RepoDigests']
-    build.docker_repo_digest ||= result.info['RepoTags'].first if result.info['RepoTags']
 
     build.save!
-
     build
   rescue Docker::Error::DockerError => e
     output_buffer.puts("Docker push failed: #{e.message}\n")

--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -61,7 +61,9 @@ class DockerBuilderService
         build.docker_repo_digest = "#{project.docker_repo}@#{matches[1]}"
       end
     end
-    build.docker_repo_digest ||= result.info['RepoTags'].first
+    # Fallbacks if registry did not send us back a digest
+    build.docker_repo_digest ||= result.info['RepoDigests'].first if result.info['RepoDigests']
+    build.docker_repo_digest ||= result.info['RepoTags'].first if result.info['RepoTags']
 
     build.save!
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,13 +54,7 @@ class Project < ActiveRecord::Base
   def docker_repo
     @docker_repo ||= begin
       registry = Rails.application.config.samson.docker.registry
-      if Rails.env.production?
-        "#{registry}/#{permalink_base}"
-      else
-        host, namespace = registry.split '/'
-        namespace ||= 'samson'
-        "#{host}/#{namespace}_non_prod/#{permalink_base}"
-      end
+      "#{registry}/#{permalink_base}"
     end
   end
 

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -1,15 +1,25 @@
 require 'docker'
 
-if ENV['DOCKER_URL'].present? && !Rails.env.test? && !ENV['PRECOMPILE']
-  Docker.url = ENV['DOCKER_URL']
-  Docker.options = { read_timeout: 600 }
+if !Rails.env.test? && !ENV['PRECOMPILE']
+  if ENV['DOCKER_URL'].present?
+    Docker.url = ENV['DOCKER_URL']
+    Docker.options = { read_timeout: 600 }
 
-  # Confirm the Docker daemon is a recent enough version
-  Docker.validate_version!
-end
+    # Confirm the Docker daemon is a recent enough version
+    Docker.validate_version!
+  end
 
+  if ENV['DOCKER_FEATURE'] && !ENV['DOCKER_REGISTRY'].present?
+    puts '*** DOCKER_REGISTRY environment variable must be configured when DOCKER_FEATURE is enabled ***'
+    exit(1)
+  end
 
-if ENV['DOCKER_FEATURE'] && !ENV['DOCKER_REGISTRY'].present?
-  puts '*** DOCKER_REGISTRY environment variable must be configured when DOCKER_FEATURE is enabled ***'
-  exit(1)
+  # Authenticate to the Docker registry if required
+  if %w(DOCKER_REGISTRY DOCKER_REGISTRY_USER DOCKER_REGISTRY_PASS DOCKER_REGISTRY_EMAIL).all? {|key| ENV[key].present? }
+    Docker.authenticate!(
+      username: ENV['DOCKER_REGISTRY_USER'],
+      password: ENV['DOCKER_REGISTRY_PASS'],
+      email: ENV['DOCKER_REGISTRY_EMAIL'])
+    puts "Authenticated for the Docker Registry #{ENV['DOCKER_REGISTRY']}"
+  end
 end

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -13,13 +13,4 @@ if !Rails.env.test? && !ENV['PRECOMPILE']
     puts '*** DOCKER_REGISTRY environment variable must be configured when DOCKER_FEATURE is enabled ***'
     exit(1)
   end
-
-  # Authenticate to the Docker registry if required
-  if %w(DOCKER_REGISTRY DOCKER_REGISTRY_USER DOCKER_REGISTRY_PASS DOCKER_REGISTRY_EMAIL).all? {|key| ENV[key].present? }
-    Docker.authenticate!(
-      username: ENV['DOCKER_REGISTRY_USER'],
-      password: ENV['DOCKER_REGISTRY_PASS'],
-      email: ENV['DOCKER_REGISTRY_EMAIL'])
-    puts "Authenticated for the Docker Registry #{ENV['DOCKER_REGISTRY']}"
-  end
 end

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -18,7 +18,6 @@ describe DeployService do
     }
   end
   let(:mock_docker_image) { stub(json: docker_image_json) }
-  let(:mock_docker_push) { stub(info: { 'RepoDigests' => [], 'RepoTags' => [] }) }
 
   before { create_repo_with_tags(git_tag) }
 
@@ -49,7 +48,7 @@ describe DeployService do
         [{ status: "Frobinating..." }.to_json],
         [{ status: "Digest: #{repo_digest}" }.to_json],
         [{ status: "Done" }.to_json]
-      ).returns(mock_docker_push)
+      )
       mock_docker_image.expects(:tag).returns(true)
       build.docker_image = mock_docker_image
     end

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -18,6 +18,7 @@ describe DeployService do
     }
   end
   let(:mock_docker_image) { stub(json: docker_image_json) }
+  let(:mock_docker_push) { stub(info: { 'RepoDigests' => [], 'RepoTags' => [] }) }
 
   before { create_repo_with_tags(git_tag) }
 
@@ -48,7 +49,7 @@ describe DeployService do
         [{ status: "Frobinating..." }.to_json],
         [{ status: "Digest: #{repo_digest}" }.to_json],
         [{ status: "Done" }.to_json]
-      )
+      ).returns(mock_docker_push)
       mock_docker_image.expects(:tag).returns(true)
       build.docker_image = mock_docker_image
     end


### PR DESCRIPTION
Allow docker images to be uploaded to the main Docker Hub registry. Required because the new Kubernetes Deployment API is only available on the Google Compute Engine environment, so needed to use a docker registry that hosts in that environment could access.

Now if you use Docker Hub, for example, you just have to set the following ENV vars:
DOCKER_REGISTRY=registry.hub.docker.com/shender
DOCKER_REGISTRY_USER=shender
DOCKER_REGISTRY_PASS=xxxxx
DOCKER_REGISTRY_EMAIL=shender@zendesk.com

/cc @zendesk/samson @jonmoter @sbrnunes @msufa 

### References
 - Jira link: 

### Risks
 - None