### PR TITLE
show/inspect status of all pods for a given release

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -102,7 +102,12 @@ module Kubernetes
 
         # logs - container fails to boot
         @output.puts "\nLOGS:"
-        @output.puts client.get_pod_log(pod.name, namespace, previous: pod.restarted?)
+        logs = begin
+          client.get_pod_log(pod.name, namespace, previous: pod.restarted?)
+        rescue KubeException
+          "No logs found"
+        end
+        @output.puts logs
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -77,7 +77,7 @@ module Kubernetes
 
     def pod_statuses(release)
       pods = release.clients.flat_map { |client, query| fetch_pods(client, query) }
-      release.release_docs.map { |release_doc| release_status(pods, release_doc) }
+      release.release_docs.flat_map { |release_doc| release_statuses(pods, release_doc) }
     end
 
     def fetch_pods(client, query)
@@ -117,27 +117,31 @@ module Kubernetes
       end
     end
 
-    def release_status(pods, release_doc)
+    def release_statuses(pods, release_doc)
       group = release_doc.deploy_group
       role = release_doc.kubernetes_role
 
-      pod = pods.detect { |pod| pod.role_id == role.id && pod.deploy_group_id == group.id }
+      pods = pods.select { |pod| pod.role_id == role.id && pod.deploy_group_id == group.id }
 
-      live, details = if pod
-        if pod.live?
-          if pod.restarted?
-            [false, RESTARTED]
-          else
-            [true, "Live"]
-          end
-        else
-          [false, "Waiting (#{pod.phase}, not Ready)"]
-        end
+      statuses = if pods.empty?
+        [[false, "Missing"]]
       else
-        [false, "Missing"]
+        pods.map do |pod|
+          if pod.live?
+            if pod.restarted?
+              [false, RESTARTED]
+            else
+              [true, "Live"]
+            end
+          else
+            [false, "Waiting (#{pod.phase}, not Ready)"]
+          end
+        end
       end
 
-      ReleaseStatus.new(live, details, role.name, group.name)
+      statuses.map do |live, details|
+        ReleaseStatus.new(live, details, role.name, group.name)
+      end
     end
 
     def print_statuses(statuses)

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -68,7 +68,7 @@ module Kubernetes
     end
 
     def clients
-      release_docs.map(&:deploy_group).map do |deploy_group|
+      release_docs.map(&:deploy_group).uniq.map do |deploy_group|
         query = {
           namespace: deploy_group.kubernetes_namespace,
           label_selector: {

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -86,6 +86,13 @@ describe Kubernetes::DeployExecutor do
       doc.ram.must_equal config.ram
     end
 
+    it "shows status of all pods when replicase or daemonset was used" do
+      pod_reply[:items] << pod_reply[:items].first
+      assert execute!
+      out.must_include "resque_worker: Live\n  resque_worker: Live"
+      out.must_include "SUCCESS"
+    end
+
     describe "build" do
       before do
         build.update_column(:docker_repo_digest, nil)

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -1,6 +1,6 @@
 require_relative '../../test_helper'
 
-SingleCov.covered! uncovered: 17
+SingleCov.covered! uncovered: 16
 
 describe Kubernetes::Release do
   let(:build)  { builds(:docker_build) }


### PR DESCRIPTION
before it only logged the first pod per role

```
Production:
  app-server: Waiting (Pending, not Ready)
  app-server: Waiting (Pending, not Ready)
  worker: Waiting (Pending, not Ready)
```