### PR TITLE
sort often used commands to the front

### DIFF
--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -14,7 +14,9 @@ class Command < ActiveRecord::Base
 
   # own commands in front then all available
   def self.for_object(object)
-    (object.commands + Command.for_project(object.project)).uniq
+    usages = usage_ids
+    available = Command.for_project(object.project).sort_by { |c| -usages.count(c.id) }
+    (object.commands + available).uniq
   end
 
   def self.for_project(project)

--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -12,8 +12,17 @@ class Command < ActiveRecord::Base
     where(project_id: nil)
   end
 
+  # own commands in front then all available
+  def self.for_object(object)
+    (object.commands + Command.for_project(object.project)).uniq
+  end
+
   def self.for_project(project)
-    where('project_id IS NULL OR project_id = ?', project.id)
+    if project && project.persisted?
+      where('project_id IS NULL OR project_id = ?', project.id)
+    else
+      global
+    end
   end
 
   def global?

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -24,16 +24,6 @@ class Macro < ActiveRecord::Base
     end
   end
 
-  def all_commands
-    command_scope = Command.for_project(project)
-
-    if command_ids.any?
-      command_scope = command_scope.where(['id NOT in (?)', command_ids])
-    end
-
-    commands + command_scope
-  end
-
   private
 
   def reorder_commands(command_ids = self.command_ids)

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -133,16 +133,6 @@ class Stage < ActiveRecord::Base
     end
   end
 
-  def all_commands
-    command_scope = project ? Command.for_project(project) : Command.global
-
-    if command_ids.any?
-      command_scope = command_scope.where(['id NOT in (?)', command_ids])
-    end
-
-    commands + command_scope
-  end
-
   def datadog_tags_as_array
     datadog_tags.to_s.split(";").map(&:strip)
   end

--- a/app/views/macros/_fields.html.erb
+++ b/app/views/macros/_fields.html.erb
@@ -18,7 +18,7 @@
   <legend>Commands</legend>
 
   <div id="commands">
-    <%= form.collection_check_boxes(:command_ids, form.object.all_commands, :id, :command) do |b| %>
+    <%= form.collection_check_boxes(:command_ids, Command.for_object(form.object), :id, :command) do |b| %>
       <div class="row stage-bar bar">
         <div data-id="<%= b.value %>" class="col-lg-offset-2 col-lg-2 command-checkbox">
           <%= b.check_box %>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -69,7 +69,7 @@
 
   <div id="commands">
     <% usage_ids = Command.usage_ids %>
-    <%= form.collection_check_boxes(:command_ids, form.object.all_commands, :id, :command) do |b| %>
+    <%= form.collection_check_boxes(:command_ids, Command.for_object(form.object), :id, :command) do |b| %>
       <% command = b.object %>
       <% others = usage_ids.count(command.id) - (b.check_box.include?('checked') ? 1 : 0) %>
       <% others_warning = "#{others} others" if others > 0 %>

--- a/test/models/command_test.rb
+++ b/test/models/command_test.rb
@@ -2,6 +2,8 @@ require_relative '../test_helper'
 
 describe Command do
   describe '.for_object' do
+    let(:stage) { stages(:test_staging) }
+
     it "shows global for new stage" do
       Command.for_object(Stage.new).must_equal Command.global
     end
@@ -11,9 +13,20 @@ describe Command do
     end
 
     it "sorts own commands in front" do
-      stage = stages(:test_staging)
+      stage.commands.size.must_be :>=, 1
       Command.for_object(stage).must_equal(
         stage.commands + (Command.global - stage.commands)
+      )
+    end
+
+    it "sorts highly used commands to the front" do
+      command = Command.create!(command: 'new')
+      (Stage.all - [stage]).each do |stage|
+        StageCommand.create!(stage: stage, command: command)
+      end
+
+      Command.for_object(stage).must_equal(
+        stage.commands + [command] + (Command.global - stage.commands - [command])
       )
     end
   end

--- a/test/models/command_test.rb
+++ b/test/models/command_test.rb
@@ -1,0 +1,20 @@
+require_relative '../test_helper'
+
+describe Command do
+  describe '.for_object' do
+    it "shows global for new stage" do
+      Command.for_object(Stage.new).must_equal Command.global
+    end
+
+    it "shows global for new stage with new project" do
+      Command.for_object(Stage.new(project: Project.new)).must_equal Command.global
+    end
+
+    it "sorts own commands in front" do
+      stage = stages(:test_staging)
+      Command.for_object(stage).must_equal(
+        stage.commands + (Command.global - stage.commands)
+      )
+    end
+  end
+end

--- a/test/models/macro_test.rb
+++ b/test/models/macro_test.rb
@@ -26,25 +26,4 @@ describe Macro do
       end
     end
   end
-
-  describe '#all_commands' do
-    describe 'with commands' do
-      before do
-        Command.create!(command: 'test')
-      end
-
-      it 'includes all commands, sorted' do
-        subject.all_commands.must_equal(subject.commands + Command.global)
-      end
-    end
-
-    describe 'no commands' do
-      let(:project) { projects(:test) }
-      subject { project.macros.build }
-
-      it 'includes all commands' do
-        subject.all_commands.must_equal(Command.for_project(project))
-      end
-    end
-  end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -174,35 +174,6 @@ describe Stage do
     end
   end
 
-  describe '#all_commands' do
-    describe 'with commands' do
-      before do
-        Command.create!(command: 'test')
-      end
-
-      it 'includes all commands, sorted' do
-        subject.all_commands.must_equal(subject.commands + Command.global)
-      end
-    end
-
-    describe 'no commands' do
-      let(:project) { projects(:test) }
-      subject { project.stages.build }
-
-      it 'includes all commands' do
-        subject.all_commands.must_equal(Command.for_project(project))
-      end
-    end
-
-    describe 'no project' do
-      subject { Stage.new }
-
-      it 'includes all commands' do
-        subject.all_commands.must_equal(Command.global)
-      end
-    end
-  end
-
   describe 'unlocked_for/locked?/locked_for?' do
     describe 'with a lock' do
       before do


### PR DESCRIPTION
we have lots of commands and we should encourage reused -> often used goes to the top and unused can slowly fade away ...

@zendesk/runway 

<img width="857" alt="screen shot 2016-01-28 at 8 31 05 pm" src="https://cloud.githubusercontent.com/assets/11367/12667290/39e52cc2-c5fe-11e5-8fd1-fa7cf697c47a.png">

### Risks
 - None