### PR TITLE
Use stringed keys on Github webhook data

### DIFF
--- a/app/models/changeset/code_push.rb
+++ b/app/models/changeset/code_push.rb
@@ -15,11 +15,11 @@ class Changeset::CodePush
   end
 
   def sha
-    data[:after]
+    data['after']
   end
 
   def branch
-    data[:ref][/refs\/heads\/(.+)/, 1]
+    data['ref'][/refs\/heads\/(.+)/, 1]
   end
 
   def service_type

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -13,7 +13,7 @@ class Changeset::IssueComment
 
   def self.valid_webhook?(params)
     comment = params['comment'] || {}
-    (comment['body'] =~ Changeset::PullRequest::WEBHOOK_FILTER).present?
+    !(comment['body'] =~ Changeset::PullRequest::WEBHOOK_FILTER).nil?
   end
 
   def sha

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -12,8 +12,8 @@ class Changeset::IssueComment
   end
 
   def self.valid_webhook?(params)
-    comment = params[:comment] || {}
-    comment[:body] =~ Changeset::PullRequest::WEBHOOK_FILTER
+    comment = params['comment'] || {}
+    (comment['body'] =~ Changeset::PullRequest::WEBHOOK_FILTER).present?
   end
 
   def sha

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -40,7 +40,6 @@ class Changeset::PullRequest
 
   def self.valid_webhook?(params)
     data = params['pull_request'] || {}
-    puts data.inspect
     return false unless data['state'] == 'open'
 
     (data['body'] =~ WEBHOOK_FILTER).present?

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -34,15 +34,16 @@ class Changeset::PullRequest
   end
 
   def self.changeset_from_webhook(project, params = {})
-    data = Sawyer::Resource.new(Octokit.agent, params[:pull_request])
+    data = Sawyer::Resource.new(Octokit.agent, params['pull_request'])
     new(project.github_repo, data)
   end
 
   def self.valid_webhook?(params)
-    data = params[:pull_request] || {}
-    return false unless data[:state] == 'open'
+    data = params['pull_request'] || {}
+    puts data.inspect
+    return false unless data['state'] == 'open'
 
-    data[:body] =~ WEBHOOK_FILTER
+    (data['body'] =~ WEBHOOK_FILTER).present?
   end
 
   attr_reader :repo

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -42,7 +42,7 @@ class Changeset::PullRequest
     data = params['pull_request'] || {}
     return false unless data['state'] == 'open'
 
-    (data['body'] =~ WEBHOOK_FILTER).present?
+    !(data['body'] =~ WEBHOOK_FILTER).nil?
   end
 
   attr_reader :repo

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -32,7 +32,7 @@ describe Changeset::PullRequest do
 
   describe ".changeset_from_webhook" do
     it 'finds the pull request' do
-      webhook_data = {number: 42, pull_request: {state: 'open'}}
+      webhook_data = {'number' => 42, 'pull_request' => {'state' => 'open'}}
       pr = Changeset::PullRequest.changeset_from_webhook(project, webhook_data)
 
       pr.state.must_equal 'open'


### PR DESCRIPTION
This is an attempt to properly assess the validity of a Github webhook. The added functionality was not parsing correctly due to the format of the incoming webhook data. After downloading a copy of the data from the log servers and testing locally, this was the most obvious potential problem.

@zendesk/samson

### Risks
- Level: Low
