### PR TITLE
use execute_command more

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -111,7 +111,7 @@ class BuildsController < ApplicationController
     @git_sha ||= begin
       # Create/update local cache to avoid getting a stale reference
       current_project.with_lock(holder: 'BuildsController#create') do
-        current_project.repository.setup_local_cache!
+        current_project.repository.update_local_cache!
       end
 
       current_project.repository.commit_from_ref(new_build_params[:git_ref], length: nil)

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -79,7 +79,7 @@ class Build < ActiveRecord::Base
 
     unless project.repository.last_pulled
       project.with_lock(holder: 'Build reference validation') do
-        project.repository.setup_local_cache!
+        project.repository.update_local_cache!
       end
     end
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -45,7 +45,7 @@ class Deploy < ActiveRecord::Base
   end
 
   def short_reference
-    if reference =~ /\A[0-9a-f]{40}\Z/
+    if reference =~ Build::SHA1_REGEX
       reference[0...7]
     else
       reference

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -169,7 +169,7 @@ class JobExecution
   def setup!(dir)
     locked = lock_project do
       return false unless @repository.setup!(dir, @reference)
-      commit = @repository.commit_from_ref(@reference, length: 40)
+      commit = @repository.commit_from_ref(@reference, length: nil)
       tag = @repository.tag_from_ref(@reference)
       @job.update_git_references!(commit: commit, tag: tag)
     end

--- a/lib/references_service.rb
+++ b/lib/references_service.rb
@@ -28,7 +28,7 @@ class ReferencesService
   def references_from_cached_repo
     git_references = nil
     lock_project do
-      return unless repository.update!
+      return unless repository.update_local_cache! # TODO test this ...
       tags = repository.tags
       git_references = repository.branches.push(*tags).sort_by { |ref| [-ref.length, ref] }.reverse
     end

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -16,7 +16,7 @@ describe BuildsController do
   end
 
   def stub_git_reference_check(returns: false)
-    GitRepository.any_instance.stubs(:setup_local_cache!).returns(true)
+    GitRepository.any_instance.stubs(:update_local_cache!).returns(true)
     GitRepository.any_instance.stubs(:commit_from_ref).returns(returns)
   end
 

--- a/test/support/git_repo_test_support.rb
+++ b/test/support/git_repo_test_support.rb
@@ -53,8 +53,8 @@ module GitRepoTestHelper
     `git rev-parse HEAD`.strip
   end
 
-  def number_of_commits
-    `git rev-list HEAD --count`.strip.to_i
+  def number_of_commits(ref='HEAD')
+    `git rev-list #{ref} --count`.strip.to_i
   end
 
   def update_workspace


### PR DESCRIPTION
@zendesk/samson 

also unrelated cleanup ... hiding `update!` method and making everyone use update_local_cache which will clone or update as necessary