### PR TITLE
dry up secrets

### DIFF
--- a/app/views/admin/secrets/edit.html.erb
+++ b/app/views/admin/secrets/edit.html.erb
@@ -6,9 +6,7 @@
 <section>
   <% url = (id ? admin_secret_path(params[:id]) : admin_secrets_path) %>
   <% method = (id ? :put : :post) %>
-  <% parse_environment_permalink = SecretStorage.parse_secret_key_part(id, :environment) %>
-  <% parse_project_permalink, key = SecretStorage.parse_secret_key_part(id, :project) %>
-  <% parse_deploy_group_permalink = SecretStorage.parse_secret_key_part(id, :deploy_group) %>
+  <% data = (id ? SecretStorage.parse_secret_key(id) : {}) %>
   <% key = id.to_s %>
   <%= form_tag url, class: "form-horizontal", method: method do %>
     <fieldset>
@@ -17,7 +15,7 @@
         <%= label_tag 'secret[environment_permalink]', "Environment", class: "col-lg-2 control-label" %>
         <div class="col-lg-4">
           <%= select_tag 'secret[environment_permalink]',
-            options_for_select(@environment_permalinks, parse_environment_permalink),
+            options_for_select(@environment_permalinks, data[:environment_permalink]),
             class: "form-control", include_blank: true, disabled: !!id,
             onchange: "populateProjectSelectList()" %>
         </div>
@@ -26,8 +24,9 @@
       <div class="form-group">
         <%= label_tag 'secret[project_permalink]', "Project", class: "col-lg-2 control-label" %>
         <div class="col-lg-4">
-          <%= select_tag 'secret[project_permalink]', options_for_select(@project_permalinks, parse_project_permalink),
-            class: "form-control", disabled: !!id %>
+          <%= select_tag 'secret[project_permalink]',
+            options_for_select(@project_permalinks, data[:project_permalink]),
+            class: "form-control", include_blank: true, disabled: !!id %>
         </div>
       </div>
 
@@ -35,15 +34,15 @@
         <%= label_tag 'secret[deploy_group_permalink]', "Deploy Group", class: "col-lg-2 control-label" %>
         <div class="col-lg-4">
           <%= select_tag 'secret[deploy_group_permalink]',
-            options_for_select(@deploy_group_permalinks, parse_deploy_group_permalink),
-            class: "form-control", disabled: !!id %>
+            options_for_select(@deploy_group_permalinks, data[:deploy_group_permalink]),
+            class: "form-control", include_blank: true, disabled: !!id %>
         </div>
       </div>
 
       <div class="form-group">
         <%= label_tag 'secret[key]', 'Key', class: "col-lg-2 control-label" %>
         <div class="col-lg-6">
-          <%= text_field_tag 'secret[key]', key, class: "form-control", disabled: !!id %>
+          <%= text_field_tag 'secret[key]', data[:key], class: "form-control", disabled: !!id %>
         </div>
       </div>
 

--- a/app/views/admin/secrets/index.html.erb
+++ b/app/views/admin/secrets/index.html.erb
@@ -17,7 +17,7 @@
         <tr>
           <td><%= key %></td>
           <td>
-            <% permalink = SecretStorage.parse_secret_key_part(key, :project) %>
+            <% permalink = SecretStorage.parse_secret_key(key).fetch(:project_permalink) %>
             <% if name = project_list[permalink] %>
               <%= link_to name, project_path(permalink) %>
             <% elsif permalink == 'global' %>

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -2,6 +2,61 @@ require_relative '../../../test/test_helper'
 require_relative '../lib/samson_kubernetes/hash_kuber_selector'
 require 'celluloid/test'
 
+# Mock up vault client
+class VaultClient
+  def logical
+    @logical ||= Logical.new
+  end
+
+  def self.vault_response_object(data)
+    Response.new(data)
+  end
+
+  class Response
+    attr_accessor :lease_id, :lease_duration, :renewable, :data, :auth
+    def initialize(data)
+      self.lease_id = nil
+      self.lease_duration = nil
+      self.renewable = nil
+      self.auth = nil
+      self.data = JSON.parse(data).symbolize_keys
+    end
+
+    def to_h
+      instance_values.symbolize_keys
+    end
+  end
+
+  class Logical
+    def list(key)
+      uri = URI("https://127.0.0.1:8200/v1/#{key}?list=true")
+      Net::HTTP.get(uri)
+    end
+
+    def read(key)
+      uri = URI("https://127.0.0.1:8200/v1/#{key}")
+      Response.new(Net::HTTP.get(uri))
+    end
+
+    def delete(key)
+      uri = URI("https://127.0.0.1:8200/v1/#{key}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      req = Net::HTTP::Delete.new(uri.path)
+      http.request(req)
+    end
+
+    def write(key, body)
+      uri = URI("https://127.0.0.1:8200/v1/#{key}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      req = Net::HTTP::Put.new(uri.path)
+      req.body = body.to_json
+      http.request(req)
+    end
+  end
+end
+
 class ActiveSupport::TestCase
   def self.it_responds_with_unauthorized(&block)
     it 'responds with unauthorized' do

--- a/test/controllers/admin/secrets_controller_test.rb
+++ b/test/controllers/admin/secrets_controller_test.rb
@@ -52,7 +52,7 @@ describe Admin::SecretsController do
 
     describe '#update' do
       it "is unauthrized" do
-        put :update, id: secret, secret: {project_permalink: SecretStorage.parse_secret_key_part(secret.id, :project) }
+        put :update, id: secret, secret: {value: 'xxx'}
         assert_unauthorized
       end
     end
@@ -124,11 +124,7 @@ describe Admin::SecretsController do
     end
 
     describe '#update' do
-      let(:attributes) {{
-        value: 'hi', environment_permalink: SecretStorage.parse_secret_key_part(secret.id, :environment),
-        project_permalink: SecretStorage.parse_secret_key_part(secret.id, :project),
-        deploy_group_permalink: SecretStorage.parse_secret_key_part(secret.id, :deploy_group)
-      }}
+      let(:attributes) { { value: 'hi' } }
 
       before do
         patch :update, id: secret.id, secret: attributes
@@ -143,12 +139,7 @@ describe Admin::SecretsController do
       end
 
       describe 'invalid' do
-        let(:attributes) {{
-          value: '',
-          environment_permalink: SecretStorage.parse_secret_key_part(secret.id, :environment),
-          project_permalink: SecretStorage.parse_secret_key_part(secret.id, :project),
-          deploy_group_permalink: SecretStorage.parse_secret_key_part(secret.id, :deploy_group)
-        }}
+        let(:attributes) { { value: '' } }
 
         it 'fails to update' do
           assert_template :edit

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -42,55 +42,39 @@ describe SecretStorage do
     end
   end
 
-  describe ".parse_secret_key_part" do
-    let(:secret_key) { 'marry/had/a/little' }
-    it "returs the environment" do
-      SecretStorage.parse_secret_key_part(secret_key, :environment).must_equal('marry')
+  describe ".parse_secret_key" do
+    it "parses parts" do
+      SecretStorage.parse_secret_key('marry/had/a/little/lamb').must_equal(
+        environment_permalink: "marry",
+        project_permalink: "had",
+        deploy_group_permalink: "a",
+        key: "little/lamb"
+      )
     end
 
-    it "returns the project" do
-      SecretStorage.parse_secret_key_part(secret_key, :project).must_equal('had')
-    end
-
-    it "returns the deploy_group" do
-      SecretStorage.parse_secret_key_part(secret_key, :deploy_group).must_equal('a')
-    end
-
-    it "returns the key" do
-      SecretStorage.parse_secret_key_part(secret_key, :key).must_equal('little')
-    end
-
-    it "fails with invalid key" do
-      SecretStorage.parse_secret_key_part('foo/bar/whatever', :key).must_be_nil
+    it "ignores missing parts" do
+      SecretStorage.parse_secret_key('').must_equal(
+        environment_permalink: nil,
+        project_permalink: nil,
+        deploy_group_permalink: nil,
+        key: nil
+      )
     end
   end
 
-  describe ". generate_secret_key" do
+  describe ".generate_secret_key" do
     it "generates a private key" do
-      SecretStorage.generate_secret_key('production', 'foo', 'bar', 'snafu').must_equal("production/foo/bar/snafu")
+      SecretStorage.generate_secret_key(
+        environment_permalink: 'production',
+        project_permalink: 'foo',
+        deploy_group_permalink: 'bar',
+        key: 'snafu'
+      ).must_equal("production/foo/bar/snafu")
     end
 
-    it "fails raises when missing environment" do
-      assert_raises ArgumentError do
-        SecretStorage.generate_secret_key(nil, 'foo', 'bar', 'snafu')
-      end
-    end
-
-    it "fails raises when missing project" do
-      assert_raises ArgumentError do
-        SecretStorage.generate_secret_key('env', nil, 'bar', 'snafu')
-      end
-    end
-
-    it "fails raises when missing deploy_group" do
-      assert_raises ArgumentError do
-        SecretStorage.generate_secret_key('env', 'foo', nil, 'snafu')
-      end
-    end
-
-    it "fails raises when missing key" do
-      assert_raises ArgumentError do
-        SecretStorage.generate_secret_key('env', 'foo', 'group', nil)
+    it "fails raises when missing keys" do
+      assert_raises KeyError do
+        SecretStorage.generate_secret_key({})
       end
     end
   end
@@ -147,56 +131,25 @@ describe SecretStorage do
   end
 
   describe SecretStorage::HashicorpVault do
-    let(:response_headers) { {'Content-Type': 'application/json'} }
-
-    describe ".client" do
-      it 'creates a valid client' do
-        assert_instance_of(VaultClient, SecretStorage::HashicorpVault.vault_client)
-      end
-    end
-
     describe ".read" do
-      before do
-        fail_data = {data: { vault:nil}}.to_json
-        # client gets a 200 and nil body when key is missing
-        stub_request(:get, "https://127.0.0.1:8200/v1/secret/this/key/isnot/there").
-          to_return(status: 200, body: fail_data, headers: {'Content-Type': 'application/json'})
-        # this is the auth request, just needs to return 200 for our purposes
-        stub_request(:post, "https://127.0.0.1:8200/v1/auth/cert/login")
-        # using the stubbed client
-        stub_request(:get, "https://127.0.0.1:8200/v1/secret/production/foo/pod2/isbar").
-          to_return(status: 200, headers: {'Content-Type': 'application/json'})
-        stub_request(:get, "https://127.0.0.1:8200/v1/secret/notgoingtobethere").
-          to_return(status: 200, headers: {'Content-Type': 'application/json'})
-        not_branch = ['is_now_a_leaf']
-        stub_request(:get, "https://127.0.0.1:8200/v1/secret/?list=true").
-          to_return(status: 200, body: not_branch, headers: response_headers)
-      end
-
-      it "gets a value based on a key with /s" do
-        SecretStorage::HashicorpVault.read('production/foo/pod2/isbar').must_equal({
+      it "gets a value based on a key with /secret" do
+        stub_request(:get, "https://127.0.0.1:8200/v1/secret/production/foo/pod2/bar").
+          to_return(body: '{"vault": "bar"}')
+        SecretStorage::HashicorpVault.read('production/foo/pod2/bar').must_equal(
           lease_id: nil,
           lease_duration: nil,
           renewable: nil,
           auth: nil,
           value: "bar"
-        })
+        )
       end
 
       it "fails to read a key" do
+        stub_request(:get, "https://127.0.0.1:8200/v1/secret/production/foo/pod2/bar").
+          to_return(body: '{"vault":null}')
         assert_raises ActiveRecord::RecordNotFound do
-          SecretStorage::HashicorpVault.read('this/key/isnot/there')
+          SecretStorage::HashicorpVault.read('production/foo/pod2/bar')
         end
-      end
-
-      it "invalid key conversion fails for a read" do
-        assert_raises ArgumentError do
-          SecretStorage::HashicorpVault.convert_path('foopy%2Fthecat', :notvalid)
-        end
-      end
-
-      it "recusivly translates keys" do
-        assert SecretStorage::HashicorpVault.keys
       end
     end
 
@@ -205,48 +158,55 @@ describe SecretStorage do
         stub_request(:delete, "http://127.0.0.1:8200/v1/secret/production/foo/group/isbar")
       end
 
-      it "deletes key with /s" do
+      it "deletes key with /secret" do
         assert SecretStorage::HashicorpVault.delete('production/foo/group/isbar')
       end
     end
 
     describe ".write" do
-      before do
-        stub_request(:put, "https://127.0.0.1:8200/v1/secret/env/foo/bar/isbar%2Ffoo").
-          with(:body => "{\"vault\":\"whatever\"}")
-      end
-
-      it "wirtes a key with /s" do
-        assert SecretStorage::HashicorpVault.write('production/foo/group/isbar/foo', {environment_permalink: 'env', project_permalink: 'foo', deploy_group_permalink: 'bar', key_permalink: 'isbar', value: 'whatever'})
+      it "writes a key with /secret" do
+        stub_request(:put, "https://127.0.0.1:8200/v1/secret/production/foo/group/isbar%2Ffoo").
+          with(body: "{\"vault\":\"whatever\"}")
+        assert SecretStorage::HashicorpVault.write('production/foo/group/isbar/foo', {value: 'whatever'})
       end
     end
 
     describe ".keys" do
-      before do
+      it "lists all keys with recursion" do
         first_keys = ["production/project/group/this/", "production/project/group/that/"]
         stub_request(:get, "https://127.0.0.1:8200/v1/secret/?list=true").
-          to_return(status: 200, body: first_keys, headers: response_headers)
+          to_return(body: first_keys)
 
         stub_request(:get, "https://127.0.0.1:8200/v1/secret/production/project/group/this/?list=true").
-          to_return(status: 200, body: ["key"], headers: response_headers)
+          to_return(body: ["key"])
 
         stub_request(:get, "https://127.0.0.1:8200/v1/secret/production/project/group/that/?list=true").
-          to_return(status: 200, body: ["key"], headers: response_headers)
+          to_return(body: ["key"])
 
         stub_request(:get, "https://127.0.0.1:8200/v1/secret/production/project/group/this/key?list=true").
-          to_return(status: 200, body: [], headers: response_headers)
+          to_return(body: [])
 
         stub_request(:get, "https://127.0.0.1:8200/v1/secret/production/project/group/that/key?list=true").
-          to_return(status: 200, body: [], headers: response_headers)
+          to_return(body: [])
 
-
-      end
-
-      it "lists all keys with recursion" do
-        SecretStorage::HashicorpVault.keys().must_equal([
+        SecretStorage::HashicorpVault.keys.must_equal([
           "production/project/group/this/key",
           "production/project/group/that/key"
         ])
+      end
+    end
+
+    describe ".vault_client" do
+      it 'creates a valid client' do
+        assert_instance_of(VaultClient, SecretStorage::HashicorpVault.send(:vault_client))
+      end
+    end
+
+    describe ".convert_path" do
+      it "fails with invalid direction" do
+        assert_raises ArgumentError do
+          SecretStorage::HashicorpVault.send(:convert_path, 'x', :ooops)
+        end
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,67 +25,6 @@ require 'mocha/setup'
 
 require 'sucker_punch/testing/inline'
 
-# Mock up vault client
-class VaultClient
-  def logical
-    @logical ||= Logical.new
-  end
-
-  def self.vault_response_object(data)
-    Response.new(data)
-  end
-
-  class Response
-    attr_accessor :lease_id, :lease_duration, :renewable, :data, :auth
-    def initialize(data)
-      self.lease_id = nil
-      self.lease_duration = nil
-      self.renewable = nil
-      self.auth = nil
-      self.data = data
-    end
-
-    def to_h
-      instance_values.symbolize_keys
-    end
-  end
-
-  class Logical
-    def list(key)
-      uri = URI("https://127.0.0.1:8200/v1/#{key}?list=true")
-      Net::HTTP.get(uri)
-    end
-
-    def read(key)
-      response_data = {
-        "secret/production/foo/pod2/isbar": { vault: "bar"},
-        "secret/this/key/isnot/there": {vault: nil}
-      }
-
-      uri = URI("https://127.0.0.1:8200/v1/#{key}")
-      Net::HTTP.get(uri)
-      Response.new(response_data[key.to_sym])
-    end
-
-    def delete(key)
-      uri = URI("https://127.0.0.1:8200/v1/#{key}")
-      http = Net::HTTP.new(uri.host, uri.port)
-      req = Net::HTTP::Delete.new(uri.path)
-      http.request(req)
-    end
-
-    def write(key, body)
-      uri = URI("https://127.0.0.1:8200/v1/#{key}")
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      req = Net::HTTP::Put.new(uri.path)
-      req.body = body.to_json
-      http.request(req)
-    end
-  end
-end
-
 # Use ActiveSupport::TestCase for everything that was not matched before
 MiniTest::Spec::DSL::TYPES[-1] = [//, ActiveSupport::TestCase]
 


### PR DESCRIPTION
best review each commit, first is only a bunch of indent

 - use same path logic for db and vault
 - avoid duplicating key ordering knowledge
 - make initial `new` view blank / do not pre-select anything
 - cleanup tests to have mocks per test and not global
 - move test helpers into kubernetes folder

<img width="566" alt="screen shot 2016-05-19 at 1 51 29 pm" src="https://cloud.githubusercontent.com/assets/11367/15409319/161eacb4-1dc9-11e6-9962-73b48f310bca.png">

<img width="790" alt="screen shot 2016-05-19 at 2 03 46 pm" src="https://cloud.githubusercontent.com/assets/11367/15409781/20d3ddee-1dcb-11e6-9b63-df0c25a62fd9.png">


