### PR TITLE
use git clone --shared

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -37,7 +37,7 @@ class GitRepository
     if mirror
       executor.execute!("git -c core.askpass=true clone --mirror #{from} #{to}")
     else
-      executor.execute!("git clone #{from} #{to}")
+      executor.execute!("git clone --shared #{from} #{to}")
     end
   end
   add_method_tracer :clone!


### PR DESCRIPTION
This doesn't hardlink / copy all objects from repos. For our largest repo, it cuts the clone from 3.3G to 300MB.