### PR TITLE
do not blow up when connection to github fails

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -82,7 +82,7 @@ class Changeset
         GITHUB.compare(repo, previous_commit, commit)
       end
     end
-  rescue Octokit::Error => e
+  rescue Octokit::Error, Faraday::ConnectionFailed => e
     NullComparison.new("GitHub: #{e.message.sub("Octokit::", "").underscore.humanize}")
   end
 

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -37,7 +37,8 @@ describe Changeset do
     {
       Octokit::NotFound => "GitHub: Not found",
       Octokit::Unauthorized => "GitHub: Unauthorized",
-      Octokit::InternalServerError => "GitHub: Internal server error"
+      Octokit::InternalServerError => "GitHub: Internal server error",
+      Faraday::ConnectionFailed.new("Oh no") => "GitHub: Oh no"
     }.each do |exception, message|
       it "catches #{exception} exceptions" do
         GITHUB.expects(:compare).raises(exception)


### PR DESCRIPTION
@zendesk/paas

just saw this blow up while on the train ... not sure why it is not an Octokit error, but it should not blow up :)