### PR TITLE
put new stages at the back, they are usually just 1-off spam

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -26,6 +26,7 @@ class Stage < ActiveRecord::Base
   accepts_nested_attributes_for :new_relic_applications, allow_destroy: true, reject_if: :no_newrelic_name?
 
   attr_writer :command
+  before_create :ensure_ordering
   before_save :build_new_project_command
 
   def self.reorder(new_order)
@@ -222,5 +223,10 @@ class Stage < ActiveRecord::Base
 
   def permalink_scope
     Stage.unscoped.where(project_id: project_id)
+  end
+
+  def ensure_ordering
+    return unless project
+    self.order = project.stages.maximum(:order).to_i + 1
   end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -377,7 +377,7 @@ describe Stage do
     end
   end
 
-  describe 'production flag' do
+  describe '#production?' do
     let(:stage) { stages(:test_production) }
     before { DeployGroup.stubs(:enabled?).returns(true) }
 
@@ -425,6 +425,13 @@ describe Stage do
       stage.save
       stage_updated_at.wont_equal stage.updated_at
       project_updated_at.wont_equal stage.project.updated_at
+    end
+  end
+
+  describe "#ensure_ordering" do
+    it "puts new stages to the back" do
+      new = stage.project.stages.create! name: 'Newish'
+      new.order.must_equal 1
     end
   end
 end


### PR DESCRIPTION
ops creates a new podX stage to deploy something new and it messes up the natural order of stages ... lets avoid that ...

@zendesk/runway 

### Risks
 - None