### PR TITLE
show js errors

### DIFF
--- a/app/assets/javascripts/error.js
+++ b/app/assets/javascripts/error.js
@@ -1,0 +1,10 @@
+// show errors immediately so we can catch them early and fix
+$(function(){
+  if($('meta[name=environment]').first().attr('content') == "development") {
+    window.onerror = function(msg, url, line, col, error) {
+      var extra = !col ? '' : '\ncolumn: ' + col;
+      extra += !error ? '' : '\nerror: ' + error;
+      alert("Error: " + msg + "\nurl: " + url + "\nline: " + line + extra);
+    };
+  }
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="stream-origin" content="<%= Rails.application.config.samson.stream_origin %>">
     <meta name="deploy-origin" content="<%= Rails.application.config.samson.deploy_origin %>">
+    <meta name="environment" content="<%= Rails.env %>">
   </head>
 
   <body class="<%= controller_action %>" ng-app="samson">


### PR DESCRIPTION
makes debugging easier / errors visible so we don't ship them by accident

<img width="405" alt="screen shot 2016-04-11 at 8 00 16 pm" src="https://cloud.githubusercontent.com/assets/11367/14448719/1a75ea32-0020-11e6-95e5-5f5614cdeab6.png">

@zendesk/samson 