### PR TITLE
support stdout logging in dev via RAILS_LOG_TO_STDOUT

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,6 +43,9 @@
     },
     "DEPLOY_TASKS": {
       "value": "db:migrate"
+    },
+    "RAILS_LOG_TO_STDOUT": {
+      "value": "true"
     }
   },
   "scripts": {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,17 +29,9 @@ Samson::Application.configure do
   # number of complex assets.
   config.assets.debug = false
 
-  # Lograge
-  # For testing purposes, you need to have something like this in your asl.conf (Mac OS X):
-  # ? [= Sender samson] file /Users/myuser/Code/samson/log/samson.log mode=0644
-  # require 'syslog/logger'
-  # config.logger = Syslog::Logger.new('samson')
-  if ENV['DOCKER'] == 'true'
-    config.logger = Logger.new(STDOUT)
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
   end
-
-  # config.lograge.enabled = true
-  # config.lograge.formatter = Lograge::Formatters::Logstash.new
 
   BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,17 +81,18 @@ Samson::Application.configure do
   # Lograge
   config.lograge.enabled = true
 
-  # custom_options can be a lambda or hash
-  # if it's a lambda then it must return a hash
   config.lograge.custom_options = lambda do |event|
+    # show params for every request
     unwanted_keys = %w[format action controller]
     params = event.payload[:params].reject { |key,_| unwanted_keys.include? key }
-
-    # capture some specific timing values you are interested in
     { :params => params }
   end
 
-  require 'syslog/logger'
-  config.logger = Syslog::Logger.new('samson')
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  else
+    require 'syslog/logger'
+    config.logger = Syslog::Logger.new('samson')
+    config.lograge.formatter = Lograge::Formatters::Logstash.new
+  end
 end


### PR DESCRIPTION
new rails 5 shinyness ...
I was hoping production would work, but somehow syslogger does not go into stdout ... so making it use the same stdout logger as development with docker ... 

Heroku log lines now look like this:
```
2016-05-11T05:23:46.806416+00:00 app[web.1]: method=GET path=/ping format=html controller=ping action=show status=200 duration=0.50 view=0.00 db=0.00 params={}
```

@sandlerr 
/cc @zendesk/samson 


