### PR TITLE
Fixing some project access rights

### DIFF
--- a/app/views/deploys/_buddy_check.html.erb
+++ b/app/views/deploys/_buddy_check.html.erb
@@ -9,7 +9,7 @@
       or
       <%= link_to "Bypass", buddy_check_project_deploy_path(@project, @deploy), method: :post, class: "btn btn-danger" %>
     </div>
-  <% elsif current_user.is_deployer? %>
+  <% elsif is_user_deployer_for_project? %>
     <p>This deploy requires a buddy.</p>
     <div class="buddy-approval">
       <%= link_to "Approve", buddy_check_project_deploy_path(@project, @deploy), method: :post, class: "btn btn-primary btn-xl" %>

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -2,7 +2,7 @@
   <%= @project.name %>
 
   <div class="pull-right">
-    <% if current_user.is_deployer? %>
+    <% if is_user_deployer_for_project? %>
       <% unless @deploy.succeeded? || @deploy.active? %>
         <%= link_to "Redeploy", project_stage_deploys_path(@project, @deploy.stage, deploy: { reference: @deploy.reference }), method: :post, class: "btn btn-danger" %>
       <% end %>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -20,7 +20,7 @@
     <% end %>
   </td>
   <td>
-    <% if current_user.is_deployer? %>
+    <% if is_user_deployer_for_project? %>
       <%= render 'deploy_to_button', release: release, stages: @stages %>
     <% end %>
   </td>


### PR DESCRIPTION
When the project access right were introduced, allowing Users with system level Viewer access to have special permissions on certain projects, a couple of places were missed, including in the buddy check feature.

/cc @zendesk/samson

### Steps to reproduce
Start a deploy to production. The deploy screen should display the buddy check request.

### Risks
 - None