### PR TITLE
reduce redundant messages and group roles by deploy group

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -93,7 +93,7 @@ module Kubernetes
           namespace: deploy_group.kubernetes_namespace,
           label_selector: {
             deploy_group_id: deploy_group.id,
-            project_id: project.id, # TODO: use project_id once normalize PR is merged
+            project_id: project_id,
             release_id: id
           }.to_kuber_selector
         }


### PR DESCRIPTION
@zendesk/paas 

based on previous PR, only look at the second commit.

before:
![screen shot 2016-04-29 at 1 23 34 pm](https://cloud.githubusercontent.com/assets/11367/14928584/9abe8348-0e0d-11e6-8709-5c885461ce6d.png)



after:
![screen shot 2016-04-29 at 1 23 23 pm](https://cloud.githubusercontent.com/assets/11367/14928585/a1450d0e-0e0d-11e6-9293-72d26f46d3b7.png)

