### PR TITLE
add Job#summary_for_process

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -29,6 +29,11 @@ class Job < ActiveRecord::Base
     "#{user.name} #{summary_action} against #{short_reference}"
   end
 
+  def summary_for_process
+    t = (Time.now.to_i - start_time.to_i)
+    "ProcessID: #{pid} Running: #{t} seconds"
+  end
+
   def user
     super || NullUser.new(user_id)
   end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -27,6 +27,14 @@ describe JobsController do
         end
       end
 
+      describe 'with a running job' do
+        setup { get :show, project_id: project.to_param, id: jobs(:running_test) }
+
+        it "renders the template" do
+          assert_template :show
+        end
+      end
+
       it "fails with unknown job" do
         assert_raises ActiveRecord::RecordNotFound do
           get :show, project_id: project.to_param, id: "job:nope"

--- a/test/helpers/status_helper_test.rb
+++ b/test/helpers/status_helper_test.rb
@@ -1,0 +1,16 @@
+require_relative '../test_helper'
+
+describe StatusHelper do
+  include ERB::Util
+  include DateTimeHelper
+
+  describe "#status_panel" do
+    it "accepts a deploy" do
+      refute_nil status_panel(deploys(:succeeded_production_test))
+    end
+
+    it "accepts a job" do
+      refute_nil status_panel(jobs(:running_test))
+    end
+  end
+end


### PR DESCRIPTION
@zendesk/samson

This fixes the exception thrown when trying to view a job:
```
ActionView::Template::Error (undefined method `summary_for_process' for #<Job:0x007fa27939bed0>):
    1: <%= status_panel @job %>
  app/helpers/status_helper.rb:25:in `status_panel'
  app/views/jobs/_header.html.erb:1:in `_app_views_jobs__header_html_erb__4278462716950424045_70167894051740'
```

### Risks
Low: Continued issues with Job page

