### PR TITLE
allow bypass buddy check

### DIFF
--- a/app/controllers/concerns/stage_permitted_params.rb
+++ b/app/controllers/concerns/stage_permitted_params.rb
@@ -11,6 +11,7 @@ module StagePermittedParams
         :email_committers_on_automated_deploy_failure,
         :static_emails_on_automated_deploy_failure,
         :use_github_deployment_api,
+        :bypass_buddy_check,
         deploy_group_ids: [],
         command_ids: [],
         new_relic_applications_attributes: [:id, :name, :_destroy]

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -22,6 +22,7 @@ class Stage < ActiveRecord::Base
   default_scope { order(:order) }
 
   validates :name, presence: true, uniqueness: { scope: [:project, :deleted_at] }
+  validate :validate_bypass_used_correctly
 
   accepts_nested_attributes_for :new_relic_applications, allow_destroy: true, reject_if: :no_newrelic_name?
 
@@ -218,5 +219,11 @@ class Stage < ActiveRecord::Base
   def ensure_ordering
     return unless project
     self.order = project.stages.maximum(:order).to_i + 1
+  end
+
+  def validate_bypass_used_correctly
+    if bypass_buddy_check? && !production?
+      errors.add(:bypass_buddy_check, 'makes no sense when set but not being in production')
+    end
   end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -155,7 +155,7 @@ class Stage < ActiveRecord::Base
   end
 
   def deploy_requires_approval?
-    BuddyCheck.enabled? && production?
+    BuddyCheck.enabled? && !bypass_buddy_check? && production?
   end
 
   def automated_failure_emails(deploy)

--- a/app/views/deploy_groups/_deploy_group_select.html.erb
+++ b/app/views/deploy_groups/_deploy_group_select.html.erb
@@ -46,3 +46,16 @@
     <% end %>
   </div>
 </div>
+
+<% if BuddyCheck.enabled? %>
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+      <div class="checkbox">
+        <%= form.label :bypass_buddy_check do %>
+          <%= form.check_box :bypass_buddy_check %>
+          Bypass buddy check
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/deploy_groups/_deploy_group_select.html.erb
+++ b/app/views/deploy_groups/_deploy_group_select.html.erb
@@ -53,7 +53,7 @@
       <div class="checkbox">
         <%= form.label :bypass_buddy_check do %>
           <%= form.check_box :bypass_buddy_check %>
-          Bypass buddy check
+          Bypass buddy check (Does not deploy code)
         <% end %>
       </div>
     </div>

--- a/db/migrate/20160205015635_add_bypass_buddy_check_to_stages.rb
+++ b/db/migrate/20160205015635_add_bypass_buddy_check_to_stages.rb
@@ -1,0 +1,5 @@
+class AddBypassBuddyCheckToStages < ActiveRecord::Migration
+  def change
+    add_column :stages, :bypass_buddy_check, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151211031950) do
+ActiveRecord::Schema.define(version: 20160205015635) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -353,6 +353,7 @@ ActiveRecord::Schema.define(version: 20151211031950) do
     t.string   "datadog_monitor_ids",                          limit: 255
     t.string   "jenkins_job_names",                            limit: 255
     t.string   "next_stage_ids"
+    t.boolean  "bypass_buddy_check",                                         default: false
   end
 
   add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", length: {"project_id"=>nil, "permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -438,4 +438,28 @@ describe Stage do
       new.order.must_equal 1
     end
   end
+
+  describe "#ensure_valid_bypass" do
+    before { stage.deploy_groups.clear }
+
+    it "is valid when not production and not bypassed" do
+      assert_valid stage
+    end
+
+    it "is valid when production and not bypassed" do
+      stage.production = true
+      assert_valid stage
+    end
+
+    it "is valid when production and bypassed" do
+      stage.production = true
+      stage.bypass_buddy_check = true
+      assert_valid stage
+    end
+
+    it "invalid when not production and bypassed" do
+      stage.bypass_buddy_check = true
+      refute_valid stage
+    end
+  end
 end


### PR DESCRIPTION
some stages need to be deployed automatically or do not affect production code (like check or deploy artifact construction) so having a straight forward way of disabling the buddy check would be great since it would stop the practice of not picking any deploy group, which hurts documentation and command reuse

@zendesk/runway @steved 

<img width="569" alt="screen shot 2016-02-04 at 6 03 55 pm" src="https://cloud.githubusercontent.com/assets/11367/12836022/e7166350-cb69-11e5-9198-a9e1cfd8741c.png">

### Risks
 - None