### PR TITLE
swap includes for joins in several places on the Deploy model

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -105,19 +105,19 @@ class Deploy < ActiveRecord::Base
   end
 
   def self.pending
-    includes(:job).where(jobs: { status: 'pending' })
+    joins(:job).where(jobs: { status: 'pending' })
   end
 
   def self.running
-    includes(:job).where(jobs: { status: 'running' })
+    joins(:job).where(jobs: { status: 'running' })
   end
 
   def self.successful
-    includes(:job).where(jobs: { status: 'succeeded' })
+    joins(:job).where(jobs: { status: 'succeeded' })
   end
 
   def self.finished_naturally
-    includes(:job).where(jobs: { status: ['succeeded', 'failed'] })
+    joins(:job).where(jobs: { status: ['succeeded', 'failed'] })
   end
 
   def self.prior_to(deploy)


### PR DESCRIPTION
### Description

In our private plugin we have call `Deploy.successful.where(...)`, which pulls back the longtext `jobs.output`. This is having an extreme effect on query performance causing requests to timeout.

The `where` syntax seems to be supported for `joins` as it is used in the `self.expired` method.

/cc @zendesk/samson @zendesk/vegemite @seancaffery 

### Risks
* [low] performance problems. Some of the patched methods are unused.