### PR TITLE
make replace work again

### DIFF
--- a/app/assets/javascripts/streams.js
+++ b/app/assets/javascripts/streams.js
@@ -18,9 +18,15 @@ function startStream() {
     var origin = $('meta[name=deploy-origin]').first().attr('content');
     var source = new EventSource(origin + streamUrl, { withCredentials: true });
 
-    var addLine = function(data) {
+    var addLine = function(data, replace) {
       var msg = JSON.parse(data).msg;
-      $messages.append(msg + "\n");
+      if (replace) {
+        $messages.children().last().remove();
+      } else {
+        msg = "\n" + msg;
+      }
+      $messages.append(msg);
+
       if (following) {
         $messages.scrollTop($messages[0].scrollHeight);
       }
@@ -63,8 +69,7 @@ function startStream() {
     }, false);
 
     source.addEventListener('replace', function(e) {
-      $messages.children().last().remove();
-      addLine(e.data);
+      addLine(e.data, true);
     }, false);
 
     source.addEventListener('started', function(e) {

--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -53,21 +53,34 @@ class TerminalExecutor
   end
 
   def execute_command!(command)
-    Open3.popen2e(whitelisted_env, command, in: '/dev/null', unsetenv_others: true, pgroup: true)  do |stdin, oe, wait_thr|
-      @pid = wait_thr.pid
+    Tempfile.open('samson-execute') do |f|
+      f.write command
+      f.flush
+      options = {in: '/dev/null', unsetenv_others: true, pgroup: true}
 
-      @pgid = begin
-        Process.getpgid(@pid)
-      rescue Errno::ESRCH
-        nil
+      # http://stackoverflow.com/questions/1401002/trick-an-application-into-thinking-its-stdin-is-interactive-not-a-pipe
+      script = if RbConfig::CONFIG["target_os"].include?("darwin")
+        "script -q /dev/null sh #{f.path}"
+      else
+        "script -qfec 'sh #{f.path}'"
       end
 
-      oe.each(256) do |line|
-        @output.write line.gsub("\n", "\r\n")
-      end
+      Open3.popen2e(whitelisted_env, script, options)  do |_stdin, oe, wait_thr|
+        @pid = wait_thr.pid
 
-      wait_thr.value
-    end.success?
+        @pgid = begin
+          Process.getpgid(@pid)
+        rescue Errno::ESRCH
+          nil
+        end
+
+        oe.each(256) do |line|
+          @output.write line.gsub(/\r?\n/, "\r\n") # script on travis returns \n and \r\n on osx and our servers
+        end
+
+        wait_thr.value
+      end.success?
+    end
   end
 
   def whitelisted_env

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered! uncovered: 2
 
 describe TerminalExecutor do
   def with_env(env)
@@ -27,6 +27,11 @@ describe TerminalExecutor do
     it 'records stderr' do
       subject.execute!('echo "hi" >&2', 'echo "hello" >&2')
       output.string.must_equal("hi\r\nhello\r\n")
+    end
+
+    it 'pretends to be a tty to show progress bars and fancy colors' do
+      subject.execute!('ruby -e "puts STDOUT.tty?"')
+      output.string.must_equal("true\r\n")
     end
 
     it 'stops on failure' do


### PR DESCRIPTION
2bf25bdfb123b4e12997ee3e49e7eee5789b955c disabled tty ... now we bring it back end support replacement during streaming

@sandlerr @mblaschke 

fix for bug found in https://github.com/zendesk/samson/pull/864

### Risks
- Low: output breaks
