### PR TITLE
Update to use correct casing for GitHub

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -81,7 +81,7 @@ class Changeset
       end
     end
   rescue Octokit::Error => e
-    NullComparison.new("Github: #{e.message.sub("Octokit::", "").underscore.humanize}")
+    NullComparison.new("GitHub: #{e.message.sub("Octokit::", "").underscore.humanize}")
   end
 
   def find_pull_requests

--- a/app/models/github_deployment.rb
+++ b/app/models/github_deployment.rb
@@ -8,13 +8,13 @@ class GithubDeployment
   end
 
   def create_github_deployment
-    Rails.logger.info "Creating Github Deployment..."
+    Rails.logger.info "Creating GitHub Deployment..."
 
     GITHUB.create_deployment(@project.github_repo, @deploy.reference, deployment_options)
   end
 
   def update_github_deployment_status(deployment)
-    Rails.logger.info "Updating Github Deployment Status..."
+    Rails.logger.info "Updating GitHub Deployment Status..."
 
     GITHUB.create_deployment_status(deployment.url, state, deployment_status_options)
   end

--- a/app/models/github_notification.rb
+++ b/app/models/github_notification.rb
@@ -6,7 +6,7 @@ class GithubNotification
   end
 
   def deliver
-    Rails.logger.info "Updating Github PR..."
+    Rails.logger.info "Updating GitHub PR..."
 
     pull_requests = @deploy.changeset.pull_requests
 
@@ -17,7 +17,7 @@ class GithubNotification
         status = GITHUB.add_comment(@project.github_repo, pull_id, body)
 
         if status == "201"
-          Rails.logger.info "Updated Github PR: #{pull_id}"
+          Rails.logger.info "Updated GitHub PR: #{pull_id}"
         else
           Rails.logger.info "Failed to update PR: #{pull_id}, status: #{status}"
         end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,7 +4,7 @@
   <div class="login">
     <% if Rails.application.config.samson.auth.github %>
       <%= link_to omniauth_path('github'), class: "action github" do %>
-        <%= image_tag image_url('github.png') %> Login with Github
+        <%= image_tag image_url('github.png') %> Login with GitHub
       <% end %>
     <% end %>
     <% if Rails.application.config.samson.auth.google %>

--- a/app/views/shared/_github_link.html.erb
+++ b/app/views/shared/_github_link.html.erb
@@ -1,3 +1,3 @@
-<%= link_to project.repository_homepage, class: "github", target: "_blank", title: "View repository on Github" do %>
+<%= link_to project.repository_homepage, class: "github", target: "_blank", title: "View repository on GitHub" do %>
   <i class="fa fa-github"></i>
 <% end %>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -172,7 +172,7 @@
 </fieldset>
 
 <fieldset>
-  <legend>Github</legend>
+  <legend>GitHub</legend>
   <div class="col-lg-6 checkbox col-lg-offset-2">
     <%= form.label :update_github_pull_requests do %>
       <%= form.check_box :update_github_pull_requests %>

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,20 +1,20 @@
 # Continuous Integration support
 
-Samson can be integrated with CI services through web-hooks. Web-hooks are just URLs that add to your 
+Samson can be integrated with CI services through web-hooks. Web-hooks are just URLs that add to your
 favourite CI service to allow it to tell Samson that a new release or deploy should be triggered.
 
 Each project has it's own set of web-hook URLs. You can find a list of them for the various CI services Samson supports on the
 'webhooks' tab when you navigate to your project within Samson.
 
 There are 2 uses of web-hooks in Samson:
-* Create a release for the project within Samson. I.e., Increment a version number, and tag the repo within Github so you can deploy tags instead of 'master'.
+* Create a release for the project within Samson. I.e., Increment a version number, and tag the repo within GitHub so you can deploy tags instead of 'master'.
 * Automatically trigger a deploy to your target hosts.
 
 You can combine those 2 above as well.
 
 ## Workflow Summary
 
--> Push a change to a branch in Github (e.g. master)
+-> Push a change to a branch in GitHub (e.g. master)
 -> CI validates the change
 -> CI makes webhook call back to Samson
 -> Samson receives webhook call
@@ -38,7 +38,7 @@ You can combine those 2 above as well.
 * Buildkite
     * You can add a webhook per project under settings/notifications
     * You can add any value to the 'Token' field, as it is not used
-* Github
+* GitHub
     * You may add a webhook for push events
 
 Note: to skip a deploy, add "[deploy skip]" to your commit message, and Samson will ignore the webhook from CI.

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -30,7 +30,7 @@ viewer:
   external_id: 'google-3'
 
 github_viewer:
-  name: "Github Viewer"
+  name: "GitHub Viewer"
   email: "gh+viewer@example.com"
   role_id: <%= Role::VIEWER.id %>
   external_id: 'github-3'

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -33,9 +33,9 @@ describe Changeset do
     end
 
     {
-      Octokit::NotFound => "Github: Not found",
-      Octokit::Unauthorized => "Github: Unauthorized",
-      Octokit::InternalServerError => "Github: Internal server error",
+      Octokit::NotFound => "GitHub: Not found",
+      Octokit::Unauthorized => "GitHub: Unauthorized",
+      Octokit::InternalServerError => "GitHub: Internal server error",
     }.each do |exception, message|
       it "catches #{exception} exceptions" do
         GITHUB.expects(:compare).raises(exception)


### PR DESCRIPTION
Where possible (that is outside of class names, etc) use the correct casing for
the word GitHub.