### PR TITLE
[WIP] Use git worktree instead of cloning cached repos

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -151,7 +151,7 @@ class Project < ActiveRecord::Base
       begin
         output = repository.executor.output
         with_lock(output: output, holder: 'Initial Repository Setup') do
-          is_cloned = repository.clone!(from: repository_url, mirror: true)
+          is_cloned = repository.clone!(from: repository_url)
           log.error("Could not clone git repository #{repository_url} for project #{name} - #{output.string}") unless is_cloned
         end
       rescue => e

--- a/test/lib/references_service_test.rb
+++ b/test/lib/references_service_test.rb
@@ -22,7 +22,7 @@ describe ReferencesService do
   let!(:project) { Project.create!(name: 'test_project', repository_url: repository_url) }
 
   before do
-    project.repository.clone!(mirror: true)
+    project.repository.clone!
   end
 
   it 'returns a sorted set of tags and branches' do

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -84,17 +84,6 @@ describe GitRepository do
     end
   end
 
-  describe "#cheakout!" do
-    it 'switches to a different branch' do
-      create_repo_with_an_additional_branch
-      repository.clone!.must_equal(true)
-      repository.send(:checkout!, 'master').must_equal(true)
-      Dir.chdir(repository.repo_cache_dir) { current_branch.must_equal('master') }
-      repository.send(:checkout!, 'test_user/test_branch').must_equal(true)
-      Dir.chdir(repository.repo_cache_dir) { current_branch.must_equal('test_user/test_branch') }
-    end
-  end
-
   describe "#commit_from_ref" do
     it 'returns the short commit id' do
       create_repo_with_tags
@@ -116,7 +105,7 @@ describe GitRepository do
 
     it 'returns the commit of a branch' do
       create_repo_with_an_additional_branch('my_branch')
-      repository.clone!(mirror: true)
+      repository.clone!
       repository.commit_from_ref('my_branch').must_match /^[0-9a-f]{7}$/
     end
 
@@ -131,7 +120,7 @@ describe GitRepository do
         git checkout master
       SHELL
 
-      repository.clone!(mirror: true)
+      repository.clone!
       sha = repository.commit_from_ref('annotated_tag', length: 40)
       sha.must_match /^[0-9a-f]{40}$/
       repository.commit_from_ref('test_branch', length: 40).must_equal(sha)
@@ -167,13 +156,13 @@ describe GitRepository do
   describe "#tags" do
     it 'returns the tags repository' do
       create_repo_with_tags
-      repository.clone!(mirror: true)
+      repository.clone!
       repository.tags.to_a.must_equal %w(v1 )
     end
 
     it 'returns an empty set of tags' do
       create_repo_without_tags
-      repository.clone!(mirror: true)
+      repository.clone!
       repository.tags.must_equal []
     end
   end
@@ -181,7 +170,7 @@ describe GitRepository do
   describe "#branches" do
     it 'returns the branches of the repository' do
       create_repo_with_an_additional_branch
-      repository.clone!(mirror: true)
+      repository.clone!
       repository.branches.to_a.must_equal %w(master test_user/test_branch)
     end
   end
@@ -209,7 +198,7 @@ describe GitRepository do
     it 'updates an existing repository to a branch' do
       create_repo_with_an_additional_branch
       Dir.mktmpdir do |temp_dir|
-        repository.send(:clone!, mirror: true)
+        repository.send(:clone!)
         assert repository.setup!(temp_dir, 'test_user/test_branch')
         Dir.chdir(temp_dir) { current_branch.must_equal('test_user/test_branch') }
       end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -22,7 +22,7 @@ describe JobExecution do
     create_repo_with_tags('v1')
     user.name = 'John Doe'
     user.email = 'jdoe@test.com'
-    project.repository.clone!(mirror: true)
+    project.repository.clone!
     job.deploy = deploy
     JobExecution.enabled = true
     JobExecution.clear_registry


### PR DESCRIPTION
This PR uses `git worktree` to create a copy of cached repos for a job instead of cloning. This is a work in progress. I still need to update tests but wanted to get some feedback early on. In particular i've removed the mirror option from clone, now all repos will be cloned as a mirror, I couldn't see any instances of needing a non mirror clone apart from the case that was replaced with the worktree.

/cc @zendesk/samson and @grosser 
### TODO
- [ ] Update tests
- [ ] Prune worktrees from the cached repo after a job has finished executing (inside the ensure)
### Tasks
- [ ] :+1: from team
### Risks
- Level: Med

Changing the way that job directories are setup so there's some risk involved here.
