### PR TITLE
validate every template we read, removing overhead of checks accross …

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/role_verifications_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/role_verifications_controller.rb
@@ -4,7 +4,12 @@ class Kubernetes::RoleVerificationsController < ApplicationController
 
   def create
     input = params[:role].presence || '{}'
-    unless @errors = Kubernetes::RoleVerifier.new(input).verify
+    filename = (input.start_with?('{', '[') ? 'test.json' : 'test.yml')
+    begin
+      Kubernetes::RoleConfigFile.new(input, filename)
+    rescue Samson::Hooks::UserError
+      @errors = $!.message
+    else
       flash.now[:notice] = "Valid!"
     end
     render :new

--- a/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_yaml.rb
@@ -218,15 +218,7 @@ module Kubernetes
 
     def container
       @container ||= begin
-        containers = template[:spec].fetch(:template, {}).fetch(:spec, {}).fetch(:containers, [])
-        if containers.empty?
-          # TODO: support building and replacement for multiple containers
-          raise(
-            Samson::Hooks::UserError,
-            "Template #{@doc.template_name} has #{containers.size} containers, having 1 section is valid."
-          )
-        end
-        containers.first
+        template[:spec].fetch(:template, {}).fetch(:spec, {}).fetch(:containers, []).first
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
@@ -3,20 +3,26 @@ module Kubernetes
     DEPLOYISH = RoleConfigFile::DEPLOY_KINDS
     JOBS = RoleConfigFile::JOB_KINDS
 
-    def initialize(role_definition)
+    SUPPORTED_KINDS = [
+      ['Deployment'],
+      ['DaemonSet'],
+      ['Deployment', 'Service'],
+      ['Job']
+    ].freeze
+
+    def initialize(elements)
       @errors = []
-      @elements = load(role_definition)
+      @elements = elements.compact
     end
 
     def verify
       return @errors if @errors.any?
+      return ["No content found"] if @elements.blank?
       verify_name
-      verify_deployish
+      verify_kinds
       verify_containers
-      verify_no_mixing
       verify_job_container_name
       verify_job_restart_policy
-      verify_service
       verify_numeric_limits
       verify_project_and_role_consistent
       @errors.presence
@@ -28,15 +34,11 @@ module Kubernetes
       @errors << "Needs a metadata.name" unless map_attributes([:metadata, :name]).all?
     end
 
-    def verify_deployish
-      expected = DEPLOYISH + JOBS
-      return if (map_attributes([:kind]) & expected).any?
-      @errors << "Did not include supported kinds: #{expected.join(", ")}"
-    end
-
-    def verify_service
-      return if map_attributes([:kind]).count('Service') <= 1
-      @errors << "Can only have maximum of 1 Service"
+    def verify_kinds
+      kinds = map_attributes([:kind]).sort
+      return if SUPPORTED_KINDS.include?(kinds)
+      supported = SUPPORTED_KINDS.map { |c| c.join(' + ') }.join(', ')
+      @errors << "Unsupported combination of kinds: #{kinds.join(' + ')}, supported combinations are: #{supported}"
     end
 
     # spec actually allows this, but blows up when used
@@ -47,17 +49,6 @@ module Kubernetes
       @errors << "Numeric cpu limits are not supported"
     end
 
-    def load(role_definition)
-      if role_definition.start_with?('{', '[')
-        Array.wrap(JSON.load(role_definition))
-      else
-        YAML.load_stream(role_definition).compact
-      end
-    rescue
-      @errors << "Unable to parse role definition"
-      nil
-    end
-
     def verify_project_and_role_consistent
       labels = @elements.flat_map do |resource|
         kind = resource['kind']
@@ -65,9 +56,13 @@ module Kubernetes
         label_paths =
           case kind
           when 'Service'
-            [['spec', 'selector']]
+            [
+              ['metadata', 'labels'],
+              ['spec', 'selector']
+            ]
           when *DEPLOYISH
             [
+              ['metadata', 'labels'],
               ['spec', 'template', 'metadata', 'labels'],
               ['spec', 'selector', 'matchLabels'],
             ]
@@ -81,13 +76,16 @@ module Kubernetes
           end
 
         label_paths.map do |path|
-          path.inject(resource) { |r, k| r[k] || {} }.slice('project', 'role')
+          found = path.inject(resource) { |r, k| r[k] || {} }.slice('project', 'role')
+          if found.size != 2
+            @errors << "Missing label or role for #{kind} #{path.join('.')}"
+          end
+          found
         end
       end
 
-      labels = labels.uniq
-      return if labels.size == 1 && labels.first.size == 2
-      @errors << "Project and role labels must be consistent accross Deployment/DaemonSet/Service/Job"
+      return if labels.uniq.size == 1
+      @errors << "Project and role labels must be consistent across Deployment/DaemonSet/Service/Job"
     end
 
     def verify_containers
@@ -96,13 +94,6 @@ module Kubernetes
       containers = map_attributes([:spec, :template, :spec, :containers], elements: deployish)
       return if containers.all? { |c| c.is_a?(Array) && c.size >= 1 }
       @errors << "#{expected.join("/")} need at least 1 container"
-    end
-
-    def verify_no_mixing
-      expected = DEPLOYISH + JOBS
-      deployish = @elements.select { |e| expected.include?(e['kind']) }
-      return if deployish.size == 1
-      @errors << "Only 1 item of type #{expected.join('/')} is supported per role"
     end
 
     # job needs a name since we atm do not enforce it's uniqueness like we do for service

--- a/plugins/kubernetes/app/views/kubernetes/role_verifications/new.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/role_verifications/new.html.erb
@@ -3,7 +3,7 @@ Paste role yaml/json here to verify it.
 <% if @errors %>
   <h2>Errors</h2>
   <ul>
-    <% @errors.each do |error| %>
+    <% @errors.split("\n").each do |error| %>
       <li><%= error %></li>
     <% end %>
   </ul>

--- a/plugins/kubernetes/test/controllers/kubernetes/role_verifications_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/role_verifications_controller_test.rb
@@ -24,6 +24,21 @@ describe Kubernetes::RoleVerificationsController do
         assert assigns[:errors]
         assert_template :new
       end
+
+      it "fails nicely with borked template" do
+        post :create, role: "---"
+        assigns[:errors].must_include "Error found when parsing test.yml"
+      end
+
+      it "reports invalid json" do
+        post :create, role: "{oops"
+        assigns[:errors].must_include "Error found when parsing test.json"
+      end
+
+      it "reports invalid yaml" do
+        post :create, role: "}foobar:::::"
+        assigns[:errors].must_include "Error found when parsing test.yml"
+      end
     end
   end
 end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -83,7 +83,7 @@ describe Kubernetes::DeployExecutor do
         namespace: 'staging',
         deploy_group: deploy_group
       )
-      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/deployments/test").
+      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/deployments/some-project-rc").
         to_return(status: 404) # checks for previous deploys ... but there are none
       stub_request(:post, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/deployments").
         to_return(body: "{}") # creates deployment
@@ -245,7 +245,7 @@ describe Kubernetes::DeployExecutor do
           }
         }.to_yaml)
         GitRepository.any_instance.stubs(:file_content).with('kubernetes/app_server.yml', anything).
-          returns(kubernetes_faked_raw_template.to_yaml)
+          returns(read_kubernetes_sample_file('kubernetes_deployment.yml'))
 
         # check if the job already exists ... it does not
         stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/jobs/test").

--- a/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
@@ -53,16 +53,7 @@ describe Kubernetes::DeployGroupRole do
           kubernetes_role: kubernetes_roles(:app_server)
         ).first
       end
-      let(:content) do
-        {
-          'kind' => 'Deployment',
-          'spec' => {
-            'replicas' => 3,
-            'template' =>
-              {'spec' => {'containers' => [{'resources' => {'limits' => {'ram' => '200Mi', 'cpu' => '250m'}}}]}}
-          }
-        }.to_yaml
-      end
+      let(:content) { read_kubernetes_sample_file('kubernetes_deployment.yml') }
 
       before do
         kubernetes_deploy_group_roles(:test_pod100_app_server).delete
@@ -71,9 +62,9 @@ describe Kubernetes::DeployGroupRole do
 
       it "fills in missing roles" do
         assert Kubernetes::DeployGroupRole.seed!(stage)
-        created_role.cpu.must_equal 0.25
-        created_role.ram.must_equal 191
-        created_role.replicas.must_equal 3
+        created_role.cpu.must_equal 0.5
+        created_role.ram.must_equal 95
+        created_role.replicas.must_equal 2
       end
 
       it "does nothing when there is no deployment" do

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -12,7 +12,7 @@ describe Kubernetes::Release do
   let(:project) { projects(:test) }
   let(:app_server) { kubernetes_roles(:app_server) }
   let(:resque_worker) { kubernetes_roles(:resque_worker) }
-  let(:role_config_file) { read_kubernetes_sample_file('kubernetes_role_config_file.yml') }
+  let(:role_config_file) { read_kubernetes_sample_file('kubernetes_deployment.yml') }
 
   describe 'validations' do
     it 'is valid by default' do

--- a/plugins/kubernetes/test/samples/kubernetes_deployment.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_deployment.yml
@@ -37,6 +37,7 @@ metadata:
   name: some-project
   labels:
     project: some-project
+    role: some-role
 spec:
   ports:
   - port: 80

--- a/plugins/kubernetes/test/samples/kubernetes_job.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_job.yml
@@ -1,0 +1,21 @@
+---
+# http://kubernetes.io/docs/user-guide/jobs/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    project: some-project
+    role: job-role
+  name: pi
+spec:
+  template:
+    metadata:
+      labels:
+        project: some-project
+        role: job-role
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl"]
+      restartPolicy: Never

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -103,27 +103,8 @@ class ActiveSupport::TestCase
   end
 
   def kubernetes_fake_raw_template
-    Kubernetes::ReleaseDoc.any_instance.stubs(raw_template: kubernetes_faked_raw_template.to_yaml)
+    Kubernetes::ReleaseDoc.any_instance.stubs(raw_template: read_kubernetes_sample_file('kubernetes_deployment.yml'))
   end
-
-  def kubernetes_faked_raw_template
-    {
-      'kind' => 'Deployment',
-      'spec' => {
-        'template' => {
-          'metadata' => {'labels' => {'pre_defined' => 'foobar', 'project' => 'foobar', 'role' => 'app-server'}},
-          'spec' => {'containers' => [{}]}
-        },
-        'selector' => {'matchLabels' => {'pre_defined' => 'foobar', 'project' => 'foobar', 'role' => 'app-server'}}
-      },
-      'metadata' => {
-        'name' => 'test',
-        'labels' => {'project' => 'foobar', 'role' => 'app-server'}
-      }
-    }
-  end
-
-  private
 
   def read_kubernetes_sample_file(file_name)
     File.read("#{Rails.root}/plugins/kubernetes/test/samples/#{file_name}")


### PR DESCRIPTION
…the codebase

@zendesk/paas 

reading a config file now means verifying it, so we will no longer have any invalid files or need ad-hoc checks all over the place, also simplifies testing

 - enforce only known 'kind' combinations ... Deployment, DaemonSet, Deployment+Service,Job
 - enforce metadata.labels being set for everything