### PR TITLE
reuse local fetching code for role file lookups

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -57,10 +57,8 @@ class Build < ActiveRecord::Base
     @docker_image = image
   end
 
-  def file_from_repo(path, ttl: 1.hour)
-    Rails.cache.fetch([self, path], expire_in: ttl) do
-      project.repository.file_content git_sha, path
-    end
+  def file_from_repo(path)
+    project.repository.file_content path, git_sha
   end
 
   def url

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,23 +25,26 @@ module Samson
 
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
-    servers = []
-    options = { value_max_bytes: 3000000, compress: true, expires_in: 1.day }
+    if Rails.env.test?
+      config.cache_store = :memory_store
+    else
+      servers = []
+      options = { value_max_bytes: 3000000, compress: true, expires_in: 1.day }
 
-    # support memcachier env used by heroku
-    # https://devcenter.heroku.com/articles/memcachier#rails-3-and-4
-    if ENV["MEMCACHIER_SERVERS"]
-      servers = (ENV["MEMCACHIER_SERVERS"]).split(",")
-      options.merge!(
-        username: ENV["MEMCACHIER_USERNAME"],
-        password: ENV["MEMCACHIER_PASSWORD"],
-        failover: true,
-        socket_timeout: 1.5,
-        socket_failure_delay: 0.2
-      )
+      # support memcachier env used by heroku
+      # https://devcenter.heroku.com/articles/memcachier#rails-3-and-4
+      if ENV["MEMCACHIER_SERVERS"]
+        servers = (ENV["MEMCACHIER_SERVERS"]).split(",")
+        options.merge!(
+          username: ENV["MEMCACHIER_USERNAME"],
+          password: ENV["MEMCACHIER_PASSWORD"],
+          failover: true,
+          socket_timeout: 1.5,
+          socket_failure_delay: 0.2
+        )
+      end
+      config.cache_store = :dalli_store, servers, options
     end
-
-    config.cache_store = :dalli_store, servers, options
 
     # Raise exceptions
     config.active_record.raise_in_transactional_callbacks = true

--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -2,51 +2,40 @@ Project.class_eval do
   has_many :kubernetes_releases, class_name: 'Kubernetes::Release'
   has_many :roles, class_name: 'Kubernetes::Role'
 
-  def file_from_repo(path, git_ref, ttl: 1.hour)
-    # Caching by Git reference
-    Rails.cache.fetch([git_ref, path], expire_in: ttl) do
-      data = GITHUB.contents(github_repo, path: path, ref: git_ref)
-      Base64.decode64(data[:content])
-    end
-  rescue Octokit::NotFound
-    nil
+  def file_from_repo(path, git_ref)
+    repository.file_content path, git_ref
   end
 
-  def directory_contents_from_repo(path, git_ref, ttl: 1.hour)
-    # Caching by Git reference
-    Rails.cache.fetch([git_ref, path], expire_in: ttl) do
-      GITHUB.contents(github_repo, path: path, ref: git_ref).map(&:path).select { |file_name|
-        file_name.ends_with?('.yml', '.yaml', '.json')
-      }
-    end
-  rescue Octokit::NotFound
-    nil
+  def kubernetes_config_files_in_repo(git_ref)
+    path = 'kubernetes'
+    return [] unless files = repository.file_content(path, git_ref)
+    files.split("\n").grep(/\.(yml|yaml|json)$/).map { |f| "#{path}/#{f}" }
   end
 
   # Imports the new kubernetes roles. This operation is atomic: if one role fails to be imported, none
   # of them will be persisted and the soft deletion will be rollbacked.
   def refresh_kubernetes_roles!(git_ref)
-    config_files = directory_contents_from_repo('kubernetes', git_ref)
+    config_files = kubernetes_config_files_in_repo(git_ref)
+    return if config_files.to_a.empty?
 
-    unless config_files.to_a.empty?
-      Project.transaction do
-        roles.each(&:soft_delete!)
+    Project.transaction do
+      roles.each(&:soft_delete!)
 
-        kubernetes_config_files(config_files, git_ref) { |config_file|
-          roles.create!(
-            config_file: config_file.file_path,
-            name: config_file.deployment.metadata.labels.role,
-            service_name: config_file.service.metadata.name,
-            ram: config_file.deployment.ram_mi,
-            cpu: config_file.deployment.cpu_m,
-            replicas: config_file.deployment.spec.replicas,
-            deploy_strategy: config_file.deployment.strategy_type)
-        }
-
-        # Need to reload the project to refresh the association otherwise
-        # the soft deleted roles will be rendered by the JSON serializer
-        reload.roles.not_deleted
+      kubernetes_config_files(config_files, git_ref) do |config_file|
+        roles.create!(
+          config_file: config_file.file_path,
+          name: config_file.deployment.metadata.labels.role,
+          service_name: config_file.service.metadata.name,
+          ram: config_file.deployment.ram_mi,
+          cpu: config_file.deployment.cpu_m,
+          replicas: config_file.deployment.spec.replicas,
+          deploy_strategy: config_file.deployment.strategy_type
+        )
       end
+
+      # Need to reload the project to refresh the association otherwise
+      # the soft deleted roles will be rendered by the JSON serializer
+      reload.roles.not_deleted
     end
   end
 

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -144,7 +144,6 @@ module Kubernetes
     def create_release(build)
       # build config for every cluster and role we want to deploy to
       group_config = @job.deploy.stage.deploy_groups.map do |group|
-        # raise "#{group.name} needs to be on kubernetes" unless group.
         roles = Kubernetes::Role.where(project_id: @job.project_id).map do |role|
           {id: role.id, replicas: role.replicas} # TODO make replicas configureable
         end

--- a/plugins/kubernetes/test/controllers/kubernetes_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes_roles_controller_test.rb
@@ -240,7 +240,7 @@ describe KubernetesRolesController do
     let(:contents) { parse_role_config_file('kubernetes_role_config_file') }
 
     before do
-      Project.any_instance.stubs(:directory_contents_from_repo).returns(['some_folder/file_name.yml'])
+      Project.any_instance.stubs(:kubernetes_config_files_in_repo).returns(['some_folder/file_name.yml'])
       Project.any_instance.stubs(:file_from_repo).returns(contents)
     end
 
@@ -283,7 +283,7 @@ describe KubernetesRolesController do
 
     as_a_admin do
       before do
-        Project.any_instance.stubs(:directory_contents_from_repo).returns([])
+        Project.any_instance.stubs(:kubernetes_config_files_in_repo).returns([])
       end
 
       it 'responds with a 404 if no config files where found' do

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -125,7 +125,7 @@ describe GitRepository do
       execute_on_remote_repo <<-SHELL
         git checkout test_branch
         echo "blah blah" >> bar.txt
-        git add bar
+        git add bar.txt
         git commit -m "created bar.txt"
         git tag -a annotated_tag -m "This is really worth tagging"
         git checkout master
@@ -241,31 +241,31 @@ describe GitRepository do
     let(:sha) { repository.commit_from_ref('master', length: nil) }
 
     it 'finds content' do
-      repository.file_content(sha, 'foo').must_equal "monkey"
+      repository.file_content('foo', sha).must_equal "monkey"
     end
 
     it 'returns nil when file does not exist' do
-      repository.file_content(sha, 'foox').must_equal nil
+      repository.file_content('foox', sha).must_equal nil
     end
 
     it 'returns nil when sha does not exist' do
-      repository.file_content('a' * 40, 'foox').must_equal nil
+      repository.file_content('foox', 'a' * 40).must_equal nil
     end
 
-    it "does not support non-shas" do
-      assert_raises ArgumentError do
-        repository.file_content('a' * 41, 'foox')
-      end
+    it "always updates for non-shas" do
+      repository.expects(:sha_exist?).never
+      repository.expects(:update!)
+      repository.file_content('foox', 'a' * 41).must_equal nil
     end
 
     it "does not update when sha exists to save time" do
       repository.expects(:update!).never
-      repository.file_content(sha, 'foo').must_equal "monkey"
+      repository.file_content('foo', sha).must_equal "monkey"
     end
 
     it "updates when sha is missing" do
       repository.expects(:update!)
-      repository.file_content('a' * 40, 'foo').must_equal nil
+      repository.file_content('foo', 'a' * 40).must_equal nil
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -319,8 +319,6 @@ describe User do
   end
 
   describe "#starred_project?" do
-    before { Rails.cache.clear }
-
     let(:user) { users(:viewer) }
     let(:project) { projects(:test) }
 

--- a/test/support/git_repo_test_support.rb
+++ b/test/support/git_repo_test_support.rb
@@ -4,7 +4,9 @@ module GitRepoTestHelper
   end
 
   def execute_on_remote_repo(cmds)
-    `exec 2> /dev/null; cd #{repo_temp_dir}; #{cmds}`
+    result = `exec 2>&1; set -e; cd #{repo_temp_dir}; #{cmds}`
+    raise "FAIL: #{result}" unless $?.success?
+    result
   end
 
   def create_repo_without_tags


### PR DESCRIPTION
@zendesk/samson 

 - reuse git repository local fetching logic in project
 - make repo setup commands raise when they fail
 - use memory store so we get an actual cache
 - don't fail a bunch of commands when checkout/update fails

### Risks
- Low: slowdown due to repo downloads/updates

