### PR TITLE
allow creating a Kubernetes config without an ENV var

### DIFF
--- a/plugins/kubernetes/app/controllers/admin/kubernetes/clusters_controller.rb
+++ b/plugins/kubernetes/app/controllers/admin/kubernetes/clusters_controller.rb
@@ -70,12 +70,11 @@ class Admin::Kubernetes::ClustersController < ApplicationController
   end
 
   def load_default_config_file
-    var = 'KUBE_CONFIG_FILE'
-    if (file = ENV[var])
+    if (file = ENV['KUBE_CONFIG_FILE'])
       @config_file = ::Kubernetes::ClientConfigFile.new(file)
-      @context_options = @config_file.context_names
-    else
-      render text: "#{var} is not configured, for local development it should be ~/.kube/config", status: :bad_request
+    elsif (last_cluster = ::Kubernetes::Cluster.last)
+      @config_file = last_cluster.kubeconfig
     end
+    @context_options = @config_file.try(:context_names) || []
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -48,11 +48,11 @@ module Kubernetes
       false
     end
 
-    private
-
     def kubeconfig
-      @config_file ||= Kubernetes::ClientConfigFile.new(config_filepath)
+      @kubeconfig ||= Kubernetes::ClientConfigFile.new(config_filepath)
     end
+
+    private
 
     def test_client_connection
       if File.exists?(config_filepath)

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -42,15 +42,33 @@ class ActiveSupport::TestCase
 
   def with_example_kube_config
     Tempfile.open('config') do |t|
-      t.write({'users': [], 'clusters': [], 'apiVersion': '1', 'current-context': 'vagrant', 'contexts': []}.to_yaml)
+      config = {
+        'apiVersion' => '1',
+        'users' => [],
+        'clusters' => [
+          {
+            'name' => 'somecluster',
+            'cluster' => { 'server' => 'http://k8s.example.com' }
+          }
+        ],
+        'contexts' => [
+          {
+            'name' => 'default',
+            'context' => { 'cluster' => 'somecluster', 'user' => '' }
+          }
+        ],
+        'current-context' => 'default'
+      }
+      t.write(config.to_yaml)
       t.flush
       yield t.path
     end
   end
 
-  def create_kubernetes_cluster
+  def create_kubernetes_cluster(attr = {})
     Kubernetes::Cluster.any_instance.stubs(connection_valid?: true)
-    Kubernetes::Cluster.create!(name: 'Foo', config_filepath: __FILE__, config_context: 'y')
+    cluster_attr = { name: 'Foo', config_filepath: __FILE__, config_context: 'y' }.merge(attr)
+    Kubernetes::Cluster.create!(cluster_attr)
   end
 
   private


### PR DESCRIPTION
The ENV var KUBE_CONFIG_FILE is not strictly necessary for creating a new cluster, so don't blow up if it's not set.

If another cluster exists, default to the config file that cluster uses.

/cc @zendesk/paas, @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
