### PR TITLE
PAAS-144 env vars for logging

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160510153731) do
+ActiveRecord::Schema.define(version: 20160512204809) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                       null: false
@@ -214,6 +214,7 @@ ActiveRecord::Schema.define(version: 20160510153731) do
     t.integer  "build_id"
     t.integer  "user_id"
     t.integer  "project_id",         limit: 4,                       null: false
+    t.integer  "deploy_id",          limit: 4
   end
 
   add_index "kubernetes_releases", ["build_id"], name: "index_kubernetes_releases_on_build_id"

--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -1,4 +1,5 @@
 require 'kubeclient'
+require 'celluloid/io'
 
 module Kubernetes
   class Cluster < ActiveRecord::Base

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -230,6 +230,7 @@ module Kubernetes
       raise Samson::Hooks::UserError, errors.join("\n") if errors.any?
 
       release = Kubernetes::Release.create_release(
+        deploy_id: @job.deploy.id,
         deploy_groups: group_config,
         build_id: build.id,
         user: @job.user,

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -7,6 +7,7 @@ module Kubernetes
     belongs_to :user
     belongs_to :build
     belongs_to :project
+    belongs_to :deploy
     has_many :release_docs, class_name: 'Kubernetes::ReleaseDoc', foreign_key: 'kubernetes_release_id'
     has_many :deploy_groups, through: :release_docs
 

--- a/plugins/kubernetes/db/migrate/20160512204809_add_deploy_to_kubernetes_release.rb
+++ b/plugins/kubernetes/db/migrate/20160512204809_add_deploy_to_kubernetes_release.rb
@@ -1,0 +1,5 @@
+class AddDeployToKubernetesRelease < ActiveRecord::Migration
+  def change
+    add_column :kubernetes_releases, :deploy_id, :integer
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_yaml_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_yaml_test.rb
@@ -6,7 +6,10 @@ describe Kubernetes::DeployYaml do
   let(:doc) { kubernetes_release_docs(:test_release_pod_1) }
   let(:yaml) { Kubernetes::DeployYaml.new(doc) }
 
-  before { kubernetes_fake_raw_template }
+  before do
+    kubernetes_fake_raw_template
+    doc.kubernetes_release.deploy_id = 123
+  end
 
   describe "#resource_name" do
     it 'is deployment' do
@@ -28,31 +31,43 @@ describe Kubernetes::DeployYaml do
       spec.fetch(:uniqueLabelKey).must_equal "rc_unique_identifier"
       spec.fetch(:replicas).must_equal doc.replica_target
       spec.fetch(:template).fetch(:metadata).fetch(:labels).must_equal(
+        revision: "1a6f551a2ffa6d88e15eef5461384da0bfb1c194",
+        tag: "v123",
         pre_defined: "foobar",
         release_id: doc.kubernetes_release_id.to_s,
+        project: "foo",
         project_id: doc.kubernetes_release.project_id.to_s,
         role_id: doc.kubernetes_role_id.to_s,
-        role_name: "app_server",
+        role: "app_server",
+        deploy_group: 'pod1',
         deploy_group_id: doc.deploy_group_id.to_s,
-        deploy_group_namespace: "pod1"
+        deploy_id: "123",
       )
 
       metadata = result.fetch(:metadata)
       metadata.fetch(:namespace).must_equal 'pod1'
       metadata.fetch(:labels).must_equal(
         project_id: doc.kubernetes_release.project_id.to_s,
-        role_name: "app_server",
-        deploy_group_namespace: "pod1"
+        revision: "1a6f551a2ffa6d88e15eef5461384da0bfb1c194",
+        tag: "v123",
+        deploy_id: "123",
+        project: "foo",
+        role: "app_server",
+        deploy_group: "pod1",
       )
 
-      spec.fetch(:template).fetch(:spec).fetch(:containers).first.must_equal(
-        image: 'docker-registry.example.com/test@sha256:5f1d7c7381b2e45ca73216d7b06004fdb0908ed7bb8786b62f2cdfa5035fde2c',
-        resources: {
-          limits:{
-            memory: "100Mi",
-            cpu: 1.0
-          }
+      container = spec.fetch(:template).fetch(:spec).fetch(:containers).first
+      container.fetch(:image).must_equal(
+        'docker-registry.example.com/test@sha256:5f1d7c7381b2e45ca73216d7b06004fdb0908ed7bb8786b62f2cdfa5035fde2c'
+      )
+      container.fetch(:resources).must_equal(
+        limits:{
+          memory: "100Mi",
+          cpu: 1.0
         }
+      )
+      container.fetch(:env).map(&:to_h).map { |x| x.fetch(:name) }.sort.must_equal(
+        [:REVISION, :TAG, :PROJECT, :ROLE, :DEPLOY_ID, :DEPLOY_GROUP, :POD_NAME, :POD_NAMESPACE, :POD_IP].sort
       )
     end
 
@@ -83,6 +98,11 @@ describe Kubernetes::DeployYaml do
     end
 
     describe "containers" do
+      let(:result) { yaml.to_hash }
+      let(:env_values) do
+        result.fetch(:spec).fetch(:template).fetch(:spec).fetch(:containers).first.fetch(:env)
+      end
+
       it "fails without containers" do
         assert doc.raw_template.sub!("      containers:\n      - {}", '')
         e = assert_raises Samson::Hooks::UserError do
@@ -95,6 +115,13 @@ describe Kubernetes::DeployYaml do
       it "allows multiple containers, even though they will not be properly replaced" do
         assert doc.raw_template.sub!("containers:\n      - {}", "containers:\n      - {}\n      - {}")
         yaml.to_hash
+      end
+
+      it "merges existing env settings" do
+        yaml.send(:template).spec.template.spec.containers[0].env = [{name: 'Foo', value: 'Bar'}]
+        keys = env_values.map(&:to_h).map { |x| x.fetch(:name) }
+        keys.must_include 'Foo'
+        keys.size.must_be :>, 5
       end
     end
 


### PR DESCRIPTION
@zendesk/paas 

 - changing label names around a bit for easier queryability
 - adding env vars with the same values so our logger can use them
 - adding deploy_id to kubernetes release so we can easily track the release back to the deploy that caused it