### PR TITLE
Use SSL cert store instead of temp file

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/client_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/client_config_file.rb
@@ -41,7 +41,13 @@ module Kubernetes
         cluster = Cluster.new
         cluster.name = cluster_hash[:name]
         cluster.server = cluster_hash[:cluster][:server]
-        cluster.ca_data = cluster_hash[:cluster][:'certificate-authority-data']
+        ca_data = cluster_hash[:cluster][:'certificate-authority-data']
+        if ca_data
+          cluster.cert_store = OpenSSL::X509::Store.new
+          cluster.cert_store.add_cert(OpenSSL::X509::Certificate.new(Base64.decode64(ca_data)))
+        else
+          cluster.cert_store = nil
+        end
         @clusters[cluster.name] = cluster
       end
     end
@@ -84,19 +90,10 @@ module Kubernetes
     end
 
     class Cluster
-      attr_accessor :name, :server, :ca_data
+      attr_accessor :name, :server, :cert_store
 
       def url
         server + '/api/'
-      end
-
-      def ca_filepath
-        @ca_filepath ||= begin
-          tmpfile = Tempfile.new(['ca', '.crt'])
-          tmpfile.write(Base64.decode64(ca_data))
-          tmpfile.close
-          tmpfile.path
-        end
       end
     end
 
@@ -108,7 +105,7 @@ module Kubernetes
       end
 
       def use_ssl?
-        cluster.ca_data.present? && user.client_cert.present?
+        cluster.cert_store.present? && user.client_cert.present?
       end
 
       def ssl_options
@@ -117,7 +114,7 @@ module Kubernetes
         {
           client_cert: user.client_cert,
           client_key:  user.client_key,
-          ca_file:     cluster.ca_filepath,
+          cert_store:  cluster.cert_store,
           verify_ssl:  OpenSSL::SSL::VERIFY_PEER
         }
       end


### PR DESCRIPTION
Expired temp files caused SSLError exceptions when trying to connect to k8s cluster API.

/cc @henders @sbrnunes @jonmoter 

### References
 - Jira link: 

### Risks
 - None