### PR TITLE
Feature/kubernetes jobs

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621174658) do
+ActiveRecord::Schema.define(version: 20160617223512) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                       null: false
@@ -187,6 +187,35 @@ ActiveRecord::Schema.define(version: 20160621174658) do
   add_index "kubernetes_deploy_group_roles", ["deploy_group_id"], name: "index_kubernetes_deploy_group_roles_on_deploy_group_id", using: :btree
   add_index "kubernetes_deploy_group_roles", ["project_id", "deploy_group_id", "kubernetes_role_id"], name: "index_kubernetes_deploy_group_roles_on_project_id", using: :btree
 
+  create_table "kubernetes_job_docs", force: :cascade do |t|
+    t.integer  "job_id",          limit: 4,                       null: false
+    t.integer  "deploy_group_id", limit: 4,                       null: false
+    t.string   "status",          limit: 255, default: "created", null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+  end
+
+  add_index "kubernetes_job_docs", ["deploy_group_id"], name: "index_kubernetes_job_docs_on_deploy_group_id", using: :btree
+  add_index "kubernetes_job_docs", ["job_id"], name: "index_kubernetes_job_docs_on_job_id", using: :btree
+
+  create_table "kubernetes_jobs", force: :cascade do |t|
+    t.integer  "stage_id",           limit: 4,                         null: false
+    t.integer  "kubernetes_task_id", limit: 4,                         null: false
+    t.integer  "user_id",            limit: 4,                         null: false
+    t.integer  "build_id",           limit: 4
+    t.string   "status",             limit: 255,   default: "pending", null: false
+    t.string   "commit",             limit: 255
+    t.string   "tag",                limit: 255
+    t.text     "output",             limit: 65535
+    t.datetime "started_at"
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
+  end
+
+  add_index "kubernetes_jobs", ["kubernetes_task_id"], name: "index_kubernetes_jobs_on_kubernetes_task_id", using: :btree
+  add_index "kubernetes_jobs", ["stage_id"], name: "index_kubernetes_jobs_on_stage_id", using: :btree
+  add_index "kubernetes_jobs", ["user_id"], name: "index_kubernetes_jobs_on_user_id", using: :btree
+
   create_table "kubernetes_release_docs", force: :cascade do |t|
     t.integer  "kubernetes_role_id",          limit: 4,                         null: false
     t.integer  "kubernetes_release_id",       limit: 4,                         null: false
@@ -227,6 +256,17 @@ ActiveRecord::Schema.define(version: 20160621174658) do
 
   add_index "kubernetes_roles", ["project_id"], name: "index_kubernetes_roles_on_project_id", using: :btree
   add_index "kubernetes_roles", ["service_name", "deleted_at"], name: "index_kubernetes_roles_on_service_name_and_deleted_at", unique: true, length: {"service_name"=>191, "deleted_at"=>nil}, using: :btree
+
+  create_table "kubernetes_tasks", force: :cascade do |t|
+    t.integer  "project_id",  limit: 4,   null: false
+    t.string   "name",        limit: 255, null: false
+    t.string   "config_file", limit: 255
+    t.datetime "deleted_at"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  add_index "kubernetes_tasks", ["project_id"], name: "index_kubernetes_tasks_on_project_id", using: :btree
 
   create_table "locks", force: :cascade do |t|
     t.integer  "stage_id",    limit: 4

--- a/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_tabs_ctrl.js
+++ b/plugins/kubernetes/app/assets/javascripts/kubernetes/controllers/kubernetes_tabs_ctrl.js
@@ -1,0 +1,35 @@
+samson.controller('KubernetesTabsCtrl', function($rootScope, $scope, $window) {
+  $scope.tabs = [
+    {
+      index: 0,
+      title: 'Roles',
+      state: 'kubernetes.roles'
+    },
+    {
+      index: 1,
+      title: 'Tasks',
+      state: 'kubernetes.tasks'
+    },
+    {
+      index: 2,
+      title: 'Releases',
+      state: 'kubernetes.releases'
+    },
+    {
+      index: 3,
+      title: 'Dashboard',
+      state: 'kubernetes.dashboard'
+    }
+  ];
+
+  $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams) {
+    if(toState.name === 'kubernetes.roles') {
+      $window.location.href = '/projects/' + toParams.project_id + '/kubernetes/roles';
+    } else if (toState.name === 'kubernetes.tasks') {
+      $window.location.href = '/projects/' + toParams.project_id + '/kubernetes/tasks';
+    } else {
+      $scope.project_id = toParams.project_id;
+      _.findWhere($scope.tabs, {index: toState.data.selectedTab}).active = true;
+    }
+  });
+});

--- a/plugins/kubernetes/app/controllers/kubernetes/jobs_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/jobs_controller.rb
@@ -1,0 +1,48 @@
+class Kubernetes::JobsController < ApplicationController
+  include CurrentProject
+
+  before_action :authorize_project_admin!, only: [:new, :create, :destroy]
+  before_action :find_task, except: [:stream]
+
+  def new
+    @job = @task.kubernetes_jobs.build
+  end
+
+  def create
+    @job = Kubernetes::JobService.new(current_user).run!(@task, job_params)
+
+    if @job.persisted?
+      redirect_to project_kubernetes_job_path(@project, @job, kubernetes_task_id: @task)
+    else
+      render :new
+    end
+  end
+
+  def index
+    @jobs = @task.kubernetes_jobs.page(params[:page])
+  end
+
+  def show
+    @job = @task.kubernetes_jobs.find(params[:id])
+    respond_to do |format|
+      format.html
+      format.text do
+        datetime = @job.updated_at.strftime("%Y%m%d_%H%M%Z")
+        send_data @job.output,
+          type: 'text/plain',
+          filename: "#{@project.repo_name}-#{@job.id}-#{datetime}.log"
+      end
+    end
+  end
+
+  private
+
+  def find_task
+    @task = Kubernetes::Task.not_deleted.find(params[:kubernetes_task_id])
+  end
+
+  def job_params
+    params.require(:kubernetes_job).permit(:stage_id, :commit)
+  end
+
+end

--- a/plugins/kubernetes/app/controllers/kubernetes/streams_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/streams_controller.rb
@@ -1,0 +1,69 @@
+class Kubernetes::StreamsController < ApplicationController
+  newrelic_ignore if respond_to?(:newrelic_ignore)
+
+  include ActionController::Live
+  include ApplicationHelper
+  include DeploysHelper
+  include JobsHelper
+
+  helper_method :job_page_title
+
+  def show
+    response.headers['Content-Type'] = 'text/event-stream'
+    response.headers['Cache-Control'] = 'no-cache'
+    response.headers['Access-Control-Allow-Origin'] = Rails.application.config.samson.uri.to_s
+    response.headers['Access-Control-Allow-Credentials'] = true
+
+    @job = Kubernetes::Job.find(params[:id])
+    @execution = JobExecution.find_by_id(@job.id)
+
+    return response.stream.close unless @job.active? && @execution
+
+    @execution.viewers.push(current_user)
+
+    ActiveRecord::Base.clear_active_connections!
+
+    EventStreamer.new(response.stream, &method(:event_handler)).
+      start(@execution.output)
+  end
+
+  private
+
+  def event_handler(event, data)
+    case event
+    when :started, :finished
+      status_response(event)
+    when :viewers
+      viewers = data.to_a.uniq.reject { |user| user == current_user }
+      viewers.to_json(only: [:id, :name])
+    else
+      JSON.dump(msg: render_log(data))
+    end
+  end
+
+  def status_response(event)
+    @execution.viewers.delete(current_user) if event == :finished
+
+    # Need to reload data, as background thread updated the records on a separate DB connection,
+    # and .reload() doesn't bypass QueryCache'ing.
+    ActiveRecord::Base.uncached do
+      @job.reload
+      @project = @job.project
+      @deploy = @job.deploy
+    end
+
+    if @deploy
+      params = {
+        title: deploy_page_title,
+        html: render_to_body(partial: 'deploys/header', formats: :html)
+      }
+      params[:notification] = deploy_notification if event == :finished
+      JSON.dump(params)
+    else
+      JSON.dump(
+        title: job_page_title,
+        html: render_to_body(partial: 'jobs/header', formats: :html)
+      )
+    end
+  end
+end

--- a/plugins/kubernetes/app/controllers/kubernetes/tasks_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/tasks_controller.rb
@@ -1,0 +1,56 @@
+class Kubernetes::TasksController < ApplicationController
+  include CurrentProject
+
+  DEPLOYER_ACCESS = [:index, :show].freeze
+  before_action :authorize_project_deployer!, only: DEPLOYER_ACCESS
+  before_action :authorize_project_admin!, except: DEPLOYER_ACCESS
+  before_action :find_task, only: [:show, :update, :run, :destroy]
+
+  def index
+    @tasks = ::Kubernetes::Task.not_deleted.where(project: current_project).order('name desc')
+  end
+
+  def seed
+    Kubernetes::Task.seed!(@project, params.require(:ref))
+    redirect_to action: :index
+  end
+
+  def new
+    @task = Kubernetes::Task.new
+  end
+
+  def create
+    @task = Kubernetes::Task.new(task_params.merge(project: @project))
+    if @task.save
+      redirect_to action: :index
+    else
+      render :new
+    end
+  end
+
+  def show
+  end
+
+  def update
+    if @task.update_attributes(task_params)
+      redirect_to action: :index
+    else
+      render :show
+    end
+  end
+
+  def destroy
+    @task.soft_delete!
+    redirect_to action: :index
+  end
+
+  private
+
+  def find_task
+    @task = Kubernetes::Task.not_deleted.find(params[:id])
+  end
+
+  def task_params
+    params.require(:kubernetes_task).permit(:name, :config_file)
+  end
+end

--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -1,6 +1,7 @@
 Project.class_eval do
   has_many :kubernetes_releases, class_name: 'Kubernetes::Release'
   has_many :kubernetes_roles, class_name: 'Kubernetes::Role', dependent: :destroy
+  has_many :kubernetes_tasks, class_name: 'Kubernetes::Task', dependent: :destroy
   has_many :kubernetes_deploy_group_roles, class_name: 'Kubernetes::DeployGroupRole'
 
   scope :with_kubernetes_roles, -> { where(id: Kubernetes::Role.not_deleted.pluck('distinct project_id')) }

--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -27,6 +27,15 @@ module Kubernetes
       )
     end
 
+    def batch_client
+      @extension_client ||= Kubeclient::Client.new(
+        context.api_endpoint.gsub(/\/api$/, '') + '/apis',
+        'batch/v1',
+        ssl_options: context.ssl_options,
+        socket_options: client_socket_options
+      )
+    end
+
     def context
       @context ||= kubeconfig.context(config_context)
     end

--- a/plugins/kubernetes/app/models/kubernetes/executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/executor.rb
@@ -1,0 +1,122 @@
+module Kubernetes
+  class Executor
+    TICK = 2.seconds
+    RESTARTED = "Restarted".freeze
+
+    def initialize(output, job:)
+      @output = output
+      @job = job
+    end
+
+    def execute!(*)
+      build = find_or_create_build
+      return false if stopped?
+      execution = execute_for(build)
+      success = wait_to_finish(execution)
+      show_failure_cause(execution) unless success
+      success
+    end
+
+    def stop!(_signal)
+      @stopped = true
+    end
+
+    private
+
+    def wait_to_finish(_result)
+      true
+    end
+
+    def show_failure_cause(job_docs)
+      bad_pods(job_docs).each do |pod, client, deploy_group|
+        @output.puts "\n#{deploy_group.name} pod #{pod.name}:"
+        print_events(client, pod)
+        @output.puts
+        print_logs(client, pod)
+      end
+    end
+
+    # logs - container fails to boot
+    def print_logs(client, pod)
+      @output.puts "LOGS:"
+
+      pod.containers.map(&:name).each do |container|
+        @output.puts "Container #{container}" if pod.containers.size > 1
+
+        logs = begin
+          client.get_pod_log(pod.name, pod.namespace, previous: pod.restarted?, container: container)
+        rescue KubeException
+          begin
+            client.get_pod_log(pod.name, pod.namespace, previous: !pod.restarted?, container: container)
+          rescue KubeException
+            "No logs found"
+          end
+        end
+        @output.puts logs
+      end
+    end
+
+    # events - not enough cpu/ram available
+    def print_events(client, pod)
+      @output.puts "EVENTS:"
+      events = client.get_events(
+        namespace: pod.namespace,
+        field_selector: "involvedObject.name=#{pod.name}"
+      )
+      events.uniq! { |e| e.message.split("\n").sort }
+      events.each { |e| @output.puts "#{e.reason}: #{e.message}" }
+    end
+
+    def bad_pods(release)
+      release.clients.flat_map do |client, query, deploy_group|
+        bad_pods = fetch_pods(client, query).select { |p| p.restarted? || !p.live? }
+        bad_pods.map { |p| [p, client, deploy_group] }
+      end
+    end
+
+    def find_or_create_build
+      build = Build.find_by_git_sha(@job.commit) || create_build
+      wait_for_build(build)
+      ensure_build_is_successful(build) unless @stopped
+      build
+    end
+
+    def wait_for_build(build)
+      if !build.docker_repo_digest && build.docker_build_job.try(:running?)
+        @output.puts("Waiting for Build #{build.url} to finish.")
+        loop do
+          break if @stopped
+          sleep TICK
+          break if build.docker_build_job(:reload).finished?
+        end
+      end
+      build.reload
+    end
+
+    def create_build
+      @output.puts("Creating Build for #{@job.commit}.")
+      build = Build.create!(
+        git_ref: @job.commit,
+        creator: @job.user,
+        project: @job.project,
+        label: "Automated build triggered via Job ##{@job.id}"
+      )
+      DockerBuilderService.new(build).run!(push: true)
+      build
+    end
+
+    def ensure_build_is_successful(build)
+      if build.docker_repo_digest
+        @output.puts("Build #{build.url} is looking good!")
+      elsif build_job = build.docker_build_job
+        if build_job.succeeded?
+          @output.puts("Build #{build.url} is looking good!")
+        else
+          raise Samson::Hooks::UserError, "Build #{build.url} is #{build_job.status}, rerun it manually."
+        end
+      else
+        raise Samson::Hooks::UserError, "Build #{build.url} was created but never ran, run it manually."
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/job.rb
+++ b/plugins/kubernetes/app/models/kubernetes/job.rb
@@ -1,0 +1,172 @@
+module Kubernetes
+  class Job < ActiveRecord::Base
+
+    self.table_name = 'kubernetes_jobs'
+
+    ACTIVE_STATUSES = %w[pending running cancelling].freeze
+    VALID_STATUSES = ACTIVE_STATUSES + %w[failed errored succeeded cancelled].freeze
+
+    belongs_to :build
+    belongs_to :stage
+    belongs_to :user
+    has_many :job_docs
+    belongs_to :kubernetes_task,
+      inverse_of: :kubernetes_jobs,
+      class_name: 'Kubernetes::Task',
+      foreign_key: :kubernetes_task_id
+
+    delegate :project, to: :stage
+
+    validates :kubernetes_task, presence: true
+    validates :status, presence: true, inclusion: VALID_STATUSES
+    validates :commit, presence: true
+    validates :stage, presence: true
+    validates :user, presence: true
+    validate :validate_git_reference, on: :create
+    validate :validate_config_file, on: :create
+
+    def raw_template
+      @raw_template ||= build.file_from_repo(template_name)
+    end
+
+    def template_name
+      kubernetes_task.config_file
+    end
+
+    def deploy
+      nil
+    end
+
+    def output
+      super || ""
+    end
+
+    def summary
+      "#{user.name} run task #{kubernetes_task.name} #{short_reference} on #{stage.name}"
+    end
+
+    def summary_for_process
+      t = (Time.now.to_i - start_time.to_i)
+      "ProcessID: #{pid} Running task #{kubernetes_task.name}: #{t} seconds"
+    end
+
+    def project
+      stage.project
+    end
+
+    def start_time
+      created_at
+    end
+
+    def finished?
+      !ACTIVE_STATUSES.include?(status)
+    end
+
+    def active?
+      ACTIVE_STATUSES.include?(status)
+    end
+
+    %w[pending running succeeded cancelling cancelled failed errored].each do |status|
+      define_method "#{status}?" do
+        self.status == status
+      end
+    end
+
+    def error!
+      status!("errored")
+    end
+
+    def success!
+      status!("succeeded")
+    end
+
+    def fail!
+      status!("failed")
+    end
+
+    def run!
+      status!("running")
+    end
+
+    def update_output!(output)
+      update_attribute(:output, output)
+    end
+
+    def update_git_references!(commit:, tag:)
+      update_columns(commit: commit, tag: tag)
+    end
+
+    def can_be_stopped_by?(user)
+      started_by?(user) || user.admin? || user.admin_for?(project)
+    end
+
+    def started_by?(user)
+      self.user == user
+    end
+
+    def job_selector(deploy_group)
+      {
+        job_id: id,
+        deploy_group_id: deploy_group.id,
+      }
+    end
+
+    private
+
+    def status!(status)
+      update_attribute(:status, status)
+    end
+
+    # Create new client as 'Batch' API is on different path then 'v1'
+    def batch_client
+      deploy_group.kubernetes_cluster.batch_client
+    end
+
+    def job_yaml
+      @job_yaml ||= JobYaml.new(self)
+    end
+
+    # TODO: implement method
+    def resource_running?(_resource)
+      # batch_client.get_job(resource.metadata.name, resource.metadata.namespace)
+      false
+    rescue KubeException
+      false
+    end
+
+    def parsed_config_file
+      Array.wrap(Kubernetes::Util.parse_file(raw_template, template_name))
+    end
+
+    def validate_git_reference
+      if commit.blank? && tag.blank?
+        errors.add(:commit, 'must be specified')
+        return
+      end
+    end
+
+    def short_reference
+      if commit =~ /\A[0-9a-f]{40}\Z/
+        commit[0...7]
+      else
+        commit
+      end
+    end
+
+    def pid
+      execution.try :pid
+    end
+
+    def execution
+      JobExecution.find_by_id(id)
+    end
+
+    def validate_config_file
+      if build && kubernetes_task
+        if raw_template.blank?
+          errors.add(:build, "does not contain config file '#{template_name}'")
+        end
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/job_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/job_doc.rb
@@ -1,0 +1,64 @@
+module Kubernetes
+  class JobDoc < ActiveRecord::Base
+
+    self.table_name = 'kubernetes_job_docs'
+
+    belongs_to :deploy_group
+    belongs_to :job
+
+    delegate :raw_template, :template_name, :kubernetes_task, to: :job
+    delegate :build, :project, to: :job
+
+    validates :deploy_group, presence: true
+    validates :status, presence: true, inclusion: STATUSES
+
+    def client
+      deploy_group.kubernetes_cluster.client
+    end
+
+    # Create new client as 'Batch' API is on different path then 'v1'
+    def batch_client
+      deploy_group.kubernetes_cluster.batch_client
+    end
+
+    def run
+      job = Kubeclient::Job.new(job_yaml.to_hash)
+      if resource_running?(job)
+        # batch_client.update_job job
+        raise "Job already running" # TODO: Check expected behaviour
+      else
+        batch_client.create_job job
+      end
+    end
+
+    def job_selector
+      job.job_selector(deploy_group)
+    end
+
+    def kubernetes_namespace
+      deploy_group.kubernetes_namespace
+    end
+
+    private
+
+    def job_yaml
+      @job_yaml ||= JobYaml.new(self)
+    end
+
+    # TODO: implement method
+    def resource_running?(_resource)
+      # batch_client.get_job(resource.metadata.name, resource.metadata.namespace)
+      false
+    rescue KubeException
+      false
+    end
+
+    def parsed_config_file
+      Array.wrap(Kubernetes::Util.parse_file(raw_template, template_name))
+    end
+
+    def namespace
+      deploy_group.kubernetes_namespace
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/job_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/job_executor.rb
@@ -1,0 +1,101 @@
+# executes a deploy and writes log to job output
+# finishes when cluster is "Ready"
+module Kubernetes
+  class JobExecutor < Executor
+    def pid
+      "Kubernetes-job-#{object_id}"
+    end
+
+    def stopped?
+      false
+    end
+
+    private
+
+    def execute_for(build)
+      @job.update_attributes(build: build)
+      create_job_docs(build).tap do |job_doc|
+        run_job_docs(job_doc)
+      end
+    end
+
+    def bad_pods(_job_docs)
+      # TODO: What should be done here? Will do nothing in the meantime
+      []
+    end
+
+    def wait_to_finish(job_docs)
+      loop do
+        break false if stopped?
+
+        statuses = job_statuses(job_docs)
+
+        print_statuses(statuses)
+        if all_finished?(statuses)
+          @output.puts "finished... "
+          break all_completed?(statuses)
+        end
+
+        sleep TICK
+      end
+    end
+
+    # create a release, storing all the configuration
+    def create_job_docs(_build)
+      job_docs = @job.stage.deploy_groups.map do |deploy_group|
+        @job.job_docs.create(deploy_group_id: deploy_group.id)
+      end
+
+      unless job_docs.all?(&:persisted?)
+        raise Samson::Hooks::UserError, "Failed to create job: #{job_docs.map(&:errors).map(&:full_messages).inspect}"
+      end
+
+      job_docs.each do |job_doc|
+        @output.puts("Created job doc #{job_doc.id}")
+      end
+
+      job_docs
+    end
+
+    def print_statuses(statuses)
+      statuses.each do |kubernetes_job|
+        labels = kubernetes_job.metadata[:labels]
+        status = kubernetes_job.status
+        attempt_stats = {
+          active:   status.active || 0,
+          succeded: status.succeeded || 0,
+          failed:   status.failed || 0
+        }
+        @output.puts("#{labels[:deploy_group]}: #{attempt_stats.to_json}")
+      end
+    end
+
+    def all_finished?(statuses)
+      statuses.all? do |kubernetes_job|
+        last_condition = Array(kubernetes_job.status.conditions).last
+        ["Complete", "Failed"].include?(last_condition.try(:type))
+      end
+    end
+
+    def all_completed?(statuses)
+      statuses.all? do |kubernetes_job|
+        last_condition = Array(kubernetes_job.status.conditions).last
+        last_condition.try(:type) == "Complete"
+      end
+    end
+
+    def job_statuses(job_docs)
+      job_docs.flat_map do |job_doc|
+        query = {
+          namespace: job_doc.kubernetes_namespace,
+          label_selector: job_doc.job_selector.to_kuber_selector
+        }
+        job_doc.batch_client.get_jobs(query)
+      end
+    end
+
+    def run_job_docs(job_docs)
+      job_docs.each(&:run)
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/job_service.rb
+++ b/plugins/kubernetes/app/models/kubernetes/job_service.rb
@@ -1,0 +1,25 @@
+module Kubernetes
+  class JobService
+    include ::NewRelic::Agent::MethodTracer
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def run!(task, job_params)
+      job = task.kubernetes_jobs.create(job_params.merge(user: user))
+
+      if job.persisted?
+        job_execution = JobExecution.new(job.commit, job) do |execution, _tmp_dir|
+          @output = execution.output
+          job_executor = JobExecutor.new(@output, job: job)
+          job_executor.execute!
+        end
+
+        JobExecution.start_job(job_execution)
+      end
+      job
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/job_yaml.rb
+++ b/plugins/kubernetes/app/models/kubernetes/job_yaml.rb
@@ -1,0 +1,63 @@
+module Kubernetes
+  class JobYaml < Yaml
+    JOB = 'Job'.freeze
+
+    private
+
+    def template
+      @template ||= begin
+        sections = YAML.load_stream(@doc.raw_template, @doc.template_name)
+        if sections.size != 1
+          raise(
+            Samson::Hooks::UserError,
+            "Template #{@doc.template_name} has #{sections.size} sections, currently having 1 section is valid."
+          )
+        elsif sections.first['kind'] != JOB
+          raise(
+            Samson::Hooks::UserError,
+            "Template #{@doc.template_name} doesn't have a 'Job' section."
+          )
+        else
+          RecursiveOpenStruct.new(sections.first, recurse_over_arrays: true)
+        end
+      end
+    end
+
+    def set_generate_name
+      project_name = @doc.kubernetes_task.project.permalink
+      task_name    = @doc.kubernetes_task.name
+      template.metadata.generateName = "#{project_name}-#{task_name}-"
+    end
+
+    def set_timeout
+      template.spec.activeDeadlineSeconds = 10.minutes
+    end
+
+    # Sets the labels for each new Pod.
+    def set_job_labels
+      job_doc_metadata.each do |key, value|
+        template.metadata.labels[key] ||= value.to_s
+      end
+    end
+
+    # have to match Kubernetes::Release#clients selector
+    # TODO: dry
+    def job_doc_metadata
+      @job_doc_metadata ||= begin
+        task         = @doc.kubernetes_task
+        job          = @doc.job
+        deploy_group = @doc.deploy_group
+        build        = job.build
+        project      = job.project
+
+        job.job_selector(deploy_group).merge(
+          deploy_group: deploy_group.env_value.parameterize,
+          revision: build.git_sha,
+          project_id: project.id,
+          task_id: task.id,
+          tag: build.git_ref.parameterize
+        )
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/task.rb
+++ b/plugins/kubernetes/app/models/kubernetes/task.rb
@@ -1,0 +1,60 @@
+require 'soft_deletion'
+
+module Kubernetes
+  class Task < ActiveRecord::Base
+    self.table_name = 'kubernetes_tasks'
+    GENERATED = '-CHANGE-ME-'.freeze
+
+    has_soft_deletion
+
+    belongs_to :project, inverse_of: :kubernetes_tasks
+    has_many :kubernetes_jobs,
+      -> { order(created_at: :desc) },
+      foreign_key: 'kubernetes_task_id',
+      class_name: 'Kubernetes::Job'
+
+    has_many :kubernetes_deploy_group_roles,
+      class_name: 'Kubernetes::DeployGroupRole',
+      foreign_key: :kubernetes_role_id,
+      dependent: :destroy
+
+    validates :project, presence: true
+    validates :name, presence: true
+
+    scope :not_deleted, -> { where(deleted_at: nil) }
+
+    # create initial roles for a project by reading kubernetes/jobs/*{.yml,.yaml,json} files into jobs
+    def self.seed!(project, git_ref)
+      kubernetes_config_files_in_repo(project, git_ref).each do |config_file|
+        scope = where(project: project)
+        next if scope.where(config_file: config_file.file_path).exists?
+
+        name = config_file.job.metadata.labels.try(:task) || File.basename(config_file.file_path).sub(/\..*/, '')
+
+        create!(
+          project: project,
+          config_file: config_file.file_path,
+          name: name
+        )
+      end
+    end
+
+    def label_name
+      name.parameterize
+    end
+
+    class << self
+      private
+
+      def kubernetes_config_files_in_repo(project, git_ref)
+        path = 'kubernetes/tasks'
+        files = project.repository.file_content(path, git_ref) || []
+        files = files.split("\n").grep(/\.(yml|yaml|json)$/).map { |f| "#{path}/#{f}" }
+        files.map do |file|
+          file_contents = project.repository.file_content file, git_ref
+          Kubernetes::TaskConfigFile.new(file_contents, file)
+        end
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/task_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/task_config_file.rb
@@ -1,0 +1,52 @@
+module Kubernetes
+  # This file represents a Kubernetes configuration file for a specific project macro task.
+  class TaskConfigFile
+    attr_reader :file_path, :job
+
+    def initialize(contents, file_path)
+      @file_path = file_path
+      @config_file = Kubernetes::Util.parse_file(contents, file_path)
+      parse_file
+    end
+
+    private
+
+    def parse_file
+      job_hash = as_hash('Job')
+      raise 'Job specification missing in the configuration file.' if job_hash.nil?
+      @job = Job.new(job_hash)
+    rescue => ex
+      Rails.logger.error "Deployment YAML '#{file_path}' invalid: #{ex.message}"
+      raise ex
+    end
+
+    def as_hash(type)
+      hash = Array.wrap(@config_file).detect { |doc| doc['kind'] == type }.freeze
+      hash.dup.with_indifferent_access unless hash.nil?
+    end
+
+    #
+    # INNER CLASSES
+    #
+    class Job < RecursiveOpenStruct
+      def initialize(hash = nil, args = {})
+        args[:recurse_over_arrays] = true
+        super(hash, args)
+      end
+
+      def cpu_m
+        val = first_container.try(:resources).try(:limits).try(:cpu) || DEFAULT_RESOURCE_CPU
+        /(\d+(.\d+)?)/.match(val).to_s.to_f.try(:/, 1000)
+      end
+
+      def ram_mi
+        val = first_container.try(:resources).try(:limits).try(:memory) || DEFAULT_RESOURCE_RAM
+        /(\d+)/.match(val).to_s.to_i
+      end
+
+      def first_container
+        spec.template.spec.containers.first
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/yaml.rb
+++ b/plugins/kubernetes/app/models/kubernetes/yaml.rb
@@ -1,0 +1,87 @@
+module Kubernetes
+  class Yaml
+    def initialize(doc)
+      @doc = doc
+    end
+
+    def to_hash
+      @job_hash ||= begin
+        set_namespace
+        set_generate_name
+        set_timeout
+        set_job_labels
+        set_docker_image
+        # set_resource_usage
+        set_secret_sidecar if ENV.fetch("SECRET_SIDECAR_IMAGE", false)
+        set_env
+
+        hash = template.to_hash
+        Rails.logger.info "Created Kubernetes hash: #{hash.to_json}"
+        hash
+      end
+    end
+
+    def resource_name
+      template[:kind].underscore
+    end
+
+    private
+
+    def template
+      @template ||= @doc.deploy_template
+    end
+
+    def set_namespace
+      template[:metadata][:namespace] = @doc.deploy_group.kubernetes_namespace
+    end
+
+    def set_resource_usage
+      container[:resources] = {
+        limits: { cpu: @doc.cpu.to_f, memory: "#{@doc.ram}Mi" }
+      }
+    end
+
+    def set_docker_image
+      docker_path = @doc.build.docker_repo_digest || "#{@doc.build.project.docker_repo}:#{@doc.build.docker_ref}"
+      # Assume first container is one we want to update docker image in
+      container[:image] = docker_path
+    end
+
+    # helpful env vars, also useful for log tagging
+    def set_env
+      env = (container.env || [])
+
+      [:REVISION, :TAG, :DEPLOY_GROUP, :PROJECT, :TASK].each do |k|
+        env << {name: k, value: template.metadata.labels.send(k.downcase).to_s}
+      end
+
+      # dynamic lookups for unknown things during deploy
+      {
+        POD_NAME: 'metadata.name',
+        POD_NAMESPACE: 'metadata.namespace',
+        POD_IP: 'status.podIP'
+      }.each do |k, v|
+        env << {
+         name: k,
+         valueFrom: {fieldRef: {fieldPath: v}}
+       }
+      end
+
+      container.env = env
+    end
+
+    def container
+      @container ||= begin
+        containers = template[:spec].fetch(:template, {}).fetch(:spec, {}).fetch(:containers, [])
+        if containers.empty?
+          # TODO: support building and replacement for multiple containers
+          raise(
+            Samson::Hooks::UserError,
+            "Template #{@doc.template_name} has #{containers.size} containers, having 1 section is valid."
+          )
+        end
+        containers.first
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/views/kubernetes/jobs/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/jobs/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_for [@project, @job], url: project_kubernetes_jobs_path(@project, kubernetes_task_id: @task), html: { class: "form-horizontal" } do |form| %>
+  <%= render 'shared/errors', object: @task %>
+  <fieldset>
+    <div class="form-group">
+      <%= form.label :stage, 'Stage', class: "col-lg-2 control-label" %>
+      <div class="col-lg-2">
+        <%= form.collection_select :stage_id, @project.stages, :id, :name, {}, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= form.label :commit, "Git Reference", class: "col-lg-2 control-label" %>
+      <div id="scrollable-dropdown-menu" class="col-lg-4">
+        <%= form.text_field :commit, class: "form-control", autofocus: true, placeholder: "e.g. v2.1.43, master, fa0b4671", data: { prefetch_url: project_references_path(@project, format: "json") } %>
+      </div>
+    </div>
+
+
+    <div class="form-group">
+      <div class="col-lg-offset-2 col-lg-10">
+        <%= form.submit 'Run!', class: "btn btn-primary" %>
+      </div>
+    </div>
+  </fieldset>
+<% end %>

--- a/plugins/kubernetes/app/views/kubernetes/jobs/_job.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/jobs/_job.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td><span class="mouseover" data-time="<%= datetime_to_js_ms(job.created_at) %>"><%= job.created_at.rfc822 %></span></td>
+  <td><pre class="pre-command"><%= job.tag %></pre></td>
+  <td><pre class="pre-command"><%= job.commit %></pre></td>
+  <td><span class="label <%= status_label(job.status) %>"><%= job.status.titleize %></span></td>
+</tr>

--- a/plugins/kubernetes/app/views/kubernetes/jobs/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/jobs/index.html.erb
@@ -1,0 +1,24 @@
+<%= render 'projects/header', project: @project, tab: "kubernetes" %>
+
+<section class="tabs kubernetes-section clearfix">
+  <%= render 'samson_kubernetes/navigation' %>
+
+  <section>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Tag</th>
+          <th>Commit</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= static_render @jobs %>
+      </tbody>
+    </table>
+
+    <%# link_to "Execute", new_project_job_path(@project), class: "btn btn-primary" if admin_for_project? %>
+    <%= paginate @jobs %>
+  </section>
+</section>

--- a/plugins/kubernetes/app/views/kubernetes/jobs/new.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/jobs/new.html.erb
@@ -1,0 +1,11 @@
+<%= render 'projects/header', project: @project, tab: 'kubernetes' %>
+
+<section class="tabs kubernetes-section clearfix">
+  <%= render 'samson_kubernetes/navigation' %>
+
+  <section>
+    <h1>New Kubernetes Job</h1>
+
+    <%= render 'form' %>
+  </section>
+</section>

--- a/plugins/kubernetes/app/views/kubernetes/jobs/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/jobs/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title, job_page_title %>
+
+<%= breadcrumb @project, "Job ##{@job.id}" %>
+
+<h1>
+  <%= @project.name %>
+
+  <div class="pull-right">
+    <%= link_to "Back", project_jobs_path(@project), class: "btn btn-default" %>
+  </div>
+</h1>
+
+<div id="header">
+  <% if @job.finished? || @job.running? || JobExecution.enabled %>
+    <%= render 'jobs/header' %>
+  <% else %>
+    <div class="alert alert-info">
+      Samson is currently restarting, your job has been queued and will be resumed shortly.
+    </div>
+
+    <%= javascript_tag do %>
+      waitUntilEnabled("<%= enabled_jobs_path %>");
+    <% end %>
+  <% end %>
+</div>
+
+<section>
+  <div class="row" id="output" data-stream-url="<%= project_kubernetes_stream_path(@project, @job) %>">
+    <%= render 'shared/output', job: @job, deployable: @job, hide: false %>
+  </div>
+</section>
+
+<% if (@job.active? && JobExecution.enabled) || @job.running? %>
+  <%= javascript_tag do %>
+    toggleOutputToolbar();
+    startStream();
+  <% end %>
+<% end %>

--- a/plugins/kubernetes/app/views/kubernetes/tasks/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/tasks/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_for [@project, @task], html: { class: "form-horizontal" } do |form| %>
+  <%= render 'shared/errors', object: @task %>
+
+  <fieldset>
+    <div class="form-group">
+      <%= form.label :name, 'Name', class: "col-lg-2 control-label" %>
+      <div class="col-lg-2">
+        <%= form.text_field :name, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <%= form.label :config_file, class: "col-lg-2 control-label" %>
+      <div class="col-lg-4">
+        <%= form.text_field :config_file, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <div class="col-lg-offset-2 col-lg-10">
+        <% if current_user.admin_for?(@project) %>
+          <%= form.submit @task.persisted? ? 'Save' : 'Create', class: "btn btn-primary" %>
+          <%= link_to_delete [@project, @task], 'Delete', class: 'btn btn-default' if @task.persisted? %>
+        <% end %>
+        <%= link_to "Cancel", :back, class: 'btn btn-default' %>
+      </div>
+    </div>
+  </fieldset>
+<% end %>

--- a/plugins/kubernetes/app/views/kubernetes/tasks/_seed.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/tasks/_seed.html.erb
@@ -1,0 +1,16 @@
+<%= form_tag seed_project_kubernetes_tasks_path(@project), class: "form-horizontal" do %>
+  <fieldset>
+    <div class="form-group">
+      <%= label_tag :ref, 'Read tasks from branch', class: "col-lg-2 control-label" %>
+      <div class="col-lg-2">
+        <%= text_field_tag :ref, '', placeholder: 'master', class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <div class="col-lg-offset-2 col-lg-10">
+        <%= submit_tag 'Seed', class: "btn btn-primary" %>
+      </div>
+    </div>
+  </fieldset>
+<% end %>

--- a/plugins/kubernetes/app/views/kubernetes/tasks/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/tasks/index.html.erb
@@ -1,0 +1,38 @@
+<%= render 'projects/header', project: @project, tab: 'kubernetes' %>
+
+<section class="tabs kubernetes-section clearfix">
+  <%= render 'samson_kubernetes/navigation' %>
+
+  <% if @tasks.none? %>
+    <%= render 'seed' %>
+  <% else %>
+    <div class="table table-hover table-condensed">
+      <table class="table">
+        <tr>
+          <th>Name</th>
+          <th>Config</th>
+          <th></th>
+        </tr>
+
+        <% @tasks.each do |task| %>
+          <tr>
+            <td><%= link_to task.name, [@project, task] %></td>
+            <td><%= task.config_file %></td>
+            <td>
+              <%= link_to "Run!", new_project_kubernetes_job_path(@project, kubernetes_task_id: task), class: "btn btn-default" %>
+              <%= link_to "View Executions", project_kubernetes_jobs_path(kubernetes_task_id: task), class: "btn btn-default" %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  <% end %>
+
+  <% if current_user.admin_for?(@project) %>
+    <div class="admin-actions">
+      <div class="pull-right">
+        <%= link_to "New", new_project_kubernetes_task_path(@project), class: "btn btn-default" %>
+      </div>
+    </div>
+  <% end %>
+</section>

--- a/plugins/kubernetes/app/views/kubernetes/tasks/new.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/tasks/new.html.erb
@@ -1,0 +1,11 @@
+<%= render 'projects/header', project: @project, tab: 'kubernetes' %>
+
+<section class="tabs kubernetes-section clearfix">
+  <%= render 'samson_kubernetes/navigation' %>
+
+  <section>
+    <h1>New Kubernetes Task</h1>
+
+    <%= render 'form' %>
+  </section>
+</section>

--- a/plugins/kubernetes/app/views/kubernetes/tasks/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/tasks/show.html.erb
@@ -1,0 +1,11 @@
+<%= render 'projects/header', project: @project, tab: 'kubernetes' %>
+
+<section class="tabs kubernetes-section clearfix">
+  <%= render 'samson_kubernetes/navigation' %>
+
+  <section>
+    <h2>Kubernetes Task <%= @task.name %></h2>
+
+    <%= render 'form' %>
+  </section>
+</section>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_navigation.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_navigation.html.erb
@@ -1,11 +1,12 @@
 <% links = [
   ["Roles", project_kubernetes_roles_path],
+  ["Tasks", project_kubernetes_tasks_path],
   ["Releases", project_kubernetes_releases_path]
 ] %>
 
 <ul class="nav nav-tabs">
   <% links.each do |name, path| %>
     <% active = request.path.start_with?(path) %>
-    <li class="<%= "active" if active %>"><%= link_to name, active ? path : '#' %></li>
+    <li class="<%= "active" if active %>"><%= link_to name, active ? '#' : path %></li>
   <% end %>
 </ul>

--- a/plugins/kubernetes/config/initializers/kubeclient_extensions.rb
+++ b/plugins/kubernetes/config/initializers/kubeclient_extensions.rb
@@ -4,7 +4,7 @@ module Kubeclient
   class Client
     # Add Deployment and Daemonset waiting for PR:
     # https://github.com/abonas/kubeclient/pull/143
-    NEW_ENTITY_TYPES = %w[Deployment DaemonSet].map do |et|
+    NEW_ENTITY_TYPES = %w[Deployment DaemonSet Job].map do |et|
       clazz = Class.new(RecursiveOpenStruct) do
         def initialize(hash = nil, args = {})
           args[:recurse_over_arrays] = true

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -7,6 +7,14 @@ Samson::Application.routes.draw do
         end
       end
       resources :releases, only: [:index]
+
+      resources :tasks, except: :edit do
+        collection do
+          post :seed
+        end
+      end
+      resources :jobs, only: [:new, :create, :index, :show]
+      resources :streams, only: [:show]
     end
   end
 

--- a/plugins/kubernetes/db/migrate/20160602193635_create_kubernetes_tasks.rb
+++ b/plugins/kubernetes/db/migrate/20160602193635_create_kubernetes_tasks.rb
@@ -1,0 +1,11 @@
+class CreateKubernetesTasks < ActiveRecord::Migration
+  def change
+    create_table :kubernetes_tasks do |t|
+      t.references :project, null: false, index: true
+      t.string :name, null: false
+      t.string :config_file
+      t.timestamp :deleted_at
+      t.timestamps null: false
+    end
+  end
+end

--- a/plugins/kubernetes/db/migrate/20160602193922_create_kubernetes_job_docs.rb
+++ b/plugins/kubernetes/db/migrate/20160602193922_create_kubernetes_job_docs.rb
@@ -1,0 +1,10 @@
+class CreateKubernetesJobDocs < ActiveRecord::Migration
+  def change
+    create_table :kubernetes_job_docs do |t|
+      t.references :job, null: false, index: true
+      t.references :deploy_group, null: false, index: true
+      t.string :status, null: false, default: "created"
+      t.timestamps null: false
+    end
+  end
+end

--- a/plugins/kubernetes/db/migrate/20160606202534_create_kubernetes_jobs.rb
+++ b/plugins/kubernetes/db/migrate/20160606202534_create_kubernetes_jobs.rb
@@ -1,0 +1,16 @@
+class CreateKubernetesJobs < ActiveRecord::Migration
+  def change
+    create_table :kubernetes_jobs do |t|
+      t.references :stage, null: false, index: true
+      t.references :kubernetes_task, null: false, index: true
+      t.references :user, null: false, index: true
+      t.references :build
+      t.string :status, null: false, default: "pending"
+      t.string :commit
+      t.string :tag
+      t.text :output
+      t.datetime :started_at
+      t.timestamps null: false
+    end
+  end
+end

--- a/plugins/kubernetes/test/controllers/kubernetes/jobs_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/jobs_controller_test.rb
@@ -1,0 +1,124 @@
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Kubernetes::JobsController do
+  let(:project) { projects(:test) }
+  let(:stage) { stages(:test_staging) }
+  let(:admin) { users(:admin) }
+  let(:build) { builds(:docker_build) }
+  let(:task)  { kubernetes_tasks(:db_migrate) }
+  let(:job) do
+    Kubernetes::Job.create!(
+      stage: stage, kubernetes_task: task, build: build,
+      commit: build.git_sha, tag: build.git_ref, user: admin
+    )
+  end
+  let(:job_service) { stub(run!: nil) }
+  let(:execute_called) { [] }
+
+  before { kubernetes_fake_job_raw_template }
+
+  as_a_viewer do
+    describe "a GET to :index" do
+      before do
+        get :index,
+          project_id: project.to_param,
+          kubernetes_task_id: task.id
+      end
+
+      it "renders the template" do
+        assert_template :index
+      end
+    end
+
+    describe "a GET to :show" do
+      describe 'with a job' do
+        before do
+          get :show,
+            project_id: project.to_param,
+            kubernetes_task_id: task.id,
+            id: job
+        end
+
+        it "renders the template" do
+          assert_template :show
+        end
+      end
+
+      describe 'with a running job' do
+        before do
+          get :show,
+            project_id: project.to_param,
+            kubernetes_task_id: task.id,
+            id: kubernetes_jobs(:running_test)
+        end
+
+        it "renders the template" do
+          assert_template :show
+        end
+      end
+
+      it "fails with unknown job" do
+        assert_raises ActiveRecord::RecordNotFound do
+          get :show, project_id: project.to_param, kubernetes_task_id: task.id, id: "job:nope"
+        end
+      end
+
+      describe "with format .text" do
+        before { get :show, format: :text, project_id: project.to_param, kubernetes_task_id: task.id, id: job }
+
+        it "responds with a plain text file" do
+          assert_equal response.content_type, "text/plain"
+        end
+
+        it "responds with a .log file" do
+          assert response.header["Content-Disposition"] =~ /\.log"$/
+        end
+      end
+    end
+
+    unauthorized :post, :create, project_id: :foo
+  end
+
+  as_a_deployer do
+    unauthorized :post, :create, project_id: :foo
+  end
+
+  as_a_project_admin do
+    describe "#new" do
+      it "renders" do
+        get :new, project_id: project, kubernetes_task_id: task.id
+        assert_template :new
+      end
+    end
+
+    describe "#create" do
+      let(:job_params) { { "stage_id" => stage.id.to_param, "commit" => "master" } }
+
+      before do
+        Kubernetes::JobService.stubs(:new).with(user).returns(job_service)
+        job_service.stubs(:run!).capture(execute_called).returns(job)
+        JobExecution.stubs(:start_job)
+
+        post :create, kubernetes_job: job_params, project_id: project.to_param, kubernetes_task_id: task.id
+      end
+
+      it "redirects to the job path" do
+        assert_redirected_to project_kubernetes_job_path(project, job, kubernetes_task_id: task.id)
+      end
+
+      it "creates a job" do
+        assert_equal [[task, job_params]], execute_called
+      end
+
+      describe "when invalid" do
+        let(:job) { Kubernetes::Job.new }
+
+        it "renders" do
+          assert_template :new
+        end
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/test/controllers/kubernetes/tasks_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/tasks_controller_test.rb
@@ -1,0 +1,100 @@
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Kubernetes::TasksController do
+  let(:project) { task.project }
+  let(:task) { kubernetes_tasks(:db_migrate) }
+  let(:task_params) do
+    {
+      name: 'NAME',
+      config_file: 'dsfsd.yml',
+    }
+  end
+
+  as_a_viewer do
+    unauthorized :get, :index, project_id: :foo
+    unauthorized :post, :seed, project_id: :foo
+    unauthorized :get, :new, project_id: :foo
+    unauthorized :post, :create, project_id: :foo
+    unauthorized :get, :show, project_id: :foo, id: 1
+    unauthorized :put, :update, project_id: :foo, id: 1
+    unauthorized :delete, :destroy, project_id: :foo, id: 1
+  end
+
+  as_a_deployer do
+    unauthorized :post, :seed, project_id: :foo
+    unauthorized :get, :new, project_id: :foo
+    unauthorized :post, :create, project_id: :foo
+    unauthorized :put, :update, project_id: :foo, id: 1
+    unauthorized :delete, :destroy, project_id: :foo, id: 1
+
+    describe "#index" do
+      it "renders" do
+        get :index, project_id: project
+        assert_template :index
+      end
+    end
+
+    describe "#show" do
+      it "renders" do
+        get :show, project_id: project, id: task.id
+        assert_template :show
+      end
+    end
+  end
+
+  as_a_project_admin do
+    describe "#seed" do
+      it "creates tasks" do
+        Kubernetes::Task.expects(:seed!)
+        post :seed, project_id: project, ref: 'HEAD'
+        assert_redirected_to action: :index
+      end
+    end
+
+    describe "#new" do
+      it "renders" do
+        get :new, project_id: project
+        assert_template :new
+      end
+    end
+
+    describe "#create" do
+      it "creates" do
+        post :create, project_id: project, kubernetes_task: task_params
+        task = Kubernetes::Task.last
+        assert_redirected_to "/projects/foo/kubernetes/tasks"
+        task.name.must_equal 'NAME'
+      end
+
+      it "renders on failure" do
+        task_params[:name] = ''
+        post :create, project_id: project, kubernetes_task: task_params
+        assert_template :new
+      end
+    end
+
+    describe "#update" do
+      it "updates" do
+        put :update, project_id: project, id: task.id, kubernetes_task: task_params
+        assert_redirected_to "/projects/foo/kubernetes/tasks"
+        task.reload.name.must_equal 'NAME'
+      end
+
+      it "renders on failure" do
+        task_params[:name] = ''
+        put :update, project_id: project, id: task.id, kubernetes_task: task_params
+        assert_template :show
+      end
+    end
+
+    describe "#destroy" do
+      it "destroys" do
+        delete :destroy, project_id: project, id: task.id
+        task.reload.deleted_at.wont_equal nil
+        assert_redirected_to action: :index
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/test/fixtures/kubernetes/jobs.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/jobs.yml
@@ -1,0 +1,8 @@
+running_test:
+  user: super_admin
+  stage: test_staging
+  status: running
+  build: docker_build
+  kubernetes_task: db_migrate
+  output: This worked!
+  commit: staging

--- a/plugins/kubernetes/test/fixtures/kubernetes/tasks.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/tasks.yml
@@ -1,0 +1,5 @@
+---
+db_migrate:
+  project: test
+  name: db_migrate
+  config_file: 'kubernetes/tasks/db_migrate.yml'

--- a/plugins/kubernetes/test/models/kubernetes/job_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/job_test.rb
@@ -1,0 +1,202 @@
+# rubocop:disable Metrics/LineLength
+require_relative '../../test_helper'
+
+SingleCov.covered! uncovered: 16
+
+describe Kubernetes::Job do
+  let(:stage) { stages(:test_staging) }
+  let(:task)  { kubernetes_tasks(:db_migrate) }
+  let(:statuses) { Kubernetes::Job::VALID_STATUSES }
+  let(:build)  { builds(:docker_build) }
+  let(:user) { users(:deployer) }
+  let(:job) do
+    Kubernetes::Job.create!(
+      stage: stage,
+      kubernetes_task: task,
+      status: statuses.first,
+      commit: build.git_sha,
+      build: build,
+      user: user
+    )
+  end
+
+
+  before { kubernetes_fake_job_raw_template }
+
+  describe 'validations' do
+    it 'is valid by default' do
+      assert_valid job
+    end
+
+    it 'test validity of status' do
+      statuses.each do |status|
+        assert_valid job.tap { |kr| kr.status = status }
+      end
+      refute_valid job.tap { |kr| kr.status = 'foo' }
+      refute_valid job.tap { |kr| kr.status = nil }
+    end
+  end
+
+  describe 'template_name' do
+    it 'returns the template_name fetched from the configuration file of the kubernetes task' do
+      assert_equal task.config_file, job.template_name
+    end
+  end
+
+  describe 'deploy' do
+    it 'does nothing' do
+      assert_nil job.deploy
+    end
+  end
+
+  describe 'output' do
+    it 'returns an empty string if super didn\'t have anything' do
+      assert_equal job.output, ''
+    end
+  end
+
+  describe 'summary' do
+    it 'returns the proper summary' do
+      str = "#{user.name} run task #{task.name} #{build.git_sha[0...7]} on #{stage.name}"
+      assert_equal str, job.summary
+    end
+  end
+
+  describe 'summary_for_process' do
+    before { JobExecution.expects(:find_by_id).with(job.id).returns(job_execution) }
+    before { Time.stubs(:now).returns(now) }
+    let(:job_execution) { stub(pid: pid) }
+    let(:pid) { 100 }
+    let(:now) { job.start_time + 30.seconds }
+
+    it 'returns the proper summary' do
+      str = "ProcessID: #{pid} Running task #{task.name}: 30 seconds"
+
+      assert_equal str, job.summary_for_process
+    end
+  end
+
+  describe 'project' do
+    it 'returns the corresponding project' do
+      assert_equal stage.project, job.project
+    end
+  end
+
+  describe 'start_time' do
+    it 'returns the created_at value' do
+      assert_equal job.created_at, job.start_time
+    end
+  end
+
+  describe 'finished?' do
+    it 'returns false if the status is within the ACTIVE_STATUSES' do
+      Kubernetes::Job::ACTIVE_STATUSES.each do |status|
+        job.status = status
+        assert_not job.finished?, "#{status} is not within the finished statuses"
+      end
+    end
+
+    it 'returns true if the status is not among the ACTIVE_STATUSES' do
+      (Kubernetes::Job::VALID_STATUSES - Kubernetes::Job::ACTIVE_STATUSES).each do |status|
+        job.status = status
+        assert job.finished?, "'#{status}' is within the finished statuses"
+      end
+    end
+  end
+
+  describe 'active?' do
+    it 'returns true if the status is within the ACTIVE_STATUSES' do
+      Kubernetes::Job::ACTIVE_STATUSES.each do |status|
+        job.status = status
+        assert job.active?, "'#{status}' is not within the active statuses"
+      end
+    end
+
+    it 'returns false if the status is not among the ACTIVE_STATUSES' do
+      (Kubernetes::Job::VALID_STATUSES - Kubernetes::Job::ACTIVE_STATUSES).each do |status|
+        job.status = status
+        assert_not job.active?, "'#{status}' is within the active statuses"
+      end
+    end
+  end
+
+  describe 'statuses' do
+    it 'returns true if the status matches the current one' do
+      statuses = %w[pending running succeeded cancelling cancelled failed errored]
+      statuses.each do |status|
+        job.status = status
+        assert job.public_send("#{status}?"), "'#{status}' doesn't match the current status"
+      end
+    end
+
+    it 'returns false if the status doesn\'t match the current one' do
+      statuses = %w[pending running succeeded cancelling cancelled failed errored]
+      statuses.each do |status|
+        current_status = (statuses - [status]).first
+        job.status = current_status
+        assert_not job.public_send("#{status}?"), "'#{status}' do matches the current status '#{current_status}'"
+      end
+    end
+  end
+
+  describe 'error!' do
+    it "sets the status to 'errored' after triggering it" do
+      assert_not_equal 'errored', job.status, "The job status shouldn't have been 'errored'"
+      job.error!
+      assert_equal 'errored', job.status, "The job status wasn't set to errored"
+    end
+  end
+
+  describe 'success!' do
+    it "sets the status to 'success' after triggering it" do
+      assert_not_equal 'succeeded', job.status, "The job status shouldn't have been 'succeeded'"
+      job.success!
+      assert_equal 'succeeded', job.status, "The job status wasn't set to succeeded"
+    end
+  end
+
+  describe 'fail!' do
+    it "sets the status to 'failed' after triggering it" do
+      assert_not_equal 'failed', job.status, "The job status shouldn't have been 'failed'"
+      job.fail!
+      assert_equal 'failed', job.status, "The job status wasn't set to failed"
+    end
+  end
+
+  describe 'run!' do
+    it "sets the status to 'running' after triggering it" do
+      assert_not_equal 'running', job.status, "The job status shouldn't have been 'running'"
+      job.run!
+      assert_equal 'running', job.status, "The job status wasn't set to running"
+    end
+  end
+
+  describe 'update_output!' do
+    before { job.output = '' }
+    it 'sets the output to the configured one' do
+      job.update_output!('asd')
+      assert_equal 'asd', job.output
+    end
+  end
+
+  describe 'update_git_references!' do
+    before { job.commit = '' }
+    before { job.tag = '' }
+    it 'sets the commit and tag to the configured one' do
+      job.update_git_references!(commit: 'a5ca253d7a26e65948d0140869db3f12d56a43f8', tag: 'v1')
+      assert_equal 'a5ca253d7a26e65948d0140869db3f12d56a43f8', job.commit
+      assert_equal 'v1', job.tag
+    end
+  end
+
+  describe 'started_by?' do
+    let(:admin_user) { users(:admin) }
+    it 'returns true if the user started the job' do
+      assert job.started_by?(user)
+    end
+
+    it 'returns false if the user started the job' do
+      assert_not job.started_by?(admin_user)
+    end
+  end
+end

--- a/plugins/kubernetes/test/samples/kubernetes_task_config_file.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_task_config_file.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    project: some-project
+    task: db-migrate
+spec:
+  template:
+    spec:
+      containers:
+      - name: some-project
+        image: docker-registry.zende.sk/truth_service:latest
+        command: ["bin/rake", "db:migrate"]
+      restartPolicy: Never

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -120,6 +120,19 @@ class ActiveSupport::TestCase
     Kubernetes::ReleaseDoc.any_instance.stubs(raw_template: template.to_yaml)
   end
 
+  def kubernetes_fake_job_raw_template
+    Kubernetes::Job.any_instance.stubs(raw_template: {
+      'apiVersion' => 'batch/v1',
+      'kind' => 'Job',
+      'metadata' => {'labels' => {'project' => 'foobar', 'task' => 'db_migrate'}},
+      'spec' => {
+        'template' => {
+          'spec' => {'containers' => [{}]}
+        },
+      },
+    }.to_yaml)
+  end
+
   private
 
   def read_kubernetes_sample_file(file_name)


### PR DESCRIPTION
### Description
An initial integration with Kubernetes, allowing us to schedule tasks such as db migrations. It was added as a plugin without disrupting the rest of the service.

The UI now includes the Kubernetes tab, here are a few screenshots showing the new flow.

- The summary of the available Roles and the creation of one:
<img width="1193" alt="screen shot 2016-06-10 at 12 08 38 pm" src="https://cloud.githubusercontent.com/assets/1091625/15971941/08394316-2f12-11e6-942d-89cb94edfd06.png">
<img width="1200" alt="screen shot 2016-06-10 at 1 47 49 pm" src="https://cloud.githubusercontent.com/assets/1091625/15971946/0ce471b0-2f12-11e6-8a8f-5ab6aa1fa7f2.png">
The yaml to load must have a format as follows:
````
apiVersion: batch/v1
kind: Job
metadata:
  labels:
    project: app
    task: db-migrate
spec:
  template:
    spec:
      containers:
      - name: app
        image: registry/app:latest
        command: ["bin/rake", "db:migrate"]
      restartPolicy: Never
````

- The Tasks summary, its creation and the execution of a Job.
<img width="1240" alt="screen shot 2016-06-10 at 11 11 14 am" src="https://cloud.githubusercontent.com/assets/1091625/15968702/3f13d298-2f03-11e6-92e2-f361c75e868a.png">
<img width="1239" alt="screen shot 2016-06-10 at 11 12 08 am" src="https://cloud.githubusercontent.com/assets/1091625/15968706/433e0e2e-2f03-11e6-800e-97da4d9e1622.png">

- The Job execution and its progress:
![pasted image at 2016_06_15 05_14 pm](https://cloud.githubusercontent.com/assets/1091625/16096339/e172e924-331e-11e6-91ec-7910594ea4e5.png)

- A summary of the executed jobs:
<img width="1236" alt="screen shot 2016-06-10 at 11 15 39 am" src="https://cloud.githubusercontent.com/assets/1091625/15968707/4536c856-2f03-11e6-9111-a4eacb972427.png">

- A detail of the scheduled releases and the creation of one:
<img width="1206" alt="screen shot 2016-06-10 at 1 53 13 pm" src="https://cloud.githubusercontent.com/assets/1091625/15972092/db37f596-2f12-11e6-8db2-74a10fa70af0.png">
<img width="1179" alt="screen shot 2016-06-10 at 1 52 05 pm" src="https://cloud.githubusercontent.com/assets/1091625/15972094/defce75e-2f12-11e6-9305-b65be3736796.png">

We are **missing the unit tests**, though we thought we could submit the pull request for review and in the meantime, we start adding the things that we know are missing, such as a better task execution summary, a proper error management, some UI glitches and of course the unit tests.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 https://github.com/zendesk/samson/issues/869

### Risks
- Level: **Medium**
