### PR TITLE
Fix log styling if using color in log output

### DIFF
--- a/app/assets/javascripts/streams.js
+++ b/app/assets/javascripts/streams.js
@@ -20,7 +20,7 @@ function startStream() {
 
     var addLine = function(data) {
       var msg = JSON.parse(data).msg;
-      $messages.append(msg);
+      $messages.append(msg + "\n");
       if (following) {
         $messages.scrollTop($messages[0].scrollHeight);
       }

--- a/app/assets/stylesheets/deploys.scss
+++ b/app/assets/stylesheets/deploys.scss
@@ -140,7 +140,6 @@ td.status {
   white-space: pre-wrap;
   > span {
     display: inline-block;
-    width: 100%;
     cursor: pointer;
 
     &.highlighted {


### PR DESCRIPTION
Merge #807 introduced some display issues with colored logs which is fixed with this commit

Before:
![image](https://cloud.githubusercontent.com/assets/7583579/14718977/e94e31d0-07f9-11e6-9309-7f069d4bd75f.png)

After:
![image](https://cloud.githubusercontent.com/assets/7583579/14718992/fce685da-07f9-11e6-8977-d5b1f63826b4.png)


/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low (only log output)
