### PR TITLE
make sse connection lazy and active deploys read value from html

### DIFF
--- a/app/assets/javascripts/controllers/current_deploys_badge_ctrl.js
+++ b/app/assets/javascripts/controllers/current_deploys_badge_ctrl.js
@@ -1,33 +1,37 @@
 samson.controller('currentDeployBadgeCtrl', function($scope, $http, SseFactory) {
   'use strict';
 
-  $scope.currentActiveDeploys = 0;
+  var $badge = $('#currentDeploysBadge');
+  $scope.currentActiveDeploys = parseInt($badge.data('count'), 10);
 
-  SseFactory.on('deploys', function(msg) {
-    if (msg.type === 'new') {
-      $scope.currentActiveDeploys += 1;
-    } else if (msg.type === 'finish') {
-      $scope.currentActiveDeploys -= 1;
-    }
-    updateBadge();
-  });
+  // once a user has the page open for a while:
+  // - get current active count to reduce race condition
+  // - connect to stream for updates
+  setTimeout(function(){
+    $http.get('/deploys/active_count.json').success(function(result) {
+      $scope.currentActiveDeploys = result.deploy_count;
+      updateBadge();
+
+      SseFactory.on('deploys', function(msg) {
+        if (msg.type === 'new') {
+          $scope.currentActiveDeploys += 1;
+        } else if (msg.type === 'finish') {
+          $scope.currentActiveDeploys -= 1;
+        }
+        updateBadge();
+      });
+    });
+  }, 5000);
 
   function updateBadge() {
     _.defer(function() { $scope.$apply(); });
     if ($scope.currentActiveDeploys > 0) {
-      $('#currentDeploysBadge').show();
+      $badge.show();
     } else {
       $scope.currentActiveDeploys = 0;
-      $('#currentDeploysBadge').hide();
+      $badge.hide();
     }
   }
 
-  function init() {
-    $http.get('/deploys/active_count.json').success(function(result) {
-      $scope.currentActiveDeploys = result.deploy_count;
-      updateBadge();
-    });
-  }
-
-  init();
+  updateBadge();
 });

--- a/app/assets/javascripts/services/sse_factory.js
+++ b/app/assets/javascripts/services/sse_factory.js
@@ -1,23 +1,18 @@
 samson.factory('SseFactory', function() {
   'use strict';
 
-  var sse = {
-    connection: null,
+  function connect() {
+    var origin = $('meta[name=stream-origin]').first().attr('content');
+    return new EventSource(origin + '/streaming');
+  }
 
-    init: function(origin) {
-      this.connection = new EventSource(origin + '/streaming');
-    },
-
+  return {
+    connection: null, // needed for tests
     on: function(event, callback) {
+      this.connection = this.connection || connect();
       this.connection.addEventListener(event, function(e) {
         callback(JSON.parse(e.data));
       });
     }
   };
-
-  var origin = $('meta[name=stream-origin]').first().attr('content');
-
-  sse.init(origin);
-
-  return sse;
 });

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -21,18 +21,18 @@ class DeploysController < ApplicationController
     end
   end
 
-  def active_count
-    render json: { deploy_count: active_deploy_scope.count }
-  end
-
   def active
     @deploys = active_deploy_scope
     render partial: 'shared/deploys_table', layout: false if params[:partial]
   end
 
+  def active_count
+    render json: Deploy.active.count
+  end
+
   # Takes the same params that are used by the client side filtering
   # on the recent deploys pages.
-  # Returrns a paginated json object of deploys that people are
+  # Returns a paginated json object of deploys that people are
   # interested in rather than doing client side filtering.
   # params:
   #   * deployer (name of the user that started the job(s), this is a fuzzy match

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -102,6 +102,12 @@ class Deploy < ActiveRecord::Base
     includes(:job).where(jobs: { status: Job::ACTIVE_STATUSES })
   end
 
+  def self.active_count
+    Rails.cache.fetch('deploy_active_count', expires_in: 10.seconds) do
+      active.count
+    end
+  end
+
   def self.pending
     includes(:job).where(jobs: { status: 'pending' })
   end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -46,7 +46,12 @@
         <li class="current-deploys <%= 'active' if current_page?(controller: '/deploys', action: 'active') %>" ng-controller="currentDeployBadgeCtrl">
           <%= link_to active_deploys_path do %>
             Deploying
-            <%= content_tag(:span, '{{ currentActiveDeploys }}', class: 'badge badge-deploys', style: 'display: none', id: 'currentDeploysBadge') %>
+            <%= content_tag :span, '{{ currentActiveDeploys }}',
+                class: 'badge badge-deploys',
+                style: 'display: none',
+                id: 'currentDeploysBadge',
+                data: {count: Deploy.active_count}
+            %>
           <% end %>
         </li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Samson::Application.routes.draw do
     resources :deploys, only: [:index, :show, :destroy] do
       collection do
         get :active
-        get :active_count
       end
 
       member do

--- a/test/angular/controllers/current_deploys_badge_ctrl_spec.js
+++ b/test/angular/controllers/current_deploys_badge_ctrl_spec.js
@@ -4,46 +4,38 @@ describe('currentDeployBadgeCtrl', function() {
   var $rootScope,
     $scope = {},
     $controller,
-    $httpBackend,
     SseFactory,
     createController,
     fakeBadgeElement;
 
-  beforeEach(inject(function(_$controller_, _$httpBackend_, _$rootScope_, _SseFactory_) {
+  beforeEach(inject(function(_$controller_, _$rootScope_, _SseFactory_) {
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
-    $httpBackend = _$httpBackend_;
     SseFactory = _SseFactory_;
     fakeBadgeElement = {
       show: jasmine.createSpy('show'),
-      hide: jasmine.createSpy('hide')
+      hide: jasmine.createSpy('hide'),
+      data: function(){ return '0' }
     };
     spyOn(window, '$').and.returnValue(fakeBadgeElement);
     createController = function() {
       $controller = _$controller_('currentDeployBadgeCtrl', { $scope: $scope });
       $rootScope.$apply();
-      $httpBackend.flush();
     };
   }));
 
-  afterEach(function() {
-    $httpBackend.verifyNoOutstandingExpectation();
-    $httpBackend.verifyNoOutstandingRequest();
-  });
-
   describe('init', function() {
-    it('gets current active deploys', function() {
-      $httpBackend.expectGET('/deploys/active_count.json').respond('{"deploy_count":2}');
-      createController();
-      expect($scope.currentActiveDeploys).toEqual(2);
-      expect(fakeBadgeElement.show).toHaveBeenCalled();
-    });
-
     it('hides badge if there are no deploys', function() {
-      $httpBackend.expectGET('/deploys/active_count.json').respond('{"deploy_count":0}');
       createController();
       expect($scope.currentActiveDeploys).toEqual(0);
       expect(fakeBadgeElement.hide).toHaveBeenCalled();
+    });
+
+    it('show badge if there are deploys', function() {
+      fakeBadgeElement.data = function(){ return '1' }
+      createController();
+      expect($scope.currentActiveDeploys).toEqual(1);
+      expect(fakeBadgeElement.show).toHaveBeenCalled();
     });
   });
 });

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -75,20 +75,18 @@ describe DeploysController do
       end
     end
 
-    describe "a GET to :active_count" do
-      before do
-        stage.create_deploy(admin, {reference: 'reference'})
-        get :active_count, project_id: project_id
-      end
-
-      with_and_without_project do
-        it "renders json" do
-          assert_equal "application/json", @response.content_type
-          assert_response :ok
-          @response.body.must_equal "{\"deploy_count\":1}"
-        end
-      end
+  describe "a GET to :active_count" do
+    before do
+      stage.create_deploy(admin, {reference: 'reference'})
+      get :active_count
     end
+
+    it "renders json" do
+      assert_equal "application/json", @response.content_type
+      assert_response :ok
+      @response.body.must_equal "1"
+    end
+  end
 
     describe "a GET to :changeset" do
       before do


### PR DESCRIPTION
@zendesk/samson @henders 

one of the most wasteful things in samson is that we open a streaming connection (stageful / expensive) on every page load ... and do a request to active_count ... for the teeny-tiny benefit of seeing an active deploy count ... this PR is killing most of the overhead while still keeping the functionality intact ... (I'd even go so far as to make this badge completely static since I never use it and clicking on `Deploying` would still show the active count / I don't think anyone cares how many deploys are going on ...)

 - open streaming connection on demand vs always
 - query for deploy updates after the page is open for a while vs always
 - cache active deploy count vs db calls on every page load
 - use html data vs doing additional request

## Risks
 - Low: deploy badge breaking or being out of sync
 - Low: other streaming features breaking