### PR TITLE
SAMSON-226 cannot reuse a recently approved deploy when the stage was changed after the deploy

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -155,6 +155,13 @@ class Stage < ActiveRecord::Base
     emails.uniq.presence
   end
 
+  def command_updated_at
+    [
+      command_associations.maximum(:updated_at),
+      commands.maximum(:updated_at)
+    ].compact.max
+  end
+
   private
 
   def permalink_base

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered!
 
 describe DeployService do
   let(:project) { deploy.project }
@@ -72,6 +72,7 @@ describe DeployService do
           service.stubs(:bypassed?).returns(false)
           service.stubs(:latest_approved_deploy).returns(Deploy.new(id:22, buddy:other_user) )
         end
+
         it "it starts the deploy" do
           service.expects(:confirm_deploy!).once
           service.deploy!(stage, reference: reference)
@@ -125,6 +126,14 @@ describe DeployService do
         deploy.buddy = user
         service.confirm_deploy!(deploy)
       end
+    end
+  end
+
+  describe "#stop!" do
+    it "stops the deploy" do
+      deploy.job = jobs(:running_test)
+      service.stop!(deploy)
+      deploy.job.status.must_equal 'cancelled'
     end
   end
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -412,4 +412,27 @@ describe Stage do
       end
     end
   end
+
+  describe "#command_updated_at" do
+    let(:t) { 3.seconds.from_now }
+
+    it "is nil for new" do
+      Stage.new.command_updated_at.must_equal nil
+    end
+
+    it "ignores updated_at since that is changed on every deploy" do
+      stage.command_associations.clear
+      stage.command_updated_at.must_equal nil
+    end
+
+    it "is updated when command content changed" do
+      stage.commands.first.update_column(:updated_at, t)
+      stage.command_updated_at.to_i.must_equal t.to_i
+    end
+
+    it "is updated when a new command was added" do
+      stage.command_associations.first.update_column(:updated_at, t)
+      stage.command_updated_at.to_i.must_equal t.to_i
+    end
+  end
 end


### PR DESCRIPTION
@zendesk/samson

### Risks
- Medium: previously approved deploys being unable to reuse
