### PR TITLE
show deploy groups when they are set

### DIFF
--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -38,6 +38,13 @@
   <h2>Command</h2>
   <pre class="pre-command"><%= @stage.command %></pre>
 
+  <% if groups = @stage.deploy_groups.to_a.presence %>
+    <h2>Deploy groups</h2>
+    <% groups.each do |group| %>
+      <%= link_to group.name, group %>
+    <% end %>
+  <% end %>
+
   <h2>Recent deploys</h2>
   <table class="table">
     <thead>


### PR DESCRIPTION
Makes it obvious where the deploy is going / if $DEPLOY_GROUPS is set up correctly,
same info as shown on index

@zendesk/runway 

<img width="871" alt="screen shot 2016-03-02 at 5 17 19 pm" src="https://cloud.githubusercontent.com/assets/11367/13481449/a583818e-e09a-11e5-8afe-6b16c7155c7c.png">



### Risks
- None

