### PR TITLE
fix tests not working when gpg signing is globally enabled

### DIFF
--- a/test/support/git_repo_test_support.rb
+++ b/test/support/git_repo_test_support.rb
@@ -14,6 +14,7 @@ module GitRepoTestHelper
       git init
       git config user.email "test@example.com"
       git config user.name "Test User"
+      git config commit.gpgsign false
       echo monkey > foo
       git add foo
       git commit -m "initial commit"


### PR DESCRIPTION
@zendesk/paas 
```
gpg: skipped "Test User <test@example.com>": secret key not available
gpg: signing failed: secret key not available
error: gpg failed to sign the data
fatal: failed to write commit object
```