### PR TITLE
show repository redirects instead of failing with strange errors

### DIFF
--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -38,6 +38,7 @@ describe Changeset do
       Octokit::NotFound => "GitHub: Not found",
       Octokit::Unauthorized => "GitHub: Unauthorized",
       Octokit::InternalServerError => "GitHub: Internal server error",
+      Octokit::RepositoryUnavailable => "GitHub: Repository unavailable", # used to signal redirects too
       Faraday::ConnectionFailed.new("Oh no") => "GitHub: Oh no"
     }.each do |exception, message|
       it "catches #{exception} exceptions" do
@@ -45,6 +46,12 @@ describe Changeset do
         comparison = Changeset.new("foo/bar", "a", "b").comparison
         comparison.error.must_equal message
       end
+    end
+
+    # tests config/initializers/octokit.rb Octokit::RedirectAsError
+    it "converts a redirect into a NullComparison" do
+      stub_github_api("repos/foo/bar/branches/master", {}, 301)
+      Changeset.new("foo/bar", "a", "master").comparison.class.must_equal Changeset::NullComparison
     end
   end
 


### PR DESCRIPTION
before:
comparison returns a Changeset object that has nil files/commits and causes all kinds of errors

after:
changeset causes an exception and is converted to a null-comparisson and then shows this in the UI
```
GitHub: Get https://api.github.com/repos/bar/compare/9fb1144014345bc5c4daf2fb2b87456b2d0301e9...grosser/move: 301 moved permanently // see: https://developer.github.com/v3/#http redirects
```

@zendesk/paas 