### PR TITLE
Allow webhooks to trigger from any branch

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -6,7 +6,7 @@ class Webhook < ActiveRecord::Base
   belongs_to :stage
 
   def self.for_branch(branch)
-    where(branch: ['any', branch])
+    where(branch: ['', branch])
   end
 
   def self.for_source(service_type, service_name)

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -6,7 +6,7 @@ class Webhook < ActiveRecord::Base
   belongs_to :stage
 
   def self.for_branch(branch)
-    where(branch: branch)
+    where(branch: ['any', branch])
   end
 
   def self.for_source(service_type, service_name)

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -14,7 +14,14 @@
     <h2>Webhooks mappings</h2>
     <ul>
       <% @webhooks.each do |webhook| %>
-        <li><strong><%= webhook.branch %></strong> branch &rarr; <strong><%= webhook.stage.name %></strong> stage for: <%= webhook.source.humanize %> (<%= link_to "remove", [@project, webhook], method: :delete %>)</li>
+        <li>
+          <strong><%= webhook.branch.blank? ? 'Any' : webhook.branch %></strong>
+          branch &rarr;
+          <strong><%= webhook.stage.name %></strong>
+          stage for:
+          <%= webhook.source.humanize %>
+          (<%= link_to "remove", [@project, webhook], method: :delete %>)
+        </li>
       <% end %>
     </ul>
   <% end %>
@@ -22,7 +29,7 @@
   <h2>Add webhook mapping</h2>
   <%= form_for :webhook, url: project_webhooks_path(@project), html: { class: "form-inline" } do |form| %>
     <div class="form-group">
-      <%= form.text_field :branch, class: "form-control", placeholder: "Branch" %>
+      <%= form.text_field :branch, class: "form-control", placeholder: "Branch (Blank for any)" %>
     </div>
 
     &rarr;

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -77,14 +77,14 @@ describe Webhook do
 
   describe '.for_branch' do
     before do
-      %w[any master staging production feature/branch].each_with_index do |branch, index|
+      ['', 'master', 'feature/branch'].each_with_index do |branch, index|
         Webhook.create(branch: branch, stage_id: index, project_id: 1, source: 'any_code')
       end
     end
 
     it 'filters correctly' do
-      assert_equal Webhook.for_branch('feature/branch').pluck(:branch), ['any', 'feature/branch']
-      assert_equal Webhook.for_branch('staging').pluck(:branch), ['any', 'staging']
+      assert_equal Webhook.for_branch('feature/branch').pluck(:branch), ['', 'feature/branch']
+      assert_equal Webhook.for_branch('master').pluck(:branch), ['', 'master']
     end
   end
 end

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -74,4 +74,17 @@ describe Webhook do
       assert_equal Webhook.for_source('code', 'github').pluck(:source), ['any_code', 'github', 'any']
     end
   end
+
+  describe '.for_branch' do
+    before do
+      %w[any master staging production feature/branch].each_with_index do |branch, index|
+        Webhook.create(branch: branch, stage_id: index, project_id: 1, source: 'any_code')
+      end
+    end
+
+    it 'filters correctly' do
+      assert_equal Webhook.for_branch('feature/branch').pluck(:branch), ['any', 'feature/branch']
+      assert_equal Webhook.for_branch('staging').pluck(:branch), ['any', 'staging']
+    end
+  end
 end


### PR DESCRIPTION
When I originally started work on adding the ability to run a webhook from any branch, I wanted to make the `branch` column `nil` to denote any branch. However this required two things:

1. We have to change the database to remove the nil restriction
2. We have to provide a checkmark or special dropdown in the form to denote you want it to originate from any branch.

By going with `any` we are matching the same pattern as `source`.

If someone pushes their branch named `any`, it would be the correct behavior, since it's "any branch".

If someone wants to cause a webhook to only occur on their branch that happened to be named "any" for some reason, it could be a problem. Not sure if we should just bear that risk or maybe mitigate by putting something in the UI. Thoughts?

@zendesk/samson 