### PR TITLE
do not let secrets into the lean command executor, it fails when used…

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -130,7 +130,8 @@ class GitRepository
   # error: nil
   def capture_stdout(*command, dir: repo_cache_dir)
     Dir.chdir(dir) do
-      out = IO.popen(command, err: [:child, :out]) { |io| io.read.strip }
+      env = {"PATH" => ENV["PATH"], "HOME" => ENV["HOME"]} # safer and also fixes locally running with hub gem
+      out = IO.popen(env, command, unsetenv_others: true, err: [:child, :out]) { |io| io.read.strip }
       out if $?.success?
     end
   end


### PR DESCRIPTION
… with hub gem on private repos

needs HOME to find ssh keys ... and PATH to find `git`

@pschambacher 
/cc @zendesk/samson
