### PR TITLE
Bug/deployment selector

### DIFF
--- a/plugins/kubernetes/app/models/concerns/kubernetes/deploy_yaml.rb
+++ b/plugins/kubernetes/app/models/concerns/kubernetes/deploy_yaml.rb
@@ -63,6 +63,9 @@ module Kubernetes
     # Sets the metadata that is going to be used as the selector. Kubernetes will use this metadata to select the
     # old and new Replication Controllers when managing a new Deployment.
     def set_selector_metadata
+      template.spec.selector ||= RecursiveOpenStruct.new(matchLabels: {})
+      template.spec.selector.matchLabels ||= {}
+
       deployment_labels.each do |key, value|
         template.spec.selector.matchLabels[key] = value
       end

--- a/plugins/kubernetes/app/models/concerns/kubernetes/deploy_yaml.rb
+++ b/plugins/kubernetes/app/models/concerns/kubernetes/deploy_yaml.rb
@@ -64,7 +64,7 @@ module Kubernetes
     # old and new Replication Controllers when managing a new Deployment.
     def set_selector_metadata
       deployment_labels.each do |key, value|
-        template.spec.selector[key] = value
+        template.spec.selector.matchLabels[key] = value
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -18,8 +18,8 @@ describe Kubernetes::RoleConfigFile do
       config_file.deployment.spec.replicas.must_equal 2
 
       # Selector
-      config_file.deployment.spec.selector.project.must_equal 'some-project'
-      config_file.deployment.spec.selector.role.must_equal 'some-role'
+      config_file.deployment.spec.selector.matchLabels.project.must_equal 'some-project'
+      config_file.deployment.spec.selector.matchLabels.role.must_equal 'some-role'
 
       # Pod Template
       config_file.deployment.spec.template.metadata.name.must_equal 'some-project-pod'

--- a/plugins/kubernetes/test/samples/kubernetes_role_config_file.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_role_config_file.yml
@@ -9,8 +9,9 @@ metadata:
 spec:
   replicas: 2
   selector:
-    project: some-project
-    role: some-role
+    matchLabels:
+      project: some-project
+      role: some-role
   template:
     metadata:
       name: some-project-pod


### PR DESCRIPTION
Hi, we are using kubernetes 1.2 and we run into the following issue. The definition of labelSelector [changed](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_labelselector) and now to match by labels you need to nest `.matchLabels` instead of putting the labels directly into the `selector` key.

This fix only supports kubernetes 1.2. Let me know how if you want to support 1.2, and how you would like to handle the support for multiple kubernetes versions.

This fix is related with #831 . 

Also, the last commit allows the base "kubernetes/deployment.yml" to skip the the "selector.matchLabels" definition.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Med
(Incompatibility with kubernetes 1.1)