### PR TITLE
handle where Docker output has a JSON parse error [SAMSON-239]

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -108,6 +108,11 @@ class DockerBuilderService
     end
 
     parsed_chunk
+  rescue JSON::ParserError
+    # Sometimes the JSON line is too big to fit in one chunk, so we get
+    # a chunk back that is an incomplete JSON object.
+    output.puts chunk
+    { 'message' => chunk }
   end
 
   def send_after_notifications

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -46,6 +46,21 @@ describe DeployService do
       service.build_image(tmp_dir).must_equal nil
       build.docker_image_id.must_equal nil
     end
+
+    it 'catches JSON errors' do
+      push_output = [
+        [{status: 'working okay'}.to_json],
+        ['{"status":"this is incomplete JSON...']
+      ]
+
+      Docker::Image.unstub(:build_from_dir)
+      Docker::Image.expects(:build_from_dir)
+        .multiple_yields(*push_output)
+        .returns(mock_docker_image)
+
+      service.build_image(tmp_dir)
+      service.output.to_s.must_include 'this is incomplete JSON'
+    end
   end
 
   describe '#push_image' do


### PR DESCRIPTION
Adds error handling so that if Docker spits out some line of output bigger than a chunk, it doesn't blow up with a JSON parser error.

/cc @zendesk/samson, @sandlerr 

### Tasks
 - [x] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-239
 - Failing Samson build: https://samson.zende.sk/projects/zendesk_app_framework/builds/10467#L164

### Risks
- Level: Low
