### PR TITLE
Support Kubernetes Job to build Docker image

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -85,7 +85,9 @@ class BuildsController < ApplicationController
   end
 
   def new_build_params
-    params.require(:build).permit(:git_ref, :label, :description)
+    params.require(:build).permit(
+      *[:git_ref, :label, :description] + Samson::Hooks.fire(:build_params)
+    )
   end
 
   def edit_build_params

--- a/app/views/builds/new.html.erb
+++ b/app/views/builds/new.html.erb
@@ -33,6 +33,8 @@
         </div>
       </div>
 
+      <%= Samson::Hooks.render_views(:build_new, self, form: form) %>
+
       <div class="form-group">
         <%= form.label :build_image, "Build Docker Image?", class: "col-lg-2 control-label" %>
         <div class="col-lg-4">

--- a/db/migrate/20160715165508_add_kubernetes_build_column.rb
+++ b/db/migrate/20160715165508_add_kubernetes_build_column.rb
@@ -1,0 +1,5 @@
+class AddKubernetesBuildColumn < ActiveRecord::Migration
+  def change
+    add_column :builds, :kubernetes_job, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160701215002) do
+ActiveRecord::Schema.define(version: 20160715165508) do
 
   create_table "builds", force: :cascade do |t|
-    t.integer  "project_id",                       null: false
+    t.integer  "project_id",                                       null: false
     t.integer  "number",              limit: 4
-    t.string   "git_sha",             limit: 255,  null: false
-    t.string   "git_ref",             limit: 255,  null: false
+    t.string   "git_sha",             limit: 255,                  null: false
+    t.string   "git_ref",             limit: 255,                  null: false
     t.string   "docker_image_id",     limit: 255
     t.string   "docker_ref",          limit: 255
     t.string   "docker_repo_digest",  limit: 255
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20160701215002) do
     t.integer  "created_by"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "kubernetes_job",                   default: false, null: false
   end
 
   add_index "builds", ["created_by"], name: "index_builds_on_created_by", using: :btree

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -7,6 +7,7 @@ module Samson
       :stage_form,
       :stage_show,
       :project_form,
+      :build_new,
       :deploy_group_show,
       :deploy_group_form,
       :deploy_group_table_header,
@@ -25,6 +26,7 @@ module Samson
       :stage_permitted_params,
       :deploy_permitted_params, # for external plugin
       :project_permitted_params,
+      :build_params,
       :before_deploy,
       :after_deploy_setup,
       :after_deploy,

--- a/plugins/kubernetes/app/models/kubernetes/api/job.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/job.rb
@@ -1,0 +1,25 @@
+module Kubernetes
+  module Api
+    class Job
+      def initialize(api_job)
+        @job = api_job
+      end
+
+      def name
+        @job.metadata.try(:name)
+      end
+
+      def namespace
+        @job.metadata.try(:namespace)
+      end
+
+      def failure?
+        @job.status == 'Failure'
+      end
+
+      def complete?
+        (@job.status.conditions || []).detect { |c| break c['status'] == 'True' if c['type'] == 'Complete' }
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
@@ -1,0 +1,144 @@
+# Execute a job that can build/push Docker images
+# and write progress to the local job output.
+module Kubernetes
+  class BuildJobExecutor
+    WAIT_FOR_JOB = 5.minutes
+    TICK = 3.seconds
+
+    attr_reader :job
+    delegate :id, to: :job
+
+    def initialize(output, job:)
+      @output = output
+      @job = job
+      @registry = {}
+    end
+
+    def execute!(build, project, tag:, push: false, registry:, tag_as_latest: false)
+      job_log = job_name = job_namespace = ""
+      k8s_job = nil
+
+      unless valid_registry_info?(registry)
+        @output.puts "### Registry server should not be empty. Aborting..."
+        return false, job_log
+      end
+      @registry = registry
+
+      k8s_job = job_config(build, project, tag: tag, push: push, tag_as_latest: tag_as_latest)
+      job_name = k8s_job[:metadata][:name]
+      job_namespace = k8s_job[:metadata][:namespace]
+
+      @output.puts "### Running a remote Docker build job: #{job_name}"
+      success, job_log = create_and_wait_for_job(k8s_job, @output)
+
+      message = (success ? "completed successfully" : "failed or timed out")
+      @output.puts "### Remote build job #{job_name} #{message}"
+
+      return success, job_log
+    ensure
+      # Jobs will still be there regardless of their statuses
+      begin
+        @output.puts "### Cleaning up the remote build job"
+        extension_client.delete_job(job_name, job_namespace) if k8s_job
+      rescue KubeException
+        @output.puts "### Failed to clean up the remote build job"
+      end
+    end
+
+    private
+
+    def build_cluster
+      Kubernetes::Cluster.first!
+    end
+
+    def client
+      build_cluster.client
+    end
+
+    def extension_client
+      build_cluster.extension_client
+    end
+
+    def valid_registry_info?(registry)
+      registry[:serveraddress].present?
+    end
+
+    def build_job_config_path
+      ENV['KUBE_BUILD_JOB_FILE'] || File.join(Rails.root, 'plugins', 'kubernetes', 'config', 'build_job.yml')
+    end
+
+    def fill_job_details(k8s_job, build, project, tag:, push: false, tag_as_latest: false)
+      # Fill in some information to easily query the job resource
+      project_name = project.permalink.tr('_', '-')
+      labels = { project: project_name, role: "docker-build-job" }
+      k8s_job[:metadata][:name] = "#{project_name}-docker-build-#{build.id}-#{SecureRandom.hex(7)}"
+      k8s_job[:metadata][:labels].update(labels)
+      k8s_job[:spec][:template][:metadata][:labels].update(labels)
+
+      # Necessary to query the pod running the job later
+      k8s_job[:spec][:template][:metadata][:labels][:job_name] = k8s_job[:metadata][:name]
+
+      # Pass all necessary information so that remote container can build the image
+      container_params = {
+        env: [{name: 'DOCKER_REGISTRY', value: @registry[:serveraddress] }],
+        args: [
+          project.repository_url, build.git_sha, project.docker_repo, tag,
+          push ? "yes" : "no",
+          tag_as_latest ? "yes" : "no"
+        ]
+      }
+      k8s_job[:spec][:template][:spec][:containers][0].update(container_params)
+    end
+
+    def job_config(build, project, tag:, push: false, tag_as_latest: false)
+      # Read the external config path and create a new job config instance
+      contents = File.read(build_job_config_path)
+      k8s_job = Kubernetes::RoleConfigFile.new(contents, build_job_config_path).job
+      fill_job_details(k8s_job, build, project, tag: tag, push: push, tag_as_latest: tag_as_latest)
+      k8s_job
+    end
+
+    def create_and_wait_for_job(k8s_job, output)
+      extension_client.create_job(k8s_job.deep_symbolize_keys)
+      start = Time.now
+      logs = pod_name = ""
+      job_name = k8s_job[:metadata][:name]
+      job_namespace = k8s_job[:metadata][:namespace]
+
+      # We need to loop here in case the job/pod status is not ready yet.
+      # For that the API still reports the data but the job status is
+      # neither success nor failure.
+      loop do
+        sleep TICK # Sleep a bit to wait for the server
+        begin
+          job = Kubernetes::Api::Job.new(
+            extension_client.get_job(job_name, job_namespace)
+          )
+          selector = "job_name=#{job_name}" # A build job only has one pod
+          pod = Kubernetes::Api::Pod.new(
+            client.get_pods(namespace: job_namespace, label_selector: selector).first
+          )
+          # If the pod name for the job is unchanged from previous loops, it is likely that the pod finishes
+          # but the job status is not yet updated. In this case, we will get old/duplicated logs if we start
+          # a new watch stream.
+          if pod_name != pod.name
+            pod_name = pod.name
+            client.watch_pod_log(pod.name, pod.namespace).each do |line|
+              logs << line << "\n"
+              output.puts line
+            end
+          end
+        rescue StandardError
+          # Something wrong happened. It is better to reset all memorized variables for logs and previous pod name.
+          # Might get duplicated/old logs if the job finished successfully but the failure came from other sources.
+          pod_name = logs = ""
+          output.puts "### Cannot get job #{job_name}'s pod log."
+        end
+
+        return false, "" if job.failure?
+        return false, "" if start + WAIT_FOR_JOB < Time.now
+        return true, logs if job.complete?
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/views/samson_kubernetes/_build_new.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_build_new.erb
@@ -1,0 +1,6 @@
+<div class="form-group">
+  <%= form.label :kubernetes_job, "Use Remote Kubernetes Job?", class: "col-lg-2 control-label" %>
+  <div class="col-lg-4">
+    <%= form.check_box :kubernetes_job %>
+  </div>
+</div>

--- a/plugins/kubernetes/config/build_job.yml
+++ b/plugins/kubernetes/config/build_job.yml
@@ -1,0 +1,38 @@
+---
+# Sample job configuration to build and optionally
+# push a Docker image. It is used in build_job_executor.rb
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: image-build-job
+  namespace: default
+  labels:
+    project: project-name
+    role: docker-build-job
+spec:
+  autoSelector: true
+  activeDeadlineSeconds: 60
+  template:
+    metadata:
+      name: image-build-job
+      labels:
+        project: project-name
+        role: docker-build-job
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        role: docker-build-job
+      containers:
+      - name: image-build-job
+        # image: docker-registry.zende.sk/repository-build:latest
+        imagePullPolicy: Always
+        command: ["/opt/build_scripts/repository-build.rb"]
+        args: []
+        volumeMounts:
+          - name: docker-sock
+            mountPath: /var/run/docker.sock
+            readOnly: true
+      volumes:
+        - name: docker-sock
+          hostPath:
+           path: /var/run/docker.sock

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -16,6 +16,7 @@ Samson::Hooks.view :deploy_group_show, "samson_kubernetes/deploy_group_show"
 Samson::Hooks.view :deploy_group_form, "samson_kubernetes/deploy_group_form"
 Samson::Hooks.view :deploy_group_table_header, "samson_kubernetes/deploy_group_table_header"
 Samson::Hooks.view :deploy_group_table_cell, "samson_kubernetes/deploy_group_table_cell"
+Samson::Hooks.view :build_new, "samson_kubernetes/build_new"
 
 Samson::Hooks.callback :deploy_group_permitted_params do
   { cluster_deploy_group_attributes: [:kubernetes_cluster_id, :namespace] }
@@ -27,4 +28,8 @@ end
 
 Samson::Hooks.callback :edit_deploy_group do |deploy_group|
   deploy_group.build_cluster_deploy_group unless deploy_group.cluster_deploy_group
+end
+
+Samson::Hooks.callback :build_params do
+  :kubernetes_job
 end

--- a/plugins/kubernetes/test/models/kubernetes/api/job_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/job_test.rb
@@ -1,0 +1,90 @@
+require_relative '../../../test_helper'
+
+SingleCov.covered!
+
+describe Kubernetes::Api::Job do
+  let(:job_name) { 'test_job' }
+  let(:namespace) { 'test_ns' }
+
+  let(:job) { Kubernetes::Api::Job.new(build_kubeclient_job) }
+
+  describe '#name' do
+    it 'reads job name' do
+      job.name.must_equal job_name
+    end
+  end
+
+  describe '#namespace' do
+    it 'reads job namespace' do
+      job.namespace.must_equal namespace
+    end
+  end
+
+  describe '#failure?' do
+    let(:job) { Kubernetes::Api::Job.new(build_kubeclient_job) }
+
+    it 'is false when API returns a complete job data' do
+      refute job.failure?
+    end
+
+    it 'is false failed when API returns a valid condition' do
+      job.instance_variable_get(:@job).status.conditions = [{'type': 'Ready', 'status': 'True'}]
+      refute job.failure?
+    end
+
+    it 'is true when API returns failure data' do
+      job.instance_variable_get(:@job).status = 'Failure'
+      assert job.failure?
+    end
+  end
+
+  describe '#complete?' do
+    let(:job) { Kubernetes::Api::Job.new(build_kubeclient_job) }
+
+    it 'is true when API returns a complete job data' do
+      assert job.complete?
+    end
+
+    it 'is false when API returns invalid conditions' do
+      job.instance_variable_get(:@job).status.conditions = nil
+      refute job.complete?
+    end
+
+    it 'is false when API returns an empty condition' do
+      job.instance_variable_get(:@job).status.conditions = []
+      refute job.complete?
+    end
+
+    it 'is false when API returns non-empty conditions but no status' do
+      job.instance_variable_get(:@job).status.conditions = [{'type': 'Ready', 'status': 'True'}]
+      refute job.complete?
+    end
+
+    it 'is false when API returns conditions for a incompleted job' do
+      job.instance_variable_get(:@job).status.conditions = [{'type': 'Complete', 'status': 'False'}]
+      refute job.complete?
+    end
+  end
+
+  private
+
+  def build_kubeclient_job
+    data = {
+      metadata: {
+        name: job_name,
+        namespace: namespace,
+      },
+      status: {
+        conditions: [{type: 'Complete', status: 'True'}]
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {'jobName' => job_name}
+          }
+        }
+      }
+    }
+    Kubeclient::Job.new(JSON.load(data.to_json))
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
@@ -1,0 +1,164 @@
+require_relative "../../test_helper"
+
+# Skip the following lines:
+# - Simple resetting tracking variables for the next loop when
+#   there is an error creating a build job or getting/watching pod log
+SingleCov.covered! uncovered: 2
+
+describe Kubernetes::BuildJobExecutor do
+  let(:output) { StringIO.new }
+  let(:out) { output.string }
+  let(:registry_info) do
+    {
+      serveraddress: Rails.application.config.samson.docker.registry,
+      username: 'foo', password: 'bar', email: 'moo@cow.com'
+    }
+  end
+
+  let(:build) { builds(:docker_build) }
+  let(:job) { jobs(:succeeded_test) }
+  let(:project) { job.project }
+
+  let(:executor) { Kubernetes::BuildJobExecutor.new(output, job: job) }
+
+  describe '#execute!' do
+    def execute!(push: false, registry_info: nil)
+      executor.execute!(build, project,
+        tag: 'latest', push: push, registry: registry_info)
+    end
+
+    let(:client) { stub }
+    let(:extension_client) { stub }
+
+    before do
+      Kubernetes::Cluster.any_instance.stubs(:client).returns client
+      Kubernetes::Cluster.any_instance.stubs(:extension_client).returns extension_client
+    end
+
+    it 'fails when an invalid registry is passed in' do
+      invalid_registry = registry_info.dup
+      invalid_registry[:serveraddress] = ''
+      extension_client.expects(:create_job).never
+      extension_client.expects(:delete_job).never
+      success, job_log = execute!(registry_info: invalid_registry)
+      refute success
+      assert_empty job_log
+    end
+
+    describe 'when there is a valid config and registry information' do
+      let(:build_job_config_path) { kubernetes_sample_file_path('kubernetes_job.yml') }
+      let(:job_config_file) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
+      let(:labels) { {foo: 'bar'} }
+      let(:build_config) do
+        stub(job: {
+          metadata: {
+            name: 'test_job',
+            namespace: 'test_ns',
+            labels: labels
+          },
+          spec: {
+            template: {
+              metadata: {
+                name: 'test_job',
+                namespace: 'test_ns',
+                labels: labels
+              },
+              spec: {
+                containers: [{ name: 'test-job' }]
+              }
+            }
+          }
+        })
+      end
+
+      before do
+        extension_client.expects(:delete_job).once
+        Kubernetes::RoleConfigFile.expects(:new).returns build_config
+      end
+
+      around { |t| with_env "KUBE_BUILD_JOB_FILE": build_job_config_path, &t }
+
+      it 'reads the job config file and populates correct job parameters, but fails to start a job' do
+        extension_client.expects(:create_job).raises(KubeException.new(500, 'Server Error', {}))
+
+        assert_raises KubeException do
+          execute!(registry_info: registry_info)
+        end
+
+        project_name_dash = project.permalink.tr('_', '-')
+        assert_match(/^#{Regexp.quote(project_name_dash)}-docker-build-#{build.id}-[0-9a-f]{14}$/,
+          build_config.job[:metadata][:name])
+
+        labels_config = [build_config.job[:metadata][:labels], build_config.job[:spec][:template][:metadata][:labels]]
+        labels_config.each do |v|
+          assert_equal v[:project], project_name_dash
+          assert_equal v[:role], 'docker-build-job'
+          assert_equal v[:foo], 'bar'
+        end
+
+        assert_equal build_config.job[:spec][:template][:spec][:containers][0][:args],
+          [project.repository_url, build.git_sha, project.docker_repo, 'latest', 'no', 'no']
+        assert_equal build_config.job[:spec][:template][:spec][:containers][0][:env].length, 1
+      end
+
+      describe 'when the job resource is created' do
+        let(:job_api_obj) { stub }
+        let(:job_pod) { stub(first: stub(name: stub, namespace: stub)) }
+        let(:job_pod_log) { ['A long long log', 'A shorter log'] }
+        let(:pod_api_obj) { stub(name: stub, namespace: stub) }
+
+        before do
+          extension_client.expects(:create_job).once
+          extension_client.expects(:get_job).at_least_once
+          client.expects(:get_pods).returns(job_pod).at_least_once
+          client.expects(:watch_pod_log).with(
+            pod_api_obj.name, pod_api_obj.namespace
+          ).returns(job_pod_log).at_least_once
+          Kubernetes::Api::Job.expects(:new).returns(job_api_obj).at_least_once
+          Kubernetes::Api::Pod.expects(:new).returns(pod_api_obj).at_least_once
+          job_api_obj.stubs(:name).returns 'job-123'
+        end
+
+        it 'returns a failure status and an empty log when the job fails' do
+          job_api_obj.stubs(:failure?).returns true
+
+          success, job_log = execute!(registry_info: registry_info)
+          refute success
+          assert_empty job_log
+        end
+
+        it 'returns a failure status and an empty log when the job times out' do
+          start = Time.now
+          Time.stubs(:now).returns(start)
+          executor.expects(:sleep).with { Time.stubs(:now).returns(start + 1.hour); true }
+          job_api_obj.stubs(:failure?).returns false
+          job_api_obj.stubs(:complete?).returns false
+          success, job_log = execute!(registry_info: registry_info)
+
+          refute success
+          assert_empty job_log
+        end
+
+        it 'returns a success status and a non-empty log when the job completes' do
+          job_api_obj.stubs(:failure?).returns false
+          job_api_obj.stubs(:complete?).returns true
+          success, job_log = execute!(registry_info: registry_info)
+
+          assert success
+          assert_equal(job_pod_log.join("\n") << "\n", job_log)
+        end
+
+        it 'returns the job status when it fails to clean up the build job' do
+          extension_client.unstub(:delete_job)
+          extension_client.expects(:delete_job).raises(KubeException.new(404, 'Not Found', {}))
+          job_api_obj.stubs(:failure?).returns false
+          job_api_obj.stubs(:complete?).returns true
+          success, job_log = execute!(registry_info: registry_info)
+
+          assert success
+          assert_equal(job_pod_log.join("\n") << "\n", job_log)
+        end
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -106,7 +106,11 @@ class ActiveSupport::TestCase
     Kubernetes::ReleaseDoc.any_instance.stubs(raw_template: read_kubernetes_sample_file('kubernetes_deployment.yml'))
   end
 
+  def kubernetes_sample_file_path(file_name)
+    "#{Rails.root}/plugins/kubernetes/test/samples/#{file_name}"
+  end
+
   def read_kubernetes_sample_file(file_name)
-    File.read("#{Rails.root}/plugins/kubernetes/test/samples/#{file_name}")
+    File.read(kubernetes_sample_file_path(file_name))
   end
 end


### PR DESCRIPTION
This PR add the basic support to create a job on a K8s cluster running a predefined image. This image contains a script to clone the specified repository, commit, tag, etc. passed as environment variables, then optionally push the newly built image and reports the result log.

/cc @jonmoter @grosser 

### Tasks
- Fix CodeClimate and code style violations
- Create the build job image and push to registry
- Test the whole flow on the staging cluster
- Fix any issue after code review ?

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-141

### Risks
- Level: Low
