### PR TITLE
Allow to manually deploy branches with / in it's name

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
@@ -109,7 +109,7 @@ module Kubernetes
           deploy_group_id: deploy_group.id,
 
           revision: build.git_sha,
-          tag: build.git_ref
+          tag: build.git_sha
         }
       end
     end


### PR DESCRIPTION
All our deployments, except for production, are from a branch with "/" in it's name. Some way to fix this is important for us. Although I don't have any strong preference in the way. This is just an easy patch that fixes it

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

When doing a manual build from a branch name with a slash, for example
"feature/kubernetes", the deploy of that build fails with this error:
```
  *********** Couldn't deploy: Deployment.extensions "wido-web" is
  invalid: [metadata.labels: Invalid value: "feature/kubernetes": must
  have at most 63 characters, matching regex
  (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?: e.g. "MyValue" or "",
```
Using the git_sha workarounds this, although when a tag is used, then
the hash is showed too.

Maybe the field should be removed if the sha is what we want. But I did
this small patch just to get samson working on my setup and wanted to
know what you think about this.