### PR TITLE
add new migration to fix one that had a line commented out

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160429224533) do
+ActiveRecord::Schema.define(version: 20160503162523) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                       null: false

--- a/plugins/kubernetes/db/migrate/20160426223230_add_kuberetes_to_stage.rb
+++ b/plugins/kubernetes/db/migrate/20160426223230_add_kuberetes_to_stage.rb
@@ -1,6 +1,5 @@
 class AddKuberetesToStage < ActiveRecord::Migration
   def change
-    # add_column :stages, :kubernetes, :boolean, default: false, null: false
     add_column :deploys, :kubernetes, :boolean, default: false, null: false
   end
 end

--- a/plugins/kubernetes/db/migrate/20160503162523_really_add_kubernetes_to_staging.rb
+++ b/plugins/kubernetes/db/migrate/20160503162523_really_add_kubernetes_to_staging.rb
@@ -1,0 +1,5 @@
+class ReallyAddKubernetesToStaging < ActiveRecord::Migration
+  def change
+    add_column :stages, :kubernetes, :boolean, default: false, null: false
+  end
+end


### PR DESCRIPTION
A migration got checked in with a line commented out, even though `stages.kubernetes` was defined in schema.rb. So the tests passed, even though that column was created if you run `rake db:migrate`.

/cc @grosser, @fneves 

### Tasks
 - [ ] :+1: from team

### References
 - Airbrake error: https://zendesk.airbrake.io/projects/95346/groups/1674499292284790954

### Risks
- Level: Low/Med/High
