### PR TITLE
daemon sets cannot be updated, so we have to delete and create them

### DIFF
--- a/plugins/kubernetes/app/models/kuber_deploy_service.rb
+++ b/plugins/kubernetes/app/models/kuber_deploy_service.rb
@@ -26,7 +26,7 @@ class KuberDeployService
   def create_deployments!
     kuber_release.release_docs.each do |release_doc|
       log 'creating Deployment', role: release_doc.kubernetes_role.name
-      release_doc.deploy_to_kubernetes
+      release_doc.deploy
     end
   end
 

--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -14,7 +14,7 @@ module Kubernetes
       end
 
       def live?
-        @pod.status.phase == 'Running' && ready?
+        phase == 'Running' && ready?
       end
 
       def restarted?

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -258,7 +258,7 @@ module Kubernetes
     def create_deploys(release)
       release.release_docs.each do |release_doc|
         @output.puts "Creating deploy for #{release_doc.deploy_group.name} role #{release_doc.kubernetes_role.name}"
-        release_doc.deploy_to_kubernetes
+        release_doc.deploy
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
@@ -63,6 +63,8 @@ module Kubernetes
       end
     end
 
+    # have to match Kubernetes::Release#clients selector
+    # TODO: dry
     def release_doc_metadata
       @release_doc_metadata ||= begin
         release = @doc.kubernetes_release

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -1,6 +1,6 @@
 require_relative "../../test_helper"
 
-SingleCov.covered! uncovered: 18
+SingleCov.covered! uncovered: 16
 
 describe Kubernetes::ReleaseDoc do
   let(:doc) { kubernetes_release_docs(:test_release_pod_1) }
@@ -56,26 +56,58 @@ describe Kubernetes::ReleaseDoc do
     end
   end
 
-  describe "#deploy_to_kubernetes" do
+  describe "#deploy" do
     let(:client) { doc.send(:extension_client) }
 
-    it "creates when deploy does not exist" do
-      client.expects(:get_deployment).returns false
-      client.expects(:create_deployment)
-      doc.deploy_to_kubernetes
+    describe "deployment" do
+      it "creates when deploy does not exist" do
+        client.expects(:get_deployment).raises(KubeException.new(1,2,3))
+        client.expects(:create_deployment)
+        doc.deploy
+      end
+
+      it "updates when deploy exists" do
+        client.expects(:get_deployment).returns true
+        client.expects(:update_deployment)
+        doc.deploy
+      end
     end
 
-    it "updates when deploy does exist" do
-      client.expects(:get_deployment).returns true
-      client.expects(:update_deployment)
-      doc.deploy_to_kubernetes
-    end
+    describe "daemonset" do
+      before do
+        doc.send(:deploy_yaml).send(:template).kind = 'DaemonSet'
+        doc.stubs(:sleep)
+      end
 
-    it "can manage daemonsets" do
-      doc.send(:deploy_yaml).send(:template).kind = 'DaemonSet'
-      client.expects(:get_daemon_set).returns true
-      client.expects(:update_daemon_set)
-      doc.deploy_to_kubernetes
+      it "creates when daemonset does not exist" do
+        client.expects(:get_daemon_set).raises(KubeException.new(1,2,3))
+        client.expects(:create_daemon_set)
+        doc.deploy
+      end
+
+      it "deletes and created when daemonset exists without pods" do
+        client.expects(:update_daemon_set)
+        client.expects(:get_daemon_set).times(2).returns(
+          stub(status: stub(currentNumberScheduled: 0, numberMisscheduled: 0)), # initial check
+          stub(status: stub(currentNumberScheduled: 0, numberMisscheduled: 0))  # check for running
+        )
+        client.expects(:delete_daemon_set)
+        client.expects(:create_daemon_set)
+        doc.deploy
+      end
+
+      it "deletes and created when daemonset exists with pods" do
+        client.expects(:update_daemon_set)
+        client.expects(:get_daemon_set).times(4).returns(
+          stub(status: stub(currentNumberScheduled: 1, numberMisscheduled: 1)), # initial check
+          stub(status: stub(currentNumberScheduled: 1, numberMisscheduled: 1)),
+          stub(status: stub(currentNumberScheduled: 0, numberMisscheduled: 1)),
+          stub(status: stub(currentNumberScheduled: 0, numberMisscheduled: 0))
+        )
+        client.expects(:delete_daemon_set)
+        client.expects(:create_daemon_set)
+        doc.deploy
+      end
     end
   end
 


### PR DESCRIPTION
@zendesk/paas 

could possibly get into a bad state when a deploy fails and then the daemonset is missing ... 
following the process kuberctl uses to delete a daemonset