### PR TITLE
Add email notification to Projects#destroy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,7 @@ GITHUB_TOKEN={fill me in}
 # BUDDY_CHECK_TIME_LIMIT=20 # optional, max minutes a deploy is pending
 
 # PROJECT_CREATED_NOTIFY_ADDRESS=bobby-the-security-auditor@yourcompany.com
+# PROJECT_DELETED_NOTIFY_ADDRESS=bobby-the-security-auditor@yourcompany.com  #if not set uses PROJECT_CREATED_NOTIFY_ADDRESS
 
 # DEPLOY_GROUP_FEATURE=1 # optional, enable Environments and DeployGroups
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,7 +34,7 @@ class ProjectsController < ApplicationController
     @project.current_user = current_user
 
     if @project.save
-      if ENV['PROJECT_CREATED_NOTIFY_ADDRESS']
+      if Rails.application.config.samson.project_created_email
         ProjectMailer.created_email(@current_user, @project).deliver_later
       end
       redirect_to @project
@@ -62,6 +62,9 @@ class ProjectsController < ApplicationController
   def destroy
     project.soft_delete!
 
+    if Rails.application.config.samson.project_deleted_email
+      ProjectMailer.deleted_email(@current_user, project).deliver_later
+    end
     flash[:notice] = "Project removed."
     redirect_to admin_projects_path
   end

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,8 +1,15 @@
 class ProjectMailer < ApplicationMailer
   def created_email(user, project)
-    address = ENV['PROJECT_CREATED_NOTIFY_ADDRESS']
+    address = Rails.application.config.samson.project_created_email
     subject = "Samson Project Created: #{project.name}"
     body = "#{user.name_and_email} just created a new project #{project.name}"
+    mail(to: address, subject: subject, body: body)
+  end
+
+  def deleted_email(user, project)
+    address = Rails.application.config.samson.project_deleted_email
+    subject = "Samson Project Deleted: #{project.name}"
+    body = "#{user.name_and_email} just deleted project #{project.name}"
     mail(to: address, subject: subject, body: body)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,11 @@ module Samson
     config.samson.email.prefix = ENV["EMAIL_PREFIX"].presence || "DEPLOY"
     config.samson.email.sender_domain = ENV["EMAIL_SENDER_DOMAIN"].presence || "samson-deployment.com"
 
+    # Email notifications
+    config.samson.project_created_email = ENV["PROJECT_CREATED_NOTIFY_ADDRESS"]
+    config.samson.project_deleted_email = ENV["PROJECT_DELETED_NOTIFY_ADDRESS"].presence ||
+      ENV["PROJECT_CREATED_NOTIFY_ADDRESS"]
+
     # Whether or not jobs are actually executed.
     config.samson.enable_job_execution = true
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -185,6 +185,12 @@ describe ProjectsController do
       it "sets the flash" do
         request.flash[:notice].wont_be_nil
       end
+
+      it "notifies about deletion" do
+        mail = ActionMailer::Base.deliveries.last
+        mail.subject.include?("Samson Project Deleted")
+        mail.subject.include?(project.name)
+      end
     end
 
     as_a_project_admin do

--- a/test/mailers/project_mailer_test.rb
+++ b/test/mailers/project_mailer_test.rb
@@ -6,11 +6,23 @@ class ProjectMailerTest < ActionMailer::TestCase
   let(:user) { users(:admin) }
   let(:project) { projects(:test) }
 
-  it "contains user and project name" do
-    ProjectMailer.created_email(user, project).deliver_now
-    mail_sent = ActionMailer::Base.deliveries.last
-    assert mail_sent.subject.include?('Project')
-    assert mail_sent.body.include?('Admin')
-    assert mail_sent.body.include?('Project')
+  describe "#created_email" do
+    it "contains user and project name" do
+      ProjectMailer.created_email(user, project).deliver_now
+      mail_sent = ActionMailer::Base.deliveries.last
+      assert mail_sent.subject.include?('Project')
+      assert mail_sent.body.include?('Admin')
+      assert mail_sent.body.include?('Project')
+    end
+  end
+
+  describe "#deleted_email" do
+    it "contains user and project name" do
+      ProjectMailer.deleted_email(user, project).deliver_now
+      mail_sent = ActionMailer::Base.deliveries.last
+      assert mail_sent.subject.include?('Project')
+      assert mail_sent.body.include?('Admin')
+      assert mail_sent.body.include?('Project')
+    end
   end
 end


### PR DESCRIPTION
Compliance team wanted an email notification when projects are deleted

* Add an email notification to Projects#destroy
* Uses PROJECT_CREATED_NOTIFY_ADDRESS for Projects#create if a separate PROJECT_DELETED_NOTIFY_ADDRESS is not setup

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:  SAMSON-253

### Risks
- Level: Low
