### PR TITLE
no code deployed should be useable even when not using deploy groups

### DIFF
--- a/app/views/deploy_groups/_deploy_group_select.html.erb
+++ b/app/views/deploy_groups/_deploy_group_select.html.erb
@@ -46,15 +46,3 @@
     <% end %>
   </div>
 </div>
-
-<div class="form-group">
-  <div class="col-sm-offset-2 col-sm-10">
-    <div class="checkbox">
-      <%= form.label :no_code_deployed do %>
-        <%= form.check_box :no_code_deployed %>
-        <% details = "Bypass " + [("buddy check" if BuddyCheck.enabled?), "release tracking"].compact.to_sentence %>
-        Does not deploy code <abbr title="<%= details %>">?</abbr>
-      <% end %>
-    </div>
-  </div>
-</div>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -41,6 +41,18 @@
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <div class="checkbox">
+        <%= form.label :no_code_deployed do %>
+          <%= form.check_box :no_code_deployed %>
+          <% details = "Bypass " + [("buddy check" if BuddyCheck.enabled?), "release tracking"].compact.to_sentence %>
+          Does not deploy code <abbr title="<%= details %>">?</abbr>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+      <div class="checkbox">
         <%= form.label :confirm do %>
           <%= form.check_box :confirm %>
           Confirm before deployment


### PR DESCRIPTION
can be used to bypass the production check even when not using deploy groups

@sandlerr 