### PR TITLE
we need env variables inside of application.rb so we have to load earlier

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, :assets, Rails.env)
 
+Dotenv.load(Bundler.root.join('.env')) unless Rails.env.test?
+
 module Samson
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/00_dotenv.rb
+++ b/config/initializers/00_dotenv.rb
@@ -1,1 +1,0 @@
-Dotenv.load(Bundler.root.join('.env')) unless Rails.env.test?


### PR DESCRIPTION
@zendesk/samson

previously this worked because dotenv-rails always loaded the .env file during Bundler.require