### PR TITLE
adding scopes for secrets based

### DIFF
--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -1,6 +1,7 @@
 module SecretStorage
   SECRET_KEYS_PARTS = [:environment_permalink, :project_permalink, :deploy_group_permalink, :key].freeze
   SEPARATOR = "/".freeze
+  VAULT_SECRET_BACKEND = 'secret/'.freeze
 
   require 'attr_encrypted'
   class DbBackend
@@ -53,7 +54,6 @@ module SecretStorage
   end
 
   class HashicorpVault
-    VAULT_SECRET_BACKEND = 'secret/'.freeze
     # we don't really want other directories in the key,
     # and there may be other chars that we find we don't like
     ENCODINGS = {"/": "%2F"}.freeze


### PR DESCRIPTION
this addes scopes for secrets that are defined in a template

example:
      annotations:
        secret/TEST: 'staging/example-project/local-kubernets/boo'
        secret/ENVTEST: '$ENV/truth_service/$DEPLOY_GROUP/my_key'

the secret ENVTEST will be changed for each stage of the deployment with the correct env and deploy group name.  this allows for the use of a single template across multiple deploy groups/envs.

Also validates that all secrets found in annotations exist before letting the deployment happen.

* Add any screenshots if you are touching the UI
* Remember to add unit tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
https://zendesk.atlassian.net/browse/PAAS-188

### Risks
- Level: Low
