### PR TITLE
don't crash if Kubeconfig file doesn't have any users

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/client_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/client_config_file.rb
@@ -39,7 +39,7 @@ module Kubernetes
 
     def parse_clusters
       @clusters = {}
-      @config_file.fetch(:clusters).each do |cluster_hash|
+      (@config_file[:clusters] || []).each do |cluster_hash|
         cluster = Cluster.new
         cluster.name = cluster_hash[:name]
         cluster.server = cluster_hash[:cluster][:server]
@@ -56,7 +56,7 @@ module Kubernetes
 
     def parse_users
       @users = {}
-      @config_file.fetch(:users).each do |user_hash|
+      (@config_file[:users] || []).each do |user_hash|
         user = User.new
         user.name = user_hash[:name]
         user.username = user_hash[:user][:username]
@@ -75,7 +75,7 @@ module Kubernetes
 
     def parse_contexts
       @contexts = {}
-      @config_file.fetch(:contexts).each do |context_hash|
+      (@config_file[:contexts] || []).each do |context_hash|
         context = Context.new
         context.name = context_hash[:name]
         context.api_version = api_version

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -44,7 +44,7 @@ class ActiveSupport::TestCase
     Tempfile.open('config') do |t|
       config = {
         'apiVersion' => '1',
-        'users' => [],
+        'users' => nil,
         'clusters' => [
           {
             'name' => 'somecluster',


### PR DESCRIPTION
Fix crash I saw in staging when kubeconfig file has no users

/cc @zendesk/pass, @grosser 

### Tasks
 - [ ] :+1: from team

### References
 - Airbrake: https://zendesk.airbrake.io/projects/95346/groups/1677031245491938996

### Risks
- Level: Low
