### PR TITLE
sort project select and allow to search for global commands

### DIFF
--- a/app/controllers/admin/commands_controller.rb
+++ b/app/controllers/admin/commands_controller.rb
@@ -13,6 +13,7 @@ class Admin::CommandsController < ApplicationController
       end
 
       if project_id = search[:project_id].presence
+        project_id = nil if project_id == 'global'
         @commands = @commands.where(project_id: project_id)
       end
     end

--- a/app/views/admin/commands/index.html.erb
+++ b/app/views/admin/commands/index.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="col-sm-3">
     <%= label_tag "Project" %><br/>
-    <% options = options_for_select(Project.pluck(:name, :id), params[:search].try(:[], :project_id)) %>
+    <% options = options_for_select([['Global', 'global']] + Project.order('name asc').pluck(:name, :id), params[:search].try(:[], :project_id)) %>
     <%= select_tag 'search[project_id]', options, include_blank: "All", class: "form-control", style: "background-color: white; width: 100%; height: 35px" %>
   </div>
   <div class="col-sm-2">

--- a/test/controllers/admin/commands_controller_test.rb
+++ b/test/controllers/admin/commands_controller_test.rb
@@ -3,19 +3,28 @@ require_relative '../../test_helper'
 describe Admin::CommandsController do
   as_a_admin do
     describe 'GET to #index' do
+      let(:echo) { commands(:echo) }
+      let(:global) { commands(:global) }
+
       it 'renders template' do
         get :index
         assert_template :index
+        assigns[:commands].sort_by(&:id).must_equal [global, echo].sort_by(&:id)
       end
 
       it 'can filter by words' do
         get :index, search: {query: 'echo'}
-        assigns[:commands].must_equal [commands(:echo)]
+        assigns[:commands].must_equal [echo]
       end
 
       it 'can filter by project_id' do
-        get :index, search: {project_id: commands(:echo).project_id}
-        assigns[:commands].must_equal [commands(:echo)]
+        get :index, search: {project_id: echo.project_id}
+        assigns[:commands].must_equal [echo]
+      end
+
+      it 'can filter by global' do
+        get :index, search: {project_id: 'global'}
+        assigns[:commands].must_equal [global]
       end
     end
 


### PR DESCRIPTION
@zendesk/runway 

<img width="283" alt="screen shot 2016-03-16 at 9 06 31 pm" src="https://cloud.githubusercontent.com/assets/11367/13836163/b62db3fc-ebbb-11e5-9430-3d855ab03b4d.png">


### Risks
- None

