### PR TITLE
convert macros to have command associations

### DIFF
--- a/app/models/concerns/has_commands.rb
+++ b/app/models/concerns/has_commands.rb
@@ -1,0 +1,37 @@
+# expects command_associations to be defined in base class
+module HasCommands
+  def self.included(base)
+    base.class_eval do
+      before_save :build_new_project_command
+      attr_writer :command
+    end
+  end
+
+  def command
+    commands.map(&:command).join("\n")
+  end
+
+  def command_ids=(new_command_ids)
+    super.tap do
+      reorder_commands(new_command_ids.reject(&:blank?).map(&:to_i))
+    end
+  end
+
+  private
+
+  def build_new_project_command
+    return unless @command.present?
+
+    new_command = project.commands.build(command: @command)
+    command_associations.build(command: new_command).tap do
+      reorder_commands
+    end
+  end
+
+  def reorder_commands(command_ids = self.command_ids)
+    command_associations.each do |command_association|
+      command_association.position = command_ids.index(command_association.command_id) ||
+        command_associations.length
+    end
+  end
+end

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -1,21 +1,22 @@
 class Macro < ActiveRecord::Base
   has_soft_deletion default_scope: true
 
+  attr_writer :command
+
   belongs_to :project
   belongs_to :user
 
   has_many :macro_commands, autosave: true
-  has_many :commands,
-    -> { order('macro_commands.position ASC') },
+  has_many :commands, -> { order('macro_commands.position ASC') },
     through: :macro_commands, auto_include: false
 
   validates :name, presence: true, uniqueness: { scope: [:project, :deleted_at] }
-  validates :reference, :command, presence: true
+  validates :reference, presence: true
 
-  def macro_command
-    commands.map(&:command).
-      push(command).
-      join("\n")
+  before_save :build_new_project_command
+
+  def command
+    commands.map(&:command).join("\n")
   end
 
   def command_ids=(new_command_ids)
@@ -25,6 +26,15 @@ class Macro < ActiveRecord::Base
   end
 
   private
+
+  def build_new_project_command
+    return unless @command.present?
+
+    new_command = project.commands.build(command: @command)
+    macro_commands.build(command: new_command).tap do
+      reorder_commands
+    end
+  end
 
   def reorder_commands(command_ids = self.command_ids)
     macro_commands.each do |macro_command|

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -1,45 +1,15 @@
 class Macro < ActiveRecord::Base
   has_soft_deletion default_scope: true
 
-  attr_writer :command
+  include HasCommands
+
+  has_many :command_associations, autosave: true, class_name: "MacroCommand", dependent: :destroy
+  has_many :commands, -> { order("macro_commands.position ASC") },
+    through: :command_associations, auto_include: false
 
   belongs_to :project
   belongs_to :user
 
-  has_many :macro_commands, autosave: true
-  has_many :commands, -> { order('macro_commands.position ASC') },
-    through: :macro_commands, auto_include: false
-
   validates :name, presence: true, uniqueness: { scope: [:project, :deleted_at] }
   validates :reference, presence: true
-
-  before_save :build_new_project_command
-
-  def command
-    commands.map(&:command).join("\n")
-  end
-
-  def command_ids=(new_command_ids)
-    super.tap do
-      reorder_commands(new_command_ids.reject(&:blank?).map(&:to_i))
-    end
-  end
-
-  private
-
-  def build_new_project_command
-    return unless @command.present?
-
-    new_command = project.commands.build(command: @command)
-    macro_commands.build(command: new_command).tap do
-      reorder_commands
-    end
-  end
-
-  def reorder_commands(command_ids = self.command_ids)
-    macro_commands.each do |macro_command|
-      macro_command.position = command_ids.index(macro_command.command_id) ||
-        macro_commands.length
-    end
-  end
 end

--- a/app/models/macro_service.rb
+++ b/app/models/macro_service.rb
@@ -8,7 +8,7 @@ class MacroService
   def execute!(macro)
     @project.jobs.create(
       user: @user,
-      command: macro.macro_command,
+      command: macro.command,
       commit: macro.reference
     )
   end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,5 +1,6 @@
 class Stage < ActiveRecord::Base
   include Permalinkable
+  include HasCommands
 
   has_soft_deletion default_scope: true unless self < SoftDeletion::Core
 
@@ -11,9 +12,9 @@ class Stage < ActiveRecord::Base
 
   has_one :lock
 
-  has_many :stage_commands, autosave: true, dependent: :destroy
+  has_many :command_associations, autosave: true, class_name: 'StageCommand', dependent: :destroy
   has_many :commands, -> { order('stage_commands.position ASC') },
-    through: :stage_commands, auto_include: false
+    through: :command_associations, auto_include: false
 
   has_many :deploy_groups_stages
   has_many :deploy_groups, through: :deploy_groups_stages
@@ -25,9 +26,7 @@ class Stage < ActiveRecord::Base
 
   accepts_nested_attributes_for :new_relic_applications, allow_destroy: true, reject_if: :no_newrelic_name?
 
-  attr_writer :command
   before_create :ensure_ordering
-  before_save :build_new_project_command
 
   def self.reset_order(new_order)
     transaction do
@@ -124,16 +123,6 @@ class Stage < ActiveRecord::Base
     "#{name} - #{project.name}"
   end
 
-  def command
-    commands.map(&:command).join("\n")
-  end
-
-  def command_ids=(new_command_ids)
-    super.tap do
-      reorder_commands(new_command_ids.reject(&:blank?).map(&:to_i))
-    end
-  end
-
   def datadog_tags_as_array
     datadog_tags.to_s.split(";").map(&:strip)
   end
@@ -184,24 +173,6 @@ class Stage < ActiveRecord::Base
   end
 
   private
-
-  def build_new_project_command
-    return unless @command.present?
-
-    new_command = project.commands.build(command: @command)
-    stage_commands.build(command: new_command).tap do
-      reorder_commands
-    end
-  end
-
-  def reorder_commands(command_ids = self.command_ids)
-    stage_commands.each do |stage_command|
-      pos = command_ids.index(stage_command.command_id) ||
-        stage_commands.length
-
-      stage_command.position = pos
-    end
-  end
 
   def no_newrelic_name?(newrelic_attrs)
     newrelic_attrs['name'].blank?

--- a/app/views/macros/_fields.html.erb
+++ b/app/views/macros/_fields.html.erb
@@ -14,30 +14,4 @@
   </div>
 </fieldset>
 
-<fieldset>
-  <legend>Commands</legend>
-
-  <div id="commands">
-    <%= form.collection_check_boxes(:command_ids, Command.for_object(form.object), :id, :command) do |b| %>
-      <div class="row stage-bar bar">
-        <div data-id="<%= b.value %>" class="col-lg-offset-2 col-lg-2 command-checkbox">
-          <%= b.check_box %>
-        </div>
-        <div class="col-lg-8">
-          <pre data-type="textarea" class="pre-command pre-inline"><%= b.text %></pre>
-        </div>
-      </div>
-    <% end %>
-  </div>
-
-  <hr />
-
-  <p>Add a command which is specific to your macro</p>
-  <%= form.text_area :command, class: "form-control", rows: 4, placeholder: 'cap production deploy' %>
-</fieldset>
-
-<%= javascript_tag do %>
-  $(document).ready(function() {
-    $('#commands').sortable();
-  });
-<% end %>
+<%= render 'shared/commands', form: form %>

--- a/app/views/shared/_commands.html.erb
+++ b/app/views/shared/_commands.html.erb
@@ -1,0 +1,81 @@
+<fieldset>
+  <legend>Commands</legend>
+  <p>Select the commands you want to run when executing. Double click to edit commands.</p>
+
+  <div id="commands">
+    <% usage_ids = Command.usage_ids %>
+    <%= form.collection_check_boxes(:command_ids, Command.for_object(form.object), :id, :command) do |b| %>
+      <% command = b.object %>
+      <% others = usage_ids.count(command.id) - (b.check_box.include?('checked') && form.object.persisted? ? 1 : 0) %>
+      <% others_warning = "#{others} others" if others > 0 %>
+
+      <div class="row stage-bar bar">
+        <div data-id="<%= b.value %>" class="col-lg-offset-2 col-lg-2 command-checkbox">
+          <%= b.check_box %>
+        </div>
+        <div class="col-lg-8">
+          <% klass = "pre-command pre-inline #{command.global? ? 'global' : 'local'} #{'others' if others_warning}" %>
+          <pre data-type="textarea" data-others-warning="<%= others_warning %>" data-url="<%= admin_command_path(b.value, format: :json) %>" class="<%= klass %>"><%= b.text %></pre>
+        </div>
+        <%= edit_command_link command %>
+        <%= content_tag :span, others, title: others_warning + " use this. Click edit for details.", class: 'glyphicon glyphicon-lock' if others_warning %>
+      </div>
+    <% end %>
+  </div>
+
+  <hr />
+
+  <p>Add a command which is specific to your project</p>
+  <%= form.text_area :command, class: "form-control", rows: 4, value: nil, placeholder: 'cap production deploy' %>
+</fieldset>
+
+<script>
+  $(function() {
+    var $localCommands = $('#commands pre.local');
+
+    $('#commands').sortable();
+    $.fn.editableform.buttons = <%= render('commands/buttons').inspect.html_safe %>;
+
+    $localCommands.editable({
+      mode: 'inline',
+      send: 'always',
+      toggle: 'dblclick',
+      highlight: false,
+      params: function(params) {
+        return { command: { command: params.value } };
+      },
+      ajaxOptions: {
+        type: 'PATCH',
+        dataType: 'json'
+      }
+    });
+
+    $localCommands.filter(".others").dblclick(function(){
+      alert("Editing for " + $(this).data('others-warning') + ". If you do not want this, make a copy.");
+    });
+
+    $('#commands pre.global').dblclick(function(){
+      var $warning = $('<div class="cannot-edit">Global commands cannot be edited inline, use the Admin UI.</div>')
+      $(this).after($warning);
+      $warning.fadeOut(3000);
+      return false;
+    });
+
+    $('#commands').on('click', '.editable-destroy', function(event) {
+      var editable = $(this).closest('div.col-lg-8').children('.pre-command');
+
+      if(confirm('Are you sure you would like to remove this command from all stages?')) {
+        $.ajax({
+          method: 'DELETE',
+          dataType: 'json',
+          url: editable.data('url'),
+          success: function() {
+            editable.closest('.row').fadeOut();
+          }
+        });
+      }
+
+      event.preventDefault();
+    });
+  });
+</script>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -75,36 +75,7 @@
   <% end %>
 </fieldset>
 
-<fieldset>
-  <legend>Commands</legend>
-  <p>Select the commands you want to run when executing this stage. Double click to edit commands.</p>
-
-  <div id="commands">
-    <% usage_ids = Command.usage_ids %>
-    <%= form.collection_check_boxes(:command_ids, Command.for_object(form.object), :id, :command) do |b| %>
-      <% command = b.object %>
-      <% others = usage_ids.count(command.id) - (b.check_box.include?('checked') && form.object.persisted? ? 1 : 0) %>
-      <% others_warning = "#{others} others" if others > 0 %>
-
-      <div class="row stage-bar bar">
-        <div data-id="<%= b.value %>" class="col-lg-offset-2 col-lg-2 command-checkbox">
-          <%= b.check_box %>
-        </div>
-        <div class="col-lg-8">
-          <% klass = "pre-command pre-inline #{command.global? ? 'global' : 'local'} #{'others' if others_warning}" %>
-          <pre data-type="textarea" data-others-warning="<%= others_warning %>" data-url="<%= admin_command_path(b.value, format: :json) %>" class="<%= klass %>"><%= b.text %></pre>
-        </div>
-        <%= edit_command_link command %>
-        <%= content_tag :span, others, title: others_warning + " use this. Click edit for details.", class: 'glyphicon glyphicon-lock' if others_warning %>
-      </div>
-    <% end %>
-  </div>
-
-  <hr />
-
-  <p>Add a command which is specific to your project</p>
-  <%= form.text_area :command, class: "form-control", rows: 4, value: nil, placeholder: 'cap production deploy' %>
-</fieldset>
+<%= render 'shared/commands', form: form %>
 
 <fieldset>
   <legend>Dashboard</legend>
@@ -198,54 +169,3 @@
     <% end %>
   </div>
 </fieldset>
-
-<script>
-  $(document).ready(function() {
-    var $localCommands = $('#commands pre.local');
-
-    $('#commands').sortable();
-    $.fn.editableform.buttons = <%= render('commands/buttons').inspect.html_safe %>;
-
-    $localCommands.editable({
-      mode: 'inline',
-      send: 'always',
-      toggle: 'dblclick',
-      highlight: false,
-      params: function(params) {
-        return { command: { command: params.value } };
-      },
-      ajaxOptions: {
-        type: 'PATCH',
-        dataType: 'json'
-      }
-    });
-
-    $localCommands.filter(".others").dblclick(function(){
-      alert("Editing for " + $(this).data('others-warning') + ". If you do not want this, make a copy.");
-    });
-
-    $('#commands pre.global').dblclick(function(){
-      var $warning = $('<div class="cannot-edit">Global commands cannot be edited inline, use the Admin UI.</div>')
-      $(this).after($warning);
-      $warning.fadeOut(3000);
-      return false;
-    });
-
-    $('#commands').on('click', '.editable-destroy', function(event) {
-      var editable = $(this).closest('div.col-lg-8').children('.pre-command');
-
-      if(confirm('Are you sure you would like to remove this command from all stages?')) {
-        $.ajax({
-          method: 'DELETE',
-          dataType: 'json',
-          url: editable.data('url'),
-          success: function() {
-            editable.closest('.row').fadeOut();
-          }
-        });
-      }
-
-      event.preventDefault();
-    });
-  });
-</script>

--- a/db/migrate/20160407181257_remove_macros_command.rb
+++ b/db/migrate/20160407181257_remove_macros_command.rb
@@ -1,0 +1,20 @@
+class RemoveMacrosCommand < ActiveRecord::Migration
+  class OldMacro < ActiveRecord::Base
+    self.table_name = :macros
+  end
+
+  class OldMacroCommand < ActiveRecord::Base
+    self.table_name = :macro_commands
+  end
+
+  def change
+    OldMacro.find_each do |m|
+      next unless command = m.command.presence
+      max = OldMacroCommand.where(macro_id: m.id).maximum(:position) || 0
+      c = Command.create!(command: command, project_id: m.project_id)
+      OldMacroCommand.create!(position: max + 1, command_id: c.id, macro_id: m.id)
+    end
+
+    remove_column :macros, :command
+  end
+end

--- a/db/migrate/20160407181257_remove_macros_command.rb
+++ b/db/migrate/20160407181257_remove_macros_command.rb
@@ -7,7 +7,7 @@ class RemoveMacrosCommand < ActiveRecord::Migration
     self.table_name = :macro_commands
   end
 
-  def change
+  def up
     OldMacro.find_each do |m|
       next unless command = m.command.presence
       max = OldMacroCommand.where(macro_id: m.id).maximum(:position) || 0
@@ -16,5 +16,9 @@ class RemoveMacrosCommand < ActiveRecord::Migration
     end
 
     remove_column :macros, :command
+  end
+
+  def down
+    add_column :macros, :command, :text, null: false, default: ""
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160405103253) do
+ActiveRecord::Schema.define(version: 20160407181257) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -245,9 +245,8 @@ ActiveRecord::Schema.define(version: 20160405103253) do
   end
 
   create_table "macros", force: :cascade do |t|
-    t.string   "name",       limit: 255,   null: false
-    t.string   "reference",  limit: 255,   null: false
-    t.text     "command",    limit: 65535, null: false
+    t.string   "name",       limit: 255, null: false
+    t.string   "reference",  limit: 255, null: false
     t.integer  "project_id", limit: 4
     t.integer  "user_id",    limit: 4
     t.datetime "deleted_at"

--- a/test/fixtures/macros.yml
+++ b/test/fixtures/macros.yml
@@ -2,5 +2,4 @@ test:
   name: Test Macro
   project: test
   reference: master
-  command: seq 1 5
   user: admin

--- a/test/models/macro_service_test.rb
+++ b/test/models/macro_service_test.rb
@@ -9,7 +9,7 @@ describe MacroService do
   it 'creates a new job' do
     job = service.execute!(macro)
     job.persisted?.must_equal(true)
-    job.command.must_equal("echo hello\nseq 1 5")
+    job.command.must_equal("echo hello")
     job.user.must_equal(user)
     job.project.must_equal(project)
   end

--- a/test/models/macro_test.rb
+++ b/test/models/macro_test.rb
@@ -15,7 +15,7 @@ describe Macro do
     end
 
     it "is empty without commands" do
-      subject.macro_commands.clear
+      subject.command_associations.clear
       subject.command.must_equal('')
     end
   end

--- a/test/models/macro_test.rb
+++ b/test/models/macro_test.rb
@@ -4,26 +4,33 @@ describe Macro do
   subject { macros(:test) }
 
   describe '#command' do
-    describe 'adding + sorting a command' do
-      before do
-        command = Command.create!(command: 'test')
+    it 'joins all commands based on position' do
+      command = Command.create!(command: 'test')
 
-        subject.command_ids = [command.id, commands(:echo).id]
-        subject.save!
-        subject.reload
-      end
+      subject.command_ids = [command.id, commands(:echo).id]
+      subject.save!
+      subject.reload
 
-      it 'joins all commands based on position' do
-        subject.macro_command.must_equal("test\n#{commands(:echo).command}\nseq 1 5")
-      end
+      subject.command.must_equal("test\n#{commands(:echo).command}")
     end
 
-    describe 'no commands' do
-      before { subject.macro_commands.clear }
+    it "is empty without commands" do
+      subject.macro_commands.clear
+      subject.command.must_equal('')
+    end
+  end
 
-      it 'is only the macro command' do
-        subject.macro_command.must_equal('seq 1 5')
-      end
+  describe "#command=" do
+    it "adds a new comand" do
+      subject.command = "HELLOOOO"
+      subject.save!
+      subject.reload.commands.map(&:command).must_equal ["echo hello", "HELLOOOO"]
+    end
+
+    it "does not add a empty command" do
+      subject.command = "   "
+      subject.save!
+      subject.reload.commands.map(&:command).must_equal ["echo hello"]
     end
   end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -45,7 +45,7 @@ describe Stage do
   describe '#command' do
     describe 'adding a built command' do
       before do
-        subject.stage_commands.build(command:
+        subject.command_associations.build(command:
           Command.new(command: 'test')
         )
 


### PR DESCRIPTION
Get rid of command column in preparation for macros/stage unification ... see https://github.com/zendesk/samson/pull/769

existing `command` column will get converted into a actual `Command` new UI:

![screen shot 2016-04-07 at 12 01 01 pm](https://cloud.githubusercontent.com/assets/11367/14363312/6bd59794-fcb8-11e5-9c94-7964702521d1.png)

 - includes a bit of duplication, but that will go away once Macros and Stage are merged
 - migration is using only clean classes to not break once macro becomes a Stage subclass


@zendesk/samson 

### Risks
- Level: Low/Med/High

