### PR TITLE
Adding feedback that the User clicked "Deploy" to create a Kubernetes release

### DIFF
--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_create_release_ctrl.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_create_release_ctrl.js
@@ -6,6 +6,7 @@ samson.controller('KubernetesCreateReleaseCtrl',
     $scope.loadingRoles = false;
     $scope.loadingEnvironments = false;
     $scope.loadingDeployGroups = false;
+    $scope.submitting = false;
     $scope.roles = [];
     $scope.environments = [];
     $scope.environment = undefined;
@@ -75,10 +76,12 @@ samson.controller('KubernetesCreateReleaseCtrl',
     };
 
     $scope.toggleAll = function() {
-      var newState = !$scope.allToggled();
-      _.each($scope.deploy_groups, function(deploy_group) {
-        deploy_group.selected = newState;
-      });
+      if(!$scope.submitting) {
+        var newState = !$scope.allToggled();
+        _.each($scope.deploy_groups, function(deploy_group) {
+          deploy_group.selected = newState;
+        });
+      }
     };
 
     $scope.allToggled = function() {
@@ -88,7 +91,9 @@ samson.controller('KubernetesCreateReleaseCtrl',
     };
 
     $scope.toggleSelection = function(deploy_group) {
-      deploy_group.selected = !deploy_group.selected;
+      if(!$scope.submitting) {
+        deploy_group.selected = !deploy_group.selected;
+      }
     };
 
     $scope.isSelected = function(deploy_group) {
@@ -162,6 +167,8 @@ samson.controller('KubernetesCreateReleaseCtrl',
     }
 
     function createRelease() {
+      $scope.submitting = true;
+
       // Fetching only the selected deploy groups
       var selected_deploy_groups = _.filter($scope.deploy_groups, $scope.isSelected);
 
@@ -177,6 +184,7 @@ samson.controller('KubernetesCreateReleaseCtrl',
           });
         },
         function(result) {
+          $scope.submitting = false;
           handleFailure(result);
         }
       );

--- a/plugins/kubernetes/app/assets/stylesheets/kubernetes/application.css
+++ b/plugins/kubernetes/app/assets/stylesheets/kubernetes/application.css
@@ -17,6 +17,24 @@ select {
   font-size: 12px;
 }
 
+.btn .spinner {
+  display: none;
+  opacity: 0;
+  width: 0;
+
+  -webkit-transition: opacity 0.25s, width 0.25s;
+  -moz-transition: opacity 0.25s, width 0.25s;
+  -ms-transition: opacity 0.25s, width 0.25s;
+  transition: opacity 0.25s, width 0.25s;
+}
+
+.btn .spinner.visible {
+  display: inline-block;
+  width: 16px;
+  opacity: 1;
+  margin-right: 5px;
+}
+
 /*
     Kubernetes Releases
 */

--- a/plugins/kubernetes/app/views/kubernetes_releases/_create_form_step_1.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_releases/_create_form_step_1.html.erb
@@ -26,9 +26,6 @@
                 {{ build.label || 'Choose build' }} <span class="caret"></span>
               </button>
               <ul class="uib-dropdown-menu" role="menu" aria-labelledby="environment-dropdown">
-                <li role="menuitem">
-                  <a ng-click="buildChanged()"></a>
-                </li>
                 <li role="menuitem" ng-repeat="build in builds">
                   <a ng-click="buildChanged(build)">{{ build.label }}</a>
                 </li>
@@ -48,9 +45,6 @@
               {{ environment.name || 'Choose environment' }} <span class="caret"></span>
             </button>
             <ul class="uib-dropdown-menu" role="menu" aria-labelledby="environment-dropdown">
-              <li role="menuitem">
-                <a ng-click="environmentChanged()"></a>
-              </li>
               <li role="menuitem" ng-repeat="env in environments">
                 <a ng-click="environmentChanged(env)">{{ env.name }}</a>
               </li>

--- a/plugins/kubernetes/app/views/kubernetes_releases/_create_form_step_2.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_releases/_create_form_step_2.html.erb
@@ -3,7 +3,7 @@
     <span class="spinner-label">Loading Deploy Groups</span>
   </us-spinner>
   <div ng-if="notEmpty(environment.deploy_groups)" class="form-container">
-    <fieldset>
+    <fieldset ng-disabled="submitting">
       <div class="form-group clearfix">
         <label>
           <span class="order">4.</span>
@@ -58,8 +58,13 @@
     </fieldset>
   </div>
   <footer class="clearfix">
-    <button ng-click="previous()" class="btn btn-default" style="margin-right: 20px;" ng-if="isCurrentStep(2)">Back</button>
-    <button ng-click="cancel()" class="btn btn-default pull-right">Cancel</button>
-    <button ng-click="submit()" class="btn btn-primary pull-right" ng-disabled="!validate(currentStep)">Deploy</button>
+    <button ng-click="previous()" class="btn btn-default" style="margin-right: 20px;" ng-if="isCurrentStep(2)" ng-disabled="submitting">Back</button>
+    <button ng-click="cancel()" class="btn btn-default pull-right" ng-disabled="submitting">Cancel</button>
+    <button ng-click="submit()" class="btn btn-primary pull-right" ng-disabled="!validate(currentStep) || submitting">
+      <span class="spinner" ng-class="{ 'visible': submitting }">
+        <i class="glyphicon glyphicon-refresh spinning"></i>
+      </span>
+      Deploy
+    </button>
   </footer>
 </script>


### PR DESCRIPTION
Just a few fixes to the create Kubernetes Release dialog to provide feedback, while locking the form and the buttons, when the User clicks on the Deploy button.

/cc @henders, @msufa, @jonmoter 

![screenshot 2016-01-04 17 02 16](https://cloud.githubusercontent.com/assets/2833020/12095059/316b67f8-b304-11e5-9759-602c96b8f7dd.png)

