### PR TITLE
Revoke project level deploy/admin access

### DIFF
--- a/app/models/project_role.rb
+++ b/app/models/project_role.rb
@@ -5,6 +5,7 @@ class ProjectRole < ActiveHash::Base
   include ActiveModel::Serializers::JSON
 
   self.data = [
+    { id: -1, name: "default" },
     { id: 0, name: "deployer" },
     { id: 1, name: "admin" }
   ]

--- a/app/models/project_role.rb
+++ b/app/models/project_role.rb
@@ -5,7 +5,7 @@ class ProjectRole < ActiveHash::Base
   include ActiveModel::Serializers::JSON
 
   self.data = [
-    { id: -1, name: "default" },
+    { id: -1, name: "viewer" },
     { id: 0, name: "deployer" },
     { id: 1, name: "admin" }
   ]

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -6,11 +6,13 @@ You can manage the roles of all your users from the 'Admin' -> 'Users' menu.
 Role | Description
 --- | ---
 Viewer | Can view all deploys.
-Deployer | Viewer + ability to deploy projects.
-Admin | Deployer + can setup and configure projects.
+Deployer | Viewer + ability to deploy all projects.
+Admin | Deployer + can setup and configure all projects.
 Super Admin | Admin + management of user roles.
 
 # Project Roles
+
+If a User has a more permissive system-level role than the project-level role, the system-level role applies.
 
 A User with system-level role 'Admin' or 'Super Admin' is able to manage the access rights for other Users on specific
 projects, including assigning other Users as admins for those projects. This project level access control can be managed
@@ -21,5 +23,6 @@ that same project. This is done through the "Users" tab on the Project settings 
 
 Project Role | Description
 --- | ---
+Viewer | Can be used to remove Deployer or Admin Project Role and rely on his system level role.
 Deployer | Can deploy a project, regardless if his system level role.
 Admin | Deployer + can setup and configure the project, regardless of his system level role.


### PR DESCRIPTION
Add a option to project level authorizations to reduce a project level authorization to below deployer.  This allows an admin to revoke a user's project level authorization without having to remove the record in the db.  