### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ADD bin /app/bin
 ADD public /app/public
 ADD db /app/db
 ADD .env.bootstrap /app/.env
+ADD .ruby-version /app/.ruby-version
 
 # NPM
 ADD package.json /app/package.json


### PR DESCRIPTION
Just trying to build the docker image it fails, this file was needed for bundle to work for me.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

Without this, when building the docker image it fails with:

[!] There was an error parsing `Gemfile`: No such file or directory @ rb_sysopen - .ruby-version. Bundler cannot continue.

With this patch, the build works just fine.