### PR TITLE
dry up/clean up RoleConfigFile

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -37,22 +37,37 @@ module Kubernetes
     def self.seed!(project, git_ref)
       kubernetes_config_files_in_repo(project, git_ref).each do |config_file|
         scope = where(project: project)
-        next if scope.where(config_file: config_file.file_path).exists?
-
-        service_name = config_file.service && config_file.service.metadata.name
-
-        if service_name && where(service_name: service_name).exists?
-          service_name << "#{GENERATED}#{rand(9999999)}"
+        next if scope.where(config_file: config_file.path).exists?
+        begin
+          next unless deploy = config_file.deploy
+        rescue Samson::Hooks::UserError
+          next
         end
 
-        name = config_file.deployment.metadata.labels.try(:role) || File.basename(config_file.file_path).sub(/\..*/, '')
+        # deploy
+        name = deploy.fetch(:metadata, {}).fetch(:labels, {})[:role] ||
+          File.basename(config_file.path).split('.', 2).first
+        deploy_strategy = deploy.fetch(:spec, {}).fetch(:strategy, {})[:type] || 'RollingUpdate'
+
+        # service
+        begin
+          service = config_file.service
+        rescue Samson::Hooks::UserError
+          next
+        end
+        if service
+          service_name = service[:metadata][:name]
+          if where(service_name: service_name).exists?
+            service_name << "#{GENERATED}#{rand(9999999)}"
+          end
+        end
 
         create!(
           project: project,
-          config_file: config_file.file_path,
+          config_file: config_file.path,
           name: name,
           service_name: service_name,
-          deploy_strategy: config_file.deployment.strategy_type
+          deploy_strategy: deploy_strategy
         )
       end
     end
@@ -60,13 +75,13 @@ module Kubernetes
     def self.configured_for_project(project, git_sha)
       known = not_deleted.where(project: project)
 
-      necessary_role_configs = kubernetes_config_files_in_repo(project, git_sha).map(&:file_path)
-      necessary_role_configs.map do |file|
-        known.detect { |r| r.config_file == file } || begin
+      necessary_role_configs = kubernetes_config_files_in_repo(project, git_sha).map(&:path)
+      necessary_role_configs.map do |path|
+        known.detect { |r| r.config_file == path } || begin
           url = AppRoutes.url_helpers.project_kubernetes_roles_url(project)
           raise(
             Samson::Hooks::UserError,
-            "No role for #{file} is configured. Add it on kubernetes Roles tab #{url}"
+            "No role for #{path} is configured. Add it on kubernetes Roles tab #{url}"
           )
         end
       end
@@ -74,13 +89,8 @@ module Kubernetes
 
     def defaults
       return unless raw_template = project.repository.file_content(config_file, 'HEAD', pull: false)
-      begin
-        deploy = ReleaseDoc.deploy_template(raw_template, config_file)
-      rescue Samson::Hooks::UserError
-        return
-      end
-
-      replicas = deploy[:spec][:replicas]
+      deploy = RoleConfigFile.new(raw_template, config_file).deploy || return
+      replicas = deploy.fetch(:spec, {})[:replicas]
 
       return unless limits = deploy[:spec][:template][:spec][:containers].first.fetch(:resources, {})[:limits]
       return unless cpu = parse_resource_value(limits[:cpu])
@@ -106,9 +116,9 @@ module Kubernetes
         path = 'kubernetes'
         files = project.repository.file_content(path, git_ref) || []
         files = files.split("\n").grep(/\.(yml|yaml|json)$/).map { |f| "#{path}/#{f}" }
-        files.map do |file|
-          file_contents = project.repository.file_content file, git_ref
-          Kubernetes::RoleConfigFile.new(file_contents, file)
+        files.map do |path|
+          file_contents = project.repository.file_content path, git_ref
+          Kubernetes::RoleConfigFile.new(file_contents, path)
         end
       end
     end

--- a/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
@@ -1,6 +1,6 @@
 module Kubernetes
   class RoleVerifier
-    DEPLOYISH = ['Deployment', 'DaemonSet'].freeze
+    DEPLOYISH = RoleConfigFile::DEPLOY_KINDS
 
     def initialize(role_definition)
       @errors = []
@@ -25,7 +25,7 @@ module Kubernetes
     end
 
     def verify_deployish
-      expected = ['Deployment', 'DaemonSet']
+      expected = DEPLOYISH
       return if (map_attributes([:kind]) & expected).any?
       @errors << "Did not include supported kinds: #{expected.join(", ")}"
     end
@@ -85,7 +85,7 @@ module Kubernetes
       deployish = @elements.select { |e| DEPLOYISH.include?(e['kind']) }
       containers = map_attributes([:spec, :template, :spec, :containers], elements: deployish)
       return if containers.all? { |c| c.is_a?(Array) && c.size >= 1 }
-      @errors << "Deployments and DaemonSets need at least 1 container"
+      @errors << "#{DEPLOYISH.join(" and ")} need at least 1 container"
     end
 
     def map_attributes(path, elements: @elements, array: :all)

--- a/plugins/kubernetes/test/models/kubernetes/deploy_yaml_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_yaml_test.rb
@@ -70,7 +70,7 @@ describe Kubernetes::DeployYaml do
         e = assert_raises Samson::Hooks::UserError do
           yaml.to_hash
         end
-        e.message.must_include "has 0 Deployment sections, having 1 section is valid"
+        e.message.must_include "included 0 "
       end
 
       it "fails when multiple deployment sections are present" do
@@ -78,7 +78,7 @@ describe Kubernetes::DeployYaml do
         e = assert_raises Samson::Hooks::UserError do
           yaml.to_hash
         end
-        e.message.must_include "has 2 Deployment sections, having 1 section is valid"
+        e.message.must_include "included 2 objects"
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -43,7 +43,7 @@ describe Kubernetes::ReleaseDoc do
         e = assert_raises Samson::Hooks::UserError do
           doc.ensure_service
         end
-        e.message.must_equal "Template kubernetes/app_server.yml has 0 services, having 1 section is valid."
+        e.message.must_equal "Config file kubernetes/app_server.yml included 0 objects of kind Service, 1 is supported"
       end
 
       it "fails when multiple services are defined and we would only ensure the first one" do
@@ -52,7 +52,7 @@ describe Kubernetes::ReleaseDoc do
         e = assert_raises Samson::Hooks::UserError do
           doc.ensure_service
         end
-        e.message.must_equal "Template kubernetes/app_server.yml has 2 services, having 1 section is valid."
+        e.message.must_equal "Config file kubernetes/app_server.yml included 2 objects of kind Service, 1 is supported"
       end
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -3,85 +3,84 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Kubernetes::RoleConfigFile do
-  let(:contents) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
-  let(:config_file) { Kubernetes::RoleConfigFile.new(contents, 'some-file.yml') }
+  let(:content) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
+  let(:config_file) { Kubernetes::RoleConfigFile.new(content, 'some-file.yml') }
 
-  describe "#deployment" do
-    it 'loads a deployment with its contents' do
-      config_file.deployment.wont_be_nil
-
-      # Labels
-      config_file.deployment.metadata.labels.role.must_equal 'some-role'
-
-      # Replicas
-      config_file.deployment.spec.replicas.must_equal 2
-
-      # Selector
-      config_file.deployment.spec.selector.matchLabels.project.must_equal 'some-project'
-      config_file.deployment.spec.selector.matchLabels.role.must_equal 'some-role'
-
-      # Pod Template
-      config_file.deployment.spec.template.metadata.name.must_equal 'some-project-pod'
-      config_file.deployment.spec.template.metadata.labels.project.must_equal 'some-project'
-      config_file.deployment.spec.template.metadata.labels.role.must_equal 'some-role'
-    end
-
-    it "parses a Daemonset" do
-      assert contents.sub!('Deployment', 'DaemonSet')
-      config_file.deployment.spec.replicas.must_equal 2
-    end
-
-    # TODO: maybe make this consistent and move the raise outside ...
-    it "raises when no deployment is found" do
-      assert contents.sub!('Deployment', 'SomethingElse')
-      e = assert_raises RuntimeError do
-        config_file.deployment
+  describe "#initialize" do
+    it "fails with a message that points to the broken file" do
+      e = assert_raises Samson::Hooks::UserError do
+        Kubernetes::RoleConfigFile.new(content, 'some-file.json')
       end
-      e.message.must_include 'Deployment specification missing in the configuration file'
+      e.message.must_include 'some-file.json'
+    end
+  end
+
+  describe "#deploy" do
+    it 'finds a Deployment' do
+      config_file.deploy[:kind].must_equal 'Deployment'
     end
 
-    it 'tells which file failed when there is an error' do
-      Rails.logger.expects(:error).with { |m| m.must_include 'some-file.yml'; true }
-      Kubernetes::RoleConfigFile::Deployment.expects(:new).raises
-      assert_raises(RuntimeError) { config_file.deployment }
+    it "finds a Daemonset" do
+      assert content.sub!('Deployment', 'DaemonSet')
+      config_file.deploy[:kind].must_equal 'DaemonSet'
     end
 
-    describe "#strategy_type" do
-      it "defaults" do
-        config_file.deployment.strategy_type.must_equal 'RollingUpdate'
-      end
+    it "ignores others" do
+      assert content.sub!('Deployment', 'SomethingElse')
+      config_file.deploy.must_equal nil
+    end
 
-      it "uses the set value" do
-        assert contents.sub!('spec:', "spec:\n  strategy:\n    type: Foobar")
-        config_file.deployment.strategy_type.must_equal 'Foobar'
+    # general purpose assertions that also apply to all other types
+    it "passes when required and there" do
+      config_file.deploy(required: true)[:kind].must_equal 'Deployment'
+    end
+
+    it "fails when required and not there" do
+      assert content.sub!('Deployment', 'SomethingElse')
+      e = assert_raises Samson::Hooks::UserError do
+        config_file.deploy(required: true)
       end
+      e.message.must_equal(
+        "Config file some-file.yml included 0 objects of kind Deployment or DaemonSet, 1 is supported"
+      )
+    end
+
+    it "allows deep symbol access" do
+      config_file.deploy.fetch(:spec).fetch(:selector).fetch(:matchLabels).fetch(:project).must_equal 'some-project'
+    end
+
+    it "fails when there are multiple, which would be unsupported" do
+      assert content.sub!('Service', 'DaemonSet')
+      e = assert_raises Samson::Hooks::UserError do
+        config_file.deploy
+      end
+      e.message.must_equal(
+        "Config file some-file.yml included 2 objects of kind Deployment or DaemonSet, 1 or none are supported"
+      )
     end
   end
 
   describe "#service" do
-    it 'loads a service with its contents' do
-      config_file.service.wont_be_nil
-
-      # Service Name
-      config_file.service.metadata.name.must_equal 'some-project'
-
-      # Labels
-      config_file.service.metadata.labels.project.must_equal 'some-project'
-
-      # Selector
-      config_file.service.spec.selector.project.must_equal 'some-project'
-      config_file.service.spec.selector.role.must_equal 'some-role'
+    it 'loads a service with its content' do
+      config_file.service[:kind].must_equal 'Service'
     end
 
     it 'is nil when no service is found' do
-      assert contents.sub!('Service', 'SomethingElse')
+      assert content.sub!('Service', 'SomethingElse')
       config_file.service.must_equal nil
     end
+  end
 
-    it 'tells which file failed when there is an error' do
-      Rails.logger.expects(:error).with { |m| m.must_include 'some-file.yml'; true }
-      Kubernetes::RoleConfigFile::Service.expects(:new).raises
-      assert_raises(RuntimeError) { config_file.service }
+  describe "#job" do
+    before { assert content.sub!('Service', 'Job') }
+
+    it 'loads a job' do
+      config_file.job[:kind].must_equal 'Job'
+    end
+
+    it 'is nil when no job is found' do
+      assert content.sub!('Job', 'Service')
+      config_file.job.must_equal nil
     end
   end
 end

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -122,6 +122,42 @@ describe Kubernetes::Role do
       end
     end
 
+    describe "without a deploy" do
+      before do
+        config_content.shift
+        write_config 'kubernetes/a.json', config_content.to_json
+      end
+
+      it 'creates no role' do
+        Kubernetes::Role.seed! project, 'HEAD'
+        project.kubernetes_roles.must_equal []
+      end
+    end
+
+    describe "with invalid deploy" do
+      before do
+        config_content.push config_content.first
+        write_config 'kubernetes/a.json', config_content.to_json
+      end
+
+      it 'creates no role' do
+        Kubernetes::Role.seed! project, 'HEAD'
+        project.kubernetes_roles.must_equal []
+      end
+    end
+
+    describe "with invalid service" do
+      before do
+        config_content.push config_content.last
+        write_config 'kubernetes/a.json', config_content.to_json
+      end
+
+      it 'creates no role' do
+        Kubernetes::Role.seed! project, 'HEAD'
+        project.kubernetes_roles.must_equal []
+      end
+    end
+
     it "reads other file types" do
       write_config 'kubernetes/a.json', config_content.to_json
       Kubernetes::Role.seed! project, 'HEAD'

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -92,7 +92,7 @@ describe Kubernetes::RoleVerifier do
 
     it "reports missing containers" do
       role.first[:spec][:template][:spec].delete(:containers)
-      errors.must_include "Deployments and DaemonSets need at least 1 container"
+      errors.must_include "Deployment and DaemonSet need at least 1 container"
     end
 
     describe 'inconsistent labels' do


### PR DESCRIPTION
 - make role config simpler and only return hashes (no more recursive structs)
 - ignore configs without deploys / with broken deploys or services while seeding
 - reuse role config in release-doc

@zendesk/paas 