### PR TITLE
Skip misconfigured or manually created pods from dashboard

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes_dashboard_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_dashboard_controller.rb
@@ -23,6 +23,7 @@ class KubernetesDashboardController < ApplicationController
 
   def build_pod_info(roles, deploy_group_id, pod)
     labels = pod.metadata.labels
+    return unless labels.role_id && labels.release_id # skip misconfigured / manually created pods
 
     role = role(roles, labels.role_id)
     deploy_group = deploy_group(role[:deploy_groups], deploy_group_id)


### PR DESCRIPTION
If one pod does not have all the necessary labels we are unable to construct dashboard data for the other pods.

/cc @henders @sbrnunes @jonmoter

### References
 - Jira link: 

### Risks
 - None