### PR TITLE
PAAS-131 improve kubernetes failure / restart logging

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,4 +1,5 @@
-if !defined?(Rails) || Rails.env.staging? || Rails.env.production?
+from_cap = !defined?(Rails)
+if from_cap || Rails.env.staging? || Rails.env.production?
   require 'airbrake'
   Airbrake.configure do |config|
     config.api_key = ENV['AIRBRAKE_API_KEY']
@@ -6,7 +7,7 @@ if !defined?(Rails) || Rails.env.staging? || Rails.env.production?
 else
   module Airbrake
     def self.notify(ex, *_args)
-      Rails.logger.error "AIRBRAKE: #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
+      Rails.logger.error "AIRBRAKE: #{ex.class} - #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
     end
 
     def self.notify_or_ignore(ex, *_args)

--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -18,7 +18,7 @@ module Kubernetes
       end
 
       def restarted?
-        @pod.status.containerStatuses.any? { |s| s.restartCount != 0 }
+        @pod.status.containerStatuses.try(:any?) { |s| s.restartCount != 0 }
       end
 
       def phase

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -87,8 +87,8 @@ module Kubernetes
       save!
     end
 
-    def fetch_pods
-      release_docs.map(&:deploy_group).flat_map do |deploy_group|
+    def clients
+      release_docs.map(&:deploy_group).map do |deploy_group|
         query = {
           namespace: deploy_group.kubernetes_namespace,
           label_selector: {
@@ -97,8 +97,8 @@ module Kubernetes
             release_id: id
           }.to_kuber_selector
         }
-        deploy_group.kubernetes_cluster.client.get_pods(query)
-      end.map! { |p| Kubernetes::Api::Pod.new(p) }
+        [deploy_group.kubernetes_cluster.client, query, deploy_group]
+      end
     end
 
     private

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -101,6 +101,11 @@ describe Kubernetes::Api::Pod do
       refute pod.restarted?
     end
 
+    it "is not restarted when pending and not having conditions yet" do
+      pod.instance_variable_get(:@pod).status.containerStatuses = nil
+      refute pod.restarted?
+    end
+
     it "is restarted when restarting" do
       pod.instance_variable_get(:@pod).status.containerStatuses[0].restartCount = 1
       assert pod.restarted?

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -96,18 +96,18 @@ describe Kubernetes::Release do
     end
   end
 
-  describe "#fetch_pods" do
+  describe "#clients" do
     it "is empty when there are no deploy groups" do
-      release.fetch_pods.must_equal []
+      release.clients.must_equal []
     end
 
-    it "fetches information from clusters" do
+    it "returns scoped queries" do
       release = kubernetes_releases(:test_release)
       stub_request(:get, %r{http://foobar.server/api/1/namespaces/pod1/pods}).to_return(body: {
         resourceVersion: "1",
         items: [{}, {}]
       }.to_json)
-      release.fetch_pods.size.must_equal 2
+      release.clients.map { |c,q| c.get_pods(q) }.first.size.must_equal 2
     end
   end
 


### PR DESCRIPTION
@zendesk/paas 

 - stop when restarting is detected instead of continuing to poll
 - show events and logs for failed pods
