### PR TITLE
make sure that job.commit is always specified

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -112,7 +112,7 @@ class BuildsController < ApplicationController
         current_project.repository.update_local_cache!
       end
 
-      current_project.repository.commit_from_ref(new_build_params[:git_ref], length: nil)
+      current_project.repository.commit_from_ref(new_build_params[:git_ref])
     end
   end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -78,7 +78,7 @@ class Build < ActiveRecord::Base
     end
 
     if git_ref.present?
-      commit = project.repository.commit_from_ref(git_ref, length: nil)
+      commit = project.repository.commit_from_ref(git_ref)
       if commit
         self.git_sha = commit unless git_sha.present?
       else

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -47,7 +47,7 @@ class GitRepository
 
   def commit_from_ref(git_reference, length: 7)
     return unless ensure_local_cache!
-    command = ['git', 'describe', '--long', '--tags', '--all', "--abbrev=#{length || 40}", git_reference]
+    command = ['git', 'describe', '--always', '--long', '--tags', '--all', "--abbrev=#{length || 40}", git_reference]
     return unless output = capture_stdout(*command)
     output.split('-').last.sub(/^g/, '')
   end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -45,11 +45,10 @@ class GitRepository
   end
   add_method_tracer :clone!
 
-  def commit_from_ref(git_reference, length: 7)
+  def commit_from_ref(git_reference)
     return unless ensure_local_cache!
-    command = ['git', 'describe', '--always', '--long', '--tags', '--all', "--abbrev=#{length || 40}", git_reference]
-    return unless output = capture_stdout(*command)
-    output.split('-').last.sub(/^g/, '')
+    command = ['git', 'rev-parse', "#{git_reference}^{commit}"]
+    capture_stdout(*command)
   end
 
   def tag_from_ref(git_reference)

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -173,7 +173,7 @@ class JobExecution
       return false unless @repository.setup!(dir, @reference)
       commit = @repository.commit_from_ref(@reference, length: nil)
       tag = @repository.tag_from_ref(@reference)
-      @job.update_git_references!(commit: commit, tag: tag)
+      @job.update_git_references!(commit: commit, tag: tag) if commit || tag
     end
 
     if locked

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -171,9 +171,9 @@ class JobExecution
   def setup!(dir)
     locked = lock_project do
       return false unless @repository.setup!(dir, @reference)
-      commit = @repository.commit_from_ref(@reference, length: nil)
+      commit = @repository.commit_from_ref(@reference)
       tag = @repository.tag_from_ref(@reference)
-      @job.update_git_references!(commit: commit, tag: tag) if commit || tag
+      @job.update_git_references!(commit: commit, tag: tag)
     end
 
     if locked

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -94,7 +94,7 @@ class Stage < ActiveRecord::Base
 
   def create_deploy(user, attributes = {})
     deploys.create(attributes.merge(release: !no_code_deployed)) do |deploy|
-      deploy.build_job(project: project, user: user, command: script)
+      deploy.build_job(project: project, user: user, command: script, commit: deploy.reference)
     end
   end
 

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -108,6 +108,13 @@ describe GitRepository do
       repository.commit_from_ref('master', length: nil).must_match /^[0-9a-f]{40}$/
     end
 
+    it 'returns the full commit id with nil length when given a short commit id' do
+      create_repo_with_tags
+      repository.clone!
+      short_commit_id = (execute_on_remote_repo "git rev-parse --short HEAD").strip
+      repository.commit_from_ref(short_commit_id, length: nil).must_match /^[0-9a-f]{40}$/
+    end
+
     it 'returns nil if ref does not exist' do
       create_repo_with_tags
       repository.clone!

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -161,6 +161,7 @@ describe Stage do
 
     it "creates a new job" do
       deploy = subject.create_deploy(user, reference: "foo")
+      deploy.job.commit.must_equal "foo"
       deploy.job.user.must_equal user
     end
 


### PR DESCRIPTION
After the change in https://github.com/zendesk/samson/pull/1082, Samson fails to deploy from a commit hash, with the following error:

```
AIRBRAKE: NoMethodError - undefined method `shellescape' for nil:NilClass - /Users/zliu/src/zendesk/samson/app/models/job_execution.rb:212:in `block in commands'
/Users/zliu/src/zendesk/samson/app/models/job_execution.rb:210:in `each'
/Users/zliu/src/zendesk/samson/app/models/job_execution.rb:210:in `map'
/Users/zliu/src/zendesk/samson/app/models/job_execution.rb:210:in `commands'
/Users/zliu/src/zendesk/samson/app/models/job_execution.rb:148:in `execute!'
/Users/zliu/src/zendesk/samson/app/models/job_execution.rb:118:in `block in run!'
```

The value of `REVISION` is `nil`. It comes from `job.commit`, which happens to be `nil` if the job is created from `stage.create_deploy`.

- supply commit to job when creating a deploy for a stage
- make commit_from_git return long hash when given a hash
- only update git references of a job when either commit or tag is not nil

/cc @zendesk/samson @zendesk/vulcan

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

