### PR TITLE
new header + corrected clone counters

### DIFF
--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -71,7 +71,7 @@
     <% usage_ids = Command.usage_ids %>
     <%= form.collection_check_boxes(:command_ids, form.object.all_commands, :id, :command) do |b| %>
       <% command = b.object %>
-      <% others = usage_ids.count(command.id) - (b.check_box.include?('checked') ? 1 : 0) %>
+      <% others = usage_ids.count(command.id) - (b.check_box.include?('checked') && form.object.persisted? ? 1 : 0) %>
       <% others_warning = "#{others} others" if others > 0 %>
 
       <div class="row stage-bar bar">

--- a/app/views/stages/new.html.erb
+++ b/app/views/stages/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Add a stage to <%= @project.name %></h1>
+<%= breadcrumb @project, "New Stage" %>
 
 <section>
   <%= render 'form', project: @project, stage: @stage %>


### PR DESCRIPTION
New and clone previously had no link back to the project ... bring them in line with show and edit:
<img width="662" alt="screen shot 2016-02-03 at 1 54 14 pm" src="https://cloud.githubusercontent.com/assets/11367/12798531/d1311d28-ca7e-11e5-9d9d-7562a317bd00.png">

Clone has pre-checked checkboxes, so 1 was subtracted from the commands usage count, which means you could inline edit commands without any warning even though it was used by the cloned stage.

<img width="1064" alt="screen shot 2016-02-03 at 1 59 54 pm" src="https://cloud.githubusercontent.com/assets/11367/12798534/d69b8c80-ca7e-11e5-82f2-fa95c7f666e4.png">

@zendesk/runway 

### Risks
 - None
