### PR TITLE
fetch files directly from git

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -59,11 +59,8 @@ class Build < ActiveRecord::Base
 
   def file_from_repo(path, ttl: 1.hour)
     Rails.cache.fetch([self, path], expire_in: ttl) do
-      data = GITHUB.contents(project.github_repo, path: path, ref: git_sha)
-      Base64.decode64(data[:content])
+      project.repository.file_content git_sha, path
     end
-  rescue Octokit::NotFound
-    nil
   end
 
   def url

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -197,4 +197,41 @@ describe GitRepository do
       repository.clean!
     end
   end
+
+  describe "#file_content" do
+    before do
+      create_repo_without_tags
+      repository.clone!
+    end
+
+    let(:sha) { repository.commit_from_ref('master', length: nil) }
+
+    it 'finds content' do
+      repository.file_content(sha, 'foo').must_equal "monkey"
+    end
+
+    it 'returns nil when file does not exist' do
+      repository.file_content(sha, 'foox').must_equal nil
+    end
+
+    it 'returns nil when sha does not exist' do
+      repository.file_content('x' * 40, 'foox').must_equal nil
+    end
+
+    it "does not support non-shas" do
+      assert_raises ArgumentError do
+        repository.file_content('x' * 41, 'foox')
+      end
+    end
+
+    it "does not update when sha exists to save time" do
+      repository.expects(:update!).never
+      repository.file_content(sha, 'foo').must_equal "monkey"
+    end
+
+    it "updates when sha is missing" do
+      repository.expects(:update!)
+      repository.file_content('x' * 40, 'foo').must_equal nil
+    end
+  end
 end


### PR DESCRIPTION
remove github dependency and make file fetching faster

```
 Benchmark.realtime { p.repository.send :file_content, "59aa8ab37f013f4b8fe7d87e30edbc808175b51b", 'Gemfile' }
=> 0.03225039999233559
```

@zendesk/samson 

### Risks
- Low: slow operations when repo is not cached .. which should not happen since we resolve the sha before hitting this codepath anyway

