### PR TITLE
Fix typo with function rename.

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/client_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/client_config_file.rb
@@ -21,7 +21,7 @@ module Kubernetes
       contexts[context_name].try(:client)
     end
 
-    def extension_client_for_client_for(context_name)
+    def extension_client_for(context_name)
       contexts[context_name].try(:extension_client)
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -16,7 +16,7 @@ module Kubernetes
     end
 
     def extension_client
-      @extension_client ||= kubeconfig.ext_client_for(config_context)
+      @extension_client ||= kubeconfig.extension_client_for(config_context)
     end
 
     def context


### PR DESCRIPTION
Bad typo when renaming a function. 

/cc @sbrnunes @msufa 

### References
 - Jira link: 

### Risks
 - None