### PR TITLE
check 2-space indent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,7 +53,7 @@ Style/IndentHash:
   Enabled: false
 
 Style/AlignParameters:
-  Enabled: false
+  EnforcedStyle: with_fixed_indentation
 
 Style/MultilineOperationIndentation:
   Enabled: false


### PR DESCRIPTION
invalid:
```
foobarbaz :aaa,
          :bbb
```

valid:
```
foobarbaz :aaa,
  :bbb
```