### PR TITLE
small fixes and improvements to Docker Builder workflow

### DIFF
--- a/app/helpers/builds_helper.rb
+++ b/app/helpers/builds_helper.rb
@@ -9,7 +9,8 @@ module BuildsHelper
   end
 
   def short_sha value, length: 7
-    "#{value.first(length)}" if value
+    # with Docker, SHA values can be of the form "sha256:0123abc..."
+    "#{value.split(':').last[0..length]}" if value
   end
 
   def git_ref_and_sha_for build, make_link: false

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -1,6 +1,7 @@
 class Build < ActiveRecord::Base
   SHA1_REGEX = /\A[0-9a-f]{40}\Z/i
-  SHA256_REGEX = /\A[0-9a-f]{64}\Z/i
+  SHA256_REGEX = /\A(sha256:)?[0-9a-f]{64}\Z/i
+  DIGEST_REGEX = /\A[\w._-]+\/[\w_-]+@sha256:[0-9a-f]{64}\Z/i
 
   belongs_to :project
   belongs_to :docker_build_job, class_name: 'Job'
@@ -12,6 +13,7 @@ class Build < ActiveRecord::Base
   validates :project, presence: true
   validates :git_sha, format: SHA1_REGEX, allow_nil: true, uniqueness: true
   validates :docker_image_id, format: SHA256_REGEX, allow_nil: true
+  validates :docker_repo_digest, format: DIGEST_REGEX, allow_nil: true
 
   validate :validate_git_reference, on: :create
 

--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -42,6 +42,7 @@ class DockerBuilderService
     build.docker_image = Docker::Image.build_from_dir(tmp_dir) do |output_chunk|
       handle_output_chunk(output_chunk)
     end
+    output_buffer.puts('### Docker build complete')
   rescue Docker::Error::DockerError => e
     # If a docker error is raised, consider that a "failed" job instead of an "errored" job
     output_buffer.puts("Docker build failed: #{e.message}")
@@ -52,9 +53,9 @@ class DockerBuilderService
   def push_image(tag)
     build.docker_ref = tag.presence || build.label.try(:parameterize).presence || 'latest'
     build.docker_repo_digest = nil
-    build.docker_image.tag(repo: project.docker_repo, tag: build.docker_ref, force: true)
+    output_buffer.puts("### Tagging and pushing Docker image to #{project.docker_repo}:#{build.docker_ref}")
 
-    output_buffer.puts("### Pushing Docker image to #{project.docker_repo}:#{build.docker_ref}")
+    build.docker_image.tag(repo: project.docker_repo, tag: build.docker_ref, force: true)
 
     build.docker_image.push(registry_credentials) do |output_chunk|
       parsed_chunk = handle_output_chunk(output_chunk)
@@ -98,11 +99,13 @@ class DockerBuilderService
 
   def handle_output_chunk(chunk)
     parsed_chunk = JSON.parse(chunk)
-    values = parsed_chunk.each_with_object([]) do |(k,v), arr|
-      arr << "#{k}: #{v}" if v.present?
+
+    # Don't bother printing all the incremental output when pulling images
+    unless parsed_chunk['progressDetail']
+      values = parsed_chunk.map { |k,v| "#{k}: #{v}" if v.present? }.compact
+      output_buffer.puts values.join(' | ')
     end
 
-    output_buffer.puts values.join(' | ')
     parsed_chunk
   end
 

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -35,7 +35,7 @@
     <dd><%= @build.docker_status %></dd>
 
     <dt>Docker Image Id</dt>
-    <dd><%= short_sha(@build.docker_image_id.split(':').last, length: 12) %></dd>
+    <dd><%= short_sha(@build.docker_image_id, length: 12) %></dd>
 
     <dt>Docker Digest</dt>
     <dd><%= @build.docker_repo_digest %></dd>

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -35,7 +35,7 @@
     <dd><%= @build.docker_status %></dd>
 
     <dt>Docker Image Id</dt>
-    <dd><%= short_sha(@build.docker_image_id, length: 12) %></dd>
+    <dd><%= short_sha(@build.docker_image_id.split(':').last, length: 12) %></dd>
 
     <dt>Docker Digest</dt>
     <dd><%= @build.docker_repo_digest %></dd>
@@ -58,7 +58,9 @@
     </div>
   <% end %>
 
-  <%= form_for :build, url: build_docker_image_project_build_path(@build.project, @build), html: { class: "form-inline" } do |form| %>
-    <%= form.submit (job ? 'Rebuild Docker Image' : 'Build Docker Image'), class: "btn btn-primary" %>
+  <% unless docker_build_running? @build %>
+    <%= form_for :build, url: build_docker_image_project_build_path(@build.project, @build), html: { class: "form-inline" } do |form| %>
+      <%= form.submit (job ? 'Rebuild Docker Image' : 'Build Docker Image'), class: "btn btn-primary" %>
+    <% end %>
   <% end %>
 </section>

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -6,7 +6,8 @@ describe Build do
   include GitRepoTestHelper
 
   let(:project) { Project.new(id: 99999, name: 'test_project', repository_url: repo_temp_dir) }
-  let(:sha_digest) { 'cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf' }
+  let(:example_sha) { 'cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf' }
+  let(:repo_digest) { "my-registry.zende.sk/some_project@sha256:#{example_sha}" }
 
   def valid_build(attributes = {})
     Build.new(attributes.reverse_merge(project: project, git_ref: 'master'))
@@ -36,8 +37,9 @@ describe Build do
       end
     end
 
-    it 'should validate container sha' do
-      assert_valid(valid_build(docker_image_id: sha_digest))
+    it 'should validate image id' do
+      assert_valid(valid_build(docker_image_id: example_sha))
+      assert_valid(valid_build(docker_image_id: "sha256:#{example_sha}"))
       refute_valid(valid_build(docker_image_id: 'This is a string of 64 characters...............................'))
       refute_valid(valid_build(docker_image_id: 'abc'))
     end
@@ -50,6 +52,12 @@ describe Build do
         assert_valid(valid_build(git_ref: current_commit))
       end
       refute_valid(valid_build(git_ref: 'some_tag_i_made_up'))
+    end
+    
+    it 'should validate docker digest' do
+      assert_valid(valid_build(docker_repo_digest: repo_digest))
+      refute_valid(valid_build(docker_repo_digest: example_sha))
+      refute_valid(valid_build(docker_repo_digest: 'some random string'))
     end
   end
 


### PR DESCRIPTION
* fix Build logic to work with docker 1.11 image ids
* improve docker builder output by hiding progress output

In Docker 1.11, the ids for images look like `sha256:abcd...` rather than just `abcd...`

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-224

### Risks
- Level: Low
