### PR TITLE
RFC: Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ruby:2.2.3
+FROM ruby:2.2.3-slim
 
 RUN apt-get update && apt-get install -y wget apt-transport-https
 RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN echo 'deb https://deb.nodesource.com/node_0.12 jessie main' > /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update && apt-get install -y nodejs
+RUN apt-get update && apt-get install -y nodejs build-essential
 
 WORKDIR /app
 
@@ -25,6 +25,8 @@ ADD Gemfile /app/
 ADD Gemfile.lock /app/
 ADD vendor/cache /app/vendor/cache
 ADD plugins /app/plugins
+
+RUN apt-get -y install libmysqlclient-dev libpq-dev libsqlite3-dev
 RUN bundle install --quiet --local --jobs 4 || bundle check
 
 # Code


### PR DESCRIPTION
This reduces the docker image size, while being quite not-intrusive, in ~23%. It's useful for us because our internet connection is not really fast. What do you guys think of a change like this? (I've only build tested it, but will test it correctly if you are onboard with such a PR)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

This reduces the docker image size from 1GB to 790MB, 23% smaller.
Further changes may be possible, but they are probably more intrusive.
These are pretty simple and yet the shrink is considerable. So this
feels good enough for a start, at least.

This is useful for us because our internet connection is pretty slow.