### PR TITLE
INFR-1737 no-release stages do not produce releases / are invisible from dashbo…

### DIFF
--- a/app/controllers/concerns/stage_permitted_params.rb
+++ b/app/controllers/concerns/stage_permitted_params.rb
@@ -11,7 +11,7 @@ module StagePermittedParams
         :email_committers_on_automated_deploy_failure,
         :static_emails_on_automated_deploy_failure,
         :use_github_deployment_api,
-        :bypass_buddy_check,
+        :no_code_deployed,
         deploy_group_ids: [],
         command_ids: [],
         new_relic_applications_attributes: [:id, :name, :_destroy]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -129,7 +129,7 @@ class Project < ActiveRecord::Base
 
   def deploys_by_group(before)
     stages.each_with_object({}) do |stage, result|
-      if deploy = stage.deploys.successful.where("deploys.updated_at <= ?", before.to_s(:db)).first
+      if deploy = stage.deploys.successful.where(release: true).where("deploys.updated_at <= ?", before.to_s(:db)).first
         stage.deploy_groups.each do |deploy_group|
           result[deploy_group.id] ||= []
           result[deploy_group.id] << deploy
@@ -155,7 +155,7 @@ class Project < ActiveRecord::Base
           log.error("Could not clone git repository #{repository_url} for project #{name} - #{output.string}") unless is_cloned
         end
       rescue => e
-       alert_clone_error!(e)
+        alert_clone_error!(e)
       end
     end
   end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -98,7 +98,7 @@ class Stage < ActiveRecord::Base
   end
 
   def create_deploy(user, attributes = {})
-    deploys.create(attributes) do |deploy|
+    deploys.create(attributes.merge(release: !bypass_buddy_check)) do |deploy|
       deploy.build_job(project: project, user: user, command: command)
     end
   end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -98,7 +98,7 @@ class Stage < ActiveRecord::Base
   end
 
   def create_deploy(user, attributes = {})
-    deploys.create(attributes.merge(release: !bypass_buddy_check)) do |deploy|
+    deploys.create(attributes.merge(release: !no_code_deployed)) do |deploy|
       deploy.build_job(project: project, user: user, command: command)
     end
   end
@@ -156,7 +156,7 @@ class Stage < ActiveRecord::Base
   end
 
   def deploy_requires_approval?
-    BuddyCheck.enabled? && !bypass_buddy_check? && production?
+    BuddyCheck.enabled? && !no_code_deployed? && production?
   end
 
   def automated_failure_emails(deploy)
@@ -222,8 +222,8 @@ class Stage < ActiveRecord::Base
   end
 
   def validate_bypass_used_correctly
-    if bypass_buddy_check? && !production?
-      errors.add(:bypass_buddy_check, 'makes no sense when set but not being in production')
+    if no_code_deployed? && !production?
+      errors.add(:no_code_deployed, 'makes no sense when set but not being in production')
     end
   end
 end

--- a/app/views/deploy_groups/_deploy_group_select.html.erb
+++ b/app/views/deploy_groups/_deploy_group_select.html.erb
@@ -53,7 +53,7 @@
       <div class="checkbox">
         <%= form.label :bypass_buddy_check do %>
           <%= form.check_box :bypass_buddy_check %>
-          Bypass buddy check (Does not deploy code)
+          Does not deploy code <abbr title="Bypass buddy check and release tracking">?</abbr>
         <% end %>
       </div>
     </div>

--- a/app/views/deploy_groups/_deploy_group_select.html.erb
+++ b/app/views/deploy_groups/_deploy_group_select.html.erb
@@ -47,15 +47,14 @@
   </div>
 </div>
 
-<% if BuddyCheck.enabled? %>
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <div class="checkbox">
-        <%= form.label :bypass_buddy_check do %>
-          <%= form.check_box :bypass_buddy_check %>
-          Does not deploy code <abbr title="Bypass buddy check and release tracking">?</abbr>
-        <% end %>
-      </div>
+<div class="form-group">
+  <div class="col-sm-offset-2 col-sm-10">
+    <div class="checkbox">
+      <%= form.label :no_code_deployed do %>
+        <%= form.check_box :no_code_deployed %>
+        <% details = "Bypass " + [("buddy check" if BuddyCheck.enabled?), "release tracking"].compact.to_sentence %>
+        Does not deploy code <abbr title="<%= details %>">?</abbr>
+      <% end %>
     </div>
   </div>
-<% end %>
+</div>

--- a/db/migrate/20160317212902_add_release_flag_to_deploys.rb
+++ b/db/migrate/20160317212902_add_release_flag_to_deploys.rb
@@ -1,0 +1,6 @@
+class AddReleaseFlagToDeploys < ActiveRecord::Migration
+  def change
+    add_column :deploys, :release, :boolean, default: true, null: false
+    change_column_default :deploys, :release, false
+  end
+end

--- a/db/migrate/20160317215713_rename_bypass_buddy_check.rb
+++ b/db/migrate/20160317215713_rename_bypass_buddy_check.rb
@@ -1,0 +1,5 @@
+class RenameBypassBuddyCheck < ActiveRecord::Migration
+  def change
+    rename_column :stages, :bypass_buddy_check, :no_code_deployed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160317212902) do
+ActiveRecord::Schema.define(version: 20160317215713) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -355,7 +355,7 @@ ActiveRecord::Schema.define(version: 20160317212902) do
     t.string   "datadog_monitor_ids",                          limit: 255
     t.string   "jenkins_job_names",                            limit: 255
     t.string   "next_stage_ids"
-    t.boolean  "bypass_buddy_check",                                         default: false
+    t.boolean  "no_code_deployed",                                           default: false
   end
 
   add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", length: {"project_id"=>nil, "permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160316233616) do
+ActiveRecord::Schema.define(version: 20160317212902) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20160316233616) do
     t.datetime "started_at"
     t.datetime "deleted_at"
     t.integer  "build_id",   limit: 4
+    t.boolean  "release",                default: false, null: false
   end
 
   add_index "deploys", ["build_id"], name: "index_deploys_on_build_id", using: :btree

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -359,7 +359,8 @@ describe ProjectsController do
           stage: stages(:test_production),
           job: deploy.job,
           reference: "new",
-          updated_at: time - 1.day
+          updated_at: time - 1.day,
+          release: true
         )
         get :deploy_group_versions, id: project.to_param, before: time.to_s
         deploy_ids = JSON.parse(response.body).map { |_id, deploy| deploy['id'] }

--- a/test/fixtures/deploys.yml
+++ b/test/fixtures/deploys.yml
@@ -1,4 +1,5 @@
 succeeded_test:
+  release: true
   stage: test_staging
   job: succeeded_test
   reference: staging
@@ -7,6 +8,7 @@ succeeded_test:
   created_at: 2014-01-02 19:50:00
 
 succeeded_production_test:
+  release: true
   stage: test_production
   job: succeeded_production_test
   reference: v1.0

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -268,6 +268,12 @@ describe Project do
       deploys[pod100.id].must_be_nil
     end
 
+    it 'contains no non-releases' do
+      prod_deploy.update_column(:release, false)
+      deploys = project.last_deploy_by_group(Time.now)
+      deploys[pod1.id].must_equal nil
+    end
+
     it 'performs minimal number of queries' do
       Project.create!(name: 'blank_new_project', repository_url: url)
       assert_sql_queries 7 do

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -154,6 +154,7 @@ describe Stage do
     it "creates a new deploy" do
       deploy = subject.create_deploy(user, {reference: "foo"})
       deploy.reference.must_equal "foo"
+      deploy.release.must_equal true
     end
 
     it "creates a new job" do
@@ -165,6 +166,12 @@ describe Stage do
       assert_no_difference "Deploy.count + Job.count" do
         subject.create_deploy(user, {reference: ""})
       end
+    end
+
+    it "creates a no-release deploy when stage was configured to not deploy code" do
+      subject.bypass_buddy_check = true
+      deploy = subject.create_deploy(user, {reference: "foo"})
+      deploy.release.must_equal false
     end
   end
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -169,7 +169,7 @@ describe Stage do
     end
 
     it "creates a no-release deploy when stage was configured to not deploy code" do
-      subject.bypass_buddy_check = true
+      subject.no_code_deployed = true
       deploy = subject.create_deploy(user, {reference: "foo"})
       deploy.release.must_equal false
     end
@@ -460,12 +460,12 @@ describe Stage do
 
     it "is valid when production and bypassed" do
       stage.production = true
-      stage.bypass_buddy_check = true
+      stage.no_code_deployed = true
       assert_valid stage
     end
 
     it "invalid when not production and bypassed" do
-      stage.bypass_buddy_check = true
+      stage.no_code_deployed = true
       refute_valid stage
     end
   end


### PR DESCRIPTION
…ards

atm build stages show in the dashboards, which they should not, since they are not code releases.
This introduces a `release` flag for the deploy, so we know it is a proper code deploy and not some random other tasks like building assets

... in the next PR: kill macros and make them stages that do not generate releases

https://zendesk.atlassian.net/browse/INFR-1737

@zendesk/runway 

![screen shot 2016-03-17 at 2 28 12 pm](https://cloud.githubusercontent.com/assets/11367/13862368/154184a6-ec50-11e5-8a7d-435591d6ba9d.png)


### Risks
 - Low: deploys failing because db was not migrated
 - Low: users being confused because build stages are missing from the dashboards
