### PR TITLE
fix validation of Docker registry URLs

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -1,7 +1,7 @@
 class Build < ActiveRecord::Base
   SHA1_REGEX = /\A[0-9a-f]{40}\Z/i
   SHA256_REGEX = /\A(sha256:)?[0-9a-f]{64}\Z/i
-  DIGEST_REGEX = /\A[\w._-]+\/[\w_-]+@sha256:[0-9a-f]{64}\Z/i
+  DIGEST_REGEX = /\A[\w._-]+\/[\w\/_-]+@sha256:[0-9a-f]{64}\Z/i
 
   belongs_to :project
   belongs_to :docker_build_job, class_name: 'Job'

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -56,6 +56,7 @@ describe Build do
 
     it 'validates docker digest' do
       assert_valid(valid_build(docker_repo_digest: repo_digest))
+      assert_valid(valid_build(docker_repo_digest: "my-registry.zende.sk/samson/another_project@sha256:#{example_sha}"))
       refute_valid(valid_build(docker_repo_digest: example_sha))
       refute_valid(valid_build(docker_repo_digest: 'some random string'))
     end


### PR DESCRIPTION
Docker builds were failing when Samson was configured to use a subdirectory in a Docker registry, like docker-registry.zende.sk/**samson**/my-project.

/cc @zendesk/samson, @sandlerr 

### Tasks
 - [ ] :+1: from team

### References
 - Failing Samson build: https://samson.zende.sk/projects/zendesk_app_framework/builds/10756#L358

### Risks
- Level: Low

