### PR TITLE
show nice inline error descriptions instead of stuffing everything in to the flash

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -19,7 +19,6 @@ class Admin::DeployGroupsController < ApplicationController
       flash[:notice] = "Successfully created deploy group: #{@deploy_group.name}"
       redirect_to action: :index
     else
-      flash[:error] = @deploy_group.errors.full_messages
       render :edit
     end
   end
@@ -33,7 +32,6 @@ class Admin::DeployGroupsController < ApplicationController
       flash[:notice] = "Successfully saved deploy group: #{deploy_group.name}"
       redirect_to action: :index
     else
-      flash[:error] = deploy_group.errors.full_messages
       render :edit
     end
   end

--- a/app/controllers/admin/environments_controller.rb
+++ b/app/controllers/admin/environments_controller.rb
@@ -23,7 +23,6 @@ class Admin::EnvironmentsController < ApplicationController
       flash[:notice] = "Successfully saved environment: #{@environment.name}"
       redirect_to action: 'index'
     else
-      flash[:error] = @environment.errors.full_messages
       render 'edit'
     end
   end
@@ -33,7 +32,6 @@ class Admin::EnvironmentsController < ApplicationController
       flash[:notice] = "Successfully saved environment: #{environment.name}"
       redirect_to action: 'index'
     else
-      flash[:error] = environment.errors.full_messages
       render 'edit'
     end
   end

--- a/app/controllers/admin/secrets_controller.rb
+++ b/app/controllers/admin/secrets_controller.rb
@@ -58,7 +58,6 @@ class Admin::SecretsController < ApplicationController
   end
 
   def failure_response(message)
-
     flash[:error] = message
     render :edit
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -41,7 +41,6 @@ class ProjectsController < ApplicationController
       redirect_to @project
       Rails.logger.info("#{@current_user.name_and_email} created a new project #{@project.to_param}")
     else
-      flash[:error] = @project.errors.full_messages
       render :new
     end
   end
@@ -57,7 +56,6 @@ class ProjectsController < ApplicationController
     if project.update_attributes(project_params)
       redirect_to project
     else
-      flash[:error] = project.errors.full_messages
       render :edit
     end
   end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -49,7 +49,6 @@ class StagesController < ApplicationController
     if @stage.save
       redirect_to [@project, @stage]
     else
-      flash[:error] = @stage.errors.full_messages
       render :new
     end
   end
@@ -61,7 +60,6 @@ class StagesController < ApplicationController
     if @stage.update_attributes(stage_params)
       redirect_to [@project, @stage]
     else
-      flash[:error] = @stage.errors.full_messages
       render :edit
     end
   end

--- a/app/views/admin/deploy_groups/edit.html.erb
+++ b/app/views/admin/deploy_groups/edit.html.erb
@@ -2,6 +2,8 @@
 
 <section>
   <%= form_for [:admin, @deploy_group], html: { class: "form-horizontal" } do |form| %>
+    <%= render 'shared/errors', object: @deploy_group %>
+
     <%= render 'admin/deploy_groups/fields', form: form %>
 
     <hr>

--- a/app/views/admin/environments/edit.html.erb
+++ b/app/views/admin/environments/edit.html.erb
@@ -2,6 +2,8 @@
 
 <section>
   <%= form_for [:admin, @environment], html: { class: "form-horizontal" } do |form| %>
+    <%= render 'shared/errors', object: @environment %>
+
     <%= render 'admin/environments/fields', form: form %>
 
     <hr>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_for project, html: { class: "form-horizontal" } do |form| %>
+  <%= render 'shared/errors', object: project %>
+
   <fieldset>
     <div class="form-group">
       <%= form.label :name, class: "col-lg-2 control-label" %>

--- a/app/views/stages/_form.html.erb
+++ b/app/views/stages/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_for [project, stage], html: { class: "form-horizontal" } do |form| %>
+  <%= render 'shared/errors', object: stage %>
+
   <fieldset>
     <%= render 'stages/fields', form: form %>
   </fieldset>

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -59,7 +59,6 @@ describe Admin::DeployGroupsController do
         deploy_group_count = DeployGroup.count
         post :create, deploy_group: {name: nil}
         assert_template :edit
-        flash[:error].must_equal ["Permalink can't be blank", "Name can't be blank", "Environment can't be blank"]
         DeployGroup.count.must_equal deploy_group_count
       end
     end
@@ -83,7 +82,6 @@ describe Admin::DeployGroupsController do
       it 'fail to update with blank name' do
         post :update, deploy_group: {name: ''}, id: deploy_group
         assert_template :edit
-        flash[:error].must_include "Name can't be blank"
         deploy_group.reload.name.must_equal 'Pod 100'
       end
     end

--- a/test/controllers/admin/environments_controller_test.rb
+++ b/test/controllers/admin/environments_controller_test.rb
@@ -59,7 +59,6 @@ describe Admin::EnvironmentsController do
         env_count = Environment.count
         post :create, environment: {name: nil, is_production: true}
         assert_template :edit
-        flash[:error].must_equal ["Permalink can't be blank", "Name can't be blank"]
         Environment.count.must_equal env_count
       end
     end
@@ -93,7 +92,6 @@ describe Admin::EnvironmentsController do
       it 'fail to edit with blank name' do
         post :update, environment: {name: '', is_production: false}, id: environment
         assert_template :edit
-        flash[:error].must_equal ["Name can't be blank"]
         Environment.find(environment.id).name.must_equal 'Production'
       end
     end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -148,10 +148,6 @@ describe ProjectsController do
       describe "with invalid parameters" do
         let(:params) { { project: { name: "" } } }
 
-        it "sets the flash error" do
-          request.flash[:error].wont_be_nil
-        end
-
         it "renders new template" do
           assert_template :new
         end
@@ -233,10 +229,6 @@ describe ProjectsController do
         describe "with invalid parameters" do
           let(:params) { { project: { name: "" } } }
 
-          it "sets the flash error" do
-            request.flash[:error].wont_be_nil
-          end
-
           it "renders edit template" do
             assert_template :edit
           end
@@ -271,10 +263,6 @@ describe ProjectsController do
 
         describe "with invalid parameters" do
           let(:params) { { project: { name: "" } } }
-
-          it "sets the flash error" do
-            request.flash[:error].wont_be_nil
-          end
 
           it "renders edit template" do
             assert_template :edit


### PR DESCRIPTION
@zendesk/samson

before:
<img width="657" alt="screen shot 2016-04-20 at 3 46 41 pm" src="https://cloud.githubusercontent.com/assets/11367/14692865/22e72d34-070f-11e6-89a0-53e884408724.png">


after:
<img width="660" alt="screen shot 2016-04-20 at 3 46 16 pm" src="https://cloud.githubusercontent.com/assets/11367/14692862/1e3d9fac-070f-11e6-9e4d-b6a3a5d65432.png">



### Risks
- Low: errors not showing