### PR TITLE
[CVE-2015-5312] Updates Nokogiri gem to v1.6.7.1 to avoid vulnerabilities in libxml2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'kaminari'
 gem 'soft_deletion', '~> 0.4'
 gem 'dalli', '~> 2.7.0'
 gem 'active_model_serializers', '~> 0.8.0'
+gem 'nokogiri', '1.6.7.1'
 
 gem 'sawyer', '~> 0.5'
 gem 'sse-rails-engine', '~> 1.4'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'kaminari'
 gem 'soft_deletion', '~> 0.4'
 gem 'dalli', '~> 2.7.0'
 gem 'active_model_serializers', '~> 0.8.0'
-gem 'nokogiri', '1.6.7.1'
 
 gem 'sawyer', '~> 0.5'
 gem 'sse-rails-engine', '~> 1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,9 +266,9 @@ GEM
       rails (>= 3.1)
     nio4r (1.1.1)
     nio4r (1.1.1-java)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
-    nokogiri (1.6.7-java)
+    nokogiri (1.6.7.1-java)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -506,6 +506,7 @@ DEPENDENCIES
   newrelic_api
   newrelic_rpm (>= 3.7.1)
   ngannotate-rails
+  nokogiri (= 1.6.7.1)
   octokit (~> 4.0)
   omniauth (~> 1.1)
   omniauth-github (= 1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,7 +506,6 @@ DEPENDENCIES
   newrelic_api
   newrelic_rpm (>= 3.7.1)
   ngannotate-rails
-  nokogiri (= 1.6.7.1)
   octokit (~> 4.0)
   omniauth (~> 1.1)
   omniauth-github (= 1.1.1)


### PR DESCRIPTION
```
Name: nokogiri
Version: 1.6.6.4
Advisory: CVE-2015-5312
Criticality: High
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
Title: Nokogiri gem contains several vulnerabilities in libxml2
Solution: upgrade to >= 1.6.7.1
```