### PR TITLE
Fix UI Bug with user project roles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ActiveRecord::Base
       where(
         '(user_project_roles.project_id = ? AND user_project_roles.role_id >= ?) OR users.role_id >= ?',
         project_id, role_id, role_id
-      )
+      ).distinct
   }
 
   def starred_project?(project)


### PR DESCRIPTION
Fix a UI issue where if a user has user_project_roles the user is presented multiple times in the project/user pages. 

Before
<img width="1159" alt="screen shot 2016-05-16 at 12 16 34 pm" src="https://cloud.githubusercontent.com/assets/11447948/15301552/07d0fbc0-1b63-11e6-88e8-0638bef1c4d6.png">

After
<img width="1179" alt="screen shot 2016-05-16 at 12 16 51 pm" src="https://cloud.githubusercontent.com/assets/11447948/15301556/10d66f7a-1b63-11e6-9b59-70500724a550.png">


/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: SAMSON-240

### Risks
- Level: Low

Fix UI Bug with user project roles

I think this is cleaner, also doesn't result in user not appearing if a user has a lower user_project_role.role_id than their user.role_id.

Alternatively could replace “OR users.role_id >=?” with “OR
(user_project_roles.project_id IS NULL AND user.role_id >=?)”, but it would be susceptible to the 'disappearing' bug.