### PR TITLE
Added reference to the exposed ENV vars in deploy

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -194,6 +194,7 @@ class JobExecution
       PROJECT_NAME: @job.project.name,
       PROJECT_PERMALINK: @job.project.permalink,
       PROJECT_REPOSITORY: @job.project.repository_url,
+      REFERENCE: @reference,
       REVISION: @job.commit,
       TAG: (@job.tag || @job.commit),
       CACHE_DIR: artifact_cache_dir

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -136,6 +136,7 @@ describe JobExecution do
     lines.must_include "DEPLOYER=jdoe@test.com"
     lines.must_include "DEPLOYER_EMAIL=jdoe@test.com"
     lines.must_include "DEPLOYER_NAME=John Doe"
+    lines.must_include "REFERENCE=master"
     lines.must_include "REVISION=#{job.commit}"
     lines.must_include "TAG=v1"
     lines.must_include "FOO=bar"


### PR DESCRIPTION
After https://github.com/zendesk/samson/pull/1082, the `REVISION` is now derived from the user entered git reference, instead of just using that git reference directly. When the git reference is a branch name or a tag on a commit that has multiple tags, the derived `REVISION` would be a git commit hash, which is different from the original git reference. Because we only expose `REVISION` to the ENV during the deploy, the original git reference entered by the deployer might not be available to deploy script.

Sometimes the deploy script does need to know the original reference. Thus, this PR explicitly adds the original reference to the list of ENV Vars exposed by job execution context.

![image](https://cloud.githubusercontent.com/assets/314392/16420040/664cf44c-3d82-11e6-849e-10626c0a8572.png)

/cc @zendesk/samson @zendesk/vulcan @tgohn @yihongang 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Very Low

