### PR TITLE
add git to the docker image, disable interactive host key checking fo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.2.3-slim
 
-RUN apt-get update && apt-get install -y wget apt-transport-https
+RUN apt-get update && apt-get install -y wget apt-transport-https git
 RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN echo 'deb https://deb.nodesource.com/node_0.12 jessie main' > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y nodejs build-essential


### PR DESCRIPTION
@zendesk/samson I think it is reasonable to actually include `git` for a tool that shells out to git sometimes.

The second change I'm not so sure about, but I got an interactive prompt in the logs. Something like

```
The authenticity of host 'github.com (65.74.177.129)' can't be established.
RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)?
```