### PR TITLE
make user project roles unique

### DIFF
--- a/db/migrate/20160413171549_unique_roles.rb
+++ b/db/migrate/20160413171549_unique_roles.rb
@@ -1,0 +1,19 @@
+class UniqueRoles < ActiveRecord::Migration
+  class UserProjectRole < ActiveRecord::Base
+  end
+
+  def up
+    # delete the lowest permission duplicate roles
+    UserProjectRole.all.group_by(&:user_id).each do |_user, roles|
+      roles.sort_by(&:role_id)[0..-2].each(&:destroy)
+    end
+
+    add_index :user_project_roles, [:user_id, :project_id], unique: true
+    remove_index :user_project_roles, :user_id
+  end
+
+  def down
+    add_index :user_project_roles, :user_id
+    remove_index :user_project_roles, [:user_id, :project_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160409160258) do
+ActiveRecord::Schema.define(version: 20160413171549) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -377,7 +377,7 @@ ActiveRecord::Schema.define(version: 20160409160258) do
   end
 
   add_index "user_project_roles", ["project_id"], name: "index_user_project_roles_on_project_id"
-  add_index "user_project_roles", ["user_id"], name: "index_user_project_roles_on_user_id"
+  add_index "user_project_roles", ["user_id", "project_id"], name: "index_user_project_roles_on_user_id_and_project_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name",           limit: 255,                 null: false


### PR DESCRIPTION
UI only allows 1 role per user and project ... so let the db enforce that

```
>> [1][0..-2]
=> []
>> [1,2][0..-2]
=> [1]
```

tested locally by disabling the model validation and then migrating

@jonmoter 

/cc @zendesk/samson 

### Risks
- Low: users losing access