### PR TITLE
fix failing Slack plugin test

### DIFF
--- a/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
@@ -16,7 +16,7 @@ class SlackWebhookNotification
 
   def content
     subject = "[#{@project.name}] #{@deploy.summary}"
-    @content ||= SlackNotificationRenderer.render(@deploy, subject)
+    @content ||= SlackWebhookNotificationRenderer.render(@deploy, subject)
   end
 
   def _deliver(webhook)

--- a/plugins/slack_webhooks/test/models/hooks_test.rb
+++ b/plugins/slack_webhooks/test/models/hooks_test.rb
@@ -35,7 +35,7 @@ describe "slack hooks" do
       stage.slack_webhooks << SlackWebhook.new(webhook_url: 'http://example.com')
       new_stage = Stage.new
       Samson::Hooks.fire(:stage_clone, stage, new_stage)
-      new_stage.slack_webhooks.map(&:attributes).must_equal [{"id"=>nil, "webhook_url"=>"http://example.com", "stage_id"=>nil, "created_at"=>nil, "updated_at"=>nil}]
+      new_stage.slack_webhooks.map(&:attributes).must_equal [{"id"=>nil, "webhook_url"=>"http://example.com", "channel"=>nil, "stage_id"=>nil, "created_at"=>nil, "updated_at"=>nil}]
     end
   end
 end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -3,10 +3,11 @@ require_relative '../test_helper'
 describe SlackWebhookNotification do
   let(:project) { stub(name: "Glitter") }
   let(:user) { stub(name: "John Wu", email: "wu@rocks.com") }
-  let(:stage) { stub(name: "staging", slack_webhooks: [stub(webhook_url: "http://example.com")], project: project) }
+  let(:endpoint) { "https://slack.com/api/chat.postMessage" }
+  let(:webhook) { stub(webhook_url: endpoint, channel: nil) }
+  let(:stage) { stub(name: "staging", slack_webhooks: [webhook], project: project) }
   let(:deploy) { stub(summary: "hello world!", user: user, stage: stage) }
   let(:notification) { SlackWebhookNotification.new(deploy) }
-  let(:endpoint) { "https://slack.com/api/chat.postMessage" }
 
   before do
     SlackWebhookNotificationRenderer.stubs(:render).returns("foo")
@@ -27,7 +28,8 @@ describe SlackWebhookNotification do
     content = nil
     assert_requested :post, endpoint do |request|
       body = Rack::Utils.parse_query(request.body)
-      content = body.fetch("text")
+      payload = JSON.parse(body.fetch('payload'))
+      content = payload.fetch("text")
     end
 
     content.must_equal "bar"


### PR DESCRIPTION
Fix the tests that were failing for the `slack_webhooks` plugin

/cc @grosser, @irwaters 

### JIRA Issues
* https://zendesk.atlassian.net/browse/SAMSON-221

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low

