### PR TITLE
make deploy group role a real association

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160508055458) do
+ActiveRecord::Schema.define(version: 20160510153731) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                       null: false
@@ -168,16 +168,16 @@ ActiveRecord::Schema.define(version: 20160508055458) do
   end
 
   create_table "kubernetes_deploy_group_roles", force: :cascade do |t|
-    t.integer "project_id",      limit: 4,                           null: false
-    t.integer "deploy_group_id", limit: 4,                           null: false
-    t.integer "replicas",        limit: 4,                           null: false
-    t.integer "ram",             limit: 4,                           null: false
-    t.decimal "cpu",                         precision: 4, scale: 2, null: false
-    t.string  "name",            limit: 255,                         null: false
+    t.integer "project_id",         limit: 4,                         null: false
+    t.integer "deploy_group_id",    limit: 4,                         null: false
+    t.integer "replicas",           limit: 4,                         null: false
+    t.integer "ram",                limit: 4,                         null: false
+    t.decimal "cpu",                          precision: 4, scale: 2, null: false
+    t.integer "kubernetes_role_id", limit: 4,                         null: false
   end
 
   add_index "kubernetes_deploy_group_roles", ["deploy_group_id"], name: "index_kubernetes_deploy_group_roles_on_deploy_group_id", using: :btree
-  add_index "kubernetes_deploy_group_roles", ["project_id", "deploy_group_id", "name"], name: "index_kubernetes_deploy_group_roles_on_project_id", length: {"project_id"=>nil, "deploy_group_id"=>nil, "name"=>191}, using: :btree
+  add_index "kubernetes_deploy_group_roles", ["project_id", "deploy_group_id", "kubernetes_role_id"], name: "index_kubernetes_deploy_group_roles_on_project_id", using: :btree
 
   create_table "kubernetes_release_docs", force: :cascade do |t|
     t.integer  "kubernetes_role_id",          limit: 4,                         null: false
@@ -409,7 +409,6 @@ ActiveRecord::Schema.define(version: 20160508055458) do
     t.boolean  "integration",    default: false, null: false
     t.boolean  "access_request_pending",     default: false
     t.string   "time_format",            limit: 255, default: "relative", null: false
-
   end
 
   add_index "users", ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at", length: {"external_id"=>191, "deleted_at"=>nil}, using: :btree

--- a/plugins/kubernetes/app/controllers/admin/kubernetes/deploy_group_roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/admin/kubernetes/deploy_group_roles_controller.rb
@@ -28,7 +28,7 @@ class Admin::Kubernetes::DeployGroupRolesController < ApplicationController
   end
 
   def update
-    @deploy_group_role.assign_attributes(deploy_group_role_params.except(:project_id, :deploy_group_id))
+    @deploy_group_role.assign_attributes(deploy_group_role_params.except(:project_id, :deploy_group_id, :kubernetes_role_id))
     if @deploy_group_role.save
       redirect_to [:admin , @deploy_group_role]
     else
@@ -57,7 +57,7 @@ class Admin::Kubernetes::DeployGroupRolesController < ApplicationController
 
   def deploy_group_role_params
     params.require(:kubernetes_deploy_group_role).permit(
-      :name, :ram, :cpu, :replicas, :project_id, :deploy_group_id
+      :kubernetes_role_id, :ram, :cpu, :replicas, :project_id, :deploy_group_id
     )
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -208,8 +208,8 @@ module Kubernetes
       errors = []
       group_config = @job.deploy.stage.deploy_groups.map do |group|
         roles = configured_roles.map do |role|
-          role_config = roles_configs.detect do |r|
-            r.deploy_group_id == group.id && r.name == role.name # TODO: match role via id
+          role_config = roles_configs.detect do |dgr|
+            dgr.deploy_group_id == group.id && dgr.kubernetes_role_id == role.id
           end
 
           unless role_config

--- a/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
@@ -3,6 +3,7 @@ module Kubernetes
     self.table_name = 'kubernetes_deploy_group_roles'
     belongs_to :project
     belongs_to :deploy_group
-    validates :name, :ram, :cpu, :replicas, presence: true
+    belongs_to :kubernetes_role, class_name: 'Kubernetes::Role'
+    validates :ram, :cpu, :replicas, presence: true
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -7,6 +7,7 @@ module Kubernetes
     has_soft_deletion
 
     belongs_to :project, inverse_of: :kubernetes_roles
+    has_many :kubernetes_deploy_group_roles, class_name: 'Kubernetes::DeployGroupRole', dependent: :destroy
 
     DEPLOY_STRATEGIES = %w(RollingUpdate Recreate)
 

--- a/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/_form.html.erb
@@ -3,6 +3,13 @@
 
   <fieldset>
     <div class="form-group">
+      <%= form.label :deploy_group_id, 'Deploy Group', class: "col-lg-2 control-label" %>
+      <div class="col-lg-2">
+        <%= form.select :deploy_group_id, DeployGroup.pluck(:name, :id), {}, class: "form-control", disabled: @deploy_group_role.persisted? %>
+      </div>
+    </div>
+
+    <div class="form-group">
       <%= form.label :project_id, 'Project', class: "col-lg-2 control-label" %>
       <div class="col-lg-2">
         <%= form.select :project_id, current_user.administrated_projects.pluck(:name, :id), {}, class: "form-control", disabled: @deploy_group_role.persisted? %>
@@ -10,13 +17,13 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :deploy_group_id, 'Deploy Group', class: "col-lg-2 control-label" %>
+      <%= form.label :kubernetes_role_id, 'Role', class: "col-lg-2 control-label" %>
       <div class="col-lg-2">
-        <%= form.select :deploy_group_id, DeployGroup.pluck(:name, :id), {}, class: "form-control", disabled: @deploy_group_role.persisted? %>
+        <%= form.select :kubernetes_role_id, [['Loading ...', @deploy_group_role.kubernetes_role_id]], {}, class: "form-control", disabled: @deploy_group_role.persisted? %>
       </div>
     </div>
 
-    <% [[:name, 'Name'], [:cpu, 'CPU Cores'], [:ram, 'Ram in MB'], [:replicas, "Replicas"]].each do |column, label| %>
+    <% [[:cpu, 'CPU Cores'], [:ram, 'Ram in MB'], [:replicas, "Replicas"]].each do |column, label| %>
       <div class="form-group">
         <%= form.label column, label, class: "col-lg-2 control-label" %>
         <div class="col-lg-2">
@@ -34,3 +41,27 @@
     </div>
   </fieldset>
 <% end %>
+
+<script>
+  // change selectable roles when project changes, since every project has different roles
+  $(function(){
+    var project_data = <%= Kubernetes::Role.pluck(:project_id, :id, :name).group_by(&:first).to_json.html_safe %>
+    $('#kubernetes_deploy_group_role_project_id').change(function () {
+      var $role_select = $('#kubernetes_deploy_group_role_kubernetes_role_id');
+      var project_id = parseInt($(this).val(), 10);
+      var val = parseInt($role_select.val(), 10);
+      var roles = project_data[project_id];
+
+      // clear out previous options and refresh the select
+      $role_select.html('').val('');
+
+      // fill in currently selectable roles, keeping the current selection for edit or failed create
+      $.each(roles, function(i, e){
+        $role_select.append($("<option>", { value: e[1], html: e[2], selected: (e[1] === val) }));
+      });
+
+      // highlight the changed select so user sees the effect
+      $role_select.effect("highlight", {color: "#ffffe0"}, 500);
+    }).trigger('change');
+  });
+</script>

--- a/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/index.html.erb
+++ b/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/index.html.erb
@@ -7,7 +7,7 @@
       <tr>
         <th>Project</th>
         <th>Deploy Group</th>
-        <th>Name</th>
+        <th>Role</th>
         <th>CPU</th>
         <th>RAM</th>
         <th>Replicase</th>
@@ -16,9 +16,9 @@
 
       <% @deploy_group_roles.each do |deploy_group_role| %>
         <tr>
-          <td><%= link_to deploy_group_role.name, [:admin, deploy_group_role] %></td>
+          <td><%= link_to deploy_group_role.project.name, deploy_group_role.project %></td>
           <td><%= link_to deploy_group_role.deploy_group.name, [:admin, deploy_group_role.deploy_group] %></td>
-          <td></td>
+          <td><%= link_to deploy_group_role.kubernetes_role.name, [deploy_group_role.project, deploy_group_role.kubernetes_role] %></td>
           <td><%= deploy_group_role.cpu %></td>
           <td><%= deploy_group_role.ram %></td>
           <td><%= deploy_group_role.replicas %></td>

--- a/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/show.html.erb
+++ b/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/show.html.erb
@@ -2,9 +2,9 @@
 
 <section class="form-horizontal">
   <div class="form-group">
-    <label class="col-lg-2 control-label">Name</label>
+    <label class="col-lg-2 control-label">Role</label>
     <div class="col-lg-4">
-      <p class="form-control-static"><%= @deploy_group_role.name %></p>
+      <p class="form-control-static"><%= link_to @deploy_group_role.kubernetes_role.name, [@deploy_group_role.project, @deploy_group_role.kubernetes_role] %></p>
     </div>
   </div>
 

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -8,33 +8,33 @@
     <th>RAM</th>
     <th></th>
   </thead>
-  <% roles = Kubernetes::DeployGroupRole.where(project_id: @stage.project_id, deploy_group_id: @stage.deploy_groups.map(&:id)).to_a %>
-  <% names = roles.map(&:name).uniq.sort %>
+  <% project_dg_roles = Kubernetes::DeployGroupRole.where(project_id: @stage.project_id, deploy_group_id: @stage.deploy_groups.map(&:id)).to_a %>
+  <% roles = @stage.project.kubernetes_roles.sort_by(&:name) %>
 
   <% @stage.deploy_groups.sort_by(&:natural_order).each do |deploy_group| %>
-    <% group_roles = roles.select { |r| r.deploy_group_id == deploy_group.id } %>
+    <% dg_roles = project_dg_roles.select { |r| r.deploy_group_id == deploy_group.id } %>
     <tr>
       <td colspan="5"><h3><%= deploy_group.name %></h3></td>
     </tr>
-    <% names.each do |name| %>
-      <% group_role = group_roles.detect { |r| r.name == name } %>
+    <% roles.each do |role| %>
+      <% dg_role = dg_roles.detect { |r| r.kubernetes_role_id == role.id } %>
       <tr>
-        <td><%= name %></td>
-        <% if group_role %>
-          <td><%= group_role.replicas %></td>
-          <td><%= group_role.cpu %></td>
-          <td><%= group_role.ram %></td>
+        <td><%= role.name %></td>
+        <% if dg_role %>
+          <td><%= dg_role.replicas %></td>
+          <td><%= dg_role.cpu %></td>
+          <td><%= dg_role.ram %></td>
           <td>
             <% if current_user.admin_for?(@stage.project) %>
-              <%= link_to 'Edit', edit_admin_kubernetes_deploy_group_role_path(group_role) %>
+              <%= link_to 'Edit', edit_admin_kubernetes_deploy_group_role_path(dg_role) %>
             <% end %>
           </td>
         <% else %>
           <td colspan="3">Missing</td>
           <td>
             <% if current_user.admin_for?(@stage.project) %>
-              <% attributes = {name: name, project_id: @stage.project_id, deploy_group_id: deploy_group.id} %>
-              <%= link_to "Create", new_admin_kubernetes_deploy_group_role_path(group_role, kubernetes_deploy_group_role: attributes) %>
+              <% attributes = {kubernetes_role_id: role.id, project_id: @stage.project_id, deploy_group_id: deploy_group.id} %>
+              <%= link_to "Create", new_admin_kubernetes_deploy_group_role_path(kubernetes_deploy_group_role: attributes) %>
             <% end %>
           </td>
         <% end %>
@@ -42,17 +42,17 @@
     <% end %>
     <tr>
       <td>Subtotal</td>
-      <td><%= group_roles.sum(&:replicas) %></td>
-      <td><%= group_roles.sum { |gr| gr.cpu * gr.replicas } %></td>
-      <td><%= group_roles.sum { |gr| gr.ram * gr.replicas } %></td>
+      <td><%= dg_roles.sum(&:replicas) %></td>
+      <td><%= dg_roles.sum { |gr| gr.cpu * gr.replicas } %></td>
+      <td><%= dg_roles.sum { |gr| gr.ram * gr.replicas } %></td>
       <td></td>
     </tr>
   <% end %>
   <tr>
     <td><b>Total</b></td>
-    <td><%= roles.sum(&:replicas) %></td>
-    <td><%= roles.sum { |gr| gr.cpu * gr.replicas } %></td>
-    <td><%= roles.sum { |gr| gr.ram * gr.replicas } %></td>
+    <td><%= project_dg_roles.sum(&:replicas) %></td>
+    <td><%= project_dg_roles.sum { |gr| gr.cpu * gr.replicas } %></td>
+    <td><%= project_dg_roles.sum { |gr| gr.ram * gr.replicas } %></td>
     <td></td>
   </tr>
 </table>

--- a/plugins/kubernetes/db/migrate/20160510153731_change_role_name_to_id.rb
+++ b/plugins/kubernetes/db/migrate/20160510153731_change_role_name_to_id.rb
@@ -1,0 +1,46 @@
+class ChangeRoleNameToId < ActiveRecord::Migration
+  INDEX = "index_kubernetes_deploy_group_roles_on_project_id"
+
+  class KubernetesRole < ActiveRecord::Base
+  end
+
+  class KubernetesDeployGroupRole < ActiveRecord::Base
+  end
+
+  # change all role names to direct role references or delete the record
+  def up
+    add_column :kubernetes_deploy_group_roles, :kubernetes_role_id, :integer
+
+    KubernetesDeployGroupRole.find_each do |dgr|
+      if role = KubernetesRole.where(project_id: dgr.project_id, name: dgr.name).first
+        dgr.update_column(:kubernetes_role_id, role.id)
+      else
+        dgr.destroy
+      end
+    end
+
+    change_column_null :kubernetes_deploy_group_roles, :kubernetes_role_id, false
+    remove_column :kubernetes_deploy_group_roles, :name
+
+    remove_index :kubernetes_deploy_group_roles, name: INDEX
+    add_index :kubernetes_deploy_group_roles, [:project_id, :deploy_group_id, :kubernetes_role_id], name: INDEX
+  end
+
+  def down
+    add_column :kubernetes_deploy_group_roles, :name, :string
+
+    KubernetesDeployGroupRole.find_each do |dgr|
+      if role = KubernetesRole.where(id: dgr.kubernetes_role_id).first
+        dgr.update_column(:name, role.name)
+      else
+        dgr.destroy
+      end
+    end
+
+    change_column_null :kubernetes_deploy_group_roles, :name, false
+    remove_column :kubernetes_deploy_group_roles, :kubernetes_role_id
+
+    remove_index :kubernetes_deploy_group_roles, name: INDEX
+    add_index :kubernetes_deploy_group_roles, [:project_id, :deploy_group_id, :name], name: INDEX, length: {"name"=>191}
+  end
+end

--- a/plugins/kubernetes/test/controllers/admin/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/admin/kubernetes/deploy_group_roles_controller_test.rb
@@ -42,9 +42,9 @@ describe Admin::Kubernetes::DeployGroupRolesController do
       end
 
       it "can prefill" do
-        get :new, kubernetes_deploy_group_role: {name: 'foo'}
+        get :new, kubernetes_deploy_group_role: {kubernetes_role_id: kubernetes_roles(:app_server).id}
         assert_template :new
-        assigns(:deploy_group_role).name.must_equal 'foo'
+        assigns(:deploy_group_role).kubernetes_role_id.must_equal kubernetes_roles(:app_server).id
       end
     end
 
@@ -56,7 +56,7 @@ describe Admin::Kubernetes::DeployGroupRolesController do
 
   as_a_project_admin do
     describe "#create" do
-      let(:params) { {kubernetes_deploy_group_role: {project_id: project.id, name: 'Foo', deploy_group_id: deploy_group.id, cpu: 1, ram: 1, replicas: 1}} }
+      let(:params) { {kubernetes_deploy_group_role: {project_id: project.id, kubernetes_role_id: kubernetes_roles(:app_server).id, deploy_group_id: deploy_group.id, cpu: 1, ram: 1, replicas: 1}} }
 
       it "can create for projects I am admin of" do
         post :create, params
@@ -64,7 +64,7 @@ describe Admin::Kubernetes::DeployGroupRolesController do
       end
 
       it "renders when failing to create" do
-        params[:kubernetes_deploy_group_role].delete(:name)
+        params[:kubernetes_deploy_group_role].delete(:cpu)
         post :create, params
         assert_template :new
       end
@@ -91,8 +91,8 @@ describe Admin::Kubernetes::DeployGroupRolesController do
 
     describe "#update" do
       it "updates" do
-        put :update, id: deploy_group_role.id, kubernetes_deploy_group_role: {name: 'xyz'}
-        deploy_group_role.reload.name.must_equal 'xyz'
+        put :update, id: deploy_group_role.id, kubernetes_deploy_group_role: {cpu: 3.1}
+        deploy_group_role.reload.cpu.must_equal 3.1
         assert_redirected_to [:admin, deploy_group_role]
       end
 
@@ -104,12 +104,12 @@ describe Admin::Kubernetes::DeployGroupRolesController do
 
       it "does not allow updates for non-admins" do
         user.user_project_roles.delete_all
-        put :update, id: deploy_group_role.id, kubernetes_deploy_group_role: {name: 'xyz'}
+        put :update, id: deploy_group_role.id, kubernetes_deploy_group_role: {cpu: 3.1}
         assert_unauthorized
       end
 
       it "renders on failure" do
-        put :update, id: deploy_group_role.id, kubernetes_deploy_group_role: {name: ''}
+        put :update, id: deploy_group_role.id, kubernetes_deploy_group_role: {cpu: ''}
         assert_template :edit
       end
     end

--- a/plugins/kubernetes/test/fixtures/kubernetes/deploy_group_roles.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/deploy_group_roles.yml
@@ -1,7 +1,7 @@
 test_pod1_app_server:
   project: test
   deploy_group: pod1
-  name: app_server
+  kubernetes_role: app_server
   replicas: 3
   ram: 1024
   cpu: 0.5
@@ -9,7 +9,7 @@ test_pod1_app_server:
 test_pod1_resque_worker:
   project: test
   deploy_group: pod1
-  name: resque_worker
+  kubernetes_role: resque_worker
   replicas: 2
   ram: 512
   cpu: 1.0
@@ -17,7 +17,7 @@ test_pod1_resque_worker:
 test_pod100_app_server:
   project: test
   deploy_group: pod100
-  name: app_server
+  kubernetes_role: app_server
   replicas: 4
   ram: 1024
   cpu: 0.5
@@ -25,7 +25,7 @@ test_pod100_app_server:
 test_pod100_resque_worker:
   project: test
   deploy_group: pod100
-  name: resque_worker
+  kubernetes_role: resque_worker
   replicas: 5
   ram: 512
   cpu: 0.5


### PR DESCRIPTION
@zendesk/paas 

now that we no longer delete/create them all the time we can use ids to reference them

before: free form names
<img width="644" alt="screen shot 2016-05-10 at 8 56 24 am" src="https://cloud.githubusercontent.com/assets/11367/15154047/8cda09c4-1690-11e6-9637-6734154dfbea.png">

after: associated with role or deleted
![screen shot 2016-05-10 at 9 21 31 am](https://cloud.githubusercontent.com/assets/11367/15154068/a0c7e230-1690-11e6-8b54-1e3e61aed51b.png)

