### PR TITLE
lookup secrets by key

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -39,21 +39,54 @@ class TerminalExecutor
 
   private
 
-  # TODO: pick dynamic secret from just the key
   def resolve_secrets(command)
-    deploy_groups = @deploy.try(:stage).try(:deploy_groups) || []
-    allowed = {
-      environment_permalink: ['global'].concat(deploy_groups.map(&:environment).map(&:permalink)),
-      project_permalink: ['global'] << @deploy.try(:project).try(:permalink),
-      deploy_group_permalink: ['global'].concat(deploy_groups.map(&:permalink))
-    }
     command.gsub(/\b#{SECRET_PREFIX}(#{SecretStorage::SECRET_KEY_REGEX})\b/) do
       key = $1
-      parts = SecretStorage.parse_secret_key(key)
-      if allowed.all? { |k, v| v.include?(parts.fetch(k)) }
-        SecretStorage.read(key, include_secret: true).fetch(:value)
-      else
-        raise ActiveRecord::RecordNotFound, "Not allowed to access key #{key}"
+
+      # build a list of all possible ids
+      possible_ids = possible_secret_key_parts.map { |id| SecretStorage.generate_secret_key(id.merge(key: key)) }
+
+      # use the value of the first id that exists
+      value = possible_ids.detect do |id|
+        begin
+          break SecretStorage.read(id, include_secret: true).fetch(:value)
+        rescue ActiveRecord::RecordNotFound # TODO: make read not raise
+          false
+        end
+      end
+
+      value || raise(
+        ActiveRecord::RecordNotFound,
+        "Could not anything for key #{key}, tried #{possible_ids.join(', ')}"
+      )
+    end
+  end
+
+  def possible_secret_key_parts
+    @possible_secret_key_parts ||= begin
+      deploy_groups = (@deploy ? @deploy.stage.deploy_groups : [])
+      environments = deploy_groups.map(&:environment).uniq
+
+      # build list of allowed key parts
+      environment_permalinks = ['global']
+      project_permalinks = ['global']
+      deploy_group_permalinks = ['global']
+
+      environment_permalinks.concat(environments.map(&:permalink)) if environments.size == 1
+      project_permalinks << @deploy.project.permalink if @deploy
+      deploy_group_permalinks.concat(deploy_groups.map(&:permalink)) if deploy_groups.size == 1
+
+      # build a list of all key part combinations, sorted by most specific
+      deploy_group_permalinks.reverse_each.flat_map do |d|
+        project_permalinks.reverse_each.flat_map do |p|
+          environment_permalinks.reverse_each.map do |e|
+            {
+              deploy_group_permalink: d,
+              project_permalink: p,
+              environment_permalink: e,
+            }
+          end
+        end
       end
     end
   end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -227,7 +227,7 @@ describe JobExecution do
   it 'can access secrets' do
     id = "global/#{project.permalink}/global/bar"
     create_secret id
-    job.update(command: "echo 'secret://#{id}'")
+    job.update(command: "echo 'secret://bar'")
     execute_job("master")
     assert_equal 'MY-SECRET', last_line_of_output
   end


### PR DESCRIPTION
@zendesk/paas 

Problem: 
secret keys need to be customized for each deploy group/project/environment which is tedious and blocks sharing.

Solution:
Instead of hardcoding production/foo-project/zone1/my-key everywhere and having to edit stages,
only use `secret:my-key` and the backend will figure out what you wanted.

Downsides:
worst case this will mean 2**3=8 reads ... could optimize that for db backend by doing a read_multi callback

### TODO:
 - [ ] do not use raise/rescue as way of finding out if a key exists
 - [ ] use read_multi
 - [ ] figure out how to support this in secret sidecar
 - [ ] make admin UI show key components separately
 - [ ] update admin UI secret:// instructions
