### PR TITLE
make h1 use margins consistent with the rest of the UI

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -34,8 +34,8 @@ h1 {
   font-size: 20px;
   font-weight: normal;
   line-height: 20px;
-  margin-bottom: 30px;
-  margin-top: 30px;
+  margin-bottom: 20px;
+  margin-top: 0px;
   padding-bottom: 10px;
   border-bottom: 1px solid #c5c5c5;
 }
@@ -171,7 +171,7 @@ h3 {
 }
 
 .breadcrumb {
-  padding: 8px 0;
+  padding: 0;
   background: none;
   border-radius: 0;
 }


### PR DESCRIPTION
@zendesk/samson 

before: inconsistent spacing with rest of the site
<img width="278" alt="screen shot 2016-05-05 at 8 53 30 am" src="https://cloud.githubusercontent.com/assets/11367/15049180/ff9f7f18-12a1-11e6-8e5a-903ef32a43a6.png">

after:
<img width="326" alt="screen shot 2016-05-05 at 8 51 57 am" src="https://cloud.githubusercontent.com/assets/11367/15049185/047aa396-12a2-11e6-9a30-4e5d0c4ce4af.png">
<img width="219" alt="screen shot 2016-05-05 at 8 54 47 am" src="https://cloud.githubusercontent.com/assets/11367/15049188/070ff82c-12a2-11e6-8506-fdb0948a284c.png">
