### PR TITLE
automatic ecr repo creation

### DIFF
--- a/plugins/aws_ecr/README.md
+++ b/plugins/aws_ecr/README.md
@@ -8,11 +8,14 @@ which is the Docker registry service managed by AWS.
 
 AWS ECR requires you to refresh your registry credentials every 12 hours (approximately).
 Because Samson only supports to set credentials through the environment, this plugin
-runs a callback before every build requesting AWS for the new credentials. Then sets
+runs a callback before every build, requesting AWS for the new credentials. Then sets
 these credentials to the environment so the normal docker build process can use them.
+
+It also tries to create a new repository if it does not already exist.
 
 To configure this plugin you need to:
 
 * Enable docker in samson (DOCKER_FEATURE=1)
 * Set your ECR registry (DOCKER_REGISTRY=<account>.dkr.ecr.<aws-region>.amazonaws.com)
 * Set your [AWS credentials](http://docs.aws.amazon.com/sdkforruby/api/#Configuration)
+* Ensure permissions "ecr:DescribeRepositories" and "ecr:CreateRepository" are available.

--- a/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
+++ b/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
@@ -3,29 +3,55 @@ require 'aws-sdk-core'
 module SamsonAwsEcr
   class Engine < Rails::Engine
     AMAZON_REGISTRY = /\A.*\.dkr.ecr.(?<region>[\w\-]+).amazonaws.com\z/
-    mattr_accessor :ecr_client
-    mattr_accessor(:credentials_expire_at) { Time.current }
 
-    initializer :ecr_client do
-      if match = AMAZON_REGISTRY.match(ENV['DOCKER_REGISTRY'])
-        SamsonAwsEcr::Engine.ecr_client = Aws::ECR::Client.new(region: match['region'])
+    class << self
+      # we make sure the repo exists so pushes do not fail
+      # - ignores if the repo already exists
+      # - ignores if the repo cannot be created due to permission problems
+      def ensure_repository(repository)
+        return unless ecr_client
+        name = repository.split('/', 2).last
+        ecr_client.describe_repositories(repository_names: [name])
+      rescue Aws::ECR::Errors::RepositoryNotFoundException
+        ecr_client.create_repository(repository_name: name)
+      rescue Aws::ECR::Errors::AccessDenied
+        Rails.logger.info("Not allowed to create or describe repositories")
+      end
+
+      # aws credentials are only valid for a limited time, so we need to refresh them before pushing
+      def refresh_credentials
+        if credentials_stale?
+          authorization_data = ecr_client.get_authorization_token.authorization_data.first
+
+          self.credentials_expire_at = authorization_data.expires_at || raise("NO EXPIRE FOUND")
+          user, pass = Base64.decode64(authorization_data.authorization_token).split(":", 2)
+          ENV['DOCKER_REGISTRY_USER'] = user
+          ENV['DOCKER_REGISTRY_PASS'] = pass
+        end
+      rescue Aws::ECR::Errors::InvalidSignatureException
+        raise Samson::Hooks::UserError, "Invalid AWS credentials"
+      end
+
+      private
+
+      attr_accessor :credentials_expire_at
+
+      def ecr_client
+        return @ecr_client if defined?(@ecr_client)
+        @ecr_client = if match = AMAZON_REGISTRY.match(Rails.application.config.samson.docker.registry)
+          Aws::ECR::Client.new(region: match['region'])
+        end
+      end
+
+      def credentials_stale?
+        ecr_client && (!credentials_expire_at || credentials_expire_at < Time.current)
       end
     end
   end
 end
 
-Samson::Hooks.callback :before_docker_build do
-  begin
-    if SamsonAwsEcr::Engine.ecr_client && SamsonAwsEcr::Engine.credentials_expire_at < Time.current
-      authorization_token = SamsonAwsEcr::Engine.ecr_client.get_authorization_token
-      authorization_data  = authorization_token.authorization_data.first
-
-      SamsonAwsEcr::Engine.credentials_expire_at = authorization_data.expires_at || raise("NO EXPIRE FOUND")
-      user, pass = Base64.decode64(authorization_data.authorization_token).split(":")
-      ENV['DOCKER_REGISTRY_USER'] = user
-      ENV['DOCKER_REGISTRY_PASS'] = pass
-    end
-  rescue Aws::ECR::Errors::InvalidSignatureException
-    Rails.logger.error("Invalid AWS credentials")
-  end
+# need credentials to pull (via Dockerfile FROM) and push images
+Samson::Hooks.callback :before_docker_build do |_, build, _|
+  SamsonAwsEcr::Engine.ensure_repository(build.project.docker_repo)
+  SamsonAwsEcr::Engine.refresh_credentials
 end

--- a/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
+++ b/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
@@ -9,11 +9,13 @@ module SamsonAwsEcr
       # - ignores if the repo already exists
       # - ignores if the repo cannot be created due to permission problems
       def ensure_repository(repository)
-        return unless ecr_client
-        name = repository.split('/', 2).last
-        ecr_client.describe_repositories(repository_names: [name])
-      rescue Aws::ECR::Errors::RepositoryNotFoundException
-        ecr_client.create_repository(repository_name: name)
+        begin
+          return unless ecr_client
+          name = repository.split('/', 2).last
+          ecr_client.describe_repositories(repository_names: [name])
+        rescue Aws::ECR::Errors::RepositoryNotFoundException
+          ecr_client.create_repository(repository_name: name)
+        end
       rescue Aws::ECR::Errors::AccessDenied
         Rails.logger.info("Not allowed to create or describe repositories")
       end
@@ -44,7 +46,7 @@ module SamsonAwsEcr
       end
 
       def credentials_stale?
-        ecr_client && (!credentials_expire_at || credentials_expire_at < Time.current)
+        ecr_client && (!credentials_expire_at || credentials_expire_at < 1.hour.from_now)
       end
     end
   end

--- a/plugins/dockerb/test/samson_dockerb/samson_plugin_test.rb
+++ b/plugins/dockerb/test/samson_dockerb/samson_plugin_test.rb
@@ -11,7 +11,7 @@ describe SamsonDockerb do
       Samson::Hooks.fire(:after_deploy_setup, "repo", job, StringIO.new, 'abc')
     end
 
-    around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir) { test.call } } }
+    run_inside_of_temp_directory
 
     before do
       FileUtils.mkdir("repo")

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -13,7 +13,7 @@ describe SamsonEnv do
       Samson::Hooks.fire(:after_deploy_setup, Dir.pwd, job, StringIO.new, 'abc')
     end
 
-    around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir) { test.call } } }
+    run_inside_of_temp_directory
 
     before do
       project.environment_variables.create!(name: "HELLO", value: "world")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -168,6 +168,10 @@ class ActiveSupport::TestCase
   def self.with_env(env)
     around { |test| with_env(env, &test) }
   end
+
+  def self.run_inside_of_temp_directory
+    around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir) { test.call } } }
+  end
 end
 
 Mocha::Expectation.class_eval do


### PR DESCRIPTION
@zendesk/paas @rata 

 - show user a nicer error when unable to authenticate to the registry
 - only create ecr client when trying to push an image
 - add tests for previously uncovered ecr_client

FYI Error that shows when repo was not yet created:

```
status: The push refers to a repository [123.dkr.ecr.us-west-2.amazonaws.com/truth_service]
errorDetail: {"message"=>"name unknown: The repository with name 'truth_service' does not exist in the registry with id '1234'"} | error: name unknown: The repository with name 'truth_service' does not exist in the registry with id '1234'
```

### Risks
 - ecr support breaking