### PR TITLE
simple/helpful coverage enforcement with only 5% runtime overhead

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -80,13 +80,6 @@ class SessionsController < ApplicationController
     redirect_to request.env['omniauth.origin'] || root_path
   end
 
-  def restrict_end_users
-    if auth_hash.info.role == 'end-user' || auth_hash.info.email.blank?
-      flash[:error] = 'You are unauthorized.'
-      redirect_to login_path
-    end
-  end
-
   def login(options = {})
     user = User.create_or_update_from_hash(options.merge(
       external_id: "#{strategy.name}-#{auth_hash.uid}",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ActiveRecord::Base
     # attributes are always a string hash
     attributes = user.attributes.merge(hash.stringify_keys) do |key, old, new|
       if key == 'role_id'
-        if !User.exists?
+        if !User.exists? # first user will be the super admin
           Role::SUPER_ADMIN.id
         elsif new && (user.new_record? || new >= old)
           new

--- a/test/support/single_cov.rb
+++ b/test/support/single_cov.rb
@@ -1,0 +1,67 @@
+class SingleCov
+  COVERAGES = []
+
+  class << self
+    def expect(file, percent)
+      COVERAGES << [file, percent]
+    end
+
+    def verify!(result)
+      COVERAGES.each do |file, expected_percent|
+        uncovered!(file) unless coverage = result[File.expand_path(file)]
+
+        line_of_code = coverage.compact.count
+        line_of_covered_code = coverage.count { |l| l && l > 0 }
+        actual_percent = 100 * line_of_covered_code / line_of_code
+        next if actual_percent == expected_percent
+
+        details = "#{actual_percent}% vs #{expected_percent}%"
+        if actual_percent > expected_percent
+          warn "#{file} exceeds expected coverage #{details}, increment expected coverage?"
+        else
+          warn "#{file} lower then expected coverage #{details}"
+          warn "Lines missing coverage:"
+          warn coverage.select { |c| c == 0 }.each_with_index.map { |c, i| "#{file}:#{i+1}" }
+          exit 1
+        end
+      end
+    end
+
+    private
+
+    def uncovered!(file)
+      message = if File.exist?(file)
+        "#{file} does not exist and cannot be covered"
+      else
+        "#{file} was not covered during tests, possibly loaded before test start ?"
+      end
+      warn message
+      exit 1
+    end
+  end
+end
+
+# do not record or verify when only running selected tests since it would be missing data
+unless ARGV.include?('-n')
+  if defined?(SimpleCov)
+    # - do not start again when SimpleCov is used / Coverage is already started or it conflicts
+    # - do not ask for coverage when SimpleCov already does or it conflicts
+    old = SimpleCov.at_exit
+    SimpleCov.at_exit do
+      old.call
+      # SimpleCov.result returns a coverage that includes 0 instead of nil ... so use @result
+      # https://github.com/colszowka/simplecov/pull/441
+      result = SimpleCov.instance_variable_get(:@result).original_result
+      SingleCov.verify! result
+    end
+  else
+    # start recording before classes are loaded or nothing can be recorded
+    require 'coverage'
+    Coverage.start
+
+    require 'minitest'
+    Minitest.after_run do
+      SingleCov.verify! Coverage.result
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ elsif ENV['COVERAGE']
   SimpleCov.start 'rails'
 end
 
+require_relative 'support/single_cov'
+
 # rake adds these, but we don't need them / want to be in a consistent environment
 $LOAD_PATH.delete 'lib'
 $LOAD_PATH.delete 'test'


### PR DESCRIPTION
@zendesk/samson

 - 5% runtime overhead when used vs 30+% for simplecov (for single files)
 - direct inline coverage results when working on a specific file vs having to re-run rake
 - direct information on what lines need coverage
 - no overhead when running by line number / `-n`

```
app/controllers/sessions_controller.rb lower then expected coverage 94% vs 100%
Lines missing coverage:
app/controllers/sessions_controller.rb:84
app/controllers/sessions_controller.rb:85
app/controllers/sessions_controller.rb:86
```

### Risks
- None

