### PR TITLE
indexes stay on mysql but get auto dropped on postgres

### DIFF
--- a/plugins/kubernetes/db/migrate/20160510153731_change_role_name_to_id.rb
+++ b/plugins/kubernetes/db/migrate/20160510153731_change_role_name_to_id.rb
@@ -22,7 +22,7 @@ class ChangeRoleNameToId < ActiveRecord::Migration
     change_column_null :kubernetes_deploy_group_roles, :kubernetes_role_id, false
     remove_column :kubernetes_deploy_group_roles, :name
 
-    remove_index :kubernetes_deploy_group_roles, name: INDEX
+    remove_old_index
     add_index :kubernetes_deploy_group_roles, [:project_id, :deploy_group_id, :kubernetes_role_id], name: INDEX
   end
 
@@ -40,7 +40,11 @@ class ChangeRoleNameToId < ActiveRecord::Migration
     change_column_null :kubernetes_deploy_group_roles, :name, false
     remove_column :kubernetes_deploy_group_roles, :kubernetes_role_id
 
-    remove_index :kubernetes_deploy_group_roles, name: INDEX
+    remove_old_index
     add_index :kubernetes_deploy_group_roles, [:project_id, :deploy_group_id, :name], name: INDEX, length: {"name"=>191}
+  end
+
+  def remove_old_index
+    remove_index :kubernetes_deploy_group_roles, name: INDEX if index_exists?(:kubernetes_deploy_group_roles, name: INDEX)
   end
 end


### PR DESCRIPTION
@jonmoter 

heroku deploy failed with 

```
Index name 'index_kubernetes_deploy_group_roles_on_project_id' on table 'kubernetes_deploy_group_roles' does not exist/tmp/build_32431f4dab5ea561cd29f831df75536f/zendesk-samson-bcbfdda/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.5.2/lib/active_record/connection_adapters/abstract/schema_statements.rb:988:in `index_name_for_remove'

```