### PR TITLE
controler test coverage

### DIFF
--- a/app/controllers/admin/commands_controller.rb
+++ b/app/controllers/admin/commands_controller.rb
@@ -1,8 +1,9 @@
 class Admin::CommandsController < ApplicationController
   include ProjectLevelAuthorization
 
-  before_action :authorize_admin!, except: [ :update, :edit ]
   before_action :find_command, only: [ :update, :edit ]
+  before_action :authorize_project_admin!, only: [ :update, :edit ]
+  before_action :authorize_admin!, except: [ :update, :edit ]
 
   def index
     @commands = Command.order('project_id').page(params[:page])
@@ -76,6 +77,9 @@ class Admin::CommandsController < ApplicationController
 
   def find_command
     @command = Command.find(params[:id])
-    unauthorized! unless current_user.is_admin? || current_user.is_admin_for?(@command.project)
+  end
+
+  def current_project
+    @command.project
   end
 end

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DeployGroupsController < ApplicationController
   before_action :authorize_admin!
-  before_action :authorize_super_admin!, only: [ :create, :new, :update, :destroy, :deploy_all, :deploy_all_now ]
+  before_action :authorize_super_admin!, only: [ :create, :new, :update, :destroy, :deploy_all, :deploy_all_now, :edit ]
   before_action :deploy_group, only: [:show, :edit, :update, :destroy, :deploy_all, :deploy_all_now]
 
   def index
@@ -10,17 +10,17 @@ class Admin::DeployGroupsController < ApplicationController
   def new
     @deploy_group = DeployGroup.new
     Samson::Hooks.fire(:edit_deploy_group, @deploy_group)
-    render 'edit'
+    render :edit
   end
 
   def create
     @deploy_group = DeployGroup.create(deploy_group_params)
     if @deploy_group.persisted?
       flash[:notice] = "Successfully created deploy group: #{@deploy_group.name}"
-      redirect_to action: 'index'
+      redirect_to action: :index
     else
       flash[:error] = @deploy_group.errors.full_messages
-      render 'edit'
+      render :edit
     end
   end
 
@@ -31,17 +31,17 @@ class Admin::DeployGroupsController < ApplicationController
   def update
     if deploy_group.update_attributes(deploy_group_params)
       flash[:notice] = "Successfully saved deploy group: #{deploy_group.name}"
-      redirect_to action: 'index'
+      redirect_to action: :index
     else
       flash[:error] = deploy_group.errors.full_messages
-      render 'edit'
+      render :edit
     end
   end
 
   def destroy
     deploy_group.soft_delete!
     flash[:notice] = "Successfully deleted deploy group: #{deploy_group.name}"
-    redirect_to action: 'index'
+    redirect_to action: :index
   end
 
   def deploy_all

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -23,19 +23,21 @@ class BuildsController < ApplicationController
     @build.creator = current_user
     @build.save
 
-    start_docker_build if @build.persisted? && params[:build_image].present?
+    if @build.persisted? && params[:build_image].present?
+      start_docker_build
+    end
 
     respond_to do |format|
       format.html do
         if @build.persisted?
           redirect_to [current_project, @build]
         else
-          render :new, status: 422
+          render :new, status: :unprocessable_entity
         end
       end
 
       format.json do
-        render json: {}, status: @build.persisted? ? 200 : 422
+        render json: {}, status: (@build.persisted? ? :created : :unprocessable_entity)
       end
     end
   end
@@ -54,12 +56,12 @@ class BuildsController < ApplicationController
         if success
           redirect_to [current_project, @build]
         else
-          render :edit, status: 422
+          render :edit, status: :unprocessable_entity
         end
       end
 
       format.json do
-        render json: {}, status: success ? 200 : 422
+        render json: {}, status: (success ? :ok : :unprocessable_entity)
       end
     end
   end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -11,10 +11,6 @@ class DashboardsController < ApplicationController
 
   private
 
-  def ordered_projects
-    Project.ordered_for_user(current_user).with_deploy_groups
-  end
-
   def find_environment
     @environment = Environment.find_by_param!(params[:id])
   end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -52,11 +52,13 @@ class JobsController < ApplicationController
   end
 
   def destroy
-    if @job.can_be_stopped_by?(current_user)
+    # if @job.can_be_stopped_by?(current_user)
       @job.stop!
-    else
-      flash[:error] = "You do not have privileges to stop this job."
-    end
+    # else
+      # FIXME this can never happen since can_be_stopped_by?
+      # is always true for project admins, which is a before filter
+      # flash[:error] = "You do not have privileges to stop this job."
+    # end
 
     redirect_to [@project, @job]
   end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -23,9 +23,9 @@ class LocksController < ApplicationController
 
   def for_global_lock?
     case action_name
-    when 'create' then
-      !params[:lock].try(:[], :stage_id) || !params[:lock][:stage_id].present?
-    when 'destroy' then
+    when 'create'
+      (params[:lock] || {})[:stage_id].blank?
+    when 'destroy'
       !lock.stage_id
     else
       raise 'Unsupported action'
@@ -36,7 +36,7 @@ class LocksController < ApplicationController
     @lock ||= Lock.find(params[:id])
   end
 
-  #Overrides CurrentProject#require_project
+  # Overrides CurrentProject#require_project
   def require_project
     case action_name
     when 'create' then

--- a/app/controllers/macros_controller.rb
+++ b/app/controllers/macros_controller.rb
@@ -61,10 +61,6 @@ class MacrosController < ApplicationController
     )
   end
 
-  def command_params
-    params.require(:commands).permit(ids: [])
-  end
-
   def find_macro
     @macro = @project.macros.find(params[:id])
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,17 +1,16 @@
 class ProfilesController < ApplicationController
+  def show
+    @user = current_user
+  end
+
   def update
     @user = current_user
-
     if @user.update_attributes(user_params)
       Rails.logger.info("#{@user.name_and_email} updated their profile to #{@user.name_and_email}")
       redirect_to profile_path, notice: 'Your profile has been updated.'
     else
-      render action: "show"
+      render :show
     end
-  end
-
-  def show
-    @user = current_user
   end
 
   protected

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -10,10 +10,6 @@ class WebhooksController < ApplicationController
     @sources = Samson::Integration.sources
   end
 
-  def new
-    @webhooks = current_project.webhooks
-  end
-
   def create
     current_project.webhooks.create!(webhook_params)
 
@@ -27,14 +23,9 @@ class WebhooksController < ApplicationController
     redirect_to project_webhooks_path(current_project)
   end
 
-  def show
-    @webhook = current_project.webhooks.find(params[:id])
-  end
-
   private
 
   def webhook_params
     params.require(:webhook).permit(:branch, :stage_id, :source)
   end
-
 end

--- a/test/controllers/access_requests_controller_test.rb
+++ b/test/controllers/access_requests_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe AccessRequestsController do
   include AccessRequestTestSupport
   as_a_viewer do

--- a/test/controllers/admin/commands_controller_test.rb
+++ b/test/controllers/admin/commands_controller_test.rb
@@ -1,6 +1,102 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe Admin::CommandsController do
+  as_a_deployer do
+    unauthorized :get, :index
+    unauthorized :get, :new
+    unauthorized :post, :create
+    unauthorized :delete, :destroy, id: 123123
+
+    describe 'GET to #edit' do
+      it "is unauthrized" do
+        get :edit, id: commands(:echo)
+        assert_unauthorized
+      end
+    end
+
+    describe 'PUT to #update' do
+      it "is unauthrized" do
+        put :update, id: commands(:echo)
+        assert_unauthorized
+      end
+    end
+  end
+
+  as_a_project_admin do
+    unauthorized :get, :index
+    unauthorized :get, :new
+    unauthorized :post, :create
+    unauthorized :delete, :destroy, id: 123123
+
+    describe 'GET to #edit' do
+      it 'renders for local command as project-admin' do
+        get :edit, id: commands(:echo).id
+        assert_template :edit
+      end
+
+      it "is unauthrized for global commands" do
+        get :edit, id: commands(:global)
+        assert_unauthorized
+      end
+    end
+
+    describe 'PATCH to #update' do
+      let(:command) { commands(:echo) }
+      let(:attributes) {{ command: 'echo hi' }}
+      let(:format) { 'html' }
+
+      before do
+        patch :update, id: command.id, command: attributes, format: format
+      end
+
+      describe 'valid' do
+        describe 'html' do
+          it 'redirects and sets the flash' do
+            flash[:notice].wont_be_nil
+            assert_redirected_to admin_commands_path
+          end
+        end
+
+        describe 'json' do
+          let(:format) { 'json' }
+
+          it 'responds ok' do
+            assert_response :ok
+          end
+        end
+      end
+
+      describe 'invalid' do
+        let(:attributes) {{ command: nil }}
+
+        describe 'html' do
+          it 'renders and sets the flash' do
+            flash[:error].wont_be_nil
+            assert_template :edit
+          end
+        end
+
+        describe 'json' do
+          let(:format) { 'json' }
+
+          it 'responds unprocessable' do
+            assert_response :unprocessable_entity
+          end
+        end
+      end
+
+      describe 'global' do
+        let(:command) { commands(:global) }
+
+        it "is unauthrized" do
+          assert_unauthorized
+        end
+      end
+    end
+  end
+
   as_a_admin do
     describe 'GET to #index' do
       let(:echo) { commands(:echo) }
@@ -61,64 +157,16 @@ describe Admin::CommandsController do
     end
 
     describe 'GET to #edit' do
-      it "renders" do
-        get :edit, id: commands(:echo).id
+      it "renders for global commands" do
+        get :edit, id: commands(:global).id
         assert_template :edit
-      end
-
-      it 'fails for non-existent command' do
-        assert_raises ActiveRecord::RecordNotFound do
-          get :edit, id: 123123
-        end
       end
     end
 
-    describe 'PATCH to #update' do
-      before do
-        patch :update, id: commands(:echo).id,
-          command: attributes, format: format
-      end
-
-      describe 'invalid' do
-        let(:attributes) {{ command: nil }}
-
-        describe 'html' do
-          let(:format) { 'html' }
-
-          it 'renders and sets the flash' do
-            flash[:error].wont_be_nil
-            assert_template :edit
-          end
-        end
-
-        describe 'json' do
-          let(:format) { 'json' }
-
-          it 'responds unprocessable' do
-            assert_response :unprocessable_entity
-          end
-        end
-      end
-
-      describe 'valid' do
-        let(:attributes) {{ command: 'echo hi' }}
-
-        describe 'html' do
-          let(:format) { 'html' }
-
-          it 'redirects and sets the flash' do
-            flash[:notice].wont_be_nil
-            assert_redirected_to admin_commands_path
-          end
-        end
-
-        describe 'json' do
-          let(:format) { 'json' }
-
-          it 'responds ok' do
-            assert_response :ok
-          end
-        end
+    describe 'PUT to #update' do
+      it "updates a global commands" do
+        put :update, id: commands(:global).id, command: { command: 'echo hi' }
+        assert_redirected_to admin_commands_path
       end
     end
 
@@ -152,51 +200,6 @@ describe Admin::CommandsController do
             assert_response :ok
           end
         end
-      end
-    end
-  end
-
-  as_a_deployer do
-    unauthorized :get, :index
-    unauthorized :get, :new
-    unauthorized :post, :create
-    unauthorized :delete, :destroy, id: 123123
-
-    describe 'GET to #edit' do
-      it 'does not render for global command' do
-        get :edit, id: commands(:global).id
-        @unauthorized.must_equal true, "Request was not marked unauthorized"
-      end
-
-      it 'renders for local command as project-admin' do
-        UserProjectRole.create!(user: users(:deployer), project: projects(:test), role_id: Role::ADMIN.id)
-        get :edit, id: commands(:echo).id
-        assert_template :edit
-      end
-
-      it 'does not render for local command as non-project-admin' do
-        get :edit, id: commands(:echo).id
-        @unauthorized.must_equal true, "Request was not marked unauthorized"
-      end
-    end
-
-    describe 'PATCH to #update' do
-      let(:attributes) {{ command: 'echo hi' }}
-
-      it 'does not update for global command' do
-        patch :update, id: commands(:global).id, command: attributes, format: :json
-        @unauthorized.must_equal true, "Request was not marked unauthorized"
-      end
-
-      it 'updates for local command as project-admin' do
-        UserProjectRole.create!(user: user, project: projects(:test), role_id: Role::ADMIN.id)
-        patch :update, id: commands(:echo).id, command: attributes, format: :json
-        assert_response :ok
-      end
-
-      it 'does not update for local command as non-project-admin' do
-        patch :update, id: commands(:echo).id, command: attributes, format: :json
-        @unauthorized.must_equal true, "Request was not marked unauthorized"
       end
     end
   end

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe Admin::DeployGroupsController do
   let(:deploy_group) { deploy_groups(:pod100) }
   let(:stage) { stages(:test_staging) }
@@ -16,9 +18,10 @@ describe Admin::DeployGroupsController do
   as_a_deployer do
     unauthorized :get, :index
     unauthorized :post, :create
-    unauthorized :delete, :destroy, id: 1
-    unauthorized :post, :update, id: 1
     unauthorized :get, :new
+    unauthorized :get, :edit, id: 1
+    unauthorized :post, :update, id: 1
+    unauthorized :delete, :destroy, id: 1
     unauthorized :get, :deploy_all, id: 1
     unauthorized :post, :deploy_all, id: 1
   end
@@ -26,9 +29,10 @@ describe Admin::DeployGroupsController do
   as_a_admin do
     it_renders_index
     unauthorized :post, :create
-    unauthorized :delete, :destroy, id: 1
-    unauthorized :post, :update, id: 1
     unauthorized :get, :new
+    unauthorized :get, :edit, id: 1
+    unauthorized :post, :update, id: 1
+    unauthorized :delete, :destroy, id: 1
     unauthorized :get, :deploy_all, id: 1
     unauthorized :post, :deploy_all, id: 1
   end
@@ -60,17 +64,10 @@ describe Admin::DeployGroupsController do
       end
     end
 
-    describe '#delete' do
-      it 'succeeds' do
-        delete :destroy, id: deploy_group
-        assert_redirected_to admin_deploy_groups_path
-        DeployGroup.where(id: deploy_group.id).must_equal []
-      end
-
-      it 'fails for non-existent deploy_group' do
-        assert_raises ActiveRecord::RecordNotFound do
-          delete :destroy, id: -1
-        end
+    describe '#edit' do
+      it "renders" do
+        get :edit, id: deploy_group
+        assert_template :edit
       end
     end
 
@@ -88,6 +85,20 @@ describe Admin::DeployGroupsController do
         assert_template :edit
         flash[:error].must_include "Name can't be blank"
         deploy_group.reload.name.must_equal 'Pod 100'
+      end
+    end
+
+    describe '#destroy' do
+      it 'succeeds' do
+        delete :destroy, id: deploy_group
+        assert_redirected_to admin_deploy_groups_path
+        DeployGroup.where(id: deploy_group.id).must_equal []
+      end
+
+      it 'fails for non-existent deploy_group' do
+        assert_raises ActiveRecord::RecordNotFound do
+          delete :destroy, id: -1
+        end
       end
     end
 

--- a/test/controllers/admin/environments_controller_test.rb
+++ b/test/controllers/admin/environments_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe Admin::EnvironmentsController do
   def self.it_renders_index
     it 'get :index succeeds' do

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -1,7 +1,22 @@
 require_relative '../../test_helper'
 
-class Admin::ProjectsControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+SingleCov.covered!
+
+describe Admin::ProjectsController do
+  as_a_deployer do
+    unauthorized :get, :show, id: 1
+  end
+
+  as_a_project_admin do
+    unauthorized :get, :show, id: 1
+  end
+
+  as_a_admin do
+    describe "#shiw" do
+      it "renders" do
+        get :show, id: projects(:test)
+        assert_template :show
+      end
+    end
+  end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,7 +1,8 @@
 require_relative '../../test_helper'
 
-describe Admin::UsersController do
+SingleCov.covered!
 
+describe Admin::UsersController do
   as_a_viewer do
     unauthorized :get, :index
     unauthorized :get, :show, id: 1
@@ -145,6 +146,11 @@ describe Admin::UsersController do
         modified_user.update!(access_request_pending: true)
         put :update, {id: modified_user.id, user: {role_id: Role::DEPLOYER.id}}
         modified_user.reload.access_request_pending.must_equal false
+      end
+
+      it 'renders when it fails' do
+        put :update, id: modified_user.id, user: {role_id: 5}
+        assert_response :bad_request
       end
     end
 

--- a/test/controllers/commit_statuses_controller_test.rb
+++ b/test/controllers/commit_statuses_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe CommitStatusesController do
   as_a_viewer do
     unauthorized :get, :show, project_id: :foo, id: 'test/test'

--- a/test/controllers/concerns/project_level_authorization_test.rb
+++ b/test/controllers/concerns/project_level_authorization_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe "ProjectLevelAuthorization Controller" do
   class ProjectLevelAuthorizationTestController < ApplicationController
     include ProjectLevelAuthorization
@@ -21,18 +23,18 @@ describe "ProjectLevelAuthorization Controller" do
   as_a_project_deployer do
     it "can access allowed projects" do
       get :deploy, project_id: Project.first.id, test_route: true
-      refute @unauthorized
+      refute_unauthorized
     end
 
     it "cannot access forbidden projects" do
       UserProjectRole.delete_all
       get :deploy, project_id: Project.first.id, test_route: true
-      assert @unauthorized
+      assert_unauthorized
     end
 
     it "cannot access admin" do
       get :admin, project_id: Project.first.id, test_route: true
-      assert @unauthorized
+      assert_unauthorized
     end
   end
 
@@ -40,37 +42,37 @@ describe "ProjectLevelAuthorization Controller" do
     it "can access any project" do
       UserProjectRole.delete_all
       get :deploy, project_id: Project.first.id, test_route: true
-      refute @unauthorized
+      refute_unauthorized
     end
 
     it "cannot access admin" do
       get :admin, project_id: Project.first.id, test_route: true
-      assert @unauthorized
+      assert_unauthorized
     end
   end
 
   as_a_project_admin do
     it "can access allowed projects" do
       get :admin, project_id: Project.first.id, test_route: true
-      refute @unauthorized
+      refute_unauthorized
     end
 
     it "cannot access forbidden projects" do
       UserProjectRole.delete_all
       get :admin, project_id: Project.first.id, test_route: true
-      assert @unauthorized
+      assert_unauthorized
     end
   end
 
   as_a_admin do
     it "can access any project" do
       get :admin, project_id: Project.first.id, test_route: true
-      refute @unauthorized
+      refute_unauthorized
     end
 
     it "can access any project deploy" do
       get :deploy, project_id: Project.first.id, test_route: true
-      refute @unauthorized
+      refute_unauthorized
     end
   end
 end

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe DashboardsController do
   let(:production) { environments(:production) }
 

--- a/test/controllers/deploy_groups_controller_test.rb
+++ b/test/controllers/deploy_groups_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe DeployGroupsController do
   let(:deploy_group) { deploy_groups(:pod1) }
   let(:production_deploy) { deploys(:succeeded_production_test) }

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered! percent: 82
+
 describe Integrations::BaseController do
   let(:sha) { "dc395381e650f3bac18457909880829fc20e34ba" }
   let(:project) { projects(:test) }

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe Integrations::BuildkiteController do
   extend IntegrationsControllerTestHelper
 

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe Integrations::GithubController do
   extend IntegrationsControllerTestHelper
 

--- a/test/controllers/integrations/jenkins_controller_test.rb
+++ b/test/controllers/integrations/jenkins_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe Integrations::JenkinsController do
   extend IntegrationsControllerTestHelper
 

--- a/test/controllers/integrations/semaphore_controller_test.rb
+++ b/test/controllers/integrations/semaphore_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered!
+
 describe Integrations::SemaphoreController do
   extend IntegrationsControllerTestHelper
 

--- a/test/controllers/integrations/tddium_controller_test.rb
+++ b/test/controllers/integrations/tddium_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered! percent: 86
+
 describe Integrations::TddiumController do
   extend IntegrationsControllerTestHelper
 

--- a/test/controllers/integrations/travis_controller_test.rb
+++ b/test/controllers/integrations/travis_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../../test_helper'
 
+SingleCov.covered! percent: 94
+
 describe Integrations::TravisController do
   let(:sha) { "123abc" }
   let(:project) { projects(:test) }

--- a/test/controllers/macros_controller_test.rb
+++ b/test/controllers/macros_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered! percent: 97
+
 describe MacrosController do
   let(:project) { projects(:test) }
   let(:macro) { macros(:test) }

--- a/test/controllers/new_relic_controller_test.rb
+++ b/test/controllers/new_relic_controller_test.rb
@@ -1,65 +1,73 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe NewRelicController do
-  setup do
+  before do
     NewRelicApi.api_key = 'hello'
   end
 
+  as_a_viewer do
+    unauthorized :get, :show, project_id: :foo, id: 1
+  end
+
   as_a_project_deployer do
-    it "requires a project" do
-      assert_raises(ActiveRecord::RecordNotFound) do
-        get :show, project_id: 123123, id: 123123
-      end
-    end
-
-    it "requires a stage" do
-      assert_raises(ActiveRecord::RecordNotFound) do
-        get :show, project_id: projects(:test), id: 123123
-      end
-    end
-
-    it "requires a NewReclic api key" do
-      begin
-        old, NewRelicApi.api_key = NewRelicApi.api_key, ""
-        get :show, project_id: projects(:test), id: 123123
-      ensure
-        NewRelicApi.api_key = old
-      end
-      assert_response :precondition_failed
-    end
-
-    describe "success" do
-      setup do
-        NewRelic.expects(:metrics).
-          with([new_relic_applications(:production).name], initial).
-          returns('test_project' => true)
-
-        get :show, project_id: projects(:test),
-          id: stages(:test_staging).id,
-          initial: initial ? 'true' : nil
-      end
-
-      describe 'initial' do
-        let(:initial) { true }
-
-        it 'responds 200' do
-          response.status.must_equal(200)
-        end
-
-        it 'renders json representation' do
-          response.body.must_equal(JSON.dump('test_project' => true))
+    describe "#show" do
+      it "requires a project" do
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :show, project_id: 123123, id: 123123
         end
       end
 
-      describe 'not initial' do
-        let(:initial) { false }
+      it "requires a stage" do
+        assert_raises(ActiveRecord::RecordNotFound) do
+          get :show, project_id: projects(:test), id: 123123
+        end
+      end
 
-        it 'responds 200' do
-          response.status.must_equal(200)
+      it "requires a NewReclic api key" do
+        begin
+          old, NewRelicApi.api_key = NewRelicApi.api_key, ""
+          get :show, project_id: projects(:test), id: 123123
+        ensure
+          NewRelicApi.api_key = old
+        end
+        assert_response :precondition_failed
+      end
+
+      describe "success" do
+        before do
+          NewRelic.expects(:metrics).
+            with([new_relic_applications(:production).name], initial).
+            returns('test_project' => true)
+
+          get :show, project_id: projects(:test),
+            id: stages(:test_staging).id,
+            initial: initial ? 'true' : nil
         end
 
-        it 'renders json representation' do
-          response.body.must_equal(JSON.dump('test_project' => true))
+        describe 'initial' do
+          let(:initial) { true }
+
+          it 'responds 200' do
+            response.status.must_equal(200)
+          end
+
+          it 'renders json representation' do
+            response.body.must_equal(JSON.dump('test_project' => true))
+          end
+        end
+
+        describe 'not initial' do
+          let(:initial) { false }
+
+          it 'responds 200' do
+            response.status.must_equal(200)
+          end
+
+          it 'renders json representation' do
+            response.body.must_equal(JSON.dump('test_project' => true))
+          end
         end
       end
     end

--- a/test/controllers/ping_controller_test.rb
+++ b/test/controllers/ping_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe PingController do
   describe 'GET to #show' do
     setup { get :show }

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,12 +1,28 @@
 require_relative '../test_helper'
 
-describe ProfilesController do
-  describe 'a GET to #show' do
-    setup { get :show }
+SingleCov.covered!
 
-    it 'responds ok' do
-      response.status.must_equal(200)
+describe ProfilesController do
+  as_a_viewer do
+    describe 'a GET to #show' do
+      it 'renders' do
+        get :show
+        assert_template :show
+      end
     end
 
+    describe 'a PUT to #update' do
+      it 'updates' do
+        put :update, user: {name: 'Hans'}
+        assert_redirected_to profile_path
+        user.reload.name.must_equal 'Hans'
+      end
+
+      it 'renders when it fails to update' do
+        User.any_instance.expects(:update_attributes).returns false
+        put :update, user: {name: 'Hans'}
+        assert_template :show
+      end
+    end
   end
 end

--- a/test/controllers/project_roles_controller_test.rb
+++ b/test/controllers/project_roles_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe ProjectRolesController do
   let(:project) { projects(:test) }
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -1,9 +1,11 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe ProjectsController do
   let(:project) { projects(:test) }
 
-  setup do
+  before do
     Project.any_instance.stubs(:clone_repository).returns(true)
     Project.any_instance.stubs(:valid_repository_url).returns(true)
   end
@@ -101,7 +103,7 @@ describe ProjectsController do
     end
 
     as_a_admin do
-      setup do
+      before do
         post :create, params
       end
 
@@ -171,7 +173,7 @@ describe ProjectsController do
     end
 
     as_a_admin do
-      setup do
+      before do
         delete :destroy, id: project.to_param
       end
 
@@ -212,7 +214,7 @@ describe ProjectsController do
       end
 
       describe "common" do
-        setup do
+        before do
           put :update, params.merge(id: project.to_param)
         end
 
@@ -251,7 +253,7 @@ describe ProjectsController do
       end
 
       describe "common" do
-        setup do
+        before do
           put :update, params.merge(id: project.to_param)
         end
 

--- a/test/controllers/references_controller_test.rb
+++ b/test/controllers/references_controller_test.rb
@@ -1,10 +1,16 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe ReferencesController do
   before do
     reference_service = ReferencesService.new(projects(:test))
     reference_service.stubs(:find_git_references).returns(%w(master test_user/test_branch))
     ReferencesService.stubs(:new).returns(reference_service)
+  end
+
+  as_a_viewer do
+    unauthorized :get, :index, project_id: :foo
   end
 
   as_a_project_deployer do

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe ReleasesController do
   let(:project) { projects(:test) }
   let(:release) { releases(:test) }

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -1,7 +1,10 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe StagesController do
   subject { stages(:test_staging) }
+  let(:project) { subject.project }
 
   unauthorized :get, :show, project_id: :foo, id: 1, token: Rails.application.config.samson.badge_token
   unauthorized :get, :index, project_id: :foo, token: Rails.application.config.samson.badge_token, format: :svg
@@ -41,9 +44,10 @@ describe StagesController do
   end
 
   as_a_viewer do
-    unauthorized :get, :show, project_id: :foo, id: 1
+    unauthorized :get, :index, project_id: :foo
     unauthorized :get, :new, project_id: :foo
     unauthorized :post, :create, project_id: :foo
+    unauthorized :get, :show, project_id: :foo, id: 1
     unauthorized :get, :edit, project_id: :foo, id: 1
     unauthorized :patch, :update, project_id: :foo, id: 1
     unauthorized :delete, :destroy, project_id: :foo, id: 1
@@ -52,6 +56,19 @@ describe StagesController do
   end
 
   as_a_project_deployer do
+    describe "#index" do
+      it "renders html" do
+        get :index, project_id: project
+        assert_template 'index'
+      end
+
+      it "renders json" do
+        get :index, project_id: project, format: 'json'
+        response.body.must_match /\A\{\"stages\":\[/m
+        assert_response :success
+      end
+    end
+
     describe 'GET to :show' do
       describe 'valid' do
         before do

--- a/test/controllers/stars_controller_test.rb
+++ b/test/controllers/stars_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe StarsController do
   let(:current_user) { users(:viewer) }
   let(:project) { projects(:test) }

--- a/test/controllers/streams_controller_test.rb
+++ b/test/controllers/streams_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered! percent: 68
+
 describe StreamsController do
   include OutputBufferSupport
 
@@ -9,7 +11,7 @@ describe StreamsController do
 
   after { kill_extra_threads } # SSE heartbeat never finishes
 
-  as_a_deployer do
+  as_a_viewer do
     describe "a GET to :show" do
       it "should have an initial :started SSE and a :finished SSE" do
         # Override the job retrieval in the streams controller. This way we don't have

--- a/test/controllers/unauthorized_controller_test.rb
+++ b/test/controllers/unauthorized_controller_test.rb
@@ -1,5 +1,7 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe 'Unauthorized' do
   include Rack::Test::Methods
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,54 +1,20 @@
 require_relative '../test_helper'
 
+SingleCov.covered!
+
 describe UsersController do
   let(:project) { projects(:test) }
 
+  as_a_viewer do
+    unauthorized :get, :index, project_id: :foo
+  end
 
-  describe "a GET to #index" do
-    as_a_viewer do
-      unauthorized :get, :index, project_id: :foo
-    end
+  as_a_deployer do
+    unauthorized :get, :index, project_id: :foo
+  end
 
-    as_a_deployer do
-      unauthorized :get, :index, project_id: :foo
-    end
-
-    as_a_admin do
-      it 'responds successfully' do
-        get :index, project_id: project.to_param
-        users = User.all
-        assert_template :index
-        assigns(:users).wont_be_nil
-        assigns(:users).wont_be_empty
-        assigns(:users).size.must_equal users.size
-      end
-
-      it 'responds successfully to a JSON request' do
-        get :index, project_id: project.to_param, format: 'json'
-        users = User.all
-        assigns(:users).wont_be_nil
-        result = JSON.parse(response.body)
-        result['users'].wont_be_nil
-        result['users'].wont_be_nil
-        result['users'].wont_be_empty
-        result['users'].length.must_equal users.size
-        result['users'].each  do | user |
-          user_info = User.find_by(name: user['name'])
-          user_info.wont_be_nil
-        end
-      end
-
-      it 'responds as expected to a filtered search' do
-        get :index, project_id: project.to_param, search: "Admin"
-        users = User.search("Admin").page(1)
-        assert_template :index
-        assigns(:users).wont_be_nil
-        assigns(:users).wont_be_empty
-        assigns(:users).size.must_equal users.size
-      end
-    end
-
-    as_a_project_admin do
+  as_a_project_admin do
+    describe "a GET to #index" do
       it 'responds successfully' do
         get :index, project_id: project.to_param
         users = User.all

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -37,4 +37,14 @@ describe "cleanliness" do
     found.reject { |a| a =~ /^(_conditional_callback_around_|_callback_before_)/ } - ["flash"]
     found.must_equal []
   end
+
+  it "has coverage" do
+    bad = Dir["test/controllers/**/*.rb"].map do |f|
+      content = File.read(f)
+      unless content.include?("SingleCov.covered!")
+        "#{f} needs to use SingleCov.covered!"
+      end
+    end.compact
+    bad.must_equal []
+  end
 end

--- a/test/support/single_cov.rb
+++ b/test/support/single_cov.rb
@@ -36,9 +36,9 @@ class SingleCov
 
     def uncovered!(file)
       message = if File.exist?(file)
-        "#{file} does not exist and cannot be covered"
-      else
         "#{file} was not covered during tests, possibly loaded before test start ?"
+      else
+        "#{file} does not exist and cannot be covered"
       end
       warn message
       exit 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -155,7 +155,7 @@ class ActionController::TestCase
     def unauthorized(method, action, params = {})
       it "is unauthorized when doing a #{method} to #{action} with #{params}" do
         send(method, action, params)
-        @unauthorized.must_equal true, "Request was not marked unauthorized"
+        assert_unauthorized
       end
     end
 
@@ -189,6 +189,14 @@ class ActionController::TestCase
 
   def warden
     request.env['warden']
+  end
+
+  def assert_unauthorized
+    @unauthorized.must_equal true, "Request was not marked unauthorized"
+  end
+
+  def refute_unauthorized
+    refute @unauthorized, "Request was marked unauthorized"
   end
 
   def process_with_catch_warden(*args)


### PR DESCRIPTION
lots of small fixes + coverage improvements for all controllers ...
 - bringing almost all controllers up to 100% coverage
 - enforcing coverage tracking for all new controllers
 - refactoring tests into more logical order / lowering permissions where possible
 - extract assert_unauthorized helper

@zendesk/samson 

### Risks
- Low: some permission level refactoring

