### PR TITLE
remove unused role columns, they make the new UI break

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160512204809) do
+ActiveRecord::Schema.define(version: 20160523234717) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                       null: false
@@ -220,16 +220,13 @@ ActiveRecord::Schema.define(version: 20160512204809) do
   add_index "kubernetes_releases", ["build_id"], name: "index_kubernetes_releases_on_build_id"
 
   create_table "kubernetes_roles", force: :cascade do |t|
-    t.integer  "project_id",      limit: 4,                           null: false
-    t.string   "name",            limit: 255,                         null: false
+    t.integer  "project_id",      limit: 4,   null: false
+    t.string   "name",            limit: 255, null: false
     t.string   "config_file",     limit: 255
-    t.integer  "replicas",        limit: 4,                           null: false
-    t.integer  "ram",             limit: 4,                           null: false
-    t.decimal  "cpu",                         precision: 4, scale: 2, null: false
     t.string   "service_name",    limit: 255
-    t.string   "deploy_strategy", limit: 255,                         null: false
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
+    t.string   "deploy_strategy", limit: 255, null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
     t.datetime "deleted_at"
   end
 

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/factories/kubernetes_role_factory.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/factories/kubernetes_role_factory.js
@@ -1,13 +1,10 @@
 samson.factory('kubernetesRoleFactory', function() {
 
-  function KubernetesRole(id, project_id, name, config_file, replicas, ram, cpu, service_name, deploy_strategy) {
+  function KubernetesRole(id, project_id, name, config_file, service_name, deploy_strategy) {
     this.id = id;
     this.project_id = project_id;
     this.name = name;
     this.config_file = config_file;
-    this.replicas = replicas;
-    this.ram = ram;
-    this.cpu = cpu;
     this.service_name = service_name;
     this.deploy_strategy = deploy_strategy;
   }
@@ -18,9 +15,6 @@ samson.factory('kubernetesRoleFactory', function() {
       data.project_id,
       data.name,
       data.config_file,
-      data.replicas,
-      data.ram,
-      data.cpu,
       data.service_name,
       data.deploy_strategy
     );

--- a/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
@@ -26,7 +26,7 @@ class Kubernetes::RolesController < ApplicationController
   def create
     @role = Kubernetes::Role.new(role_params.merge(project: @project))
     if @role.save
-      redirect_to [@project, @role]
+      redirect_to action: :index
     else
       render :new
     end
@@ -37,7 +37,7 @@ class Kubernetes::RolesController < ApplicationController
 
   def update
     if @role.update_attributes(role_params)
-      redirect_to [@project, @role]
+      redirect_to action: :index
     else
       render :show
     end
@@ -55,6 +55,6 @@ class Kubernetes::RolesController < ApplicationController
   end
 
   def role_params
-    params.require(:kubernetes_role).permit(:name, :config_file, :service_name, :ram, :cpu, :replicas, :deploy_strategy)
+    params.require(:kubernetes_role).permit(:name, :config_file, :service_name, :deploy_strategy)
   end
 end

--- a/plugins/kubernetes/app/controllers/kubernetes_releases_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes_releases_controller.rb
@@ -23,12 +23,11 @@ class KubernetesReleasesController < ApplicationController
     attributes = params.require(:kubernetes_release).permit(:build_id, deploy_groups: [:id, roles: [:id, :replicas]]).
       merge(user: current_user, project: current_project)
 
-    # UI does not have cpu/ram, so use the defaults
+    # UI does not have cpu/ram, so use something
     attributes.fetch(:deploy_groups).each do |dg|
       dg.fetch(:roles).each do |role|
-        r = ::Kubernetes::Role.find(role.fetch(:id))
-        role[:cpu] = r.cpu
-        role[:ram] = r.ram
+        role[:cpu] = 0.1
+        role[:ram] = 50
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -15,9 +15,6 @@ module Kubernetes
     validates :project, presence: true
     validates :name, presence: true
     validates :deploy_strategy, presence: true, inclusion: DEPLOY_STRATEGIES
-    validates :replicas, presence: true, numericality: { greater_than: 0 }
-    validates :ram, presence: true, numericality: { greater_than: 0 }
-    validates :cpu, presence: true, numericality: { greater_than: 0 }
     validates :service_name, uniqueness: {scope: :deleted_at, allow_nil: true}
 
     scope :not_deleted, -> { where(deleted_at: nil) }
@@ -40,9 +37,6 @@ module Kubernetes
           config_file: config_file.file_path,
           name: name,
           service_name: service_name,
-          ram: config_file.deployment.ram_mi, # TODO: remove this column
-          cpu: config_file.deployment.cpu_m, # TODO: remove this column
-          replicas: config_file.deployment.spec.replicas || 1, # TODO: remove this column
           deploy_strategy: config_file.deployment.strategy_type
         )
       end
@@ -65,10 +59,6 @@ module Kubernetes
 
     def label_name
       name.parameterize
-    end
-
-    def ram_with_units
-      "#{ram}Mi" if ram.present?
     end
 
     class << self

--- a/plugins/kubernetes/app/views/kubernetes_releases/_create_form_step_1.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes_releases/_create_form_step_1.html.erb
@@ -90,9 +90,6 @@
                 <td>{{role.name}}</td>
                 <td>{{role.config_file}}</td>
                 <td>{{role.service_name}}</td>
-                <td>{{role.replicas}}</td>
-                <td>{{role.cpu}} cores</td>
-                <td>{{role.ram}} Mi</td>
               </tr>
               </tbody>
             </table>

--- a/plugins/kubernetes/db/migrate/20160523234717_remove_role_columns.rb
+++ b/plugins/kubernetes/db/migrate/20160523234717_remove_role_columns.rb
@@ -1,0 +1,17 @@
+class RemoveRoleColumns < ActiveRecord::Migration
+  def up
+    remove_column :kubernetes_roles, :cpu
+    remove_column :kubernetes_roles, :ram
+    remove_column :kubernetes_roles, :replicas
+  end
+
+  def down
+    add_column :kubernetes_roles, :cpu, :decimal, precision: 4, scale: 2, null: false, default: 0
+    add_column :kubernetes_roles, :ram, :integer, null: false, default: 0
+    add_column :kubernetes_roles, :replicas, :integer, null: false, default: 0
+
+    change_column_default :kubernetes_roles, :cpu, nil
+    change_column_default :kubernetes_roles, :ram, nil
+    change_column_default :kubernetes_roles, :replicas, nil
+  end
+end

--- a/plugins/kubernetes/test/controllers/kubernetes/roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/roles_controller_test.rb
@@ -10,9 +10,6 @@ describe Kubernetes::RolesController do
       name: 'NAME',
       service_name: 'SERVICE_NAME',
       config_file: 'dsfsd.yml',
-      cpu: 1,
-      ram: 1,
-      replicas: 1,
       deploy_strategy: 'RollingUpdate'
     }
   end
@@ -74,7 +71,7 @@ describe Kubernetes::RolesController do
       it "creates" do
         post :create, project_id: project, kubernetes_role: role_params
         role = Kubernetes::Role.last
-        assert_redirected_to [project, role]
+        assert_redirected_to "/projects/foo/kubernetes/roles"
         role.name.must_equal 'NAME'
       end
 
@@ -86,9 +83,9 @@ describe Kubernetes::RolesController do
     end
 
     describe "#update" do
-      it "creates" do
+      it "updates" do
         put :update, project_id: project, id: role.id, kubernetes_role: role_params
-        assert_redirected_to [project, role]
+        assert_redirected_to "/projects/foo/kubernetes/roles"
         role.reload.name.must_equal 'NAME'
       end
 

--- a/plugins/kubernetes/test/controllers/kubernetes_releases_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes_releases_controller_test.rb
@@ -243,7 +243,7 @@ describe KubernetesReleasesController do
           roles: [
             {
               id: app_server.id,
-              replicas: app_server.replicas
+              replicas: 1
             }
           ]
         }
@@ -254,7 +254,7 @@ describe KubernetesReleasesController do
   def multiple_roles_release_params
     single_role_release_params.tap do |params|
       params[:deploy_groups].each do |dg|
-        dg[:roles].push(id: resque_worker.id, replicas: resque_worker.replicas)
+        dg[:roles].push(id: resque_worker.id, replicas: 1)
       end
     end
   end

--- a/plugins/kubernetes/test/fixtures/kubernetes/roles.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/roles.yml
@@ -3,16 +3,10 @@ app_server:
   project: test
   name: app_server
   deploy_strategy: RollingUpdate
-  replicas: 3
-  ram: 1024
-  cpu: 0.5
   config_file: 'kubernetes/app_server.yml'
 
 resque_worker:
   project: test
   name: resque_worker
   deploy_strategy: Recreate
-  replicas: 2
-  ram: 512
-  cpu: 1.0
   config_file: 'kubernetes/resque_worker.yml'

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -54,16 +54,14 @@ describe Kubernetes::Release do
         release = Kubernetes::Release.create_release(multiple_roles_release_params)
         release.build.id.must_equal release_params[:build_id]
         release.release_docs.count.must_equal 2
-        release.release_docs.first.kubernetes_role.id.must_equal app_server.id
         release.release_docs.first.kubernetes_role.name.must_equal app_server.name
-        release.release_docs.first.kubernetes_role.replicas.must_equal app_server.replicas
-        release.release_docs.first.kubernetes_role.cpu.must_equal app_server.cpu
-        release.release_docs.first.kubernetes_role.ram.must_equal app_server.ram
-        release.release_docs.second.kubernetes_role.id.must_equal resque_worker.id
+        release.release_docs.first.replica_target.must_equal 1
+        release.release_docs.first.cpu.must_equal 1
+        release.release_docs.first.ram.must_equal 50
         release.release_docs.second.kubernetes_role.name.must_equal resque_worker.name
-        release.release_docs.second.kubernetes_role.replicas.must_equal resque_worker.replicas
-        release.release_docs.second.kubernetes_role.cpu.must_equal resque_worker.cpu
-        release.release_docs.second.kubernetes_role.ram.must_equal resque_worker.ram
+        release.release_docs.second.replica_target.must_equal 2
+        release.release_docs.second.cpu.must_equal 2
+        release.release_docs.second.ram.must_equal 100
         assert_release_count(@current_release_count + 1)
       end
     end
@@ -153,9 +151,9 @@ describe Kubernetes::Release do
           roles: [
             {
               id: app_server.id,
-              replicas: app_server.replicas,
-              cpu: app_server.cpu,
-              ram: app_server.ram
+              replicas: 1,
+              cpu: 1,
+              ram: 50
             }
           ]
         }
@@ -166,7 +164,7 @@ describe Kubernetes::Release do
   def multiple_roles_release_params
     release_params.tap do |params|
       params[:deploy_groups].each do |dg|
-        dg[:roles].push(id: resque_worker.id, replicas: resque_worker.replicas, cpu: resque_worker.cpu, ram: resque_worker.ram)
+        dg[:roles].push(id: resque_worker.id, replicas: 2, cpu: 2, ram: 100)
       end
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -28,14 +28,6 @@ describe Kubernetes::Role do
       {
         'kind' => 'Deployment',
         'metadata' => {'labels' => {'role' => 'ROLE1'}},
-        'spec' => {
-          'replicas' => 1,
-          'template' => {
-            'spec' => {
-              'containers' => [{'resources' => {'limits' => {'ram_mi' => 23, 'cpu_m' => 11.12}}}]
-            }
-          }
-        },
         'strategy_type' => 'RollingUpdate'
       },
       {
@@ -49,20 +41,6 @@ describe Kubernetes::Role do
   describe 'validations' do
     it 'is valid' do
       assert_valid role
-    end
-
-    it 'validates CPU is a float' do
-      [nil, 'abc', 0, -2].each do |v|
-        role.cpu = v
-        refute_valid role
-      end
-    end
-
-    it 'validates RAM is a int' do
-      [nil, 'abc', 0, -2].each do |v|
-        role.ram = v
-        refute_valid role
-      end
     end
 
     it 'is valid with known deploy strategy' do
@@ -95,13 +73,6 @@ describe Kubernetes::Role do
         other.soft_delete!
         assert_valid role
       end
-    end
-  end
-
-  describe '#ram_with_units' do
-    it 'converts to kubernetes format' do
-      role.ram = 512
-      role.ram_with_units.must_equal '512Mi'
     end
   end
 
@@ -144,9 +115,6 @@ describe Kubernetes::Role do
           config_file: 'sdfsdf.yml',
           name: 'sdfsdf',
           service_name: nil,
-          ram: 1,
-          cpu: 1,
-          replicas: 1,
           deploy_strategy: 'RollingUpdate'
         )
         Kubernetes::Role.seed! project, 'HEAD'


### PR DESCRIPTION
@zendesk/paas

we no longer use these columns because we read from deploy_group_role ... and not having them set made the `role new` UI break

## Risks:
 - low: angular releases UI will deploy 1/1/50 instead of role defaults

