### PR TITLE
make sure there is a test for everything

### DIFF
--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -74,4 +74,66 @@ describe "cleanliness" do
       "has trailing whitespace" if content =~ / $/
     end
   end
+
+  it "tests all files" do
+    known_missing = [
+      "test/controllers/application_controller_test.rb",
+      "test/controllers/changelogs_controller_test.rb",
+      "test/controllers/concerns/authorization_test.rb",
+      "test/controllers/concerns/current_project_test.rb",
+      "test/controllers/concerns/current_user_test.rb",
+      "test/controllers/concerns/stage_permitted_params_test.rb",
+      "test/helpers/admin/commands_helper_test.rb",
+      "test/helpers/admin/projects_helper_test.rb",
+      "test/helpers/builds_helper_test.rb",
+      "test/helpers/date_time_helper_test.rb",
+      "test/helpers/deploys_helper_test.rb",
+      "test/helpers/flash_helper_test.rb",
+      "test/helpers/jobs_helper_test.rb",
+      "test/helpers/sessions_helper_test.rb",
+      "test/helpers/webhooks_helper_test.rb",
+      "test/mailers/application_mailer_test.rb",
+      "test/models/changeset/code_push_test.rb",
+      "test/models/changeset/issue_comment_test.rb",
+      "test/models/changeset/jira_issue_test.rb",
+      "test/models/concerns/has_commands_test.rb",
+      "test/models/concerns/has_role_test.rb",
+      "test/models/concerns/searchable_test.rb",
+      "test/models/datadog_notification_test.rb",
+      "test/models/deploy_groups_stage_test.rb",
+      "test/models/job_service_test.rb",
+      "test/models/job_viewers_test.rb",
+      "test/models/macro_command_test.rb",
+      "test/models/new_relic_test.rb",
+      "test/models/new_relic_application_test.rb",
+      "test/models/null_user_test.rb",
+      "test/models/restart_signal_handler_test.rb",
+      "test/models/role_test.rb",
+      "test/models/stage_command_test.rb",
+      "test/models/star_test.rb",
+      "test/serializers/build_serializer_test.rb",
+      "test/serializers/deploy_serializer_test.rb",
+      "test/serializers/project_serializer_test.rb",
+      "test/serializers/stage_serializer_test.rb",
+      "test/serializers/user_serializer_test.rb",
+      "test/lib/generators/plugin/plugin_generator_test.rb",
+      "test/lib/generators/plugin/templates/test_helper_test.rb",
+      "test/lib/samson/integration_test.rb",
+      "test/lib/warden/strategies/basic_strategy_test.rb",
+      "test/lib/warden/strategies/session_strategy_test.rb"
+    ]
+
+    expected_tests = (
+      Dir['app/**/*.rb'].map { |f| [f, f.sub('app/', 'test/').sub('.rb', '_test.rb')] } +
+      Dir['lib/**/*.rb'].map { |f| [f, f.sub('lib/', 'test/lib/').sub('.rb', '_test.rb')] }
+    )
+    missing = expected_tests.reject { |_, t| all_tests.include?(t) }
+
+    if fixed = (known_missing - missing.map(&:last)).presence
+      raise "Remove #{fixed.inspect} from known_missing!"
+    else
+      missing.reject! { |_, t| known_missing.include?(t) }
+      assert missing.empty?, missing.map { |f, t| "missing test for #{f} at #{t}" }.join("\n")
+    end
+  end
 end


### PR DESCRIPTION
@zendesk/samson

```
either shows this when a new test was added:
Remove ["test/serializers/stage_serializer_test.rb"] from known_missing!

or this when someone added a file without a test:
missing test for lib/warden/strategies/basic_strategy.rb at test/lib/warden/strategies/basic_strategy_test.rb
```
### Risks
- None

