### PR TITLE
Adding the ability to run the plugins tests as part of a regular build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ env:
   matrix:
     - TASK=js
     - TASK=precompile
-    - DATABASE_URL=mysql2://travis@127.0.0.1/samson_test USE_UTF8MB4=1 TASK=rake
-    - DATABASE_URL=postgresql://postgres@127.0.0.1/samson_test TASK=rake
-    - DATABASE_URL=sqlite3://null$PWD/db/test.sqlite3 TASK=rake
+    - DATABASE_URL=mysql2://travis@127.0.0.1/samson_test USE_UTF8MB4=1 TASK=rake:default
+    - DATABASE_URL=postgresql://postgres@127.0.0.1/samson_test TASK=rake:default
+    - DATABASE_URL=sqlite3://null$PWD/db/test.sqlite3 TASK=rake:default
+    - DATABASE_URL=mysql2://travis@127.0.0.1/samson_test USE_UTF8MB4=1 TASK=rake:test:plugins
+    - DATABASE_URL=postgresql://postgres@127.0.0.1/samson_test TASK=rake:test:plugins
+    - DATABASE_URL=sqlite3://null$PWD/db/test.sqlite3 TASK=rake:test:plugins
 script: script/ci
 before_script:
   - mysql -u root -e 'set GLOBAL innodb_large_prefix = true'

--- a/Rakefile
+++ b/Rakefile
@@ -5,18 +5,11 @@ require File.expand_path('../config/application', __FILE__)
 
 Samson::Application.load_tasks
 
-Rake::Task["default"].clear
 task default: :test
 
-namespace :plugins do
-  Rails::TestTask.new(:test) do |t|
-    t.pattern = "plugins/*/test/**/*_test.rb"
-  end
-end
-
 namespace :test do
-  Rails::TestTask.new(:default) do |t|
-    t.pattern = "{test,plugins/*/test}/**/*_test.rb"
+  Rails::TestTask.new(:plugins) do |t|
+    t.pattern = 'plugins/*/test/**/*_test.rb'
   end
 
   task js: :environment do

--- a/script/ci
+++ b/script/ci
@@ -16,8 +16,11 @@ precompile)
   export DATABASE_URL=mysql2://none@none/none
   bundle exec rake assets:precompile
   ;;
-rake)
+rake:default)
   bundle exec rake db:create default
+  ;;
+rake:test:plugins)
+  bundle exec rake db:create test:plugins
   ;;
 *)
   echo "Unknown task"


### PR DESCRIPTION
I've noticed the plugins tests are not being run as part of the default build, not even in Travis. Because of that, we've been accumulating a few failed tests.

I do not know if this was intentional or not, so let me know if it was. Nevertheless, this PR intends to make the plugin tests run by default as part of a regular build.

I also noticed that when executing `rake plugins:test` the plugins tests were being executed against the `development` environment, instead of the `test` environment, which was messing up my development database all the time. So, I moved the whole task into the `test` namespace.

This PR is depending on #664 and #717. All plugin tests have been fixed in PR #717.

/cc @zendesk/samson, @jonmoter, @henders, @steved 

### Tasks
 - [x] Changed Rakefile to make plugins tests run as part of the normal build
 - [x] Fix failing tests

### Risks
 - Breaking the default build in the CI server