### PR TITLE
[INFR-1683] pass env vars to Docker build container

### DIFF
--- a/plugins/docker_binary_builder/README.md
+++ b/plugins/docker_binary_builder/README.md
@@ -24,6 +24,8 @@ If the directory '/opt/samson_build_cache' exists on the Docker host, it will mo
 docker build image. That way you could then instruct Maven to use '/build/cache/.m2' as the cache directory for all your 
 projects.
 
+The build container will also receive all global (`All` selected in the env var's combo box) environment variables that are configured for a project, assuming the `env` plugin is enabled.
+
 ## Example Setup
 
 'Dockerfile' contents

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -77,7 +77,8 @@ class BinaryBuilder
   def create_container_options
     options = {
       'Cmd' => [BUILD_SCRIPT],
-      'Image' => image_name
+      'Image' => image_name,
+      'Env' => env_vars_for_project
     }
 
     # Mount a cache directory for sharing .m2, .ivy2, .bundler directories between build containers.
@@ -132,5 +133,13 @@ class BinaryBuilder
 
   def docker_api_version
     @docker_api_version ||= Docker.version['ApiVersion']
+  end
+
+  def env_vars_for_project
+    if defined?(EnvironmentVariable) # make sure 'env' plugin is enabled
+      EnvironmentVariable.env(@project, nil).map { |name, value| "#{name}=#{value}" }
+    else
+      []
+    end
   end
 end

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -48,6 +48,7 @@ describe BinaryBuilder do
         {
           'Cmd' => ['/app/build.sh'],
           'Image' => 'foo_build:abc-19f',
+          'Env' => [],
           'Volumes' => { '/opt/samson_build_cache' => {} },
           'HostConfig' => {
             'Binds' => ['/opt/samson_build_cache:/build/cache'],
@@ -63,6 +64,7 @@ describe BinaryBuilder do
         {
           'Cmd' => ['/app/build.sh'],
           'Image' => 'foo_build:abc-19f',
+          'Env' => [],
           'Mounts' => [
             {
               'Source' => '/opt/samson_build_cache',
@@ -76,6 +78,14 @@ describe BinaryBuilder do
           }
         }
       )
+    end
+
+    it 'sets up global environment variables for the build container' do
+      project.environment_variables.create!(name: 'FIRST', value: 'first')
+      project.environment_variables.create!(name: 'SECOND', value: 'second')
+      project.environment_variables.create!(name: 'THIRD', value: 'third',
+                                            scope_type: 'Environment', scope_id: environments(:production).id)
+      builder.send(:create_container_options)['Env'].must_equal %w(FIRST=first SECOND=second)
     end
 
     it 'throws exception with api < 1.15' do


### PR DESCRIPTION
Pass environment variables configured for a project to the build container.

This PR is just a first naive approach and all comments and suggestions are welcome.

Open issues and considerations:
- With this PR `docker_binary_builder` plugin now depends on `env` plugin, though the builds should still work even if the `env` plugin is not enabled, no env vars will be passed in such scenario.
- We are passing project level env vars, because it is possible to spin up a build outside a deploy with no environment / stage / deploy group associated.
- We will pass in **all global** environment variables configured for a project (configured for all environments and stages)

/cc @zendesk/samson @andreionut @fneves @henders 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/INFR-1683

### Risks
- Level: Low