### PR TITLE
Fix typo

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -50,7 +50,7 @@ class DockerBuilderService
   end
   add_method_tracer :build_image
 
-  def push_image(tag, tag_as_latest: false)
+  def push_image(tag, push_to_latest: false)
     build.docker_ref = tag.presence || build.label.try(:parameterize).presence || 'latest'
     build.docker_repo_digest = nil
     output.puts("### Tagging and pushing Docker image to #{project.docker_repo}:#{build.docker_ref}")
@@ -66,7 +66,7 @@ class DockerBuilderService
       end
     end
 
-    push_latest if tag_as_latest && build.docker_ref != 'latest'
+    push_latest if push_as_latest && build.docker_ref != 'latest'
 
     build.save!
     build


### PR DESCRIPTION
/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

Commit e3594b032196991b3c076545ecd03838ca2d5b8b introduced a
push_to_latest param in push_image() callers, but when defining it in
push_image() it was called "tag_as_latest".

This is clearly a typo, and without having any preference, I choose to
make the param in push_image() "push_to_latest". Please feel free to
change it, just let's make sure it's used with the same name :)