### PR TITLE
search users by role and make role display reflect internal role logic

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -186,6 +186,10 @@ h3 {
   background-color: #00a704;
 }
 
+label.disabled {
+  color: grey;
+}
+
 /* Buttons */
 
 .btn .btn-primary .disabled {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,9 @@ class UsersController < ApplicationController
 
   def index
     @users = User.search_by_criteria(params)
+    if role_id = params[:role_id]
+      @users = @users.with_role(role_id, current_project.id)
+    end
 
     respond_to do |format|
       format.html

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,16 @@
+module UsersHelper
+  # multiple are checked, but browser only shows last
+  def user_project_role_radio(user, project, role_name, role_id)
+    global_access = (user.role_id >= role_id.to_i)
+    disabled = (user.role_id > role_id.to_i)
+    project_access = (user.project_role_for(project).try(:role_id).to_i >= role_id.to_i)
+    checked = (global_access || project_access)
+    title = "User is a global #{user.role.name.capitalize}" if global_access
+
+    label_tag :role_id, class: ('disabled' if global_access), title: title do
+      radio_button_tag(:role_id, role_id.to_s, checked, disabled: disabled) <<
+        " " <<
+        role_name.titlecase
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,13 @@ class User < ActiveRecord::Base
   validates :time_format, inclusion: { in: TIME_FORMATS }
 
   scope :search, ->(query) { where("name like ? or email like ?", "%#{query}%", "%#{query}%") }
+  scope :with_role, -> (role_id, project_id) {
+    joins('LEFT OUTER JOIN user_project_roles on users.id = user_project_roles.user_id').
+      where(
+        '(user_project_roles.project_id = ? AND user_project_roles.role_id >= ?) OR users.role_id >= ?',
+        project_id, role_id, role_id
+      )
+  }
 
   def starred_project?(project)
     starred_project_ids.include?(project.id)

--- a/app/views/shared/_project_role.html.erb
+++ b/app/views/shared/_project_role.html.erb
@@ -1,10 +1,6 @@
 <%= form_tag project_project_roles_path(project, user_id: user.id), class: 'autosubmit' do %>
   <% options = [['None', nil]] + UserProjectRole::ROLES.map { |r| [r.name, r.id] } %>
   <% options.each do |name, id| %>
-    <%= label_tag do %>
-      <% checked = user.project_role_for(project).try(:role_id) == id %>
-      <%= radio_button_tag :role_id, id.to_s, checked %>
-      <%= name.titlecase %>
-    <% end %>
+    <%= user_project_role_radio user, project, name, id %>
   <% end %>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,22 @@
 <section id="user-project-roles" class="tabs">
   <h2 class="section-subtitle">Project Level Roles</h2>
 
-  <%= render partial: "shared/search_bar", locals: {url: project_users_path, query: params[:search]} %>
+  <%= form_tag '?', method: :get do %>
+    <div class="col-md-6 clearfix">&nbsp;</div>
+
+    <div class="col-md-3 clearfix">
+      <%= text_field_tag :search, params[:search], class: 'form-control', placeholder: 'Search' %>
+    </div>
+
+    <div class="col-md-2 clearfix">
+      <% roles = [['', '']] + UserProjectRole::ROLES.map { |r| [r.name.capitalize, r.id] } %>
+      <%= select_tag :role_id, options_for_select(roles, params[:role_id]), class: 'form-control' %>
+    </div>
+
+    <div class="col-md-1 clearfix">
+      <%= submit_tag "Search", class: "btn btn-default form-control" %>
+    </div>
+  <% end %>
 
   <table class="table table-hover table-condensed">
     <thead>
@@ -18,10 +33,10 @@
     <tbody>
     <% if @users.empty? %>
       <tr>
-        <td>No user was found!</td>
+        <td>No users found.</td>
       </tr>
     <% else %>
-        <%= render @users %>
+        <%= static_render @users %>
     <% end %>
     </tbody>
   </table>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -15,38 +15,28 @@ describe UsersController do
 
   as_a_project_admin do
     describe "a GET to #index" do
-      it 'responds successfully' do
+      it 'renders' do
         get :index, project_id: project.to_param
-        users = User.all
         assert_template :index
-        assigns(:users).wont_be_nil
-        assigns(:users).wont_be_empty
-        assigns(:users).size.must_equal users.size
+        assigns(:users).size.must_equal User.count
       end
 
-      it 'responds successfully to a JSON request' do
+      it 'renders JSON' do
         get :index, project_id: project.to_param, format: 'json'
-        users = User.all
-        assigns(:users).wont_be_nil
-        result = JSON.parse(response.body)
-        result['users'].wont_be_nil
-        users = result['users']
-        users.wont_be_nil
-        users.wont_be_empty
-        users.length.must_equal users.size
-        users.each  do | user |
-          user_info = User.find_by(name: user['name'])
-          user_info.wont_be_nil
-        end
+        users = JSON.parse(response.body).fetch('users')
+        users.size.must_equal User.count
       end
 
-      it 'responds as expected to a filtered search' do
+      it 'filters' do
         get :index, project_id: project.to_param, search: "Admin"
-        users = User.search("Admin").page(1)
         assert_template :index
-        assigns(:users).wont_be_nil
-        assigns(:users).wont_be_empty
-        assigns(:users).size.must_equal users.size
+        assigns(:users).map(&:name).sort.must_equal ["Admin", "Deployer Project Admin", "Super Admin"]
+      end
+
+      it 'filters by role' do
+        get :index, project_id: project.to_param, role_id: Role::ADMIN.id
+        assert_template :index
+        assigns(:users).map(&:name).sort.must_equal ["Admin", "Deployer Project Admin", "Super Admin"]
       end
     end
   end

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -1,0 +1,62 @@
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe UsersHelper do
+  let(:project) { projects(:test) }
+
+  describe "#user_project_role_radio" do
+    it "allows upgrade for unchecked" do
+      result = user_project_role_radio users(:viewer), project, 'Foo', Role::ADMIN.id
+      result.wont_include 'checked'
+      result.wont_include 'global'
+      result.wont_include 'disabled="disabled"'
+    end
+
+    describe "with global access" do
+      it "allows to re-check current" do
+        result = user_project_role_radio users(:admin), project, 'Foo', Role::ADMIN.id
+        result.must_include 'checked'
+        result.must_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+
+      it "blocks downgrades" do
+        result = user_project_role_radio users(:admin), project, 'Foo', Role::DEPLOYER.id
+        result.must_include 'checked'
+        result.must_include 'global'
+        result.must_include 'disabled="disabled"'
+      end
+
+      it "allows upgrades upgrades" do
+        result = user_project_role_radio users(:deployer), project, 'Foo', Role::ADMIN.id
+        result.wont_include 'checked'
+        result.wont_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+    end
+
+    describe 'with project access' do
+      it "allows to re-check current" do
+        result = user_project_role_radio users(:project_admin), project, 'Foo', Role::ADMIN.id
+        result.must_include 'checked'
+        result.wont_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+
+      it "allows downgrades" do
+        result = user_project_role_radio users(:project_admin), project, 'Foo', Role::DEPLOYER.id
+        result.must_include 'checked'
+        result.must_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+
+      it "allows upgrade" do
+        result = user_project_role_radio users(:project_deployer), project, 'Foo', Role::ADMIN.id
+        result.wont_include 'checked'
+        result.wont_include 'global'
+        result.wont_include 'disabled="disabled"'
+      end
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -224,7 +224,7 @@ describe User do
     end
   end
 
-  describe "search_for scope" do
+  describe ".search" do
 
     let!(:a_singular_user) do
       User.create!(name: 'FindMe', email: 'find.me@example.org')
@@ -254,14 +254,35 @@ describe User do
       User.search('does not exist').count.must_equal(0)
     end
 
-    it 'must return all results with an empty query' do
+    it 'returns all results with an empty query' do
       User.search('').count.must_equal(User.count)
     end
 
-    it 'must return all results with a nil query' do
+    it 'returns all results with a nil query' do
       User.search(nil).count.must_equal(User.count)
     end
+  end
 
+  describe ".with_role" do
+    let(:project) { projects(:test) }
+
+    it "filters everything when asking for a unreachable role" do
+      User.with_role(Role::SUPER_ADMIN.id + 1, project.id).size.must_equal 0
+    end
+
+    it "filters nothing when asking for anything" do
+      User.with_role(Role::VIEWER.id, project.id).size.must_equal User.count
+    end
+
+    it 'filters by deployer' do
+      User.with_role(Role::DEPLOYER.id, project.id).map(&:name).sort.must_equal \
+        ["Admin", "Deployer", "Deployer Project Admin", "DeployerBuddy", "Project Deployer", "Super Admin"]
+    end
+
+    it 'filters by admin' do
+      User.with_role(Role::ADMIN.id, project.id).map(&:name).sort.must_equal \
+        ["Admin", "Deployer Project Admin", "Super Admin"]
+    end
   end
 
   describe 'soft delete!' do


### PR DESCRIPTION
@zendesk/samson 

 - search users by role to find all admins/deployers for a project /fyi @joshdellinger @Rchirackal 
 - can no longer select None when user is a >= Deployer
 - can no longer select Deployer when user is a >= Admin

<img width="1164" alt="screen shot 2016-05-04 at 9 28 29 am" src="https://cloud.githubusercontent.com/assets/11367/15022569/252234cc-11e1-11e6-8c3c-dbb3ae6ce83e.png">


### Risks
- Low: unable to assign project level roles correctly