### PR TITLE
remove pod_ip it is not working and hides actual errors

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
@@ -185,8 +185,7 @@ module Kubernetes
       # dynamic lookups for unknown things during deploy
       {
         POD_NAME: 'metadata.name',
-        POD_NAMESPACE: 'metadata.namespace',
-        POD_IP: 'status.podIP'
+        POD_NAMESPACE: 'metadata.namespace'
       }.each do |k, v|
         env << {
          name: k,

--- a/plugins/kubernetes/test/models/kubernetes/deploy_yaml_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_yaml_test.rb
@@ -104,7 +104,7 @@ describe Kubernetes::DeployYaml do
       it "fills then environment with string values" do
         env = container.fetch(:env)
         env.map { |x| x.fetch(:name) }.sort.must_equal(
-          [:REVISION, :TAG, :PROJECT, :ROLE, :DEPLOY_ID, :DEPLOY_GROUP, :POD_NAME, :POD_NAMESPACE, :POD_IP].sort
+          [:REVISION, :TAG, :PROJECT, :ROLE, :DEPLOY_ID, :DEPLOY_GROUP, :POD_NAME, :POD_NAMESPACE].sort
         )
         env.map { |x| x[:value] }.map(&:class).map(&:name).sort.uniq.must_equal(["NilClass", "String"])
       end


### PR DESCRIPTION
@zendesk/paas 

previous error:
```
failedValidation: Error validating pod foo from api, ignoring: spec.containers[0].env[13].valueFrom.fieldRef.fieldPath: invalid value 'status.podIP': error converting fieldPath
```

actual hidden error:
```
failedMount: Unable to mount volumes for pod foo
```