### PR TITLE
rename command -> script to make it more obvious what is going on under the hood

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -71,7 +71,7 @@ class Admin::DeployGroupsController < ApplicationController
 
   def stages_in_same_environment(project, environment)
     project.stages.select do |stage|
-      stage.command.include?("$DEPLOY_GROUPS") && # is dynamic
+      stage.script.include?("$DEPLOY_GROUPS") && # is dynamic
         stage.deploy_groups.where(environment: environment || deploy_group.environment).exists? # is made to go to this environment
     end.sort_by { |stage| only_to_current_group?(stage) ? 0 : 1 }
   end

--- a/app/models/concerns/has_commands.rb
+++ b/app/models/concerns/has_commands.rb
@@ -7,7 +7,7 @@ module HasCommands
     end
   end
 
-  def command
+  def script
     commands.map(&:command).join("\n")
   end
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -188,7 +188,7 @@ class Deploy < ActiveRecord::Base
   # commands and deploy groups can change via many different paths,
   # so we validate once a user actually tries to execute the command
   def validate_stage_uses_deploy_groups_properly
-    if DeployGroup.enabled? && stage.deploy_groups.none? && stage.command.include?("$DEPLOY_GROUPS")
+    if DeployGroup.enabled? && stage.deploy_groups.none? && stage.script.include?("$DEPLOY_GROUPS")
       errors.add(:stage, "contains at least one command using the $DEPLOY_GROUPS environment variable, but there are no Deploy Groups associated with this stage.")
     end
   end

--- a/app/models/macro_service.rb
+++ b/app/models/macro_service.rb
@@ -8,7 +8,7 @@ class MacroService
   def execute!(macro)
     @project.jobs.create(
       user: @user,
-      command: macro.command,
+      command: macro.script,
       commit: macro.reference
     )
   end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -92,7 +92,7 @@ class Stage < ActiveRecord::Base
 
   def create_deploy(user, attributes = {})
     deploys.create(attributes.merge(release: !no_code_deployed)) do |deploy|
-      deploy.build_job(project: project, user: user, command: command)
+      deploy.build_job(project: project, user: user, command: script)
     end
   end
 

--- a/app/views/shared/_commands.html.erb
+++ b/app/views/shared/_commands.html.erb
@@ -1,5 +1,5 @@
 <fieldset>
-  <legend>Commands</legend>
+  <legend>Script</legend>
   <p>Select the commands you want to run when executing. Double click to edit commands.</p>
 
   <div id="commands">

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -29,8 +29,8 @@
 
   <%= Samson::Hooks.render_views(:stage_show, self) %>
 
-  <h2>Command</h2>
-  <pre class="pre-command"><%= @stage.command %></pre>
+  <h2>Script</h2>
+  <pre class="pre-command"><%= "set -ex\n" + @stage.script %></pre>
 
   <% if groups = @stage.deploy_groups.sort_by(&:natural_order).to_a.presence %>
     <h2>Deploy groups</h2>

--- a/test/controllers/macros_controller_test.rb
+++ b/test/controllers/macros_controller_test.rb
@@ -7,7 +7,7 @@ describe MacrosController do
   let(:macro) { macros(:test) }
   let(:macro_service) { stub(execute!: nil) }
   let(:execute_called) { [] }
-  let(:job) { Job.create!(commit: macro.reference, command: macro.command, project: project, user: user) }
+  let(:job) { Job.create!(commit: macro.reference, command: macro.script, project: project, user: user) }
 
   before do
     MacroService.stubs(:new).with(project, user).returns(macro_service)

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -159,7 +159,7 @@ describe StagesController do
         it 'is created' do
           subject.persisted?.must_equal(true)
           subject.command_ids.must_include(commands(:echo).id)
-          subject.command.must_equal(commands(:echo).command + "\ntest2 command\ntest command")
+          subject.script.must_equal(commands(:echo).command + "\ntest2 command\ntest command")
         end
 
         it 'redirects' do

--- a/test/models/macro_test.rb
+++ b/test/models/macro_test.rb
@@ -13,12 +13,12 @@ describe Macro do
       subject.save!
       subject.reload
 
-      subject.command.must_equal("test\n#{commands(:echo).command}")
+      subject.script.must_equal("test\n#{commands(:echo).command}")
     end
 
     it "is empty without commands" do
       subject.command_associations.clear
-      subject.command.must_equal('')
+      subject.script.must_equal('')
     end
   end
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -119,7 +119,7 @@ describe Project do
       project = Project.create!(params)
       stage = project.stages.where(name: 'Production').first
       stage.wont_be_nil
-      stage.command.must_equal("echo hello\ntest command")
+      stage.script.must_equal("echo hello\ntest command")
     end
   end
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -57,7 +57,7 @@ describe Stage do
       end
 
       it 'add new command to the end' do
-        subject.command.must_equal("#{commands(:echo).command}\ntest")
+        subject.script.must_equal("#{commands(:echo).command}\ntest")
       end
     end
 
@@ -71,7 +71,7 @@ describe Stage do
       end
 
       it 'joins all commands based on position' do
-        subject.command.must_equal("test\n#{commands(:echo).command}")
+        subject.script.must_equal("test\n#{commands(:echo).command}")
       end
     end
 
@@ -79,7 +79,7 @@ describe Stage do
       before { subject.commands.clear }
 
       it 'is empty' do
-        subject.command.must_be_empty
+        subject.script.must_be_empty
       end
     end
   end


### PR DESCRIPTION
samson is running a bash script that shows commands and fails when a sub-command fails ... if someone was to copy-paste that, it would need a `set -ex` anyway ... and this would make the inner working of samson more obvious

Also resolves the naming conflict between doing `command=` which expects a single command and `command` returning the full script.

before:
<img width="280" alt="screen shot 2016-04-20 at 5 56 36 pm" src="https://cloud.githubusercontent.com/assets/11367/14694832/440dfd8c-0721-11e6-8008-d89e7d26f549.png">


after:
<img width="242" alt="screen shot 2016-04-20 at 5 57 22 pm" src="https://cloud.githubusercontent.com/assets/11367/14694840/5ac1e26e-0721-11e6-8d43-6a289290bd1f.png">


@zendesk/samson 
/cc @jonmoter 

### Risks
- Low: stage/macros failures

