### PR TITLE
Display Slack webhook fields in stage edit form

### DIFF
--- a/plugins/slack_webhooks/app/views/samson_slack_webhooks/_fields.html.erb
+++ b/plugins/slack_webhooks/app/views/samson_slack_webhooks/_fields.html.erb
@@ -2,7 +2,7 @@
   <legend>Slack</legend>
 
   <% stage = form.object %>
-  <% stage.slack_webhooks.build unless stage.slack_webhooks.last.try(:webhook_url).blank? %>
+  <% stage.slack_webhooks.build %>
 
   <div class="col-lg-offset-2">
     <p>Details of the webhook to be notified on deploys.</p>

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -192,6 +192,9 @@ describe StagesController do
 
         it 'renders' do
           assert_template :edit
+
+          assert_select '#stage_slack_webhooks_attributes_0_webhook_url'
+          assert_select '#stage_slack_webhooks_attributes_0_channel'
         end
 
         it 'renders with no environments configured' do


### PR DESCRIPTION
Related to #837 

![image](https://cloud.githubusercontent.com/assets/1674029/14911625/df5a64f2-0df6-11e6-8538-21884156db98.png)

I'm not quite sure that the tests location is correct (tightly coupled), but I couldn't figure where else to place it. Please tell me if it's the wrong place.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team
