### PR TITLE
do not show kubernetes roles when not using kubernetes on a stage

### DIFF
--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -1,65 +1,66 @@
-<h2><%= link_to "Kubernetes Roles", project_kubernetes_roles_path(@stage.project) %></h2>
+<% if @stage.kubernetes %>
+  <h2><%= link_to "Kubernetes Roles", project_kubernetes_roles_path(@stage.project) %></h2>
 
-<table class="table table-hover table-condensed">
-  <thead>
-    <th>Deploy Group</th>
-    <th>Replicas</th>
-    <th>CPU</th>
-    <th>RAM</th>
-    <th></th>
-  </thead>
-  <% project_dg_roles = Kubernetes::DeployGroupRole.where(project_id: @stage.project_id, deploy_group_id: @stage.deploy_groups.map(&:id)).to_a %>
-  <% roles = @stage.project.kubernetes_roles.sort_by(&:name) %>
+  <table class="table table-hover table-condensed">
+    <thead>
+      <th>Deploy Group</th>
+      <th>Replicas</th>
+      <th>CPU</th>
+      <th>RAM</th>
+      <th></th>
+    </thead>
+    <% project_dg_roles = Kubernetes::DeployGroupRole.where(project_id: @stage.project_id, deploy_group_id: @stage.deploy_groups.map(&:id)).to_a %>
+    <% roles = @stage.project.kubernetes_roles.sort_by(&:name) %>
 
-  <% @stage.deploy_groups.sort_by(&:natural_order).each do |deploy_group| %>
-    <% dg_roles = project_dg_roles.select { |r| r.deploy_group_id == deploy_group.id } %>
-    <tr>
-      <td colspan="5"><h3><%= deploy_group.name %></h3></td>
-    </tr>
-    <% roles.each do |role| %>
-      <% dg_role = dg_roles.detect { |r| r.kubernetes_role_id == role.id } %>
+    <% @stage.deploy_groups.sort_by(&:natural_order).each do |deploy_group| %>
+      <% dg_roles = project_dg_roles.select { |r| r.deploy_group_id == deploy_group.id } %>
       <tr>
-        <td><%= role.name %></td>
-        <% if dg_role %>
-          <td><%= dg_role.replicas %></td>
-          <td><%= dg_role.cpu %></td>
-          <td><%= dg_role.ram %></td>
-          <td>
-            <% if current_user.admin_for?(@stage.project) %>
-              <%= link_to 'Edit', edit_admin_kubernetes_deploy_group_role_path(dg_role) %>
-            <% end %>
-          </td>
-        <% else %>
-          <td colspan="3">Missing</td>
-          <td>
-            <% if current_user.admin_for?(@stage.project) %>
-              <% attributes = {kubernetes_role_id: role.id, project_id: @stage.project_id, deploy_group_id: deploy_group.id} %>
-              <%= link_to "Create", new_admin_kubernetes_deploy_group_role_path(kubernetes_deploy_group_role: attributes) %>
-            <% end %>
-          </td>
-        <% end %>
+        <td colspan="5"><h3><%= deploy_group.name %></h3></td>
+      </tr>
+      <% roles.each do |role| %>
+        <% dg_role = dg_roles.detect { |r| r.kubernetes_role_id == role.id } %>
+        <tr>
+          <td><%= role.name %></td>
+          <% if dg_role %>
+            <td><%= dg_role.replicas %></td>
+            <td><%= dg_role.cpu %></td>
+            <td><%= dg_role.ram %></td>
+            <td>
+              <% if current_user.admin_for?(@stage.project) %>
+                <%= link_to 'Edit', edit_admin_kubernetes_deploy_group_role_path(dg_role) %>
+              <% end %>
+            </td>
+          <% else %>
+            <td colspan="3">Missing</td>
+            <td>
+              <% if current_user.admin_for?(@stage.project) %>
+                <% attributes = {kubernetes_role_id: role.id, project_id: @stage.project_id, deploy_group_id: deploy_group.id} %>
+                <%= link_to "Create", new_admin_kubernetes_deploy_group_role_path(kubernetes_deploy_group_role: attributes) %>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+      <tr>
+        <td>Subtotal</td>
+        <td><%= dg_roles.sum(&:replicas) %></td>
+        <td><%= dg_roles.sum { |gr| gr.cpu * gr.replicas } %></td>
+        <td><%= dg_roles.sum { |gr| gr.ram * gr.replicas } %></td>
+        <td></td>
       </tr>
     <% end %>
     <tr>
-      <td>Subtotal</td>
-      <td><%= dg_roles.sum(&:replicas) %></td>
-      <td><%= dg_roles.sum { |gr| gr.cpu * gr.replicas } %></td>
-      <td><%= dg_roles.sum { |gr| gr.ram * gr.replicas } %></td>
+      <td><b>Total</b></td>
+      <td><%= project_dg_roles.sum(&:replicas) %></td>
+      <td><%= project_dg_roles.sum { |gr| gr.cpu * gr.replicas } %></td>
+      <td><%= project_dg_roles.sum { |gr| gr.ram * gr.replicas } %></td>
       <td></td>
     </tr>
-  <% end %>
-  <tr>
-    <td><b>Total</b></td>
-    <td><%= project_dg_roles.sum(&:replicas) %></td>
-    <td><%= project_dg_roles.sum { |gr| gr.cpu * gr.replicas } %></td>
-    <td><%= project_dg_roles.sum { |gr| gr.ram * gr.replicas } %></td>
-    <td></td>
-  </tr>
-</table>
+  </table>
 
-<script>
-  $(function(){
-    // hide command section when kubernetes is selected
-    $("#script-section").toggle(<%= !@stage.kubernetes %>);
-  });
-</script>
+  <script>
+    $(function(){
+      $("#script-section").hide(); // hide command section
+    });
+  </script>
+<% end %>


### PR DESCRIPTION
@zendesk/paas

atm we show missing roles etc UI that is not useful / confusing when the stage is not using kubernetes ... so let's hide it

before: showing kubernetes and commands
<img width="529" alt="screen shot 2016-06-02 at 8 58 00 am" src="https://cloud.githubusercontent.com/assets/11367/15751781/3ef1c400-28a0-11e6-95aa-ffc0616d4e68.png">
