### PR TITLE
[DATAM-226]update docker binary plugin to have additional option to skip untar

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -90,6 +90,7 @@ class ProjectsController < ApplicationController
         :permalink,
         :release_branch,
         :deploy_with_docker,
+        :extract_docker_packaged_artifact,
         :auto_release_docker_image,
         stages_attributes: stage_permitted_params
       ] + Samson::Hooks.fire(:project_permitted_params)

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -59,6 +59,10 @@
           <%= form.check_box :deploy_with_docker %>
           <%= form.label :deploy_with_docker, 'Deploy with Docker' %>
         </div>
+        <div class="checkbox">
+          <%= form.check_box :extract_docker_packaged_artifact %>
+          <%= form.label :extract_docker_packaged_artifact, 'Extract the tar artifact built within Docker' %>
+        </div>
       </div>
     </div>
     <% end %>

--- a/db/migrate/20160318170635_projects_add_extract_docker_binary.rb
+++ b/db/migrate/20160318170635_projects_add_extract_docker_binary.rb
@@ -1,0 +1,5 @@
+class ProjectsAddExtractDockerBinary < ActiveRecord::Migration
+  def change
+    add_column :projects, :extract_docker_packaged_artifact, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160316233616) do
+ActiveRecord::Schema.define(version: 20160318170635) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -284,6 +284,7 @@ ActiveRecord::Schema.define(version: 20160316233616) do
     t.string   "owner",              limit: 255
     t.boolean  "deploy_with_docker",               default: false, null: false
     t.boolean  "auto_release_docker_image",        default: false, null: false
+    t.boolean  "extract_docker_packaged_artifact", default: true,  null: false
   end
 
   add_index "projects", ["permalink", "deleted_at"], name: "index_projects_on_permalink_and_deleted_at", length: {"permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -48,7 +48,7 @@ class BinaryBuilder
     artifacts_tar.close
 
     untar(artifacts_tar.path)
-    untar(File.join(@dir, ARTIFACTS_FILE))
+    untar(File.join(@dir, ARTIFACTS_FILE)) if @project.try(:extract_docker_packaged_artifact?)
   end
 
   def untar(file_path)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -119,7 +119,9 @@ describe ProjectsController do
             project: {
               name: "Hello",
               repository_url: "git://foo.com/bar",
-              stages_attributes: stage_params
+              stages_attributes: stage_params,
+              deploy_with_docker: true,
+              extract_docker_packaged_artifact: false
             }
           }
         end
@@ -131,6 +133,8 @@ describe ProjectsController do
 
         it "creates a new project" do
           project.wont_be_nil
+          project.deploy_with_docker.must_equal true
+          project.extract_docker_packaged_artifact.must_equal false
           project.stages.wont_be_empty
           project.stages.first.name.must_equal 'foobar'
           project.stages.first.deploy_group_ids.must_equal [DeployGroup.all.first.id]


### PR DESCRIPTION
:ghost:

Add a project settings on the admin screen to allow customisation of whether or not to untar the artifact binary created from docker container when using the docker binary builder plugin..

![image](https://cloud.githubusercontent.com/assets/929147/13870170/012c10a4-ed30-11e5-98c6-09372ae16890.png)

/cc @zendesk/samson, @henders, @zendesk/bunyip  

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/DATAM-226