### PR TITLE
create cache directory before trying to resolve a git ref [SAMSON-207]

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -106,6 +106,13 @@ class BuildsController < ApplicationController
   end
 
   def git_sha
-    current_project.repository.commit_from_ref(new_build_params[:git_ref], length: nil)
+    @git_sha ||= begin
+      # Create/update local cache to avoid getting a stale reference
+      current_project.with_lock(holder: 'BuildsController#create') do
+        current_project.repository.setup_local_cache!
+      end
+
+      current_project.repository.commit_from_ref(new_build_params[:git_ref], length: nil)
+    end
   end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -79,8 +79,10 @@ class Build < ActiveRecord::Base
 
     return if errors.include?(:git_ref) || errors.include?(:git_sha)
 
-    project.with_lock(holder: 'Build reference validation') do
-      project.repository.setup_local_cache!
+    unless project.repository.last_pulled
+      project.with_lock(holder: 'Build reference validation') do
+        project.repository.setup_local_cache!
+      end
     end
 
     if git_ref.present?


### PR DESCRIPTION
If you try creating a Build before running a stage, you get a crash. This fixes it.

Also handles a scenario where if you create a Build with a branch, it could map that to the wrong SHA if the local cache wasn't up to date.

I tried writing a unit test for this, but all the logic around creating cached repos defeated me. Welcome to have help here.

/cc @zendesk/samson, @grosser 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-207

### Risks
- Level: Low

