### PR TITLE
[SAMSOM-123] make reorder work with references to deleted stages

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -28,7 +28,7 @@ class Stage < ActiveRecord::Base
   attr_writer :command
   before_save :build_new_project_command
 
-  before_soft_delete :check_stage_references
+  before_soft_delete :verify_not_part_of_pipeline
 
   def self.reorder(new_order)
     transaction do
@@ -224,14 +224,5 @@ class Stage < ActiveRecord::Base
 
   def permalink_scope
     Stage.unscoped.where(project_id: project_id)
-  end
-
-  def check_stage_references
-    project.stages.each do |s|
-      if s.next_stage_ids.include?(id)
-        errors[:base] << "Stage #{name} is referenced by another stage and cannot be deleted"
-        return false
-      end
-    end
   end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -28,8 +28,6 @@ class Stage < ActiveRecord::Base
   attr_writer :command
   before_save :build_new_project_command
 
-  before_soft_delete :verify_not_part_of_pipeline
-
   def self.reorder(new_order)
     transaction do
       new_order.each.with_index { |stage_id, index| Stage.update stage_id.to_i, order: index.to_i }

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -3,4 +3,9 @@ Stage.class_eval do
   serialize :next_stage_ids, Array
 
   validate :valid_pipeline?, if: :next_stage_ids_changed?
+
+  # duplicate call from models/stage.rb, but this is needed
+  # to load the soft delete methods
+  has_soft_deletion default_scope: true
+  before_soft_delete :verify_not_part_of_pipeline
 end

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -2,5 +2,5 @@ Stage.class_eval do
   prepend SamsonPipelines::StageConcern
   serialize :next_stage_ids, Array
 
-  validate :valid_pipeline?
+  validate :valid_pipeline?, if: :next_stage_ids_changed?
 end

--- a/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
+++ b/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
@@ -30,4 +30,16 @@ module SamsonPipelines::StageConcern
     end
     true
   end
+
+  # Make sure that this stage isn't referenced by another stage in a pipeline.
+  # This will stop soft_deletion of the stage.
+  def verify_not_part_of_pipeline
+    project.stages.each do |s|
+      if s.next_stage_ids.include?(id)
+        errors[:base] << "Stage #{name} is in a pipeline from #{s.name} and cannot be deleted"
+        return false
+      end
+    end
+    true
+  end
 end

--- a/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
+++ b/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
@@ -40,6 +40,5 @@ module SamsonPipelines::StageConcern
         return false
       end
     end
-    true
   end
 end

--- a/plugins/pipelines/test/models/stage_test.rb
+++ b/plugins/pipelines/test/models/stage_test.rb
@@ -80,8 +80,21 @@ describe Stage do
     end
 
     it 'only validates if next_stage_ids changes' do
+      Stage.any_instance.expects(:valid_pipeline?).never
       stage1.update!(order: 2)
       stage1.valid?.must_equal true
+    end
+  end
+
+  describe '#verify_not_part_of_pipeline' do
+    it 'allows soft delete if the stage is not part of a pipeline' do
+      stage1.soft_delete.must_equal true
+    end
+
+    it 'returns false if this stage is referenced by another' do
+      stage1.update!(next_stage_ids: [ stage2.id ])
+      stage2.soft_delete.must_equal false
+      stage2.errors.messages.must_equal base: ["Stage stage2 is in a pipeline from stage1 and cannot be deleted"]
     end
   end
 end

--- a/plugins/pipelines/test/models/stage_test.rb
+++ b/plugins/pipelines/test/models/stage_test.rb
@@ -78,5 +78,10 @@ describe Stage do
       stage1.valid?.must_equal false
       stage1.errors.messages.must_equal base: ["Stage stage2 causes a circular pipeline with this stage"]
     end
+
+    it 'only validates if next_stage_ids changes' do
+      stage1.update!(order: 2)
+      stage1.valid?.must_equal true
+    end
   end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -17,6 +17,31 @@ describe Stage do
     end
   end
 
+  describe '.reorder' do
+    let(:project) { projects(:test) }
+    let(:stage1) { Stage.create!(project: project, name: 'stage1', order: 1) }
+    let(:stage2) { Stage.create!(project: project, name: 'stage2', order: 2) }
+    let(:stage3) { Stage.create!(project: project, name: 'stage3', order: 3) }
+
+    it 'updates the order on stages' do
+      Stage.reorder [stage3.id, stage2.id, stage1.id]
+
+      stage1.order.must_equal 2
+      stage2.order.must_equal 1
+      stage3.order.must_equal 0
+    end
+
+    it 'succeeds even if a stages points to a deleted stage' do
+      stage1.update! next_stage_ids: [stage3.id]
+      stage3.soft_delete!
+
+      Stage.reorder [stage2.id, stage1.id]
+
+      stage1.order.must_equal 1
+      stage2.order.must_equal 0
+    end
+  end
+
   describe '#command' do
     describe 'adding a built command' do
       before do

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -26,9 +26,9 @@ describe Stage do
     it 'updates the order on stages' do
       Stage.reorder [stage3.id, stage2.id, stage1.id]
 
-      stage1.order.must_equal 2
-      stage2.order.must_equal 1
-      stage3.order.must_equal 0
+      stage1.reload.order.must_equal 2
+      stage2.reload.order.must_equal 1
+      stage3.reload.order.must_equal 0
     end
 
     it 'succeeds even if a stages points to a deleted stage' do
@@ -37,8 +37,8 @@ describe Stage do
 
       Stage.reorder [stage2.id, stage1.id]
 
-      stage1.order.must_equal 1
-      stage2.order.must_equal 0
+      stage1.reload.order.must_equal 1
+      stage2.reload.order.must_equal 0
     end
   end
 


### PR DESCRIPTION
Only check for circular pipelines when next_stage_ids is changed and only allow soft_delete if the stage is not referenced by any other stage

/cc @steved @grosser @jonmoter 

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-123

### Risks
 - Low. Circular pipeline check only runs in limited cases now. 