### PR TITLE
show plugin backtraces in production too

### DIFF
--- a/config/initializers/show_plugin_backtrace.rb
+++ b/config/initializers/show_plugin_backtrace.rb
@@ -1,6 +1,7 @@
-# by default backtrace from plugins is hidden
+# by default backtrace from plugins are hidden in test output and production logs
 # to update: add a error into a file inside a plugin and run the test
 # backtrace should show the exact line of the error
+require 'rails/backtrace_cleaner'
 old = Rails::BacktraceCleaner::APP_DIRS_PATTERN
 Rails::BacktraceCleaner.send(:remove_const, :APP_DIRS_PATTERN)
 Rails::BacktraceCleaner::APP_DIRS_PATTERN = Regexp.union(old, %r{^/?plugin})


### PR DESCRIPTION
@zendesk/samson 

atm debugging plugins is impossible since we do not see plugin code in the production logs ... but now we do:

before:
```
ActionView::Template::Error (undefined method `name' for nil:NilClass):
  app/controllers/concerns/current_user.rb:31:in `block in login_user'
  config/initializers/paper_trail.rb:13:in `with_whodunnit'
```

after:
```
ActionView::Template::Error (undefined method `name' for nil:NilClass):
  plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/index.html.erb:21:in `block in _plugins_kubernetes_app_views_admin_kubernetes_deploy_group_roles_index_html_erb___2916526286086711020_69962863687000'
  plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/index.html.erb:17:in `_plugins_kubernetes_app_views_admin_kubernetes_deploy_group_roles_index_html_erb___2916526286086711020_69962863687000'
  app/controllers/concerns/current_user.rb:31:in `block in login_user'
```