### PR TITLE
support DaemonSet when deploying kubernetes

### DIFF
--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -28,7 +28,7 @@ Project.class_eval do
           service_name: config_file.service.metadata.name,
           ram: config_file.deployment.ram_mi,
           cpu: config_file.deployment.cpu_m,
-          replicas: config_file.deployment.spec.replicas,
+          replicas: config_file.deployment.spec.replicas || 1, # daemonsets do not have replicas ...
           deploy_strategy: config_file.deployment.strategy_type
         )
       end

--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -19,7 +19,7 @@ module Kubernetes
     end
 
     def parse_deployment
-      deployment_hash = as_hash('Deployment')
+      deployment_hash = as_hash('Deployment') || as_hash('DaemonSet')
       raise 'Deployment specification missing in the configuration file.' if deployment_hash.nil?
       @deployment = Deployment.new(deployment_hash)
     rescue => ex

--- a/plugins/kubernetes/config/initializers/watchers.rb
+++ b/plugins/kubernetes/config/initializers/watchers.rb
@@ -4,7 +4,9 @@ require 'kubeclient'
 
 module Kubeclient
   class Client
-    NEW_ENTITY_TYPES = %w(Deployment).map do |et|
+    # Add Deployment and Daemonset waiting for PR:
+    # https://github.com/abonas/kubeclient/pull/143
+    NEW_ENTITY_TYPES = %w(Deployment DaemonSet).map do |et|
       clazz = Class.new(RecursiveOpenStruct) do
         def initialize(hash = nil, args = {})
           args.merge!(recurse_over_arrays: true)

--- a/plugins/kubernetes/test/controllers/kubernetes_releases_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes_releases_controller_test.rb
@@ -8,7 +8,7 @@ describe KubernetesReleasesController do
   let(:deploy_group) { deploy_groups(:pod1) }
   let(:app_server) { kubernetes_roles(:app_server) }
   let(:resque_worker) { kubernetes_roles(:resque_worker) }
-  let(:role_config_file) { parse_role_config_file('kubernetes_role_config_file') }
+  let(:role_config_file) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
 
   as_a_viewer do
     describe 'a GET to #index' do

--- a/plugins/kubernetes/test/controllers/kubernetes_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes_roles_controller_test.rb
@@ -237,7 +237,7 @@ describe KubernetesRolesController do
 
   describe 'a GET to #refresh' do
     let(:role) { kubernetes_roles(:app_server) }
-    let(:contents) { parse_role_config_file('kubernetes_role_config_file') }
+    let(:contents) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
 
     before do
       Project.any_instance.stubs(:kubernetes_config_files_in_repo).returns(['some_folder/file_name.yml'])

--- a/plugins/kubernetes/test/decorators/project_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/project_decorator_test.rb
@@ -6,7 +6,7 @@ describe Project do
   include GitRepoTestHelper
 
   let(:project) { projects(:test) }
-  let(:contents) { parse_role_config_file('kubernetes_role_config_file') }
+  let(:contents) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
 
   describe '#file_from_repo' do
     it 'returns the file contents' do

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -1,9 +1,11 @@
 require_relative "../../test_helper"
 
-SingleCov.covered! uncovered: 37
+SingleCov.covered! uncovered: 29
 
 describe Kubernetes::ReleaseDoc do
   let(:doc) { kubernetes_release_docs(:test_release_pod_1) }
+
+  before { kubernetes_fake_raw_template }
 
   describe "#ensure_service" do
     it "does nothing when no service is defined" do
@@ -19,6 +21,29 @@ describe Kubernetes::ReleaseDoc do
       doc.stubs(service: stub(running?: false))
       doc.expects(:client).returns(stub(create_service: nil))
       doc.ensure_service.must_equal "creating Service"
+    end
+  end
+
+  describe "#deploy_to_kubernetes" do
+    let(:client) { doc.send(:extension_client) }
+
+    it "creates when deploy does not exist" do
+      client.expects(:get_deployment).returns false
+      client.expects(:create_deployment)
+      doc.deploy_to_kubernetes
+    end
+
+    it "updates when deploy does exist" do
+      client.expects(:get_deployment).returns true
+      client.expects(:update_deployment)
+      doc.deploy_to_kubernetes
+    end
+
+    it "can manage daemonsets" do
+      doc.send(:deploy_yaml).send(:template).kind = 'DaemonSet'
+      client.expects(:get_daemon_set).returns true
+      client.expects(:update_daemon_set)
+      doc.deploy_to_kubernetes
     end
   end
 end

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -10,7 +10,7 @@ describe Kubernetes::Release do
   let(:project) { projects(:test) }
   let(:app_server) { kubernetes_roles(:app_server) }
   let(:resque_worker) { kubernetes_roles(:resque_worker) }
-  let(:role_config_file) { parse_role_config_file('kubernetes_role_config_file') }
+  let(:role_config_file) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
 
   describe 'validations' do
     it 'is valid by default' do

--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -4,7 +4,7 @@ SingleCov.covered! uncovered: 3
 
 describe Kubernetes::RoleConfigFile do
   describe 'Parsing a valid Kubernetes config file' do
-    let(:contents) { parse_role_config_file('kubernetes_role_config_file') }
+    let(:contents) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
 
     let(:config_file) { Kubernetes::RoleConfigFile.new(contents, 'some-file.yml') }
 
@@ -47,12 +47,22 @@ describe Kubernetes::RoleConfigFile do
   end
 
   describe 'Parsing a Kubernetes with a missing deployment' do
-    let(:contents) { parse_role_config_file('kubernetes_invalid_role_config_file') }
+    let(:contents) { read_kubernetes_sample_file('kubernetes_invalid_role_config_file.yml') }
 
     it 'raises an exception' do
       assert_raises RuntimeError do
         Kubernetes::RoleConfigFile.new(contents, 'some-file.yml')
       end
+    end
+  end
+
+  describe 'Parsing DaemonSet' do
+    let(:contents) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
+
+    it "returns a deployment" do
+      assert contents.sub!('Deployment', 'DaemonSet')
+      config_file = Kubernetes::RoleConfigFile.new(contents, 'some-file.yml')
+      config_file.deployment.spec.replicas.must_equal 2
     end
   end
 end

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -32,14 +32,6 @@ class ActiveSupport::TestCase
     end
   end
 
-  def parse_role_config_file(file_name)
-    read_file "#{file_name}.yml"
-  end
-
-  def parse_json_response_file(file_name)
-    read_file "#{file_name}.json"
-  end
-
   def with_example_kube_config
     Tempfile.open('config') do |t|
       config = {
@@ -84,7 +76,7 @@ class ActiveSupport::TestCase
 
   private
 
-  def read_file(file_name)
+  def read_kubernetes_sample_file(file_name)
     File.read("#{Rails.root}/plugins/kubernetes/test/samples/#{file_name}")
   end
 end


### PR DESCRIPTION
@zendesk/paas 

reusing the deploy parsing logic and sending to a different endpoint
only second commit, first is part of another PR