### PR TITLE
Reduce the frequency of output sampling

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -45,7 +45,7 @@ class TerminalExecutor
     end
 
     begin
-      output.each(56) {|line| @output.write(line) }
+      output.each(256) {|line| @output.write(line) }
     rescue Errno::EIO
       # The IO has been closed.
     end


### PR DESCRIPTION
When executing a command we sample the output streams, reading N bytes at a time. Before, the somewhat low value of N caused a very high number of output messages to be propagated through the system, slowing things down. By increasing N we reduce the message throughput.