### PR TITLE
highlighted lines a bit like github

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -264,6 +264,7 @@ $(function () {
   (function() {
     var HASH_REGEX = /^#L(\d+)(?:-L(\d+))?$/;
     var $highlightedLines;
+    var LINES_SELECTOR = '#messages span';
 
     function linesFromHash() {
       var result = HASH_REGEX.exec(window.location.hash);
@@ -284,7 +285,7 @@ $(function () {
       } else {
         end = start + 1;
       }
-      $highlightedLines = $('#messages span').slice(start, end).addClass('highlighted');
+      $highlightedLines = $(LINES_SELECTOR).slice(start, end).addClass('highlighted');
     }
 
     function removeHighlight() {
@@ -302,12 +303,16 @@ $(function () {
       }
     }
 
+    function indexOfLine($line) {
+      return $line.index(LINES_SELECTOR) + 1;
+    }
+
     $('#messages').on('click', 'span', function(event) {
       event.preventDefault();
-      var clickedNumber = $(event.currentTarget).index('#messages span') + 1;
+      var clickedNumber = indexOfLine($(event.currentTarget));
       var shift = event.shiftKey;
       if (shift && $highlightedLines.length === 1) {
-        var requestedLines = [$highlightedLines.index('#messages span') + 1, clickedNumber].sort();
+        var requestedLines = [indexOfLine($highlightedLines), clickedNumber].sort();
         window.location.hash = 'L' + requestedLines[0] + '-L' + requestedLines[1];
       } else {
         window.location.hash = 'L' + clickedNumber;

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -288,7 +288,9 @@ $(function () {
     }
 
     function removeHighlight() {
-      $highlightedLines && $highlightedLines.removeClass('highlighted');
+      if ($highlightedLines) {
+        $highlightedLines.removeClass('highlighted');
+      }
     }
 
     function scrollToHash() {
@@ -296,7 +298,7 @@ $(function () {
       var nextLines = linesFromHash();
       addHighlight.apply(this, nextLines);
       if ($highlightedLines) {
-        $highlightedLines.get(0).scrollIntoView(true)
+        $highlightedLines.get(0).scrollIntoView(true);
       }
     }
 

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -321,7 +321,7 @@ $(function () {
 
     $(window).on('hashchange', scrollToHash);
     scrollToHash();
-  })();
+  }());
 });
 
 function toggleOutputToolbar() {

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -260,6 +260,61 @@ $(function () {
       $("#output-follow").click();
     }
   });
+
+  (function() {
+    var HASH_REGEX = /^#L(\d+)(?:-L(\d+))?$/;
+    var $highlightedLines;
+
+    function linesFromHash() {
+      var result = HASH_REGEX.exec(window.location.hash);
+      if (result === null) {
+        return [];
+      } else {
+        return result.slice(1);
+      }
+    }
+
+    function addHighlight(start, end) {
+      if (!start) {
+        return;
+      }
+      start = Number(start) - 1;
+      if (end) {
+        end = Number(end);
+      } else {
+        end = start + 1;
+      }
+      $highlightedLines = $('#messages span').slice(start, end).addClass('highlighted');
+    }
+
+    function removeHighlight() {
+      $highlightedLines && $highlightedLines.removeClass('highlighted');
+    }
+
+    function scrollToHash() {
+      removeHighlight();
+      var nextLines = linesFromHash();
+      addHighlight.apply(this, nextLines);
+      if ($highlightedLines) {
+        $highlightedLines.get(0).scrollIntoView(true)
+      }
+    }
+
+    $('#messages').on('click', 'span', function(event) {
+      event.preventDefault();
+      var clickedNumber = $(event.currentTarget).index('#messages span') + 1;
+      var shift = event.shiftKey;
+      if (shift && $highlightedLines.length === 1) {
+        var requestedLines = [$highlightedLines.index('#messages span') + 1, clickedNumber].sort();
+        window.location.hash = 'L' + requestedLines[0] + '-L' + requestedLines[1];
+      } else {
+        window.location.hash = 'L' + clickedNumber;
+      }
+    });
+
+    $(window).on('hashchange', scrollToHash);
+    scrollToHash();
+  })();
 });
 
 function toggleOutputToolbar() {

--- a/app/assets/stylesheets/deploys.scss
+++ b/app/assets/stylesheets/deploys.scss
@@ -135,3 +135,13 @@ td.status {
 #ref-problem-list {
   margin-top: 10px;
 }
+
+#messages > span {
+  display: inline-block;
+  width: 100%;
+  cursor: pointer;
+
+  &.highlighted {
+    background-color: #0700d6;
+  }
+}


### PR DESCRIPTION
cc @zendesk/vegemite @jden @zendesk/samson 

### Description

* Add description here
* Add any screenshots if you are touching the UI
* Remember to add unit tests

/cc @zendesk/samson

Inspired by Github. Highlights and scrolls to lines that are in the fragment on page load or clicked (and shift-clicked). If my choice of colour scheme offends anyone (or we use text that will be hard to read on that background) please shout out in this PR or submit another to change it. AFAIK we mostly only have white and red text.

<img width="1164" alt="screen shot 2016-04-06 at 1 01 53 pm" src="https://cloud.githubusercontent.com/assets/5535625/14306263/fc85459e-fbf7-11e5-8624-b8d3e8470749.png">


### References
* #790 

### Risks
* [medium] JS errors on the deploy page