### PR TITLE
mime types needs 0.3s to load ... we do not need all these types

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,4 @@ JENKINS_URL=http://www.test-url.com
 JENKINS_USERNAME=user@test.com
 JENKINS_API_KEY=japikey
 PROJECT_CREATED_NOTIFY_ADDRESS=blah@example.com
+RUBY_MIME_TYPES_LAZY_LOAD=true


### PR DESCRIPTION
@zendesk/samson

standalone time is 0.3s `fork { puts(Benchmark.realtime { require 'mime/types' })}`

when running a benchmark this only yielded 0.1s improvement, but it's a step in the right direction ...

```
without:
runs: 10
total: 54.48
average: 5.45
range: 5.35..5.54

with:
runs: 10
total: 53.86
average: 5.39
range: 5.27..5.82
```