### PR TITLE
New pod error watcher and base class for cluster watchers

### DIFF
--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_dashboard_ctrl.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_dashboard_ctrl.js
@@ -144,7 +144,8 @@ samson.controller('KubernetesDashboardCtrl',
           id: msg.release,
           build: msg.build,
           live_replicas: msg.live_replicas,
-          target_replicas: msg.target_replicas
+          target_replicas: msg.target_replicas,
+          failed: msg.failed
         };
         deploy_group.releases.push(release);
       }
@@ -154,6 +155,7 @@ samson.controller('KubernetesDashboardCtrl',
 
     function updateReleaseState(release, msg) {
       release.live_replicas = msg.live_replicas;
+      release.failed = msg.failed;
       $scope.$apply();
     }
 

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/directives/kubernetes_deploy_progress_directive.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/directives/kubernetes_deploy_progress_directive.js
@@ -24,8 +24,9 @@ samson.directive('deployProgressWidget', function() {
       };
 
       $scope.deployFailed = function() {
-        // TODO: figure out if this will ever be used
-        return false;
+        return _.some($scope.deployGroup.releases, function(release) {
+          return $scope.currentRelease(release) ? release.failed : false;
+        });
       };
 
       $scope.targetStateReached = function(release) {

--- a/plugins/kubernetes/app/controllers/kubernetes_dashboard_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_dashboard_controller.rb
@@ -60,11 +60,13 @@ class KubernetesDashboardController < ApplicationController
   end
 
   def build_release(release_id, role_id)
+    release_doc = release_doc(release_id, role_id)
     {
         id: release_id,
         build: build_label(release_id),
-        target_replicas: target_replicas(release_id, role_id),
-        live_replicas: 0
+        target_replicas: release_doc.replica_target,
+        live_replicas: 0, # we don't know if the data in the DB is up to date, we'll recreate it from pod info
+        failed: release_doc.failed?
     }
   end
 
@@ -76,9 +78,9 @@ class KubernetesDashboardController < ApplicationController
     DeployGroup.find(deploy_group_id).name
   end
 
-  def target_replicas(release_id, role_id)
+  def release_doc(release_id, role_id)
     Kubernetes::ReleaseDoc.find_by(kubernetes_release_id: release_id,
-                                   kubernetes_role_id: role_id).replica_target
+                                   kubernetes_role_id: role_id)
   end
 
   def build_label(release_id)

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -20,6 +20,10 @@ module Kubernetes
       define_method("#{s}?") { status == s }
     end
 
+    def fail!
+      update_attribute(:status, :failed)
+    end
+
     def has_service?
       kubernetes_role.has_service? && service_template.present?
     end

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -56,9 +56,10 @@ module Kubernetes
 
       if replicas_live >= replica_target
         self.status ='live'
-      elsif replicas_live > 0
+      elsif replicas_live > 0 && !failed?
         self.status ='spinning_up'
       end
+      save!
     end
 
     def client

--- a/plugins/kubernetes/app/models/watchers/base_cluster_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/base_cluster_watcher.rb
@@ -1,0 +1,72 @@
+require 'celluloid/current'
+require 'celluloid/io'
+
+module Watchers
+  class BaseClusterWatcher
+    include Celluloid::IO
+    include Celluloid::Internals::Logger
+
+    finalizer :stop_watching
+
+    def initialize(watch_stream)
+      @watch_stream = watch_stream
+      async :start_watching
+    end
+
+    def start_watching
+      info 'watcher started'
+      @watch_stream.each do |notice|
+        base_handle_notice notice
+      end
+    end
+
+    def stop_watching
+      info 'watcher stopped'
+      if @watch_stream
+        @watch_stream.finish
+        @watch_stream = nil
+      end
+    end
+
+    def self.watcher_symbol(cluster)
+      "#{self.name.demodulize.underscore}_#{cluster.id}".to_sym
+    end
+
+    def self.start_watcher(cluster)
+      watcher_name = watcher_symbol(cluster)
+      supervise as: watcher_name, args: [cluster.client]
+    end
+
+    def self.restart_watcher(cluster)
+      watcher = Actor[watcher_symbol(cluster)]
+      watcher.terminate if watcher and watcher.alive?
+      start_watcher(cluster)
+    end
+
+    protected
+
+    def base_handle_notice(notice)
+      debug notice.to_s
+      handle_notice(notice) unless handle_error(notice)
+    end
+
+    def handle_error(notice)
+      if notice.type == 'ERROR'
+        error notice.object.message
+        true
+      else
+        false
+      end
+    end
+
+    def handle_notice(_notice)
+      fail 'handle_notice not implemented!'
+    end
+
+    %w{debug info warn error}.each do |level|
+      define_method level do |message|
+        super "#{name} -> #{message}"
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/watchers/cluster_pod_error_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/cluster_pod_error_watcher.rb
@@ -1,0 +1,35 @@
+module Watchers
+  class ClusterPodErrorWatcher < BaseClusterWatcher
+    include Celluloid::Notifications
+
+    def initialize(client)
+      @client = client
+      super(@client.watch_events(field_selector: 'involvedObject.kind=Pod'))
+    end
+
+    private
+
+    def handle_notice(notice)
+      if error_notice?(notice.object.reason)
+        rc_name = rc_name(notice.object.involvedObject)
+        publish(rc_name, notice) if rc_name
+      end
+    end
+
+    def rc_name(involved_object)
+      pod = @client.get_pod(involved_object.name, involved_object.namespace)
+      pod.metadata.labels ? pod.metadata.labels.replication_controller : nil
+    rescue KubeException => e
+      if e.error_code == 404
+        warn e.to_s
+        nil
+      else
+        raise
+      end
+    end
+
+    def error_notice?(reason)
+      reason == 'failed' || reason == 'failedScheduling'
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/watchers/cluster_pod_error_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/cluster_pod_error_watcher.rb
@@ -11,14 +11,14 @@ module Watchers
 
     def handle_notice(notice)
       if error_notice?(notice.object.reason)
-        rc_name = rc_name(notice.object.involvedObject)
-        publish(rc_name, notice) if rc_name
+        project_name = project_name(notice.object.involvedObject)
+        publish(project_name, notice) if project_name
       end
     end
 
-    def rc_name(involved_object)
+    def project_name(involved_object)
       pod = @client.get_pod(involved_object.name, involved_object.namespace)
-      pod.metadata.labels ? pod.metadata.labels.replication_controller : nil
+      pod.metadata.labels ? pod.metadata.labels.project : nil
     rescue KubeException => e
       if e.error_code == 404
         warn e.to_s

--- a/plugins/kubernetes/app/models/watchers/cluster_pod_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/cluster_pod_watcher.rb
@@ -1,72 +1,17 @@
-require 'celluloid/current'
-require 'celluloid/io'
-
 module Watchers
-  class ClusterPodWatcher
-    include Celluloid::IO
+  class ClusterPodWatcher < BaseClusterWatcher
     include Celluloid::Notifications
-    include Celluloid::Internals::Logger
-
-    finalizer :stop_watching
 
     def initialize(client)
-      @client = client
-      @watch_stream = nil
-      async :start_watching
-    end
-
-    def start_watching
-      info 'watcher started'
-      @watch_stream = @client.watch_pods
-      @watch_stream.each do |notice|
-        handle_notice notice
-      end
-    end
-
-    def stop_watching
-      info 'watcher stopped'
-      if @watch_stream
-        @watch_stream.finish
-        @watch_stream = nil
-      end
-    end
-
-    def self.pod_watcher_symbol(cluster)
-      "cluster_pod_watcher_#{cluster.id}".to_sym
-    end
-
-    def self.start_watcher(cluster)
-      watcher_name = pod_watcher_symbol(cluster)
-      supervise as: watcher_name, args: [cluster.client]
-    end
-
-    def self.restart_watcher(cluster)
-      watcher = Actor[pod_watcher_symbol(cluster)]
-      watcher.terminate if watcher and watcher.alive?
-      start_watcher(cluster)
+      super(client.watch_pods)
     end
 
     private
 
-    def handle_error(notice)
-      if notice.type == 'ERROR'
-        error notice.object.message
-        true
-      else
-        false
-      end
-    end
-
     def handle_notice(notice)
-      debug notice.to_s
-      return if handle_error(notice) || !notice.object.metadata.labels
-      project = notice.object.metadata.labels['project']
-      publish(project, notice) if project
-    end
-
-    %w{debug info warn error}.each do |level|
-      define_method level do |message|
-        super "#{name} -> #{message}"
+      if notice.object.metadata.labels
+        project = notice.object.metadata.labels['project']
+        publish(project, notice) if project
       end
     end
   end

--- a/plugins/kubernetes/app/models/watchers/deploy_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/deploy_watcher.rb
@@ -39,12 +39,7 @@ module Watchers
     private
 
     def handle_event_update(release_doc)
-      if release_doc.failed?
-        false # no update needed, the release has already failed
-      else
-        release_doc.update_attribute(:status, :failed)
-        true
-      end
+      release_doc.failed? ? false : release_doc.fail!
     end
 
     def handle_pod_update(release_doc, data)

--- a/plugins/kubernetes/config/initializers/watchers.rb
+++ b/plugins/kubernetes/config/initializers/watchers.rb
@@ -81,5 +81,8 @@ Celluloid.logger = Rails.logger
 $CELLULOID_DEBUG = true
 
 if ENV['SERVER_MODE'] && !ENV['PRECOMPILE']
-  Kubernetes::Cluster.all.each { |cluster| Watchers::ClusterPodWatcher::start_watcher(cluster) }
+  Kubernetes::Cluster.all.each do |cluster|
+    Watchers::ClusterPodWatcher::start_watcher(cluster)
+    Watchers::ClusterPodErrorWatcher::start_watcher(cluster)
+  end
 end


### PR DESCRIPTION
- Extracted a common base class for cluster watchers
- Created new watcher to observe pod error notices (scheduling failed, could not download Docker image, etc.)
- Added a new `failed` release status
- Added a timeout for a release
 - default 10minutes, configurable
 - if the release is not successful and no new pod has started within the timeout period, the release is considered failed

/cc @sbrnunes @henders @jonmoter 

### References
 - Jira link: 

### Risks
 - None