### PR TITLE
resolve secrets when executing commands

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -21,7 +21,7 @@ class JobExecution
 
   def initialize(reference, job, env = {}, &block)
     @output = OutputBuffer.new
-    @executor = TerminalExecutor.new(@output, verbose: true)
+    @executor = TerminalExecutor.new(@output, verbose: true, project: job.project)
     @viewers = JobViewers.new(@output)
 
     @subscribers = []

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -56,13 +56,15 @@ module SecretStorage
     allowed
   end
 
+  SECRET_KEY_REGEX = %r{[\w\/-]+}
   BACKEND = ENV.fetch('SECRET_STORAGE_BACKEND', 'SecretStorage::DbBackend').constantize
 
   class << self
     delegate :delete, :keys, to: :backend
 
     def write(key, data)
-      return false if key.blank? || key =~ /\s/ || data.blank? || data[:value].blank?
+      return false unless key =~ /\A#{SECRET_KEY_REGEX}\z/
+      return false if data.blank? || data[:value].blank?
       backend.write(key, data)
     end
 

--- a/app/views/admin/secrets/index.html.erb
+++ b/app/views/admin/secrets/index.html.erb
@@ -1,3 +1,5 @@
+<% project_list = Project.pluck(:permalink, :name).to_h %>
+
 <h1>Secrets</h1>
 
 <section class="clearfix">
@@ -13,14 +15,20 @@
     <tbody>
       <% @secret_keys.each do |key| %>
         <tr>
-          <td>
-            <% permalink = key.split('/', 2).first %>
-            <%= permalink == 'global' ? 'Global' : link_to(permalink, project_path(permalink)) %>
-          </td>
           <td><%= key %></td>
           <td>
-            <%= link_to "Edit", edit_admin_secret_path(key) %>
-            <%= link_to_delete(admin_secret_path(key)) %>
+            <% permalink = key.split('/', 2).first %>
+            <% if name = project_list[permalink] %>
+              <%= link_to name, project_path(permalink) %>
+            <% elsif permalink == 'global' %>
+              Global
+            <% else %>
+              Unknown
+            <% end %>
+          </td>
+          <td>
+            <%= link_to "Edit", edit_admin_secret_path(key) %> |
+            <%= link_to_delete admin_secret_path(key) %>
           </td>
         </tr>
       <% end %>
@@ -28,6 +36,7 @@
   </table>
 
   <div class="admin-actions">
+    To use in commands, prefix <%= TerminalExecutor::SECRET_PREFIX %>
     <div class="pull-right">
       <%= link_to "New Secret", new_admin_secret_path, class: "btn btn-default" %>
     </div>

--- a/test/controllers/admin/secrets_controller_test.rb
+++ b/test/controllers/admin/secrets_controller_test.rb
@@ -3,10 +3,6 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Admin::SecretsController do
-  def create_secret(key)
-    SecretStorage::DbBackend::Secret.create!(id: key, value: '111', updater_id: users(:admin).id, creator_id: users(:admin).id)
-  end
-
   def create_global
     create_secret 'global/foo'
   end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -224,6 +224,13 @@ describe JobExecution do
     end
   end
 
+  it 'can access secrets' do
+    create_secret "#{project.permalink}/bar"
+    job.update(command: "echo '#{"secret://#{project.permalink}/bar"}'")
+    execute_job("master")
+    assert_equal 'MY-SECRET', last_line_of_output
+  end
+
   describe 'when JobExecution is disabled' do
     before do
       JobExecution.enabled = false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -138,6 +138,10 @@ class ActiveSupport::TestCase
   class << self
     undef :test
   end
+
+  def create_secret(key)
+    SecretStorage::DbBackend::Secret.create!(id: key, value: 'MY-SECRET', updater_id: users(:admin).id, creator_id: users(:admin).id)
+  end
 end
 
 Mocha::Expectation.class_eval do


### PR DESCRIPTION
@zendesk/samson @zendesk/paas 

 - resolve `secret://` usages in commands
 - do not print secrets
 - only allow to access global or project specific secrets

### Risks
- Medium: accidentally exposing secrets

