### PR TITLE
ignore soft deleted roles in a few places

### DIFF
--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -3,7 +3,7 @@ Project.class_eval do
   has_many :kubernetes_roles, class_name: 'Kubernetes::Role', dependent: :destroy
   has_many :kubernetes_deploy_group_roles, class_name: 'Kubernetes::DeployGroupRole'
 
-  scope :with_kubernetes_roles, -> { where(id: Kubernetes::Role.pluck('distinct project_id')) }
+  scope :with_kubernetes_roles, -> { where(id: Kubernetes::Role.not_deleted.pluck('distinct project_id')) }
 
   def name_for_label
     name.parameterize('-')

--- a/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
@@ -12,7 +12,7 @@ module Kubernetes
         project_id: stage.project_id,
         deploy_group_id: stage.deploy_groups.map(&:id)
       ).to_a
-      roles = stage.project.kubernetes_roles.sort_by(&:name)
+      roles = stage.project.kubernetes_roles.not_deleted.sort_by(&:name)
 
       stage.deploy_groups.sort_by(&:natural_order).map do |deploy_group|
         dg_roles = project_dg_roles.select { |r| r.deploy_group_id == deploy_group.id }

--- a/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/_form.html.erb
@@ -50,7 +50,7 @@
 <script>
   // change selectable roles when project changes, since every project has different roles
   $(function(){
-    var project_data = <%= Kubernetes::Role.pluck(:project_id, :id, :name).group_by(&:first).to_json.html_safe %>
+    var project_data = <%= Kubernetes::Role.not_deleted.pluck(:project_id, :id, :name).group_by(&:first).to_json.html_safe %>
     $('#kubernetes_deploy_group_role_project_id').change(function () {
       var $role_select = $('#kubernetes_deploy_group_role_kubernetes_role_id');
       var project_id = parseInt($(this).val(), 10);

--- a/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
@@ -30,6 +30,18 @@ describe Kubernetes::DeployGroupRole do
         ]]
       )
     end
+
+    it "ignores soft deleted roles" do
+      kubernetes_roles(:app_server).soft_delete!
+      Kubernetes::DeployGroupRole.matrix(stage).must_equal(
+        [[
+          stage.deploy_groups.first,
+          [
+            [kubernetes_roles(:resque_worker), kubernetes_deploy_group_roles(:test_pod100_resque_worker)]
+          ]
+        ]]
+      )
+    end
   end
 
   describe "#seed!" do


### PR DESCRIPTION
atm blocks deploys since the deploy complains that there is no deploy-group-role for a deleted role

@zendesk/paas 

 - no longer showing in the matrix
 - no longer showing in deploy group role select
 - no longer able to select projects that have deleted roles