### PR TITLE
store project_id directly on release for easier querying

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160429203410) do
+ActiveRecord::Schema.define(version: 20160429224533) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                       null: false
@@ -191,6 +191,7 @@ ActiveRecord::Schema.define(version: 20160429203410) do
     t.datetime "updated_at"
     t.integer  "build_id"
     t.integer  "user_id"
+    t.integer  "project_id",         limit: 4,                       null: false
   end
 
   add_index "kubernetes_releases", ["build_id"], name: "index_kubernetes_releases_on_build_id"

--- a/plugins/kubernetes/app/controllers/kubernetes_releases_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_releases_controller.rb
@@ -21,6 +21,6 @@ class KubernetesReleasesController < ApplicationController
 
   def release_params
     params.require(:kubernetes_release).permit(:build_id, deploy_groups: [:id, roles: [:id, :replicas]])
-      .merge(user: current_user)
+      .merge(user: current_user, project: current_project)
   end
 end

--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -1,5 +1,5 @@
 Project.class_eval do
-  has_many :kubernetes_releases, through: :builds, class_name: 'Kubernetes::Release'
+  has_many :kubernetes_releases, class_name: 'Kubernetes::Release'
   has_many :roles, class_name: 'Kubernetes::Role'
 
   def file_from_repo(path, git_ref, ttl: 1.hour)

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -126,7 +126,7 @@ module Kubernetes
         {id: group.id, roles: roles}
       end
 
-      release = Kubernetes::Release.create_release(deploy_groups: group_config, build_id: build.id, user: @job.user)
+      release = Kubernetes::Release.create_release(deploy_groups: group_config, build_id: build.id, user: @job.user, project: @job.project)
       unless release.persisted?
         raise Samson::Hooks::UserError, "Failed to create release: #{release.errors.full_messages.inspect}"
       end

--- a/plugins/kubernetes/db/migrate/20160429224533_normalize_project_id.rb
+++ b/plugins/kubernetes/db/migrate/20160429224533_normalize_project_id.rb
@@ -1,0 +1,11 @@
+class NormalizeProjectId < ActiveRecord::Migration
+  def up
+    add_column :kubernetes_releases, :project_id, :integer
+    ActiveRecord::Base.connection.execute 'UPDATE kubernetes_releases JOIN builds ON kubernetes_releases.build_id = builds.id SET kubernetes_releases.project_id = builds.project_id'
+    change_column_null :kubernetes_releases, :project_id, false
+  end
+
+  def down
+    remove_column :kubernetes_releases, :project_id
+  end
+end

--- a/plugins/kubernetes/test/fixtures/kubernetes/releases.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/releases.yml
@@ -2,18 +2,22 @@ test_release:
   user: deployer
   build: docker_build
   status: live
+  project: test
 
 second_test_release:
   user: deployer
   build: docker_build
   status: live
+  project: test
 
 live_release:
   user: deployer
   build: docker_build
   status: live
+  project: test
 
 created_release:
   user: deployer
   build: docker_build
   status: created
+  project: test

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -5,19 +5,12 @@ SingleCov.covered! uncovered: 18
 describe Kubernetes::Release do
   let(:build)  { builds(:docker_build) }
   let(:user)   { users(:deployer) }
-  let(:release) { Kubernetes::Release.new(build: build, user: user) }
+  let(:release) { Kubernetes::Release.new(build: build, user: user, project: project) }
   let(:deploy_group) { deploy_groups(:pod1) }
   let(:project) { projects(:test) }
   let(:app_server) { kubernetes_roles(:app_server) }
   let(:resque_worker) { kubernetes_roles(:resque_worker) }
   let(:role_config_file) { parse_role_config_file('kubernetes_role_config_file') }
-
-  describe 'validations' do
-    it 'asserts image is in registry' do
-      release.build = builds(:staging)    # does not have a docker image pushed
-      refute_valid(release, :build)
-    end
-  end
 
   describe 'validations' do
     it 'is valid by default' do
@@ -34,7 +27,6 @@ describe Kubernetes::Release do
   end
 
   describe '#create_release' do
-
     describe 'with one single role' do
       before do
         expect_file_contents_from_repo
@@ -119,6 +111,20 @@ describe Kubernetes::Release do
     end
   end
 
+  describe "#validate_project_ids_are_in_sync" do
+    it 'ensures project ids are in sync' do
+      release.project_id = 123
+      refute_valid(release, :build)
+    end
+  end
+
+  describe '#validate_docker_image_in_registry' do
+    it 'ensures image is in registry' do
+      release.build = builds(:staging) # does not have a docker image pushed
+      refute_valid(release, :build)
+    end
+  end
+
   def expect_file_contents_from_repo
     Build.any_instance.expects(:file_from_repo).returns(role_config_file)
   end
@@ -130,6 +136,7 @@ describe Kubernetes::Release do
   def release_params
     {
       build_id: build.id,
+      project: project,
       deploy_groups: [
         {
           id: deploy_group.id,


### PR DESCRIPTION
we are doing unnecessary queries in a few places and adding indirection ... also means we need joins ... just normalize it like most other things already do ...

@zendesk/paas 