### PR TITLE
only check docker when docker is enabled and make it fail fast instea…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,10 @@ GITHUB_TOKEN={fill me in}
 
 # DEPLOY_GROUP_FEATURE=1 # optional, enable Environments and DeployGroups
 
+## Docker
 # DOCKER_FEATURE=1 # optional, experimental docker support
+# DOCKER_REGISTRY= # required, where to push/pull your docker images
+# DOCKER_URL= # optional, use this url instead of connecting to unix socket
 
 # FLOWDOCK_API_TOKEN= # required for the flowdock integration
 
@@ -67,6 +70,7 @@ GITHUB_TOKEN={fill me in}
 # REQUEST_ACCESS_EMAIL_ADDRESS_LIST= # optional, space separated list of email addresses (managers mailing list, JIRA, etc.)
 # REQUEST_ACCESS_EMAIL_PREFIX= # optional, email subject prefix
 
+## Secret storage
 # SECRET_STORAGE_BACKEND= # optional, should be one of: SecretStorage::DbBackend (default) or SecretStorage::HashicorpVault
 # VAULT_ADDR= # optinal, url to vault server if it is being used for secret storage, defaults to localhost
 # VAULT_SSL_CERT= # required if using vault secret backend, path to pem file used for client ssl auth wiht vault server

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -1,16 +1,15 @@
 require 'docker'
 
-if !Rails.env.test? && !ENV['PRECOMPILE']
-  if ENV['DOCKER_URL'].present?
-    Docker.url = ENV['DOCKER_URL']
-    Docker.options = { read_timeout: 600 }
-
-    # Confirm the Docker daemon is a recent enough version
-    Docker.validate_version!
-  end
-
-  if ENV['DOCKER_FEATURE'] && !ENV['DOCKER_REGISTRY'].present?
+if !Rails.env.test? && !ENV['PRECOMPILE'] && ENV['DOCKER_FEATURE']
+  if ENV['DOCKER_REGISTRY'].blank?
     puts '*** DOCKER_REGISTRY environment variable must be configured when DOCKER_FEATURE is enabled ***'
-    exit(1)
+    exit 1
   end
+
+  if (url = ENV['DOCKER_URL'].presence)
+    Docker.url = url
+  end
+
+  Docker.options = { read_timeout: 600, connect_timeout: 2 }
+  Docker.validate_version! # Confirm the Docker daemon is a recent enough version
 end


### PR DESCRIPTION
…d of hanging

reproduce by taking down docker but leaving DOCKER_URL set

Discussion: 
 - should we enforce DOCKER_URL to be set ?
 - DOCKER_REGISTRY env var is not documented

# Risks
 - Failing to boot when docker is too slow