### PR TITLE
Parse alternate style markdown headers for risks section

### DIFF
--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -3,8 +3,8 @@ class Changeset::PullRequest
   CODE_ONLY = "[A-Z][A-Z\\d]+-\\d+"  # e.g., S4MS0N-123, SAM-456
   PUNCT = "\\s|\\p{Punct}|~|="
 
-  # Matches a section heading named "Risks".
-  RISKS_SECTION = /#+\s+Risks.*\n/i
+  # Matches a markdown section heading named "Risks".
+  RISKS_SECTION = /^\s*#*\s*Risks?\s*#*\s*\n(?:\s*[-=]*\s*\n)?/i
 
   # Matches URLs to JIRA issues.
   JIRA_ISSUE_URL = %r[https?:\/\/[\da-z\.\-]+\.[a-z\.]{2,6}\/browse\/#{CODE_ONLY}(?=#{PUNCT}|$)]
@@ -62,7 +62,7 @@ class Changeset::PullRequest
 
   def risks
     return @risks if defined?(@risks)
-    @risks = @data.body.to_s.split(RISKS_SECTION, 2)[1].to_s.strip.presence
+    @risks = parse_risks(@data.body.to_s)
     @risks = nil if @risks =~ /\A\s*\-?\s*None\Z/i
     @risks
   end
@@ -72,6 +72,10 @@ class Changeset::PullRequest
   end
 
   private
+
+  def parse_risks(body)
+    body.to_s.split(RISKS_SECTION, 2)[1].to_s.strip.presence
+  end
 
   def parse_jira_issues
     custom_jira_url = ENV['JIRA_BASE_URL']

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -310,6 +310,23 @@ describe Changeset::PullRequest do
       pr.risks.must_equal nil
     end
 
+    it "finds risks with underline style markdown headers" do
+      body.replace(<<-BODY.strip_heredoc)
+        Risks
+        =====
+          - Snakes
+      BODY
+      pr.risks.must_equal "- Snakes"
+    end
+
+    it "finds risks with closing hashes in atx style markdown headers" do
+      body.replace(<<-BODY.strip_heredoc)
+        ## Risks ##
+          - Planes
+      BODY
+      pr.risks.must_equal "- Planes"
+    end
+
     context "with nothing risky" do
       before { no_risks }
 


### PR DESCRIPTION
Currently, risks only show up if they are using hash-style headers,
e.g. `## Risks`. Markdown also specifies underline style, which is
useful for certain unixy environments which treat # as a comment-beginning
character and would otherwise ignore the heading, such as when creating
PRs using github's `hub` tool. This alternate style of headers looks like

```md
Heading 1
----

Heading 2
====
```

This PR updates samson to parse the risks section regardless of heading style.

Required
======
- [ ] Approval of @zendesk/samson

Risks
=====
- None