### PR TITLE
remove and restore StageCommands so usage numbers match on admin/comm…

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -11,7 +11,7 @@ class Stage < ActiveRecord::Base
 
   has_one :lock
 
-  has_many :stage_commands, autosave: true
+  has_many :stage_commands, autosave: true, dependent: :destroy
   has_many :commands,
     -> { order('stage_commands.position ASC') },
     through: :stage_commands, auto_include: false

--- a/app/models/stage_command.rb
+++ b/app/models/stage_command.rb
@@ -1,4 +1,6 @@
 class StageCommand < ActiveRecord::Base
+  has_soft_deletion default_scope: true
+
   belongs_to :stage
   belongs_to :command, autosave: true
 end

--- a/db/migrate/20160316233616_soft_delete_stage_command.rb
+++ b/db/migrate/20160316233616_soft_delete_stage_command.rb
@@ -1,0 +1,9 @@
+class SoftDeleteStageCommand < ActiveRecord::Migration
+  def change
+    add_column :stage_commands, :deleted_at, :timestamp
+
+    # Mark all old StageCommand as deleted
+    deleted_stages = Stage.with_deleted { Stage.where('deleted_at IS NOT NULL').pluck(:id) }
+    StageCommand.where(stage_id: deleted_stages).update_all(deleted_at: Time.now)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160205015635) do
+ActiveRecord::Schema.define(version: 20160316233616) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -329,6 +329,7 @@ ActiveRecord::Schema.define(version: 20160205015635) do
     t.integer  "position",   limit: 4, default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "deleted_at"
   end
 
   create_table "stages", force: :cascade do |t|

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -462,4 +462,16 @@ describe Stage do
       refute_valid stage
     end
   end
+
+  describe "#destroy" do
+    it "soft deletes all it's StageCommand" do
+      assert_difference "StageCommand.count", -1 do
+        stage.soft_delete!
+      end
+
+      assert_difference "StageCommand.count", +1 do
+        stage.soft_undelete!
+      end
+    end
+  end
 end


### PR DESCRIPTION
…ands and commands/edit

atm admins/commands shows that a command is used, but clicking on edit shows no usage ...

![screen shot 2016-03-16 at 4 43 52 pm](https://cloud.githubusercontent.com/assets/11367/13832123/560a1ad0-eb96-11e5-8621-fc554636e205.png)

@zendesk/runway 

### Risks
- Level: Low ... when a command is deleted restoring the stage would result in an invalid StageCommand

