### PR TITLE
remove user from macros, it was never used

### DIFF
--- a/app/controllers/macros_controller.rb
+++ b/app/controllers/macros_controller.rb
@@ -2,7 +2,8 @@ class MacrosController < ApplicationController
   include ProjectLevelAuthorization
 
   before_action :authorize_project_deployer!
-  before_action :authorize_project_admin!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :authorize_project_admin!, only: [:new, :create, :edit, :update]
+  before_action :authorize_super_admin!, only: [:destroy]
   before_action :find_macro, only: [:edit, :update, :execute, :destroy]
 
   def index
@@ -47,12 +48,8 @@ class MacrosController < ApplicationController
   end
 
   def destroy
-    if @macro.user == current_user || current_user.is_super_admin?
-      @macro.soft_delete!
-      redirect_to project_macros_path(@project)
-    else
-      head :unauthorized
-    end
+    @macro.soft_delete!
+    redirect_to project_macros_path(@project)
   end
 
   private

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -8,7 +8,6 @@ class Macro < ActiveRecord::Base
     through: :command_associations, auto_include: false
 
   belongs_to :project
-  belongs_to :user
 
   validates :name, presence: true, uniqueness: { scope: [:project, :deleted_at] }
   validates :reference, presence: true

--- a/db/migrate/20160408193842_remove_user_from_macro.rb
+++ b/db/migrate/20160408193842_remove_user_from_macro.rb
@@ -1,0 +1,5 @@
+class RemoveUserFromMacro < ActiveRecord::Migration
+  def change
+    remove_column :macros, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407181257) do
+ActiveRecord::Schema.define(version: 20160408193842) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -248,7 +248,6 @@ ActiveRecord::Schema.define(version: 20160407181257) do
     t.string   "name",       limit: 255, null: false
     t.string   "reference",  limit: 255, null: false
     t.integer  "project_id", limit: 4
-    t.integer  "user_id",    limit: 4
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -19,25 +19,46 @@ describe Admin::UsersController do
   as_a_admin do
     unauthorized :delete, :destroy, id: 1
     unauthorized :put, :update, id: 1
-  end
 
-  as_a_admin do
-    describe 'a GET to #index' do
-      before do
+    describe 'a html GET to #index' do
+      it 'succeeds' do
         get :index
+        assert_template :index, partial: '_search_bar'
       end
 
-      it 'succeeds' do
+      it 'renders with search partial and search box should be empty' do
+        get :index
+
         assert_template :index, partial: '_search_bar'
+        assert_select '#search' do
+          assert_select '[name="search"]'
+          assert_select '[type="text"]'
+          assert_select '[class="form-control"]'
+          assert_select ':not([value])'
+        end
+      end
+
+      it 'index page search box should contain the query' do
+        get :index, search: 'Super Admin'
+
+        assert_template :index,  partial: '_search_bar'
+        assert_select '#search' do
+          assert_select '[name="search"]'
+          assert_select '[type="text"]'
+          assert_select '[class="form-control"]'
+          assert_select '[value="Super Admin"]'
+        end
+
+        assert_select 'tbody' do
+          assert_select 'tr', 1
+        end
       end
     end
 
     describe 'a json GET to #index' do
-      before do
-        get :index, format: :json
-      end
-
       it 'succeeds' do
+        get :index, format: :json
+
         response.success?.must_equal true
         json_response = JSON.parse response.body
         user_list = json_response['users']
@@ -48,13 +69,30 @@ describe Admin::UsersController do
           user_info.email.must_equal u['email']
         end
       end
+
+      it 'succeeds and fetches a single user' do
+        get :index, search: 'Super Admin' , format: :json
+
+        response.success?.must_equal true
+        assigns(:users).must_equal [users(:super_admin)]
+      end
+
+      it 'succeeds and with search as empty fetches all users' do
+        get :index, search: ''
+
+        response.success?.must_equal true
+        user_list = assigns(:users)
+        user_list.wont_be_nil
+        per_page = User.max_per_page || Kaminari.config.default_per_page
+        assigns(:users).size.must_equal [User.count, per_page].min
+      end
     end
-    
+
     describe 'a csv GET to #index' do
       before do
         get :index, format: :csv
       end
-      
+
       it 'succeeds, accurate and complete' do
         response.success?.must_equal true
         csv_response = CSV.parse(response.body)
@@ -83,97 +121,40 @@ describe Admin::UsersController do
       end
     end
 
-    describe 'a json get to #index with a search string' do
-      it 'succeeds and fetches a single user' do
-        get :index, search: 'Super Admin' , format: :json
-
-        response.success?.must_equal true
-        assigns(:users).must_equal [users(:super_admin)]
-      end
-
-      it 'succeeds and with search as empty fetches all users' do
-        get :index, search: ''
-
-        response.success?.must_equal true
-        user_list = assigns(:users)
-        user_list.wont_be_nil
-        per_page = User.max_per_page || Kaminari.config.default_per_page
-        assigns(:users).size.must_equal [User.count, per_page].min
-      end
-
-      it 'index page should render with search partial and search box should be empty' do
-        get :index
-
-        assert_template :index, partial: '_search_bar'
-        assert_select '#search' do
-          assert_select '[name="search"]'
-          assert_select '[type="text"]'
-          assert_select '[class="form-control"]'
-          assert_select ':not([value])'
-        end
-      end
-
-      it 'index page search box should contain the query' do
-        get :index, search: 'Super Admin'
-
-        assert_template :index,  partial: '_search_bar'
-        assert_select '#search' do
-          assert_select '[name="search"]'
-          assert_select '[type="text"]'
-          assert_select '[class="form-control"]'
-          assert_select '[value="Super Admin"]'
-        end
-        assert_select 'tbody' do
-          assert_select 'tr', 1
-        end
-      end
-    end
-
     describe 'a GET to #show' do
-      let(:user) { users(:viewer) }
-
-      before do
-        get :show, id: user.id
-      end
+      let(:modified_user) { users(:viewer) }
 
       it 'succeeds' do
-        assert_template :show, partial: '_project', locals: { user: user }
+        get :show, id: modified_user.id
+        assert_template :show, partial: '_project', locals: { user: modified_user }
       end
     end
   end
 
   as_a_super_admin do
     describe 'a PUT to #update' do
-      let(:user) { users(:viewer) }
+      let(:modified_user) { users(:viewer) }
 
       it 'updates the user role' do
-        put :update, id: user.id, user: {role_id: 2}
-        user.reload.role_id.must_equal 2
+        put :update, id: modified_user.id, user: {role_id: 2}
+        modified_user.reload.role_id.must_equal 2
         assert_response :success
+      end
+
+      it 'clears the access request pending flag' do
+        modified_user.update!(access_request_pending: true)
+        put :update, {id: modified_user.id, user: {role_id: Role::DEPLOYER.id}}
+        modified_user.reload.access_request_pending.must_equal false
       end
     end
 
     describe 'a DELETE to #destroy' do
-      let(:user) { users(:viewer) }
+      let(:modified_user) { users(:viewer) }
 
       it 'soft delete the user' do
-        delete :destroy, id: user.id
-        user.reload.deleted_at.wont_be_nil
+        delete :destroy, id: modified_user.id
+        modified_user.reload.deleted_at.wont_be_nil
         assert_redirected_to admin_users_path
-      end
-    end
-  end
-
-  describe 'a PATCH to #update' do
-    let(:user) { users(:viewer) }
-
-    as_a_super_admin do
-      it 'clears the access request pending flag' do
-        user.update!(access_request_pending: true)
-        assert(user.access_request_pending)
-        patch :update, {id: user.id, user: {role_id: Role::DEPLOYER.id}}
-        user.reload
-        refute(user.access_request_pending)
       end
     end
   end

--- a/test/controllers/macros_controller_test.rb
+++ b/test/controllers/macros_controller_test.rb
@@ -5,16 +5,14 @@ describe MacrosController do
   let(:macro) { macros(:test) }
   let(:macro_service) { stub(execute!: nil) }
   let(:execute_called) { [] }
-  let(:job) { Job.create!(commit: macro.reference, command: macro.command, project: project, user: deployer) }
+  let(:job) { Job.create!(commit: macro.reference, command: macro.command, project: project, user: user) }
 
-  setup do
-    MacroService.stubs(:new).with(project, deployer).returns(macro_service)
+  before do
+    MacroService.stubs(:new).with(project, user).returns(macro_service)
     macro_service.stubs(:execute!).capture(execute_called).returns(job)
   end
 
   as_a_viewer do
-    let(:deployer) { users(:viewer) }
-
     unauthorized :get, :index, project_id: :foo
     unauthorized :get, :new, project_id: :foo
     unauthorized :get, :edit, project_id: :foo, id: 1
@@ -24,168 +22,134 @@ describe MacrosController do
     unauthorized :delete, :destroy, project_id: :foo, id: 1
   end
 
-  as_a_deployer do
-    let(:deployer) { users(:deployer) }
+  [:as_a_project_deployer, :as_a_deployer].each do |as_a_user|
+    send as_a_user do
+      describe "a GET to :index" do
+        setup { get :index, project_id: project.to_param }
 
-    describe "a GET to :index" do
-      setup { get :index, project_id: project.to_param }
-
-      it "renders the template" do
-        assert_template :index
+        it "renders the template" do
+          assert_template :index
+        end
       end
+
+      describe 'a POST to #execute' do
+        describe 'with a macro' do
+          before do
+            JobExecution.stubs(:start_job)
+            post :execute, project_id: project.to_param, id: macro.id
+          end
+
+          it "redirects to the job path" do
+            assert_redirected_to project_job_path(project, Job.last)
+          end
+
+          it "creates a job" do
+            assert_equal [[macro]], execute_called
+          end
+        end
+
+        it 'fails for non-existent macro' do
+          assert_raises ActiveRecord::RecordNotFound do
+            post :execute, project_id: project.to_param, id: 123123123
+          end
+        end
+      end
+
+      unauthorized :get, :new, project_id: :foo
+      unauthorized :get, :edit, project_id: :foo, id: 1
+      unauthorized :post, :create, project_id: :foo
+      unauthorized :put, :update, project_id: :foo, id: 1
+      unauthorized :delete, :destroy, project_id: :foo, id: 1
     end
-
-    describe 'a POST to #execute' do
-      describe 'with a macro' do
-        setup do
-          JobExecution.stubs(:start_job)
-          post :execute, project_id: project.to_param, id: macro.id
-        end
-
-        it "redirects to the job path" do
-          assert_redirected_to project_job_path(project, job)
-        end
-
-        it "creates a job" do
-          assert_equal [[macro]], execute_called
-        end
-      end
-
-      it 'fails for non-existent macro' do
-        assert_raises ActiveRecord::RecordNotFound do
-          post :execute, project_id: project.to_param, id: 123123123
-        end
-      end
-    end
-
-    unauthorized :get, :new, project_id: :foo
-    unauthorized :get, :edit, project_id: :foo, id: 1
-    unauthorized :post, :create, project_id: :foo
-    unauthorized :put, :update, project_id: :foo, id: 1
-    unauthorized :delete, :destroy, project_id: :foo, id: 1
   end
 
-  as_a_admin do
-    let(:deployer) { users(:admin) }
-
-    describe 'a GET to #new' do
-      setup { get :new, project_id: project.to_param }
-
-      it 'renders the template' do
-        assert_template :new
-      end
-    end
-
-    describe 'a GET to #edit' do
-      describe 'with a macro' do
-        setup do
-          get :edit, project_id: project.to_param, id: macro.id
-        end
+  [:as_a_project_admin, :as_a_admin].each do |as_a_user|
+    send as_a_user do
+      describe 'a GET to #new' do
+        before { get :new, project_id: project.to_param }
 
         it 'renders the template' do
-          assert_template :edit
-        end
-      end
-
-      it 'fails for non-existent macro' do
-        assert_raises ActiveRecord::RecordNotFound do
-          get :edit, project_id: project.to_param, id: 123123
-        end
-      end
-    end
-
-    describe 'a POST to #create' do
-      describe 'with a valid macro' do
-        setup do
-          post :create, project_id: project.to_param, macro: {
-            name: 'Testing',
-            reference: 'master',
-            command: '/bin/true'
-          }
-        end
-
-        it 'redirects to the macros path' do
-          assert_redirected_to project_macros_path(project)
-        end
-      end
-
-      describe 'with an invalid macro' do
-        setup do
-          post :create, project_id: project.to_param, macro: {
-            name: 'Testing'
-          }
-        end
-
-        it 'renders the form' do
           assert_template :new
         end
       end
-    end
 
-    describe 'a PUT to #update' do
-      describe 'with a valid macro' do
-        setup do
-          post :update, project_id: project.to_param, id: macro.id, macro: {
-            name: 'New'
-          }
+      describe 'a GET to #edit' do
+        describe 'with a macro' do
+          before do
+            get :edit, project_id: project.to_param, id: macro.id
+          end
+
+          it 'renders the template' do
+            assert_template :edit
+          end
         end
 
-        it 'updates the macro' do
-          macro.reload.name.must_equal('New')
-        end
-
-        it 'redirects properly' do
-          assert_redirected_to project_macros_path(project)
-        end
-      end
-
-      describe 'with an invalid macro' do
-        setup do
-          post :update, project_id: project.to_param, id: macro.id, macro: {
-            name: ''
-          }
-        end
-
-        it 'renders the correct template' do
-          assert_template :edit
-        end
-      end
-    end
-
-    describe 'a DELETE to #destroy' do
-      describe 'with the macro creator being admin' do
-        setup do
-          delete :destroy, project_id: project.to_param, id: macro.id
-        end
-
-        it 'soft deletes the macro' do
-          lambda { project.macros.find(macro.id) }.must_raise(ActiveRecord::RecordNotFound)
-          Macro.unscoped.find(macro.id).must_equal(macro)
-        end
-
-        it 'redirects properly' do
-          assert_redirected_to project_macros_path(project)
+        it 'fails for non-existent macro' do
+          assert_raises ActiveRecord::RecordNotFound do
+            get :edit, project_id: project.to_param, id: 123123
+          end
         end
       end
 
-      describe 'as someone else' do
-        setup do
-          macro.update_attributes!(user: users(:deployer))
-          delete :destroy, project_id: project.to_param, id: macro.id
+      describe 'a POST to #create' do
+        describe 'with a valid macro' do
+          before do
+            post :create, project_id: project.to_param, macro: {
+              name: 'Testing',
+              reference: 'master',
+              command: '/bin/true'
+            }
+          end
+
+          it 'redirects to the macros path' do
+            assert_redirected_to project_macros_path(project)
+          end
         end
 
-        it 'is unauthorized' do
-          assert_response :unauthorized
+        describe 'with an invalid macro' do
+          before do
+            post :create, project_id: project.to_param, macro: {name: 'Testing'}
+          end
+
+          it 'renders the form' do
+            assert_template :new
+          end
         end
       end
+
+      describe 'a PUT to #update' do
+        describe 'with a valid macro' do
+          before do
+            post :update, project_id: project.to_param, id: macro.id, macro: {name: 'New'}
+          end
+
+          it 'updates the macro' do
+            macro.reload.name.must_equal('New')
+          end
+
+          it 'redirects properly' do
+            assert_redirected_to project_macros_path(project)
+          end
+        end
+
+        describe 'with an invalid macro' do
+          before do
+            post :update, project_id: project.to_param, id: macro.id, macro: {name: ''}
+          end
+
+          it 'renders the correct template' do
+            assert_template :edit
+          end
+        end
+      end
+
+      unauthorized :delete, :destroy, project_id: :foo, id: 1
     end
   end
 
   as_a_super_admin do
-    let(:deployer) { users(:super_admin) }
-
     describe 'a DELETE to #destroy' do
-      setup do
+      before do
         delete :destroy, project_id: project.to_param, id: macro.id
       end
 
@@ -196,164 +160,6 @@ describe MacrosController do
 
       it 'redirects properly' do
         assert_redirected_to project_macros_path(project)
-      end
-    end
-  end
-
-  as_a_project_deployer do
-    let(:deployer) { users(:project_deployer) }
-
-    describe "a GET to :index" do
-      setup { get :index, project_id: project.to_param }
-
-      it "renders the template" do
-        assert_template :index
-      end
-    end
-
-    describe 'a POST to #execute' do
-      describe 'with a macro' do
-        setup do
-          JobExecution.stubs(:start_job)
-          post :execute, project_id: project.to_param, id: macro.id
-        end
-
-        it "redirects to the job path" do
-          assert_redirected_to project_job_path(project, job)
-        end
-
-        it "creates a job" do
-          assert_equal [[macro]], execute_called
-        end
-      end
-
-      it 'fails for non-existent macro' do
-        assert_raises ActiveRecord::RecordNotFound do
-          post :execute, project_id: project.to_param, id: 123123123
-        end
-      end
-    end
-
-    unauthorized :get, :new, project_id: :foo
-    unauthorized :get, :edit, project_id: :foo, id: 1
-    unauthorized :post, :create, project_id: :foo
-    unauthorized :put, :update, project_id: :foo, id: 1
-    unauthorized :delete, :destroy, project_id: :foo, id: 1
-  end
-
-  as_a_project_admin do
-    let(:deployer) { users(:project_admin) }
-
-    describe 'a GET to #new' do
-      setup { get :new, project_id: project.to_param }
-
-      it 'renders the template' do
-        assert_template :new
-      end
-    end
-
-    describe 'a GET to #edit' do
-      describe 'with a macro' do
-        setup do
-          get :edit, project_id: project.to_param, id: macro.id
-        end
-
-        it 'renders the template' do
-          assert_template :edit
-        end
-      end
-
-      it 'fails for non-existent macro' do
-        assert_raises ActiveRecord::RecordNotFound do
-          get :edit, project_id: project.to_param, id: 123123
-        end
-      end
-    end
-
-    describe 'a POST to #create' do
-      describe 'with a valid macro' do
-        setup do
-          post :create, project_id: project.to_param, macro: {
-                          name: 'Testing',
-                          reference: 'master',
-                          command: '/bin/true'
-                      }
-        end
-
-        it 'redirects to the macros path' do
-          assert_redirected_to project_macros_path(project)
-        end
-      end
-
-      describe 'with an invalid macro' do
-        setup do
-          post :create, project_id: project.to_param, macro: {
-                          name: 'Testing'
-                      }
-        end
-
-        it 'renders the form' do
-          assert_template :new
-        end
-      end
-    end
-
-    describe 'a PUT to #update' do
-      describe 'with a valid macro' do
-        setup do
-          post :update, project_id: project.to_param, id: macro.id, macro: {
-                          name: 'New'
-                      }
-        end
-
-        it 'updates the macro' do
-          macro.reload.name.must_equal('New')
-        end
-
-        it 'redirects properly' do
-          assert_redirected_to project_macros_path(project)
-        end
-      end
-
-      describe 'with an invalid macro' do
-        setup do
-          post :update, project_id: project.to_param, id: macro.id, macro: {
-                          name: ''
-                      }
-        end
-
-        it 'renders the correct template' do
-          assert_template :edit
-        end
-      end
-    end
-
-    describe 'a DELETE to #destroy' do
-      describe 'with the macro creator being project admin' do
-        setup do
-          macro.update_attributes!(user: users(:project_admin))
-          delete :destroy, project_id: project.to_param, id: macro.id
-        end
-
-        it 'soft deletes the macro' do
-          lambda { project.macros.find(macro.id) }.must_raise(ActiveRecord::RecordNotFound)
-          Macro.unscoped.find(macro.id).must_equal(macro)
-        end
-
-        it 'redirects properly' do
-          assert_redirected_to project_macros_path(project)
-        end
-      end
-
-      describe 'as someone else' do
-        setup do
-          macro.update_attributes!(user: users(:deployer))
-          delete :destroy, project_id: project.to_param, id: macro.id
-        end
-
-        it 'is unauthorized' do
-          assert_response :unauthorized
-        end
       end
     end
   end

--- a/test/fixtures/macros.yml
+++ b/test/fixtures/macros.yml
@@ -2,4 +2,3 @@ test:
   name: Test Macro
   project: test
   reference: master
-  user: admin

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -21,4 +21,14 @@ describe "cleanliness" do
       end
     end
   end
+
+  it "does not use let(:user) inside of a as_xyz block" do
+    bad = Dir["{,plugins/*/}test/controllers/**/*.rb"].map do |f|
+      content = File.read(f)
+      if content.include?("  as_") && content.include?("let(:user)")
+        "#{f} uses as_xyz and let(:user) these do not mix!"
+      end
+    end.compact
+    bad.must_equal []
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -149,19 +149,11 @@ class ActionController::TestCase
       end
     end
 
-    %w{super_admin admin deployer viewer}.each do |user|
+    %w{super_admin admin deployer viewer project_admin project_deployer}.each do |user|
       define_method "as_a_#{user}" do |&block|
         describe "as a #{user}" do
-          setup { request.env['warden'].set_user(users(user)) }
-          instance_eval(&block)
-        end
-      end
-    end
-
-    %w{project_admin project_deployer}.each do |user|
-      define_method "as_a_#{user}" do |&block|
-        describe "as a #{user}" do
-          setup { request.env['warden'].set_user(users(user)) }
+          let(:user) { users(user) }
+          setup { request.env['warden'].set_user(self.user) }
           instance_eval(&block)
         end
       end


### PR DESCRIPTION
@zendesk/samson 

```
>> Macro.where(user_id: nil).count
=> 53
>> Macro.where('user_id is not null').count
=> 0
```

also a bunch of cleanup from @sbrnunes copy-paste-spree in https://github.com/zendesk/samson/pull/560 ... more coming later

### Risks
- None
