### PR TITLE
deploy kubernetes via regular deploy workflow

### DIFF
--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -42,10 +42,12 @@ class DeployService
   private
 
   def construct_env(stage)
-    { STAGE: stage.permalink }.tap do |env|
-      group_names = stage.deploy_groups.pluck(:env_value).sort.join(" ")
-      env[:DEPLOY_GROUPS] = group_names if group_names.present?
-    end
+    env = { STAGE: stage.permalink }
+
+    group_names = stage.deploy_groups.pluck(:env_value).sort.join(" ")
+    env[:DEPLOY_GROUPS] = group_names if group_names.present?
+
+    env
   end
 
   def latest_approved_deploy(reference, project)

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -33,8 +33,10 @@
 
   <%= Samson::Hooks.render_views(:stage_show, self) %>
 
-  <h2>Script</h2>
-  <pre class="pre-command"><%= "set -ex\n" + @stage.script %></pre>
+  <div id="script-section">
+    <h2>Script</h2>
+    <pre class="pre-command"><%= "set -ex\n" + @stage.script %></pre>
+  </div>
 
   <% if groups = @stage.deploy_groups.sort_by(&:natural_order).to_a.presence %>
     <h2>Deploy groups</h2>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422223358) do
+ActiveRecord::Schema.define(version: 20160426223230) do
 
   create_table "build_statuses", force: :cascade do |t|
     t.integer  "build_id",                                     null: false
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 20160422223358) do
     t.datetime "deleted_at"
     t.integer  "build_id",   limit: 4
     t.boolean  "release",                default: false, null: false
+    t.boolean  "kubernetes",             default: false, null: false
   end
 
   add_index "deploys", ["build_id"], name: "index_deploys_on_build_id", using: :btree
@@ -368,6 +369,7 @@ ActiveRecord::Schema.define(version: 20160422223358) do
     t.string   "next_stage_ids"
     t.boolean  "no_code_deployed",                                           default: false
     t.boolean  "docker_binary_plugin_enabled",                               default: true
+    t.boolean  "kubernetes",                                                 default: false, null: false
   end
 
   add_index "stages", ["project_id", "permalink", "deleted_at"], name: "index_stages_on_project_id_and_permalink_and_deleted_at", length: {"project_id"=>nil, "permalink"=>191, "deleted_at"=>nil}, using: :btree

--- a/plugins/kubernetes/app/decorators/deploy_decorator.rb
+++ b/plugins/kubernetes/app/decorators/deploy_decorator.rb
@@ -1,0 +1,10 @@
+Deploy.class_eval do
+  before_create :copy_kubernetes_from_stage
+
+  private
+
+  def copy_kubernetes_from_stage
+    self.kubernetes = stage.try(:kubernetes)
+    nil
+  end
+end

--- a/plugins/kubernetes/app/models/concerns/kubernetes/deploy_yaml.rb
+++ b/plugins/kubernetes/app/models/concerns/kubernetes/deploy_yaml.rb
@@ -23,15 +23,21 @@ module Kubernetes
 
     def template
       @template ||= begin
-        yaml = YAML.load_stream(raw_template, kubernetes_role.config_file).detect do |doc|
-          doc['kind'] == 'Deployment'
+        sections = YAML.load_stream(raw_template, template_name).select { |doc| doc['kind'] == 'Deployment' }
+        if sections.size == 1
+          RecursiveOpenStruct.new(sections.first, :recurse_over_arrays => true)
+        else
+          raise Samson::Hooks::UserError, "Template #{template_name} has #{sections.size} Deployment sections, having 1 section is valid."
         end
-        RecursiveOpenStruct.new(yaml, :recurse_over_arrays => true)
       end
     end
 
     def raw_template
-      @raw_template ||= build.file_from_repo(kubernetes_role.config_file)
+      @raw_template ||= build.file_from_repo(template_name)
+    end
+
+    def template_name
+      kubernetes_role.config_file
     end
 
     # This key replaces the default kubernetes key: 'deployment.kubernetes.io/podTemplateHash'

--- a/plugins/kubernetes/app/models/kuber_deploy_service.rb
+++ b/plugins/kubernetes/app/models/kuber_deploy_service.rb
@@ -32,17 +32,10 @@ class KuberDeployService
 
   def create_services!
     kuber_release.release_docs.each do |release_doc|
+      status = release_doc.ensure_service
       role = release_doc.kubernetes_role
       service = release_doc.service
-
-      if service.nil?
-        log 'no Service defined', role: role.name
-      elsif service.running?
-        log 'Service already running', role: role.name, service_name: service.name
-      else
-        log 'creating Service', role: role.name, service_name: service.name
-        release_doc.client.create_service(Kubeclient::Service.new(release_doc.service_hash))
-      end
+      log status, role: role.name, service_name: service.try(:name)
     end
   end
 

--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -17,6 +17,10 @@ module Kubernetes
         @pod.status.phase == 'Running' && ready?
       end
 
+      def restarted?
+        @pod.status.containerStatuses.any? { |s| s.restartCount != 0 }
+      end
+
       def phase
         @pod.status.phase
       end

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -1,0 +1,143 @@
+# executes a deploy and writes log to job output
+# finishes when cluster is "Ready"
+module Kubernetes
+  class DeployExecutor
+    STABLE_TICKS = 20
+
+    def initialize(output, job:)
+      @output = output
+      @job = job
+    end
+
+    def pid
+      "Kubernetes-deploy-#{object_id}"
+    end
+
+    def stop!(_signal)
+      @stopped = true
+    end
+
+    def execute!(*_commands)
+      build = find_build
+      release = create_release(build)
+      ensure_service(release)
+      create_deploys(release)
+
+      # Wait until deploys are done and show progress
+      loop do
+        if @stopped
+          @output.puts "STOPPED"
+          return false
+        end
+
+        status = release.release_docs.map { |release_doc| pod_is_live?(release_doc) }
+        if @testing_for_stability
+          if status.all?
+            @testing_for_stability += 1
+            @output.puts "Stable #{@testing_for_stability}/#{STABLE_TICKS}"
+            if STABLE_TICKS == @testing_for_stability
+              @output.puts "SUCCESS"
+              return true
+            end
+          else
+            @output.puts "UNSTABLE - service is restarting"
+            return false
+          end
+        else
+          if status.all?
+            @output.puts "READY, starting stability test"
+            @testing_for_stability = 0
+          end
+        end
+
+        sleep 2
+      end
+    end
+
+    private
+
+    # TODO only call once per cluster and filter the output
+    def pod_is_live?(release_doc)
+      group = release_doc.deploy_group
+      role = release_doc.kubernetes_role.name
+      pod = group.kubernetes_cluster.client.get_pods(
+        namespace: group.kubernetes_namespace,
+        label_selector: {
+          deploy_group_id: group.id,
+          project_id: @job.project_id,
+          release_id: release_doc.kubernetes_release_id,
+          role: role
+        }.map { |k, v| "#{k}=#{v}" }.join(',')
+      ).first
+
+      live, description = analyze_pod_status(pod)
+      @output.puts "#{group.name} #{role}: #{description}"
+      live
+    end
+
+    # find the docker build we are deploying
+    # TODO: create it and wait ... also show creation logs etc
+    def find_build
+      if build = Build.find_by_git_sha(@job.commit)
+        @output.puts("Found build #{build.id} for sha #{@job.commit}")
+      else
+        raise Samson::Hooks::UserError, "Build for sha #{@job.commit} does not exist, create it before deploying"
+      end
+      build
+    end
+
+    # create a realese, storing all the configuration
+    def create_release(build)
+      # build config for every cluster and role we want to deploy to
+      group_config = @job.deploy.stage.deploy_groups.map do |group|
+        # raise "#{group.name} needs to be on kubernetes" unless group.
+        roles = Kubernetes::Role.where(project_id: @job.project_id).map do |role|
+          {id: role.id, replicas: role.replicas} # TODO make replicas configureable
+        end
+        {id: group.id, roles: roles}
+      end
+
+      release = Kubernetes::Release.create_release(deploy_groups: group_config, build_id: build.id, user: @job.user)
+      unless release.persisted?
+        raise Samson::Hooks::UserError, "Failed to create release: #{release.errors.full_messages.inspect}"
+      end
+      @output.puts("Created release #{release.id}\nConfig: #{group_config.inspect}")
+      release
+    end
+
+    def analyze_pod_status(pod)
+      if pod
+        pod = Kubernetes::Api::Pod.new(pod)
+        if pod.live?
+          if pod.restarted?
+            [false, "Restarted"]
+          else
+            [true, "Live"]
+          end
+        else
+          [false, "Waiting (#{pod.phase}, not Ready)"]
+        end
+      else
+        [false, "Missing"]
+      end
+    end
+
+    # Create deploys
+    def create_deploys(release)
+      release.release_docs.each do |release_doc|
+        @output.puts "Creating deploy for #{release_doc.deploy_group.name} role #{release_doc.kubernetes_role.name}"
+        release_doc.deploy_to_kubernetes
+      end
+    end
+
+    # Create the service or report it's status
+    def ensure_service(release)
+      release.release_docs.each do |release_doc|
+        role = release_doc.kubernetes_role
+        service = release_doc.service
+        status = release_doc.ensure_service
+        @output.puts "#{status} for role #{role.name} / service #{service ? service.name : "none"}"
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -94,6 +94,17 @@ module Kubernetes
       end
     end
 
+    def ensure_service
+      if service.nil?
+        'no Service defined'
+      elsif service.running?
+        'Service already running'
+      else
+        client.create_service(Kubeclient::Service.new(service_hash))
+        'creating Service'
+      end
+    end
+
     private
 
     def previous_deploy?(extension_client, deployment)

--- a/plugins/kubernetes/app/models/watchers/deploy_watcher.rb
+++ b/plugins/kubernetes/app/models/watchers/deploy_watcher.rb
@@ -8,12 +8,16 @@ module Watchers
 
     class << self
       def restart_watcher(project)
-        watcher = Celluloid::Actor[watcher_symbol(project)]
-        watcher.terminate if watcher && watcher.alive?
+        stop_watcher(project)
         start_watcher(project)
       end
 
       private
+
+      def stop_watcher(project)
+        watcher = Celluloid::Actor[watcher_symbol(project)]
+        watcher.terminate if watcher && watcher.alive?
+      end
 
       def watcher_symbol(project)
         "deploy-watcher-#{project.id}".to_sym

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
@@ -1,0 +1,20 @@
+<fieldset>
+  <legend>Kubernetes</legend>
+  <div class="col-lg-6 checkbox col-lg-offset-2">
+    <%= form.label :kubernetes do %>
+      <%= form.check_box :kubernetes %>
+      Deploy via kubernetes / ignore commands.
+    <% end %>
+  </div>
+</fieldset>
+
+<script>
+  $(function(){
+    // hide command section when kubernetes is selected
+    var $checkbox = $("#stage_kubernetes");
+    $checkbox.change(function(){
+      $("#commands").parent('fieldset').toggle(!$(this).is(':checked'))
+    });
+    $checkbox.trigger('change');
+  });
+</script>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -1,0 +1,6 @@
+<script>
+  $(function(){
+    // hide command section when kubernetes is selected
+    $("#script-section").toggle(<%= !@stage.kubernetes %>);
+  });
+</script>

--- a/plugins/kubernetes/config/initializers/watchers.rb
+++ b/plugins/kubernetes/config/initializers/watchers.rb
@@ -21,6 +21,6 @@ end
 Celluloid.logger = Rails.logger
 $CELLULOID_DEBUG = true
 
-if ENV['SERVER_MODE'] && !ENV['PRECOMPILE']
+if ENV['SERVER_MODE'] && !ENV['PRECOMPILE'] && !ENV['KUBERNETES_NOT_WATCHING']
   Kubernetes::Cluster.find_each(&:watch!)
 end

--- a/plugins/kubernetes/db/migrate/20160426223230_add_kuberetes_to_stage.rb
+++ b/plugins/kubernetes/db/migrate/20160426223230_add_kuberetes_to_stage.rb
@@ -1,0 +1,6 @@
+class AddKuberetesToStage < ActiveRecord::Migration
+  def change
+    # add_column :stages, :kubernetes, :boolean, default: false, null: false
+    add_column :deploys, :kubernetes, :boolean, default: false, null: false
+  end
+end

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -11,12 +11,17 @@ end
 
 Samson::Hooks.view :project_tabs_view, 'samson_kubernetes/project_tab'
 Samson::Hooks.view :admin_menu, 'samson_kubernetes/admin_menu'
+Samson::Hooks.view :stage_form, "samson_kubernetes/stage_form"
+Samson::Hooks.view :stage_show, "samson_kubernetes/stage_show"
 
 Samson::Hooks.callback :deploy_group_permitted_params do
   { cluster_deploy_group_attributes: [:kubernetes_cluster_id, :namespace] }
 end
 
+Samson::Hooks.callback :stage_permitted_params do
+  :kubernetes
+end
+
 Samson::Hooks.callback :edit_deploy_group do |deploy_group|
   deploy_group.build_cluster_deploy_group unless deploy_group.cluster_deploy_group
 end
-

--- a/plugins/kubernetes/test/cluster_config.yml
+++ b/plugins/kubernetes/test/cluster_config.yml
@@ -1,0 +1,12 @@
+users: []
+clusters:
+- name: test-cluster
+  cluster:
+    server: http://foobar.server
+
+apiVersion: '1'
+current-context: test
+contexts:
+- name: test
+  context:
+    cluster: test-cluster

--- a/plugins/kubernetes/test/decorators/deploy_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/deploy_decorator_test.rb
@@ -1,0 +1,26 @@
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe Deploy do
+  describe "#copy_kubernetes_from_stage" do
+    let(:stage) { stages(:test_staging) }
+
+    def create_deploy
+      Deploy.create!(
+        stage: stage,
+        reference: "baz",
+        job: jobs(:succeeded_test)
+      )
+    end
+
+    it "copies kubernetes" do
+      stage.kubernetes = true
+      create_deploy.kubernetes.must_equal true
+    end
+
+    it "does not copy no kubernetes" do
+      create_deploy.kubernetes.must_equal false
+    end
+  end
+end

--- a/plugins/kubernetes/test/decorators/deploy_group_serializer_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/deploy_group_serializer_decorator_test.rb
@@ -27,7 +27,7 @@ describe DeployGroupSerializer do
       parsed = JSON.parse(DeployGroupSerializer.new(deploy_group).to_json).with_indifferent_access
       parsed[:deploy_group][:kubernetes_cluster].wont_be_nil
       parsed[:deploy_group][:kubernetes_cluster][:name].must_equal 'test'
-      parsed[:deploy_group][:kubernetes_cluster][:config_filepath].must_equal '/tmp/config'
+      parsed[:deploy_group][:kubernetes_cluster][:config_filepath].must_equal 'plugins/kubernetes/test/cluster_config.yml'
       parsed[:deploy_group][:kubernetes_cluster][:config_context].must_equal 'test'
     end
   end

--- a/plugins/kubernetes/test/fixtures/kubernetes/clusters.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/clusters.yml
@@ -1,5 +1,5 @@
 test_cluster:
   name: test
   description: test cluster
-  config_filepath: /tmp/config
+  config_filepath: plugins/kubernetes/test/cluster_config.yml
   config_context: test

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -1,0 +1,130 @@
+require_relative "../../test_helper"
+
+SingleCov.covered!
+
+describe Kubernetes::DeployExecutor do
+  let(:output) { StringIO.new }
+  let(:out) { output.string }
+  let(:stage) { deploy.stage }
+  let(:deploy) { job.deploy }
+  let(:job) { jobs(:succeeded_test) }
+  let(:build) { builds(:docker_build) }
+  let(:executor) { Kubernetes::DeployExecutor.new(output, job: job) }
+
+  before do
+    stage.update_column :kubernetes, true
+    deploy.update_column :kubernetes, true
+  end
+
+  describe "#pid" do
+    it "returns a fake pid" do
+      executor.pid.must_include "Kubernetes"
+    end
+  end
+
+  describe "#execute!" do
+    def execute!
+      stub_request(:get, %r{http://foobar.server/api/1/namespaces/staging/pods}).to_return(body: pod_reply.to_json) # checks pod status to see if it's good
+      executor.execute!
+    end
+
+    def stop_after_first_iteration
+      executor.expects(:sleep).with { executor.stop!('FAKE-SGINAL'); true }
+    end
+
+    let(:pod_reply) do
+      {
+        resourceVersion: "1",
+        items: [{
+          status: {
+            phase: "Running", conditions: [{type: "Ready", status: "True"}],
+            containerStatuses: [{restartCount: 0}]
+          }
+        }]
+      }
+    end
+    let(:pod_status) { pod_reply[:items].first[:status] }
+
+    before do
+      job.update_column(:commit, build.git_sha) # this is normally done by JobExecution
+      Kubernetes::ReleaseDoc.any_instance.stubs(raw_template: {'kind' => 'Deployment', 'spec' => {'template' => {'metadata' => {'labels' => {}}, 'spec' => {'containers' => [{}]}}}, 'metadata' => {'labels' => {}}}.to_yaml) # TODO: should inject that from current checkout and not fetch via github
+      Kubernetes::Cluster.any_instance.stubs(connection_valid?: true, namespace_exists?: true)
+      stage.deploy_groups.each do |dg|
+        dg.create_cluster_deploy_group cluster: kubernetes_clusters(:test_cluster), namespace: 'staging', deploy_group: dg
+      end
+      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/deployments/").to_return(status: 404) # checks for previous deploys ... but there are none
+      stub_request(:post, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/deployments").to_return(body: "{}") # creates deployment
+      executor.stubs(:sleep)
+    end
+
+    it "succeeds" do
+      assert execute!
+      out.must_include "resque_worker: Live\n"
+      out.must_include "SUCCESS"
+    end
+
+    it "fails when build is not found" do
+      job.update_column(:commit, 'some-unfound-sha')
+      e = assert_raises Samson::Hooks::UserError do
+        refute execute!
+      end
+      e.message.must_equal "Build for sha some-unfound-sha does not exist, create it before deploying"
+    end
+
+    it "stops the loop when stopping" do
+      executor.stop!('FAKE-SIGNAL')
+      refute execute!
+      out.wont_include "SUCCESS"
+      out.must_include "STOPPED"
+    end
+
+    it "waits when deploy is not running" do
+      pod_status[:phase] = "Pending"
+      pod_status.delete(:conditions)
+
+      stop_after_first_iteration
+      refute execute!
+
+      out.must_include "resque_worker: Waiting (Pending, not Ready)\n"
+      out.must_include "STOPPED"
+    end
+
+    it "waits when deploy is running but not ready" do
+      pod_status[:conditions][0][:status] = "False"
+
+      stop_after_first_iteration
+      refute execute!
+
+      out.must_include "resque_worker: Waiting (Running, not Ready)\n"
+      out.must_include "STOPPED"
+    end
+
+    it "fails when release has errors" do
+      Kubernetes::Release.any_instance.expects(:persisted?).at_least_once.returns(false)
+      e = assert_raises Samson::Hooks::UserError do
+        execute!
+      end
+      e.message.must_equal "Failed to create release: []" # inspected errros
+    end
+
+    it "fails when pod is failing to boot" do
+      pod_status[:containerStatuses][0][:restartCount] = 1
+      executor.instance_variable_set(:@testing_for_stability, 0)
+      refute execute!
+      out.must_include "resque_worker: Restarted"
+      out.must_include "UNSTABLE - service is restarting"
+    end
+
+    # not sure if this will ever happen ...
+    it "shows error when pod could not be found" do
+      pod_reply[:items].clear
+
+      stop_after_first_iteration
+      refute execute!
+
+      out.must_include "resque_worker: Missing\n"
+      out.must_include "STOPPED"
+    end
+  end
+end
+

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -1,8 +1,25 @@
 require_relative "../../test_helper"
 
-SingleCov.covered! uncovered: 40
+SingleCov.covered! uncovered: 37
 
 describe Kubernetes::ReleaseDoc do
-  # TODO: create some tests
+  let(:doc) { kubernetes_release_docs(:test_release_pod_1) }
+
+  describe "#ensure_service" do
+    it "does nothing when no service is defined" do
+      doc.ensure_service.must_equal "no Service defined"
+    end
+
+    it "does nothing when no service is running" do
+      doc.stubs(service: stub(running?: true))
+      doc.ensure_service.must_equal "Service already running"
+    end
+
+    it "creates the service when it does not exist" do
+      doc.stubs(service: stub(running?: false))
+      doc.expects(:client).returns(stub(create_service: nil))
+      doc.ensure_service.must_equal "creating Service"
+    end
+  end
 end
 

--- a/plugins/kubernetes/test/models/watchers/deploy_watcher_test.rb
+++ b/plugins/kubernetes/test/models/watchers/deploy_watcher_test.rb
@@ -1,7 +1,7 @@
 require_relative "../../test_helper"
 require 'celluloid/current'
 
-SingleCov.covered! uncovered: 32
+SingleCov.covered! uncovered: 33
 
 describe Watchers::DeployWatcher do
   let(:environment) { environments(:production) }

--- a/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
+++ b/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
@@ -3,4 +3,9 @@ require_relative "../test_helper"
 SingleCov.covered! uncovered: 2 unless defined?(Rake) # rake preloads all plugins
 
 describe SamsonKubernetes do
+  describe :stage_permitted_params do
+    it "adds :kubernetes" do
+      Samson::Hooks.fire(:stage_permitted_params).must_include :kubernetes
+    end
+  end
 end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -231,6 +231,15 @@ describe JobExecution do
     assert_equal 'MY-SECRET', last_line_of_output
   end
 
+  describe "kubernetes" do
+    before { stage.update_column :kubernetes, true }
+
+    it "does the execution with the kubernetes executor" do
+      Kubernetes::DeployExecutor.any_instance.expects(:execute!).returns true
+      execute_job("master")
+    end
+  end
+
   describe 'when JobExecution is disabled' do
     before do
       JobExecution.enabled = false


### PR DESCRIPTION
completely working and all tested ... erm or not ;)

/cc @zendesk/samson

 - fetch build from sha that was entered or fail
 - listens to updates sent to the SSE stream and show them in the output
 - discussion: should we just create the build while doing this / why do we need to manage builds manually ...

TODO:
 - [X] nicer logging
 - [X] stop when done / wait till it is done
 - [x] use proper plugin hooks
 - [x] make sure pid is updated in the UI when switching over
 - [X] read deploy status from k8s-log
 - [x] test everything
 - [X] log release errors when it fails to create
 - [X] log build not found error
 - [ ] override or configure roles
 - [x] kubernetes boolean for deploys
 - [ ]  validate that all deploy groups have kubernetes cluster when saving stage

### Risks
- Medium: breaking kubernetes deploys
- Medium: breaking normal deploys
- Medium: introducing some bad GC that makes samson grow

