### PR TITLE
use alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,28 @@
-FROM ruby:2.2.3-slim
+FROM ruby:2.2.4-alpine
 
-RUN apt-get update && apt-get install -y wget apt-transport-https git
-RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-RUN echo 'deb https://deb.nodesource.com/node_0.12 jessie main' > /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update && apt-get install -y nodejs build-essential
+# install packages and clear the cache after
+# - nodejs for precompile and runtime asset compilation
+# - ca-certificates so we can do ssl
+# - git because we run checkouts
+# - nokogiri requirements
+# - binaries for all the databases we support
+RUN apk add --update \
+  nodejs \
+  git \
+  ca-certificates \
+  build-base \
+  libxml2-dev \
+  libxslt-dev \
+  postgresql-dev \
+  sqlite-dev \
+  mysql-dev && \
+  rm -rf /var/cache/apk/*
+
+# bundler does not want to install as root
+RUN bundle config --global silence_root_warning 1
+
+# Use system packages to building nokogiri
+RUN bundle config build.nokogiri --use-system-libraries
 
 WORKDIR /app
 
@@ -14,7 +33,7 @@ ADD bin /app/bin
 ADD public /app/public
 ADD db /app/db
 ADD .env.bootstrap /app/.env
-ADD .ruby-version /app/.ruby-version
+RUN echo '2.2.4' > /app/.ruby-version
 
 # NPM
 ADD package.json /app/package.json
@@ -26,7 +45,6 @@ ADD Gemfile.lock /app/
 ADD vendor/cache /app/vendor/cache
 ADD plugins /app/plugins
 
-RUN apt-get -y install libmysqlclient-dev libpq-dev libsqlite3-dev
 RUN bundle install --quiet --local --jobs 4 || bundle check
 
 # Code


### PR DESCRIPTION
@rata @zendesk/samson 

sadly comes out at 929.2 MB ...

base ruby 2.2.4-alpine image is 117.4 MB

... not sure if there is an easy way to shave of the fat ... 