### PR TITLE
Allow creation of deployments on behalf of another user

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -3,7 +3,7 @@ class DeploysController < ApplicationController
 
   skip_before_action :require_project, only: [:active, :active_count, :changeset]
 
-  before_action :authorize_project_deployer!, only: [:new, :create, :confirm, :buddy_check, :destroy]
+  before_action :authorize_project_deployer!, only: [:new, :confirm, :buddy_check, :destroy]
   before_action :find_deploy, except: [:index, :active, :active_count, :new, :create, :confirm, :search]
   before_action :stage, only: :new
 
@@ -94,7 +94,9 @@ class DeploysController < ApplicationController
   end
 
   def create
-    creator = params[:on_behalf] ? User.find_by_token(params[:on_behalf]) : current_user
+    puts params[:on_behalf] if params[:on_behalf].present?
+    creator = params[:on_behalf].present? ? User.find_by_token(params[:on_behalf]) : current_user
+    unauthorized! if creator.nil? || !creator.deployer_for?(current_project)
     deploy_service = DeployService.new(creator)
     @deploy = deploy_service.deploy!(stage, deploy_params)
 

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -94,7 +94,8 @@ class DeploysController < ApplicationController
   end
 
   def create
-    deploy_service = DeployService.new(current_user)
+    creator = params[:on_behalf] ? User.find_by_token(params[:on_behalf]) : current_user
+    deploy_service = DeployService.new(creator)
     @deploy = deploy_service.deploy!(stage, deploy_params)
 
     respond_to do |format|
@@ -156,7 +157,7 @@ class DeploysController < ApplicationController
   protected
 
   def deploy_permitted_params
-    [:reference, :stage_id] + Samson::Hooks.fire(:deploy_permitted_params)
+    [:reference, :stage_id, :on_behalf] + Samson::Hooks.fire(:deploy_permitted_params)
   end
 
   def reference

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -94,7 +94,6 @@ class DeploysController < ApplicationController
   end
 
   def create
-    puts params[:on_behalf] if params[:on_behalf].present?
     creator = params[:on_behalf].present? ? User.find_by_token(params[:on_behalf]) : current_user
     unauthorized! if creator.nil? || !creator.deployer_for?(current_project)
     deploy_service = DeployService.new(creator)

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -240,8 +240,29 @@ describe DeploysController do
       end
     end
 
+    describe "a POST to :create on behalf of a deployer" do
+      let(:params) { { deploy: { reference: 'master' } } }
+
+      before do
+        deploy_service.stubs(:deploy!).capture(deploy_called).returns(deploy)
+        post :create, params.merge(
+          project_id: project.to_param,
+          stage_id: stage.to_param,
+          format: :json,
+          on_behalf: 'deployertoken'
+        )
+      end
+
+      it "creates a deploy that belongs to the deployer" do
+        this_deploy = Deploy.find_by_id JSON.parse(@response.body)['id']
+        this_deploy.job.user.must_equal users(:deployer)
+      end
+    end
+
     unauthorized :get, :new, project_id: :foo, stage_id: 2
     unauthorized :post, :create, project_id: :foo, stage_id: 2
+    unauthorized :post, :create, project_id: :foo, stage_id: 2, on_behalf: 'viewertoken'
+    unauthorized :post, :create, project_id: :foo, stage_id: 2, on_behalf: 'nonexistent'
     unauthorized :post, :buddy_check, project_id: :foo, id: 1
     unauthorized :delete, :destroy, project_id: :foo, id: 1
   end

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -241,16 +241,14 @@ describe DeploysController do
     end
 
     describe "a POST to :create on behalf of a deployer" do
-      let(:params) { { deploy: { reference: 'master' } } }
-
       before do
         deploy_service.stubs(:deploy!).capture(deploy_called).returns(deploy)
-        post :create, params.merge(
+        post :create,
+          deploy: { reference: 'master' },
           project_id: project.to_param,
           stage_id: stage.to_param,
           format: :json,
           on_behalf: 'deployertoken'
-        )
       end
 
       it "creates a deploy that belongs to the deployer" do
@@ -403,4 +401,8 @@ describe DeploysController do
       end
     end
   end
+
+  unauthorized :post, :create, project_id: :foo, stage_id: 2, on_behalf: 'viewertoken'
+  unauthorized :post, :create, project_id: :foo, stage_id: 2, on_behalf: 'nonexistent'
+  unauthorized :post, :create, project_id: :foo, stage_id: 2, on_behalf: 'deployertoken'
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -16,6 +16,7 @@ deployer:
   email: "deployer@example.com"
   role_id: <%= Role::DEPLOYER.id %>
   external_id: 'google-2'
+  token: deployertoken
 
 deployer_buddy:
   name: "DeployerBuddy"
@@ -28,6 +29,7 @@ viewer:
   email: "viewer@example.com"
   role_id: <%= Role::VIEWER.id %>
   external_id: 'google-3'
+  token: viewertoken
 
 github_viewer:
   name: "GitHub Viewer"


### PR DESCRIPTION
This allows an authenticated user to create a deployment on behalf of another user. The use case here is a chat bot, where the interaction would look like this:

> [user]: @bot, deploy inbox to production
> [bot]: @user: 👍  https://samson.domain.tld/projects/foobar/deploys/2342

…and that deployment would belong to `user`, not to the robot. All existing permissions checks are obeyed, and this does not bypass the buddy check.

/cc @zendesk/samson

### Tasks
 - [x] Determine deploy creator by token if provided
 - [x] Tests
 - [ ] :+1: from team

### Risks
- Level: Low, pending review from security team

