### PR TITLE
RFC: Make slack output less verbose

### DIFF
--- a/plugins/slack_webhooks/app/views/samson_slack_webhooks/notification.text.erb
+++ b/plugins/slack_webhooks/app/views/samson_slack_webhooks/notification.text.erb
@@ -4,15 +4,9 @@ There are no new commits since last time.
 <% else %>
 _<%= pluralize changeset.commits.count, "commit" %> by <%= changeset.author_names.to_sentence %>._
 
-*Files changed*
-
-<% changeset.files.each do |file| %>
-> <%= file.status[0].upcase %> <%= file.filename %>
-<% end %>
-
 *Commits*
 
-<% changeset.commits.each do |commit| %>
+<% changeset.commits[0..4].each do |commit| %>
 > <<%= commit.url + '|' + commit.summary %>> (<%= commit.author_name %>)
 <% end %>
 <% end %>

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
@@ -15,10 +15,6 @@ describe SlackWebhookNotificationRenderer do
     commit2 = stub("commit2", url: "#", author_name: "author2", summary: "Fix bug")
     changeset.stubs(:commits).returns([commit1, commit2])
 
-    file1 = stub("file1", status: "added", filename: "foo.rb")
-    file2 = stub("file2", status: "modified", filename: "bar.rb")
-    changeset.stubs(:files).returns([file1, file2])
-
     subject = "Deploy starting"
 
     result = SlackWebhookNotificationRenderer.render(deploy, subject)
@@ -26,11 +22,6 @@ describe SlackWebhookNotificationRenderer do
     result.must_equal <<-RESULT.strip_heredoc.chomp
 :point_right: *Deploy starting* :point_left:
 _2 commits by author1 and author2._
-
-*Files changed*
-
-> A foo.rb
-> M bar.rb
 
 *Commits*
 


### PR DESCRIPTION
Hi,
Wanted to ask you what do you think of something like this. Do you use the slack plugin? Do you prefer a detailed output? Here people don't like so detailed output, so if you prefer it more verbose maybe I can add a config for it?

What do you think?

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

