### PR TITLE
Remove CR in CRLF line endings

### DIFF
--- a/app/models/terminal_output_scanner.rb
+++ b/app/models/terminal_output_scanner.rb
@@ -26,7 +26,8 @@ class TerminalOutputScanner
   private
 
   def write(data)
-    data.scrub.scan(/\r?[^\r]*/).each do |part|
+    clean_data = data.scrub.gsub("\r\n", "\n")
+    clean_data.scan(/\r?[^\r]*/).each do |part|
       next if part == ''
       write_part(part)
     end

--- a/test/models/terminal_output_scanner_test.rb
+++ b/test/models/terminal_output_scanner_test.rb
@@ -42,6 +42,11 @@ describe TerminalOutputScanner do
     tokens.must_equal [[:append, "foobar\n"]]
   end
 
+  it "behaves well with carriage return + newlines" do
+    output("foo\r\n")
+    tokens.must_equal [[:append, "foo\n"]]
+  end
+
   it 'can handle an invalid UTF-8 character' do
     output("invalid char\255\n")
     tokens.must_equal [[:append, "invalid char�\n"]]


### PR DESCRIPTION
Without this change, a CRLF line ending would cause two tokens to be created (one for the line, and one for the LF). With this change, that same line creates just one token.

In the EventStream that my browser is currently receiving from Samson, every second line reads “append `{"msg":"<span class=\"ansible_none\">\n</span>"}`”. Since following the deploy log on large deploys is rather slow, I’d prefer to receive fewer events. Say, around 50% :-)

cc @henders @steved @jonmoter 