### PR TITLE
SAMSON-236 clean out all unnecessary gemfile requires

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,50 @@ source 'https://rubygems.org'
 
 ruby File.read('.ruby-version').strip
 
+# gems that have rails engines are are always needed
+group :preload do
+  gem 'rails', '~> 4.2.0'
+  gem 'dotenv'
+  gem 'sse-rails-engine', '~> 1.4'
+
+  # AR extensions
+  gem 'goldiloader'
+  gem 'kaminari'
+  gem 'active_model_serializers', '~> 0.8.0'
+  gem 'paper_trail'
+  gem 'soft_deletion', '~> 0.4'
+
+  # Logging
+  gem 'lograge'
+  gem 'logstash-event'
+end
+
 gem 'bundler', '>= 1.8.4'
-
-gem 'rails', '~> 4.2.0'
+gem 'dogstatsd-ruby', '~> 1.5.0'
 gem 'puma'
-gem 'dotenv'
+gem 'attr_encrypted'
+gem 'sawyer', '~> 0.5'
+gem 'dalli', '~> 2.7.0'
+gem 'omniauth', '~> 1.1'
+gem 'omniauth-oauth2', '~> 1.1'
+gem 'omniauth-github', '= 1.1.1'
+gem 'omniauth-google-oauth2', '~> 0.2.4'
+gem 'omniauth-ldap', '>= 1.0.5'
+gem 'octokit', '~> 4.0'
+gem 'faraday-http-cache', '~> 1.1'
+gem 'warden', '~> 1.2'
+gem 'active_hash', '~> 1.0'
+gem 'ansible'
+gem 'github-markdown', '~> 0.6.3'
+gem 'activeresource'
+gem 'coderay', '~> 1.1.0'
+gem 'net-http-persistent'
+gem 'concurrent-ruby'
+gem 'vault'
+gem 'docker-api'
 
-gem 'dogstatsd-ruby', '~> 1.5.0', require: 'statsd'
-gem 'goldiloader'
-gem 'attr_encrypted', require: false
+# treat included plugins like gems
+Dir[File.join(Bundler.root, 'plugins/*/')].each { |f| gemspec path: f, require: false }
 
 group :mysql2 do
   gem 'mysql2', '~> 0.3'
@@ -23,25 +58,6 @@ end
 group :sqlite do
   gem "sqlite3"
 end
-
-gem 'kaminari'
-gem 'soft_deletion', '~> 0.4'
-gem 'dalli', '~> 2.7.0'
-gem 'active_model_serializers', '~> 0.8.0'
-gem 'paper_trail'
-gem 'sawyer', '~> 0.5'
-gem 'sse-rails-engine', '~> 1.4'
-
-
-# Hashicorp vault
-gem 'vault'
-
-# Logging
-gem 'lograge'
-gem 'logstash-event'
-
-# Docker
-gem 'docker-api'
 
 group :production, :staging do
   gem 'rails_12factor'
@@ -82,26 +98,6 @@ group :assets do
   end
 end
 
-group :no_preload do
-  gem 'omniauth', '~> 1.1'
-  gem 'omniauth-oauth2', '~> 1.1'
-  gem 'omniauth-github', '= 1.1.1'
-  gem 'omniauth-google-oauth2', '~> 0.2.4'
-  gem 'omniauth-ldap', '>= 1.0.5'
-  gem 'octokit', '~> 4.0'
-  gem 'faraday-http-cache', '~> 1.1'
-  gem 'warden', '~> 1.2'
-  gem 'active_hash', '~> 1.0'
-  gem 'ansible'
-  gem 'github-markdown', '~> 0.6.3'
-  gem 'activeresource'
-  gem 'coderay', '~> 1.1.0'
-  gem 'net-http-persistent'
-  gem 'concurrent-ruby'
-
-  Dir[File.join(Bundler.root, 'plugins/*/')].each { |f| gemspec path: f, require: false } # treat included plugins like gems
-end
-
 group :development, :staging do
   gem "binding_of_caller"
   gem 'better_errors'
@@ -109,20 +105,20 @@ group :development, :staging do
 end
 
 group :development, :test do
-  gem 'byebug', require: false
-  gem 'bootscale', require: false
+  gem 'byebug'
+  gem 'bootscale'
   gem 'pry-rails'
   gem 'awesome_print'
-  gem 'brakeman', require: false
+  gem 'brakeman'
 end
 
 group :test do
   gem 'minitest-rails'
   gem 'maxitest'
-  gem 'mocha', require: false
-  gem 'webmock', require: false
+  gem 'mocha'
+  gem 'webmock'
   gem 'single_cov'
-  gem 'simplecov', require: false
+  gem 'simplecov'
   gem 'query_diet'
-  gem 'codeclimate-test-reporter', require: false
+  gem 'codeclimate-test-reporter'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+# asset gems need to be loaded before app is done loading
+ENV['PRECOMPILE'] = '1' if ARGV.include?("test:js") || ARGV.include?("assets:precompile")
+
 require File.expand_path('../config/application', __FILE__)
 
 Samson::Application.load_tasks
@@ -11,7 +14,6 @@ task default: :test
 task :asset_compilation_environment do
   ENV['SECRET_TOKEN'] = 'foo'
   ENV['GITHUB_TOKEN'] = 'foo'
-  ENV['PRECOMPILE'] = '1'
 
   config = Rails.application.config
   def config.database_configuration
@@ -59,7 +61,8 @@ namespace :test do
   end
 
   def resolve_asset(file)
-    Rails.application.assets.find_asset(file).to_a.first.pathname.to_s
+    asset = Rails.application.assets.find_asset(file).to_a.first || raise("Could not find #{file}")
+    asset.pathname.to_s
   end
 end
 

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -1,5 +1,5 @@
-require 'attr_encrypted'
 module SecretStorage
+  require 'attr_encrypted'
   class DbBackend
     class Secret < ActiveRecord::Base
       self.table_name = :secrets
@@ -49,6 +49,7 @@ module SecretStorage
     end
   end
 
+  require 'vault'
   class HashicorpVault
 
     VAULT_SECRET_BACKEND ='secret/'.freeze

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,9 +2,8 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
-Bundler.require(:default, :assets, Rails.env)
+Bundler.require(:preload)
+Bundler.require(:assets) if Rails.env.development? || ENV["PRECOMPILE"]
 
 Dotenv.load(Bundler.root.join(Rails.env.test? ? '.env.test' : '.env'))
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,12 +2,9 @@ require 'omniauth'
 
 OmniAuth.config.logger = Rails.logger
 
-require 'omniauth-github'
-require 'omniauth-google-oauth2'
-require 'omniauth-ldap'
-
 Rails.application.config.middleware.use OmniAuth::Builder do
   if Rails.application.config.samson.auth.github
+    require 'omniauth-github'
     provider :github,
       ENV["GITHUB_CLIENT_ID"],
       ENV["GITHUB_SECRET"],
@@ -20,6 +17,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   end
 
   if Rails.application.config.samson.auth.google
+    require 'omniauth-google-oauth2'
     provider OmniAuth::Strategies::GoogleOauth2,
       ENV["GOOGLE_CLIENT_ID"],
       ENV["GOOGLE_CLIENT_SECRET"],
@@ -31,6 +29,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   end
 
   if Rails.application.config.samson.auth.ldap
+    require 'omniauth-ldap'
+
     provider OmniAuth::Strategies::LDAP,
       title: Rails.application.config.samson.ldap.title,
       host: Rails.application.config.samson.ldap.host,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,6 +105,7 @@ class ActiveSupport::TestCase
   end
 
   def ar_queries
+    require 'query_diet'
     QueryDiet::Logger.queries.map(&:first) - ["select 1"]
   end
 


### PR DESCRIPTION
@zendesk/samson 

enabling us to not install asset gems for production deploys, making nodejs no longer a dependency + the deployment lighter + boot times faster