### PR TITLE
covert duplicate stages tab into manage link

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, project.name %>
 
-<%= render 'projects/header', project: project, tab: "overview" %>
+<%= render 'projects/header', project: project, tab: "stages" %>
 
 <% cache project do %>
   <section class="clearfix tabs">
@@ -12,7 +12,11 @@
             <th>Deploy Groups</th>
           <% end %>
           <th>Last Deploy</th>
-          <th></th>
+          <th class="pull-right">
+            <% if current_user.is_admin_for?(@project) %>
+              <%= link_to 'Manage', project_stages_path(@project) %>
+            <% end %>
+          </th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/shared/_project_tabs.html.erb
+++ b/app/views/shared/_project_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs">
-  <li class="<%= 'active' if active == 'overview' %>">
-    <%= link_to "Overview", project %>
+  <li class="<%= 'active' if active == 'stages' %>">
+    <%= link_to "Stages", project %>
   </li>
   <li class="<%= 'active' if active == 'releases' %>">
     <%= link_to "Releases", project_releases_path(project) %>
@@ -18,9 +18,6 @@
   </li>
   <li class="<%= 'active' if active == 'macros' %>">
     <%= link_to "Macros", project_macros_path(project) %>
-  </li>
-  <li class="<%= 'active' if active == 'stages' %>">
-    <%= link_to "Stages", project_stages_path(project) %>
   </li>
   <li class="<%= 'active' if active == 'webhooks' %>">
     <%= link_to "Webhooks", project_webhooks_path(project) %>

--- a/app/views/stages/index.html.erb
+++ b/app/views/stages/index.html.erb
@@ -1,4 +1,7 @@
-<%= render 'projects/header', project: @project, tab: "stages" %>
+<h1>
+  <%= link_to @project.name, @project %> Stages
+</h1>
+
 
 <section class="tabs">
   <ul id="stages" data-url="<%= reorder_project_stages_path(@project) %>" data-sortable="<%= is_admin_for_project? %>">


### PR DESCRIPTION
@zendesk/samson 

Overview is a list of stages so having another `Stages` tab always felt weird to me ...
It's also needed very rarely / only useable by admins -> hide it behind a link ?

old UI:
<img width="1156" alt="screen shot 2016-05-07 at 10 55 28 am" src="https://cloud.githubusercontent.com/assets/11367/15093632/3d5cdf5c-1442-11e6-9668-f6d522fc5189.png">



New project tabs:
<img width="1145" alt="screen shot 2016-05-07 at 10 54 53 am" src="https://cloud.githubusercontent.com/assets/11367/15093628/2a8fa27e-1442-11e6-8966-92b505186f59.png">


New stage management page:
<img width="506" alt="screen shot 2016-05-07 at 10 51 22 am" src="https://cloud.githubusercontent.com/assets/11367/15093616/e6bcc7e8-1441-11e6-8402-c66fa24935c5.png">
