### PR TITLE
SAMSON-254 added deployUrl as a fourth param to Jenkins builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,8 @@ GITHUB_TOKEN=
 ## Kubernets sidecar
 # SECRET_SIDECAR_IMAGE= # optional, path to the docker image that built from the secret_puller service.  service will be disabled w/o it
 
+
+## Jenkins, required for triggering Jenkins build after deployment
+# JENKINS_URL= # server_url of jenkins
+# JENKINS_USERNAME= # user id
+# JENKINS_API_KEY= # API Token from user / Configure page

--- a/.env.example
+++ b/.env.example
@@ -107,7 +107,7 @@ GITHUB_TOKEN=
 # SECRET_SIDECAR_IMAGE= # optional, path to the docker image that built from the secret_puller service.  service will be disabled w/o it
 
 
-## Jenkins, required for triggering Jenkins build after deployment
+## Jenkins, optional, for triggering Jenkins builds after deployment
 # JENKINS_URL= # server_url of jenkins
 # JENKINS_USERNAME= # user id
 # JENKINS_API_KEY= # API Token from user / Configure page

--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/LineLength
 require 'jenkins_api_client'
 
 module Samson
@@ -17,7 +16,12 @@ module Samson
     def build
       opts = {'build_start_timeout' => 60}
       originated_from = deploy.project.name + '_' + deploy.stage.name + '_' + deploy.reference
-      client.job.build(job_name, {'buildStartedBy' => deploy.user.name, 'originatedFrom' => originated_from, 'commit' => deploy.job.commit}, opts).to_i
+      client.job.build(job_name, {
+        buildStartedBy: deploy.user.name,
+        originatedFrom: originated_from,
+        commit: deploy.job.commit,
+        deployUrl: AppRoutes.url_helpers.project_deploy_url(deploy.project, deploy)
+      }, opts).to_i
     rescue Timeout::Error => e
       "Jenkins '#{job_name}' build failed to start in a timely manner.  #{e.class} #{e}"
     rescue JenkinsApi::Exceptions::ApiException => e

--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -20,7 +20,7 @@ module Samson
         buildStartedBy: deploy.user.name,
         originatedFrom: originated_from,
         commit: deploy.job.commit,
-        deployUrl: AppRoutes.url_helpers.project_deploy_url(deploy.project, deploy)
+        deployUrl: deploy.url
       }, opts).to_i
     rescue Timeout::Error => e
       "Jenkins '#{job_name}' build failed to start in a timely manner.  #{e.class} #{e}"

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -19,7 +19,7 @@ describe Samson::Jenkins do
   def stub_build_with_parameters
     stub_request(:post, "http://www.test-url.com/job/test_job/buildWithParameters").
       with(
-        body: {"buildStartedBy" => "Super Admin", "originatedFrom" => "Project_Staging_staging", "commit" => "staging", "deployUrl" => "http://www.test-url.com/projects/foo/deploys/178003093"},
+        body: {"buildStartedBy" => "Super Admin", "originatedFrom" => "Project_Staging_staging", "commit" => "staging", "deployUrl" => "http://www.test-url.com/projects/foo/deploys/#{deploy.id}"},
         headers: {'Authorization' => 'Basic dXNlckB0ZXN0LmNvbTpqYXBpa2V5'}
       ).
       to_return(status: 200, body: "", headers: {}).to_timeout

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -19,7 +19,7 @@ describe Samson::Jenkins do
   def stub_build_with_parameters
     stub_request(:post, "http://www.test-url.com/job/test_job/buildWithParameters").
       with(
-        body: {"buildStartedBy" => "Super Admin", "originatedFrom" => "Project_Staging_staging", "commit" => "staging"},
+        body: {"buildStartedBy" => "Super Admin", "originatedFrom" => "Project_Staging_staging", "commit" => "staging", "deployUrl" => "http://www.test-url.com/projects/foo/deploys/178003093"},
         headers: {'Authorization' => 'Basic dXNlckB0ZXN0LmNvbTpqYXBpa2V5'}
       ).
       to_return(status: 200, body: "", headers: {}).to_timeout


### PR DESCRIPTION
- added a new build param `deployUrl` for Jenkins builds
- added JENKINS related env vars into .env.example

/cc @zendesk/samson @zendesk/vulcan

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-254

### Risks
- Level: Low
