### PR TITLE
Set reference max width and remove old ng-controller ref

### DIFF
--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -1,0 +1,6 @@
+.dashboard-cell {
+  max-width: 7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/views/dashboards/_dashboard_table_row.html.erb
+++ b/app/views/dashboards/_dashboard_table_row.html.erb
@@ -2,6 +2,6 @@
   <td><%= link_to project.name, project %></td>
 
   <% @deploy_groups.each do |deploy_group| %>
-    <td><%= display_version(project.id, deploy_group.id) %></td>
+    <td class="dashboard-cell"><%= display_version(project.id, deploy_group.id) %></td>
   <% end %>
 </tr>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @environment.name %></h1>
 
-<section ng-controller="DashboardsCtrl">
+<section>
   <p style="float: right;">
     <a class="toggle" data-target="tr.no-deploys" href="#">Toggle Projects without Deploys</a>
   </p>


### PR DESCRIPTION
* Limit width of displayed reference to 7REMS and overflow of ellipsis.  Hovering over reference should show full value
* Remove old ng-controler reference


Old Look:
<img width="1090" alt="screen shot 2016-06-23 at 10 42 46 am" src="https://cloud.githubusercontent.com/assets/11447948/16313778/a3b79424-392f-11e6-9390-db3ce255241a.png">

New Look:
<img width="1133" alt="screen shot 2016-06-23 at 11 41 30 am" src="https://cloud.githubusercontent.com/assets/11447948/16315514/7d4e29da-3937-11e6-8cdd-f4ca0f01603a.png">


/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

