### PR TITLE
prevent accidental manipulation of viewers without syncing output and add tests

### DIFF
--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -32,7 +32,7 @@ class StreamsController < ApplicationController
     when :started, :finished
       status_response(event)
     when :viewers
-      viewers = data.uniq.reject {|user| user == current_user}
+      viewers = data.to_a.uniq.reject {|user| user == current_user}
       viewers.to_json(only: [:id, :name])
     else
       JSON.dump(msg: render_log(data))

--- a/app/models/job_viewers.rb
+++ b/app/models/job_viewers.rb
@@ -1,15 +1,21 @@
-class JobViewers < ThreadSafe::Array
+class JobViewers
   def initialize(output)
+    @list = ThreadSafe::Array.new
     @output = output
-    super()
   end
 
   def push(*args)
-    super.tap { output }
+    @list.push *args
+    output
   end
 
   def delete(*args)
-    super.tap { output }
+    @list.delete *args
+    output
+  end
+
+  def to_a
+    @list.dup
   end
 
   private

--- a/test/models/job_viewers_test.rb
+++ b/test/models/job_viewers_test.rb
@@ -1,6 +1,32 @@
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 5
+SingleCov.covered!
 
 describe JobViewers do
+  let(:output) { OutputBuffer.new }
+  let(:viewer) { JobViewers.new(output) }
+
+  describe "#push" do
+    it "adds an item and notifies the output" do
+      viewer.push :foo
+      viewer.instance_variable_get(:@list).must_equal [:foo]
+      output.instance_variable_get(:@previous).must_equal [[:viewers, viewer]]
+    end
+  end
+
+  describe "#delete" do
+    it "deletes an item and notifies the output" do
+      viewer.push :foo
+      viewer.push :bar
+      viewer.delete :foo
+      viewer.instance_variable_get(:@list).must_equal [:bar]
+      output.instance_variable_get(:@previous).must_equal [[:viewers, viewer], [:viewers, viewer], [:viewers, viewer]]
+    end
+  end
+
+  describe "#to_a" do
+    it "generates a dup" do
+      viewer.to_a.object_id.wont_equal viewer.instance_variable_get(:@list).object_id
+    end
+  end
 end


### PR DESCRIPTION
previously calling shift/unshift etc all worked but would not notify output ... bad pattern ...

@zendesk/samson 

### Risks
- None