### PR TITLE
deploy button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read('.ruby-version').strip
+
 gem 'bundler', '>= 1.8.4'
 
 gem 'rails', '~> 4.2.0'

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rails s -p $PORT

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Test Coverage](https://codeclimate.com/repos/53340bef6956800b9000675c/badges/c7c44f80cff049aef8f7/coverage.svg)](https://codeclimate.com/repos/53340bef6956800b9000675c/coverage)
 [![DockerHub Status](https://img.shields.io/docker/stars/zendesk/samson.svg)](https://hub.docker.com/r/zendesk/samson)
 
+[Demo](https://samson-demo.herokuapp.com)
+
 ### What?
 
 A web interface for deployments.

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,23 @@ module Samson
 
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
-    config.cache_store = :dalli_store, { value_max_bytes: 3000000, compress: true, expires_in: 1.day }
+    servers = []
+    options = { value_max_bytes: 3000000, compress: true, expires_in: 1.day }
+
+    # support memcachier env used by heroku
+    # https://devcenter.heroku.com/articles/memcachier#rails-3-and-4
+    if ENV["MEMCACHIER_SERVERS"]
+      servers = (ENV["MEMCACHIER_SERVERS"]).split(",")
+      options.merge!(
+        username: ENV["MEMCACHIER_USERNAME"],
+        password: ENV["MEMCACHIER_PASSWORD"],
+        failover: true,
+        socket_timeout: 1.5,
+        socket_failure_delay: 0.2
+      )
+    end
+
+    config.cache_store = :dalli_store, servers, options
 
     # Allow streaming
     config.preload_frameworks = true

--- a/config/initializers/revision.rb
+++ b/config/initializers/revision.rb
@@ -1,7 +1,6 @@
 file = Rails.root.join('REVISION')
 
-Rails.application.config.samson.revision = if File.exists?(file)
-  File.read(file).chomp
-else
-  `git rev-parse HEAD`.chomp.presence
-end
+Rails.application.config.samson.revision =
+  ENV['HEROKU_SLUG_COMMIT'] || # heroku labs:enable runtime-dyno-metadata
+  (File.exists?(file) && File.read(file).chomp) || # local file
+  `git rev-parse HEAD`.chomp.presence # local git

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,11 @@
 # Be sure to restart your server when you modify this file.
 
-Samson::Application.config.session_store :cookie_store, key: '_samson_session', domain: :all
+config = Samson::Application.config
+options = {key: '_samson_session'}
+
+# when using multiple domains we have to share our cookies
+# this breaks session on heroku when using *.herokuapp.com
+used_domains = [config.samson.deploy_origin, config.samson.stream_origin, config.samson.uri.to_s]
+options[:domain] = :all if used_domains.uniq.size != 1
+
+Samson::Application.config.session_store :cookie_store, options

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -123,3 +123,5 @@ Set the following variables in your `.env` file or set them as environment varia
 </table>
 
 For more settings that enable advanced features see the [Extra features page](extra_features.md).
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)


### PR DESCRIPTION
@zendesk/samson 

can try it here ...
https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2Fzendesk%2Fsamson%2Fblob%2Fgrosser%2Fbutton%2FREADME.md&template=https%3A%2F%2Fgithub.com%2Fzendesk%2Fsamson%2Fblob%2Fgrosser%2Fbutton%2FREADME.md

(had to push app.json to master for it to work ... because heroku does not support branches with `/`


readme preview:
https://github.com/zendesk/samson/blob/grosser/button/README.md

demo: https://samson-demo.herokuapp.com/
