### PR TITLE
[WIP] New pod error watcher and base class for cluster watchers

### DIFF
--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_dashboard_ctrl.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_dashboard_ctrl.js
@@ -151,7 +151,8 @@ samson.controller('KubernetesDashboardCtrl',
             id: msg.release,
             build: msg.build,
             live_replicas: msg.live_replicas,
-            target_replicas: msg.target_replicas
+            target_replicas: msg.target_replicas,
+            failed: msg.failed,
           };
           deploy_group.releases.push(release);
         }
@@ -161,6 +162,7 @@ samson.controller('KubernetesDashboardCtrl',
 
     function updateReleaseState(release, msg) {
       release.live_replicas = msg.live_replicas;
+      release.failed = msg.failed;
       $scope.$apply();
     }
 

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/directives/kubernetes_deploy_progress_directive.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/directives/kubernetes_deploy_progress_directive.js
@@ -24,8 +24,9 @@ samson.directive('deployProgressWidget', function() {
       };
 
       $scope.deployFailed = function() {
-        // TODO: figure out if this will ever be used
-        return false;
+        return _.some($scope.deployGroup.releases, function(release) {
+          return $scope.currentRelease(release) ? release.failed : false;
+        });
       };
 
       $scope.targetStateReached = function(release) {

--- a/plugins/kubernetes/app/controllers/kubernetes_dashboard_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_dashboard_controller.rb
@@ -60,11 +60,13 @@ class KubernetesDashboardController < ApplicationController
   end
 
   def build_release(release_id, role_id)
+    release_doc = release_doc(release_id, role_id)
     {
         id: release_id,
         build: build_label(release_id),
-        target_replicas: target_replicas(release_id, role_id),
-        live_replicas: 0
+        target_replicas: release_doc.replica_target,
+        live_replicas: 0, # we don't know if the data in the DB is up to date, we'll recreate it from pod info
+        failed: release_doc.failed?
     }
   end
 
@@ -76,9 +78,9 @@ class KubernetesDashboardController < ApplicationController
     DeployGroup.find(deploy_group_id).name
   end
 
-  def target_replicas(release_id, role_id)
+  def release_doc(release_id, role_id)
     Kubernetes::ReleaseDoc.find_by(kubernetes_release_id: release_id,
-                                   kubernetes_role_id: role_id).replica_target
+                                   kubernetes_role_id: role_id)
   end
 
   def build_label(release_id)

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -2,7 +2,7 @@ module Kubernetes
   class Release < ActiveRecord::Base
     self.table_name = 'kubernetes_releases'
 
-    STATUSES = %w[created spinning_up live spinning_down dead]
+    STATUSES = %w[created spinning_up live spinning_down dead failed]
 
     belongs_to :user
     belongs_to :build
@@ -19,9 +19,11 @@ module Kubernetes
     end
 
     def release_is_live!
-      self.status = :live
-      self.deploy_finished_at = Time.now
-      save!
+      finish_deploy(:live)
+    end
+
+    def release_failed!
+      finish_deploy(:failed)
     end
 
     def pod_labels
@@ -79,6 +81,12 @@ module Kubernetes
       if build && build.docker_repo_digest.blank?
         errors.add(:build, 'Docker image was not pushed to registry')
       end
+    end
+
+    def finish_deploy(status)
+      self.status = status
+      self.deploy_finished_at = Time.now
+      save!
     end
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -66,9 +66,10 @@ module Kubernetes
 
       if replicas_live >= replica_target
         self.status ='live'
-      elsif replicas_live > 0
+      elsif replicas_live > 0 && !failed?
         self.status ='spinning_up'
       end
+      save!
     end
 
     def client

--- a/plugins/kubernetes/app/models/watchers/base_cluster_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/base_cluster_watcher.rb
@@ -1,0 +1,72 @@
+require 'celluloid/current'
+require 'celluloid/io'
+
+module Watchers
+  class BaseClusterWatcher
+    include Celluloid::IO
+    include Celluloid::Internals::Logger
+
+    finalizer :stop_watching
+
+    def initialize(watch_stream)
+      @watch_stream = watch_stream
+      async :start_watching
+    end
+
+    def start_watching
+      info 'watcher started'
+      @watch_stream.each do |notice|
+        base_handle_notice notice
+      end
+    end
+
+    def stop_watching
+      info 'watcher stopped'
+      if @watch_stream
+        @watch_stream.finish
+        @watch_stream = nil
+      end
+    end
+
+    def self.watcher_symbol(cluster)
+      "#{self.name.demodulize.underscore}_#{cluster.id}".to_sym
+    end
+
+    def self.start_watcher(cluster)
+      watcher_name = watcher_symbol(cluster)
+      supervise as: watcher_name, args: [cluster.client]
+    end
+
+    def self.restart_watcher(cluster)
+      watcher = Actor[watcher_symbol(cluster)]
+      watcher.terminate if watcher and watcher.alive?
+      start_watcher(cluster)
+    end
+
+    protected
+
+    def base_handle_notice(notice)
+      debug notice.to_s
+      handle_notice(notice) unless handle_error(notice)
+    end
+
+    def handle_error(notice)
+      if notice.type == 'ERROR'
+        error notice.object.message
+        true
+      else
+        false
+      end
+    end
+
+    def handle_notice(_notice)
+      fail 'handle_notice not implemented!'
+    end
+
+    %w{debug info warn error}.each do |level|
+      define_method level do |message|
+        super "#{name} -> #{message}"
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/watchers/cluster_pod_error_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/cluster_pod_error_watcher.rb
@@ -1,0 +1,35 @@
+module Watchers
+  class ClusterPodErrorWatcher < BaseClusterWatcher
+    include Celluloid::Notifications
+
+    def initialize(client)
+      @client = client
+      super(@client.watch_events(field_selector: 'involvedObject.kind=Pod'))
+    end
+
+    private
+
+    def handle_notice(notice)
+      if error_notice?(notice.object.reason)
+        rc_name = rc_name(notice.object.involvedObject)
+        publish(rc_name, notice) if rc_name
+      end
+    end
+
+    def rc_name(involved_object)
+      pod = @client.get_pod(involved_object.name, involved_object.namespace)
+      pod.metadata.labels ? pod.metadata.labels.replication_controller : nil
+    rescue KubeException => e
+      if e.error_code == 404
+        warn e.to_s
+        nil
+      else
+        raise
+      end
+    end
+
+    def error_notice?(reason)
+      reason == 'failed' || reason == 'failedScheduling'
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/watchers/cluster_pod_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/cluster_pod_watcher.rb
@@ -1,72 +1,17 @@
-require 'celluloid/current'
-require 'celluloid/io'
-
 module Watchers
-  class ClusterPodWatcher
-    include Celluloid::IO
+  class ClusterPodWatcher < BaseClusterWatcher
     include Celluloid::Notifications
-    include Celluloid::Internals::Logger
-
-    finalizer :stop_watching
 
     def initialize(client)
-      @client = client
-      @watch_stream = nil
-      async :start_watching
-    end
-
-    def start_watching
-      info 'watcher started'
-      @watch_stream = @client.watch_pods
-      @watch_stream.each do |notice|
-        handle_notice notice
-      end
-    end
-
-    def stop_watching
-      info 'watcher stopped'
-      if @watch_stream
-        @watch_stream.finish
-        @watch_stream = nil
-      end
-    end
-
-    def self.pod_watcher_symbol(cluster)
-      "cluster_pod_watcher_#{cluster.id}".to_sym
-    end
-
-    def self.start_watcher(cluster)
-      watcher_name = pod_watcher_symbol(cluster)
-      supervise as: watcher_name, args: [cluster.client]
-    end
-
-    def self.restart_watcher(cluster)
-      watcher = Actor[pod_watcher_symbol(cluster)]
-      watcher.terminate if watcher and watcher.alive?
-      start_watcher(cluster)
+      super(client.watch_pods)
     end
 
     private
 
-    def handle_error(notice)
-      if notice.type == 'ERROR'
-        error notice.object.message
-        true
-      else
-        false
-      end
-    end
-
     def handle_notice(notice)
-      debug notice.to_s
-      return if handle_error(notice) || !notice.object.metadata.labels
-      rc_name = notice.object.metadata.labels['replication_controller']
-      publish(rc_name, notice) if rc_name
-    end
-
-    %w{debug info warn error}.each do |level|
-      define_method level do |message|
-        super "#{name} -> #{message}"
+      if notice.object.metadata.labels
+        rc_name = notice.object.metadata.labels['replication_controller']
+        publish(rc_name, notice) if rc_name
       end
     end
   end

--- a/plugins/kubernetes/config/initializers/watchers.rb
+++ b/plugins/kubernetes/config/initializers/watchers.rb
@@ -67,5 +67,8 @@ Celluloid.logger = Rails.logger
 $CELLULOID_DEBUG = true
 
 if ENV['SERVER_MODE'] && !ENV['PRECOMPILE']
-  Kubernetes::Cluster.all.each { |cluster| Watchers::ClusterPodWatcher::start_watcher(cluster) }
+  Kubernetes::Cluster.all.each do |cluster|
+    Watchers::ClusterPodWatcher::start_watcher(cluster)
+    Watchers::ClusterPodErrorWatcher::start_watcher(cluster)
+  end
 end


### PR DESCRIPTION
- Extracted a common base class for cluster watchers
- Created new watcher to observe pod error notices (scheduling failed, could not download Docker image, etc.)
- Added a new `failed` release status
- Added a timeout for a release
 - default 10minutes, configurable
 - if the release is not successful and no new pod has started within the timeout period, the release is considered failed

/cc @sbrnunes @henders @jonmoter 

### References
 - Jira link: 

### Risks
 - None