### PR TITLE
update docker binary plugin to support running an optional script bef…

### DIFF
--- a/plugins/docker_binary_builder/README.md
+++ b/plugins/docker_binary_builder/README.md
@@ -24,7 +24,7 @@ If the directory '/opt/samson_build_cache' exists on the Docker host, it will mo
 docker build image. That way you could then instruct Maven to use '/build/cache/.m2' as the cache directory for all your 
 projects.
 
-You can also provide a script named 'pre_binary_build.sh' to be ran, before the docker binary plugin starts building the image.
+You can also provide a script named 'pre_binary_build.sh' to be ran before the docker binary plugin starts building the image.
 
 The build container will also receive all global (`All` selected in the env var's combo box) environment variables that are configured for a project, assuming the `env` plugin is enabled.
 

--- a/plugins/docker_binary_builder/README.md
+++ b/plugins/docker_binary_builder/README.md
@@ -16,13 +16,15 @@ This plugin makes a few assumptions:
 - You have a build script 'build.sh' that can be executed to compile the needed binaries
   - This is packaged inside the Dockerfile.build image and executed
   - After binaries are compiled the build.sh script finishes by tar'ing all necessary files into an 'artifacts.tar' file.
-  
+
 If you want to share caches between builds, e.g. all your projects are Java and use Maven to build, then sharing the .m2 
 directory will be a huge time saving tactic to share all downloaded dependencies.
 
 If the directory '/opt/samson_build_cache' exists on the Docker host, it will mount it to '/build/cache' inside the 
 docker build image. That way you could then instruct Maven to use '/build/cache/.m2' as the cache directory for all your 
 projects.
+
+You can also provide a script named 'pre_binary_build.sh' to be ran, before the docker binary plugin starts building the image.
 
 The build container will also receive all global (`All` selected in the env var's combo box) environment variables that are configured for a project, assuming the `env` plugin is enabled.
 

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -5,16 +5,22 @@ class BinaryBuilder
   ARTIFACTS_FILE_PATH = "/app/#{ARTIFACTS_FILE}".freeze
   DOCKER_HOST_CACHE_DIR = '/opt/samson_build_cache'.freeze
   CONTAINER_CACHE_DIR = '/build/cache'.freeze
+  TAR_LONGLINK = '././@LongLink'.freeze
+  PRE_BUILD_SCRIPT = 'pre_binary_build.sh'.freeze
 
-  def initialize(dir, project, reference, output)
+  def initialize(dir, project, reference, output, executor = nil)
     @dir = dir
     @project = project
     @git_reference = reference
     @output_stream = output
+    @executor = executor || TerminalExecutor.new(@output_stream, verbose: true)
   end
 
   def build
     return unless @project.try(:deploy_with_docker?) && File.exists?(File.join(@dir, DOCKER_BUILD_FILE))
+
+    run_pre_build_script
+
     @output_stream.puts "Connecting to Docker host with Api version: #{docker_api_version} ..."
 
     @image = create_build_image
@@ -28,6 +34,14 @@ class BinaryBuilder
     @output_stream.puts 'Cleaning up docker build image and container...'
     @container.delete(force: true) if @container
     @image.remove(force: true) if @image
+  end
+
+  def run_pre_build_script
+    file = File.join(@dir, PRE_BUILD_SCRIPT)
+    return unless File.exist?(file)
+
+    @output_stream.puts "Running pre build script..."
+    @executor.execute! file
   end
 
   private

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -38,10 +38,12 @@ class BinaryBuilder
 
   def run_pre_build_script
     file = File.join(@dir, PRE_BUILD_SCRIPT)
-    return unless File.exist?(file)
+    return unless File.file?(file)
 
     @output_stream.puts "Running pre build script..."
-    @executor.execute! file
+    success = @executor.execute! file
+
+    raise "Error running pre build script" unless success
   end
 
   private

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -6,7 +6,8 @@ describe BinaryBuilder do
     let(:dir) { '/tmp' }
     let(:reference) { 'aBc-19F' }
     let(:output) { StringIO.new }
-    let(:builder) { BinaryBuilder.new(dir, project, reference, output) }
+    let(:executor) { TerminalExecutor.new(@output_stream, verbose: true) }
+    let(:builder) { BinaryBuilder.new(dir, project, reference, output, executor) }
     let(:fake_image) { stub(remove: true) }
     let(:fake_container) { stub(delete: true, start: true, attach: true, copy: true) }
 
@@ -31,9 +32,29 @@ describe BinaryBuilder do
 
     it 'builds image if docker flag is set for project and dockerfile.build exists' do
       File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_BUILD_FILE)).returns(true)
+      File.expects(:exists?).with(File.join(dir, BinaryBuilder::PRE_BUILD_SCRIPT)).returns(false)
+      executor.expects(:execute!).with(File.join(dir, BinaryBuilder::PRE_BUILD_SCRIPT)).never
+
       project.update_attributes(deploy_with_docker: true)
       builder.build
       output.string.must_equal [
+        "Connecting to Docker host with Api version: 1.19 ...\n",
+        "Now building the build container...\n",
+        "Now starting Build container...\n",
+        "Grabbing '/app/artifacts.tar' from build container...\n",
+        "Continuing docker build...\n",
+        "Cleaning up docker build image and container...\n"].join
+    end
+
+    it 'run pre build shell script if it is available' do
+      File.expects(:exists?).with(File.join(dir, BinaryBuilder::DOCKER_BUILD_FILE)).returns(true)
+      File.expects(:exists?).with(File.join(dir, BinaryBuilder::PRE_BUILD_SCRIPT)).returns(true)
+      executor.expects(:execute!).with(File.join(dir, BinaryBuilder::PRE_BUILD_SCRIPT)).once
+
+      project.update_attributes(deploy_with_docker: true)
+      builder.build
+      output.string.must_equal [
+        "Running pre build script...\n",
         "Connecting to Docker host with Api version: 1.19 ...\n",
         "Now building the build container...\n",
         "Now starting Build container...\n",


### PR DESCRIPTION
:ghost:

Update docker binary plugin to allow an optional script to be run before starting the build of the docker image. The reason that the prebuild is required is because for building python apps with 'closed source' dependencies, pip does not work within the container as we do not have access to the closed source github repo. Thus pre build step is used for checking out the relevant dependencies on the deploy server before triggering the docker binary build.

As the pre-build script is optional, it should not affects existing projects that does not require hooking into the stage before the binary build.

/cc @zendesk/samson @zendesk/bunyip

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: 

### Risks
- Level: None
