### PR TITLE
heroku: run rake db:migrate on every push

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-ruby.git
+https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks.git

--- a/app.json
+++ b/app.json
@@ -37,6 +37,12 @@
     },
     "BUNDLE_WITHOUT": {
       "value": "mysql2:sqlite"
+    },
+    "BUILDPACK_URL": {
+      "value": "https://github.com/ddollar/heroku-buildpack-multi.git"
+    },
+    "DEPLOY_TASKS": {
+      "value": "db:migrate"
     }
   },
   "scripts": {


### PR DESCRIPTION
@zendesk/samson

deploy pipeline is already set up, now every master push will also go to heroku including new migrations :)

```
remote: -----> Preparing app for Rails asset pipeline
remote:        Running: rake assets:precompile
remote:        Asset precompilation completed (4.93s)
remote:        Cleaning assets
remote:        Running: rake assets:clean
remote:
remote: =====> Downloading Buildpack: https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks.git
remote: =====> Detected Framework: Rake
remote: Migrating to Empty (20160423034210)
remote: == 20160423034210 Empty: migrating ============================================
remote: == 20160423034210 Empty: migrated (0.0000s) ===================================
remote:
remote: Using release configuration from last framework (Rake).
remote:
remote: -----> Discovering process types
remote:        Procfile declares types     -> web
remote:        Default types for buildpack -> console, rake, worker
remote:
```

### Risks
- Level: Low/Med/High

