### PR TITLE
WIP [SAMSON-218] adding stage name deploy info screens

### DIFF
--- a/app/views/projects/_deploy.html.erb
+++ b/app/views/projects/_deploy.html.erb
@@ -8,7 +8,9 @@
       <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.changeset.hotfix? %>
       <%= link_to "#{deploy.summary}", [@project || deploy.project, deploy] %>
     </td>
-    <td><%= link_to deploy.stage.name, [deploy.project, deploy.stage] %></td>
+    <% unless @stage %>
+     <td><%= link_to deploy.stage.name, [deploy.project, deploy.stage] %></td>
+    <% end %>
     <td><span class="label <%= status_label(deploy.status) %>"><%= deploy.status.titleize %></span></td>
   </tr>
 <% end %>

--- a/app/views/projects/_deploy.html.erb
+++ b/app/views/projects/_deploy.html.erb
@@ -8,6 +8,7 @@
       <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.changeset.hotfix? %>
       <%= link_to "#{deploy.summary}", [@project || deploy.project, deploy] %>
     </td>
+    <td><%= link_to deploy.stage.name, [deploy.project, deploy.stage] %></td>
     <td><span class="label <%= status_label(deploy.status) %>"><%= deploy.status.titleize %></span></td>
   </tr>
 <% end %>

--- a/app/views/projects/_deploy.html.erb
+++ b/app/views/projects/_deploy.html.erb
@@ -9,7 +9,7 @@
       <%= link_to "#{deploy.summary}", [@project || deploy.project, deploy] %>
     </td>
     <% unless @stage %>
-     <td><%= link_to deploy.stage.name, [deploy.project, deploy.stage] %></td>
+      <td><%= link_to deploy.stage.name, [deploy.project, deploy.stage] %></td>
     <% end %>
     <td><span class="label <%= status_label(deploy.status) %>"><%= deploy.status.titleize %></span></td>
   </tr>

--- a/app/views/shared/_deploys_table.html.erb
+++ b/app/views/shared/_deploys_table.html.erb
@@ -8,7 +8,9 @@
 
         <th>When</th>
         <th>Who</th>
-        <th>Stage</th>
+        <% unless @stage %>
+          <th>Stage</th>
+        <% end %>
         <th>Status</th>
         <th></th>
       </tr>

--- a/app/views/shared/_deploys_table.html.erb
+++ b/app/views/shared/_deploys_table.html.erb
@@ -8,6 +8,7 @@
 
         <th>When</th>
         <th>Who</th>
+        <th>Stage</th>
         <th>Status</th>
         <th></th>
       </tr>

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -51,6 +51,7 @@
       <tr>
         <th>When</th>
         <th>Who</th>
+        <th>Stage</th>
         <th>Status</th>
       </tr>
     </thead>

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -51,7 +51,9 @@
       <tr>
         <th>When</th>
         <th>Who</th>
-        <th>Stage</th>
+        <% unless @stage %>
+          <th>Stage</th>
+        <% end %>
         <th>Status</th>
       </tr>
     </thead>


### PR DESCRIPTION
* Add description here
adding the stage name to the various info screens about deployments.  this does exist as part of the summary, but there is want for it to be there specifically.  

* Add any screenshots if you are touching the UI
![screen shot 2016-03-30 at 3 23 09 pm](https://cloud.githubusercontent.com/assets/155554/14159563/5bc49ba8-f68b-11e5-8ea9-01f047a8270e.png)

* Remember to add unit tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:
https://zendesk.atlassian.net/browse/SAMSON-218

### Risks
- Level: Low/Med/High
Low