### PR TITLE
Redirect user to login page if not logged in

### DIFF
--- a/app/controllers/unauthorized_controller.rb
+++ b/app/controllers/unauthorized_controller.rb
@@ -20,7 +20,7 @@ class UnauthorizedController < ActionController::Metal
     respond_to do |format|
       format.html do
         flash[:authorization_error] = "You are not authorized to view this page."
-        redirect_back_or(root_path)
+        redirect_back_or(login_path)
       end
 
       format.json do

--- a/test/controllers/unauthorized_controller_test.rb
+++ b/test/controllers/unauthorized_controller_test.rb
@@ -23,11 +23,11 @@ describe 'Unauthorized' do
       end
 
       describe 'without a referer' do
-        it 'redirects to the root path' do
+        it 'redirects to the login path' do
           last_response.must_be(:redirect?)
 
           # Really just '/', but Rack insists on using the full SERVER_NAME
-          last_response.headers['Location'].must_equal('http://example.org/')
+          last_response.headers['Location'].must_equal('http://example.org/login')
         end
       end
 


### PR DESCRIPTION
This seemed to work in our samson deployment a few days ago, but currently we just experience redirect loops if no user is logged in instead of redirecting to the login page. Looking through the code, we couldn't figure out how that was ever happening so we added this. Not sure if it's necessary or what might have broken.

/cc @zendesk/samson

### Risks
- Level: Low