### PR TITLE
Add a flag to disable the docker binary builder plugin for a stage.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160317215713) do
+ActiveRecord::Schema.define(version: 20160405103253) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -356,6 +356,7 @@ ActiveRecord::Schema.define(version: 20160317215713) do
     t.string   "jenkins_job_names",                            limit: 255
     t.string   "next_stage_ids"
     t.boolean  "no_code_deployed",                                           default: false
+    t.boolean  "docker_binary_plugin_enabled",                               default: true
   end
 
   add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", length: {"project_id"=>nil, "permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -144,7 +144,7 @@ class BinaryBuilder
         'dockerfile' => DOCKER_BUILD_FILE,
         't' => image_name
       }
-    )
+    ) { |chunk| @output_stream.write chunk }
   end
 
   def docker_api_version

--- a/plugins/docker_binary_builder/app/views/samson_docker_binary_builder/_stage_fields.html.erb
+++ b/plugins/docker_binary_builder/app/views/samson_docker_binary_builder/_stage_fields.html.erb
@@ -1,0 +1,9 @@
+<fieldset>
+  <legend>Docker Binary Builder</legend>
+  <div class="col-lg-6 checkbox col-lg-offset-2">
+    <%= form.label :docker_binary_plugin_enabled do %>
+      <%= form.check_box :docker_binary_plugin_enabled %>
+      Use Docker to build/compile artifacts (<a href="https://github.com/zendesk/samson/tree/master/plugins/docker_binary_builder">docs</a>)
+    <% end %>
+  </div>
+</fieldset>

--- a/plugins/docker_binary_builder/db/migrate/20160405103253_add_enable_docker_binary_builder_to_stage.rb
+++ b/plugins/docker_binary_builder/db/migrate/20160405103253_add_enable_docker_binary_builder_to_stage.rb
@@ -1,0 +1,5 @@
+class AddEnableDockerBinaryBuilderToStage < ActiveRecord::Migration
+  def change
+    add_column :stages, :docker_binary_plugin_enabled, :boolean, default: true
+  end
+end

--- a/plugins/docker_binary_builder/lib/samson_docker_binary_builder/samson_plugin.rb
+++ b/plugins/docker_binary_builder/lib/samson_docker_binary_builder/samson_plugin.rb
@@ -3,10 +3,20 @@ module SamsonDockerBinaryBuilder
   end
 end
 
+Samson::Hooks.view :stage_form, 'samson_docker_binary_builder/stage_fields'
+
 Samson::Hooks.callback :before_docker_build do |dir, build, output|
   BinaryBuilder.new(dir, build.project, build.git_ref, output).build
 end
 
 Samson::Hooks.callback :after_deploy_setup do |dir, job, output, reference|
-  BinaryBuilder.new(dir, job.project, reference, output).build
+  if job.deploy.try(:stage).try(:docker_binary_plugin_enabled)
+    BinaryBuilder.new(dir, job.project, reference, output).build
+  else
+    output.puts 'Skipping binary build phase!'
+  end
+end
+
+Samson::Hooks.callback :stage_permitted_params do
+  :docker_binary_plugin_enabled
 end

--- a/plugins/docker_binary_builder/test/lib/samson_plugin_test.rb
+++ b/plugins/docker_binary_builder/test/lib/samson_plugin_test.rb
@@ -1,0 +1,29 @@
+require_relative '../test_helper'
+
+describe SamsonDockerBinaryBuilder do
+  describe '#after_deploy_setup' do
+    let(:admin) { users(:admin) }
+    let(:stage) { stages(:test_production) }
+    let(:deploy) { stage.create_deploy(admin, { reference: 'reference' }) }
+    let(:dir) { '/tmp' }
+    let(:output) { StringIO.new }
+
+    before do
+      BinaryBuilder.any_instance.stubs(:build).returns(true)
+    end
+
+    it 'does nothing if stage has docker_binary_plugin_enabled disabled' do
+      deploy.stage.update(docker_binary_plugin_enabled: false)
+      BinaryBuilder.any_instance.expects(:build).never
+      Samson::Hooks.fire(:after_deploy_setup, dir, deploy.job, output, deploy.reference)
+      output.string.must_equal "Skipping binary build phase!\n"
+    end
+
+    it 'kicks off the docker build after_deploy_setup is fired' do
+      deploy.stage.update(docker_binary_plugin_enabled: true)
+      BinaryBuilder.any_instance.expects(:build).once
+      Samson::Hooks.fire(:after_deploy_setup, dir, deploy.job, output, deploy.reference)
+      output.string.must_equal ''
+    end
+  end
+end


### PR DESCRIPTION
At the moment if you have a ```Dockerfile.build``` file in your repo, the Docker Binary Builder plugin will attempt to create the docker image during a deploy even if you don't need it.
This just adds a flag so you can disable it for a Stage.

![screen shot 2016-04-05 at 16 31 21](https://cloud.githubusercontent.com/assets/515143/14287749/f2ae8b0e-fb4b-11e5-8faf-dc3315278c86.png)

![master_deploy__succeeded__-_acrocentric](https://cloud.githubusercontent.com/assets/515143/14287752/f4ff5faa-fb4b-11e5-82f9-2941d6b5e063.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Med

