### PR TITLE
Fix for empty referer when creating access request

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -6,7 +6,7 @@ class AccessRequestsController < ApplicationController
   end
 
   def new
-    session[:access_request_back_to] ||= request.referer
+    session[:access_request_back_to] ||= request.referer || root_path
     @projects = Project.all.order(:name)
     @roles = ProjectRole.all
   end


### PR DESCRIPTION
This might happen when someone pastes a link in the browser to create an access request. Take the user to the root page in such case.

/cc @zendesk/samson

### References
 - Jira link: 

### Risks
 - None