### PR TITLE
Improve Releases discoverability and setup

### DIFF
--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -4,12 +4,11 @@
 
 <% cache [@project, @releases.current_page] do %>
   <section class="clearfix tabs">
-
-    <p class="pull-right">
-      <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
-    </p>
-
     <% if @releases.any? %>
+      <p class="pull-right">
+        <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
+      </p>
+
       <table class="table table-hover release-list">
         <thead>
           <tr>
@@ -27,7 +26,9 @@
 
       <%= paginate @releases %>
     <% else %>
-      <p>There haven't been any releases yet.</p>
+      <div class="alert alert-warning">
+        <p>Configure a <%= link_to "release branch", edit_project_path(@project, anchor: "project_release_branch") %> to automatically create releases whenever a branch is pushed to.</p>
+      </div>
     <% end %>
 
   </section>

--- a/app/views/releases/new.html.erb
+++ b/app/views/releases/new.html.erb
@@ -9,7 +9,7 @@
       <div class="form-group">
         <%= form.label :commit, "SHA", class: "col-lg-2 control-label" %>
         <div class="col-lg-4">
-          <%= form.text_field :commit, class: "form-control" %>
+          <%= form.text_field :commit, class: "form-control", value: @project.deploys.last.try(:commit) %>
           <p class="help-block">This commit will be tagged with the version number <%= @release.version %>.</p>
         </div>
       </div>

--- a/app/views/shared/_project_tabs.html.erb
+++ b/app/views/shared/_project_tabs.html.erb
@@ -2,11 +2,9 @@
   <li class="<%= 'active' if active == 'overview' %>">
     <%= link_to "Overview", project %>
   </li>
-  <% if project.manage_releases? %>
-    <li class="<%= 'active' if active == 'releases' %>">
-      <%= link_to "Releases", project_releases_path(project) %>
-    </li>
-  <% end %>
+  <li class="<%= 'active' if active == 'releases' %>">
+    <%= link_to "Releases", project_releases_path(project) %>
+  </li>
   <% if project.deploy_with_docker? %>
     <li class="<%= 'active' if active == 'builds' %>">
       <%= link_to "Builds", project_builds_path(project) %>


### PR DESCRIPTION
* Always show the Releases tab.
* Improve the setup process for Releases a bit.

![](http://cl.ly/0U3C0f401k04/Image%202016-04-19%20at%202.25.49%20PM.png)
/cc @zendesk/samson

### Risks
- Level: Low. Doesn't change any existing behavior.
