### PR TITLE
make role names valid in kubernetes / make resources have a unique name

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -216,16 +216,18 @@ ActiveRecord::Schema.define(version: 20160629232753) do
   add_index "kubernetes_releases", ["build_id"], name: "index_kubernetes_releases_on_build_id"
 
   create_table "kubernetes_roles", force: :cascade do |t|
-    t.integer  "project_id",   limit: 4,   null: false
-    t.string   "name",         limit: 255, null: false
-    t.string   "config_file",  limit: 255
-    t.string   "service_name", limit: 255
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.integer  "project_id",    limit: 4,   null: false
+    t.string   "name",          limit: 255, null: false
+    t.string   "config_file",   limit: 255
+    t.string   "service_name",  limit: 255
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.datetime "deleted_at"
+    t.string   "resource_name", limit: 255, null: false
   end
 
   add_index "kubernetes_roles", ["project_id"], name: "index_kubernetes_roles_on_project_id", using: :btree
+  add_index "kubernetes_roles", ["resource_name", "deleted_at"], name: "index_kubernetes_roles_on_resource_name_and_deleted_at", unique: true, length: {"resource_name"=>191, "deleted_at"=>nil}, using: :btree
   add_index "kubernetes_roles", ["service_name", "deleted_at"], name: "index_kubernetes_roles_on_service_name_and_deleted_at", unique: true, length: {"service_name"=>191, "deleted_at"=>nil}, using: :btree
 
   create_table "locks", force: :cascade do |t|

--- a/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
@@ -55,6 +55,6 @@ class Kubernetes::RolesController < ApplicationController
   end
 
   def role_params
-    params.require(:kubernetes_role).permit(:name, :config_file, :service_name)
+    params.require(:kubernetes_role).permit(:name, :config_file, :service_name, :resource_name)
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -44,7 +44,7 @@ module Kubernetes
         # FYI per docs it is supposed to use batch api, but extension api works
         job = Kubeclient::Job.new(resource_template)
         if deployed
-          extension_client.delete_job job.metadata.name, job.metadata.namespace
+          extension_client.delete_job kubernetes_role.resource_name, job.metadata.namespace
         end
         extension_client.create_job job
       else
@@ -115,7 +115,7 @@ module Kubernetes
     def deployed
       extension_client.send(
         "get_#{resource_template.fetch('kind').underscore}",
-        resource_template.fetch('metadata').fetch('name'),
+        kubernetes_role.resource_name,
         deploy_group.kubernetes_namespace
       )
     rescue KubeException

--- a/plugins/kubernetes/app/models/kubernetes/resource_template.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_template.rb
@@ -152,9 +152,9 @@ module Kubernetes
           deploy_id: release.deploy_id,
           project_id: release.project_id,
           role_id: role.id,
-          deploy_group: deploy_group.env_value.parameterize,
+          deploy_group: deploy_group.env_value.parameterize.tr('_', '-'),
           revision: release.git_sha,
-          tag: release.git_ref.parameterize
+          tag: release.git_ref.parameterize.tr('_', '-')
         )
       end
     end

--- a/plugins/kubernetes/app/models/kubernetes/resource_template.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_template.rb
@@ -11,6 +11,7 @@ module Kubernetes
     def to_hash
       @to_hash ||= begin
         set_rc_unique_label_key
+        set_name
         set_namespace
         set_replica_target
         set_spec_template_metadata
@@ -121,6 +122,10 @@ module Kubernetes
 
     def set_replica_target
       template[:spec][:replicas] = @doc.replica_target if template[:kind] == 'Deployment'
+    end
+
+    def set_name
+      template[:metadata][:name] = @doc.kubernetes_role.resource_name
     end
 
     def set_namespace

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -14,7 +14,7 @@ module Kubernetes
     }.freeze
 
     self.table_name = 'kubernetes_roles'
-    GENERATED = '-CHANGE-ME-'.freeze
+    GENERATED = '-change-me-'.freeze
 
     has_soft_deletion
 
@@ -28,7 +28,13 @@ module Kubernetes
 
     validates :project, presence: true
     validates :name, presence: true, format: Kubernetes::RoleVerifier::VALID_LABEL
-    validates :service_name, uniqueness: {scope: :deleted_at, allow_nil: true}
+    validates :service_name,
+      uniqueness: {scope: :deleted_at, allow_nil: true},
+      format: Kubernetes::RoleVerifier::VALID_LABEL,
+      allow_nil: true
+    validates :resource_name,
+      uniqueness: {scope: :deleted_at, allow_nil: true},
+      format: Kubernetes::RoleVerifier::VALID_LABEL
 
     scope :not_deleted, -> { where(deleted_at: nil) }
 
@@ -50,10 +56,17 @@ module Kubernetes
           end
         end
 
+        # ensure we have a unique resource name
+        resource_name = deploy.fetch(:metadata).fetch(:name)
+        if where(resource_name: resource_name).exists?
+          resource_name = "#{project.permalink}-#{resource_name}".tr('_', '-')
+        end
+
         create!(
           project: project,
           config_file: config_file.path,
           name: name,
+          resource_name: resource_name,
           service_name: service_name
         )
       end
@@ -90,10 +103,6 @@ module Kubernetes
       ram /= 1024**2 # we store megabyte
 
       {cpu: cpu, ram: ram.round, replicas: replicas}
-    end
-
-    def resource_name
-      "#{project.permalink}-#{name}"
     end
 
     private

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -27,7 +27,7 @@ module Kubernetes
     before_validation :nilify_service_name
 
     validates :project, presence: true
-    validates :name, presence: true
+    validates :name, presence: true, format: Kubernetes::RoleVerifier::VALID_LABEL
     validates :service_name, uniqueness: {scope: :deleted_at, allow_nil: true}
 
     scope :not_deleted, -> { where(deleted_at: nil) }
@@ -92,8 +92,8 @@ module Kubernetes
       {cpu: cpu, ram: ram.round, replicas: replicas}
     end
 
-    def label_name
-      name.parameterize
+    def resource_name
+      "#{project.permalink}-#{name}"
     end
 
     private

--- a/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
@@ -31,7 +31,6 @@ module Kubernetes
 
     private
 
-    # we do not use this directly, but if a template is supposed to be used via kubectl it needs a name
     def verify_name
       @errors << "Needs a metadata.name" unless map_attributes([:metadata, :name]).all?
     end

--- a/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
@@ -24,6 +24,13 @@
     </div>
 
     <div class="form-group">
+      <%= form.label :resource_name, class: "col-lg-2 control-label" %>
+      <div class="col-lg-4">
+        <%= form.text_field :resource_name, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="form-group">
       <div class="col-lg-offset-2 col-lg-10">
         <% if current_user.admin_for?(@project) %>
           <%= form.submit @role.persisted? ? 'Save' : 'Create', class: "btn btn-primary" %>

--- a/plugins/kubernetes/db/migrate/20160629185512_add_resource_name_to_kubernetes_roles.rb
+++ b/plugins/kubernetes/db/migrate/20160629185512_add_resource_name_to_kubernetes_roles.rb
@@ -1,0 +1,64 @@
+class AddResourceNameToKubernetesRoles < ActiveRecord::Migration
+  def up
+    add_column :kubernetes_roles, :resource_name, :string
+    backfill_resource_names
+    change_column_null :kubernetes_roles, :resource_name, false
+    add_index :kubernetes_roles, [:resource_name, :deleted_at], unique: true, length: {resource_name: 191}
+  end
+
+  def down
+    remove_index :kubernetes_roles, [:resource_name, :deleted_at]
+    remove_column :kubernetes_roles, :resource_name
+  end
+
+  private
+
+  # backfill all resource_name values from their last release
+  def backfill_resource_names
+    Kubernetes::Role.where(resource_name: nil).find_each do |role|
+      warn "Role #{role.id} #{role.project.permalink}/#{role.name}"
+      if role.resource_name = parse_resource_name_from_template(role)
+        warn "Using name #{role.resource_name}"
+      else
+        role.resource_name = "#{role.project.permalink}-#{role.name.parameterize}".tr('_', '-')
+        warn "Using generated name #{role.resource_name}"
+      end
+
+      role.save(validate: false)
+    end
+  end
+
+  def parse_resource_name_from_template(role)
+    unless doc = Kubernetes::ReleaseDoc.where(kubernetes_role_id: role.id).last
+      warn "No release doc found"
+      return
+    end
+
+    unless template = doc.send(:raw_template)
+      warn "No file found in git"
+      return
+    end
+
+    unless elements = Array.wrap(Kubernetes::Util.parse_file(template, role.config_file)).compact
+      warn "No resource found in template"
+      return
+    end
+
+    unless resource = elements.detect { |e| ['Deployment', 'DaemonSet', 'Job'].include?(e['kind']) }
+      warn "No name found in resource"
+      return
+    end
+
+    unless name = resource.fetch('metadata', {})['name']
+      warn "no name found in resource"
+      return
+    end
+
+    if Kubernetes::Role.where(resource_name: name).exists?
+      warn "Role with name #{name} already exists"
+      return
+    end
+
+    name
+  end
+end

--- a/plugins/kubernetes/test/controllers/kubernetes/roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/roles_controller_test.rb
@@ -7,9 +7,10 @@ describe Kubernetes::RolesController do
   let(:role) { kubernetes_roles(:app_server) }
   let(:role_params) do
     {
-      name: 'NAME',
-      service_name: 'SERVICE_NAME',
-      config_file: 'dsfsd.yml'
+      name: 'name',
+      service_name: 'service-name',
+      config_file: 'dsfsd.yml',
+      resource_name: 'name-app-server'
     }
   end
 
@@ -71,7 +72,7 @@ describe Kubernetes::RolesController do
         post :create, project_id: project, kubernetes_role: role_params
         role = Kubernetes::Role.last
         assert_redirected_to "/projects/foo/kubernetes/roles"
-        role.name.must_equal 'NAME'
+        role.name.must_equal 'name'
       end
 
       it "renders on failure" do
@@ -85,7 +86,7 @@ describe Kubernetes::RolesController do
       it "updates" do
         put :update, project_id: project, id: role.id, kubernetes_role: role_params
         assert_redirected_to "/projects/foo/kubernetes/roles"
-        role.reload.name.must_equal 'NAME'
+        role.reload.name.must_equal 'name'
       end
 
       it "renders on failure" do

--- a/plugins/kubernetes/test/fixtures/kubernetes/roles.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/roles.yml
@@ -1,10 +1,12 @@
 ---
 app_server:
   project: test
-  name: app_server
+  name: app-server
   config_file: 'kubernetes/app_server.yml'
+  resource_name: test-app-server
 
 resque_worker:
   project: test
-  name: resque_worker
+  name: resque-worker
   config_file: 'kubernetes/resque_worker.yml'
+  resource_name: test-resque-worker

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -53,7 +53,7 @@ describe Kubernetes::ReleaseDoc do
         e = assert_raises Samson::Hooks::UserError do
           doc.ensure_service
         end
-        e.message.must_equal "Service name for role app_server was generated and needs to be changed before deploying."
+        e.message.must_equal "Service name for role app-server was generated and needs to be changed before deploying."
       end
 
       it "fails when service is required by the role, but not defined" do
@@ -133,7 +133,7 @@ describe Kubernetes::ReleaseDoc do
 
       it "deletes and then creates when job exists" do
         client.expects(:get_job).returns true
-        client.expects(:delete_job).with('foo-app_server', 'pod1')
+        client.expects(:delete_job).with('test-app-server', 'pod1')
         client.expects(:create_job)
         doc.deploy
       end
@@ -179,7 +179,7 @@ describe Kubernetes::ReleaseDoc do
 
     it "asks kubernetes for daemon set since we do not know how many nodes it will match" do
       doc.resource_template['kind'] = 'DaemonSet'
-      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/pod1/daemonsets/foo-app_server").
+      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/pod1/daemonsets/test-app-server").
         to_return(body: {status: {desiredNumberScheduled: 3}}.to_json)
       doc.desired_pod_count.must_equal 3
     end

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -133,7 +133,7 @@ describe Kubernetes::ReleaseDoc do
 
       it "deletes and then creates when job exists" do
         client.expects(:get_job).returns true
-        client.expects(:delete_job).with('some-project-rc', 'pod1')
+        client.expects(:delete_job).with('foo-app_server', 'pod1')
         client.expects(:create_job)
         doc.deploy
       end
@@ -179,7 +179,7 @@ describe Kubernetes::ReleaseDoc do
 
     it "asks kubernetes for daemon set since we do not know how many nodes it will match" do
       doc.resource_template['kind'] = 'DaemonSet'
-      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/pod1/daemonsets/some-project-rc").
+      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/pod1/daemonsets/foo-app_server").
         to_return(body: {status: {desiredNumberScheduled: 3}}.to_json)
       doc.desired_pod_count.must_equal 3
     end

--- a/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
@@ -53,7 +53,7 @@ describe Kubernetes::ResourceTemplate do
     end
 
     it "overrides the name" do
-      yaml.to_hash[:metadata][:name].must_equal 'foo-app_server'
+      template.to_hash[:metadata][:name].must_equal 'test-app-server'
     end
 
     describe "containers" do

--- a/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
@@ -52,6 +52,10 @@ describe Kubernetes::ResourceTemplate do
       )
     end
 
+    it "overrides the name" do
+      yaml.to_hash[:metadata][:name].must_equal 'foo-app_server'
+    end
+
     describe "containers" do
       let(:result) { template.to_hash }
       let(:container) { result.fetch(:spec).fetch(:template).fetch(:spec).fetch(:containers).first }

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -115,7 +115,8 @@ describe Kubernetes::Role do
           project: project,
           config_file: 'sdfsdf.yml',
           name: 'sdfsdf',
-          service_name: nil
+          service_name: nil,
+          resource_name: 'ssddssd'
         )
         Kubernetes::Role.seed! project, 'HEAD'
         project.kubernetes_roles.map(&:service_name).must_equal [nil, nil]
@@ -146,6 +147,18 @@ describe Kubernetes::Role do
       end
     end
 
+    it "generates a unique resource_name when metadata.name is already in use" do
+      project.update_column(:permalink, 'foo_bar') # check we remove _ correctly
+      created = Kubernetes::Role.create!(role.attributes)
+      config_content[0]['metadata']['name'] = created.resource_name
+      write_config 'kubernetes/a.json', config_content.to_json
+
+      Kubernetes::Role.seed! project, 'HEAD'
+
+      names = Kubernetes::Role.all.map(&:resource_name)
+      names.must_equal ["test-app-server", "foo-bar-test-app-server"]
+    end
+
     it "reads other file types" do
       write_config 'kubernetes/a.json', config_content.to_json
       Kubernetes::Role.seed! project, 'HEAD'
@@ -171,7 +184,7 @@ describe Kubernetes::Role do
       write_config 'kubernetes/a.yml', config_content_yml
       Kubernetes::Role.seed! project, 'HEAD'
       names = Kubernetes::Role.all.map(&:service_name)
-      names.last.must_match /#{existing_name}-CHANGE-ME-\d+/
+      names.last.must_match /#{existing_name}-change-me-\d+/
     end
 
     it "does not seed without role label" do

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -56,6 +56,13 @@ describe Kubernetes::Role do
         assert_valid role
       end
     end
+
+    describe "name" do
+      it 'is invalid with a name we could not use in kubernetes' do
+        role.name = 'foo_bar'
+        refute_valid role
+      end
+    end
   end
 
   describe '.seed' do
@@ -191,13 +198,6 @@ describe Kubernetes::Role do
       assert_raises Samson::Hooks::UserError do
         Kubernetes::Role.configured_for_project(project, 'HEAD')
       end
-    end
-  end
-
-  describe "#label_name" do
-    it "is url safe" do
-      role.name = 'ÍÎapp_server'
-      role.label_name.must_equal 'iiapp_server'
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -86,6 +86,16 @@ describe Kubernetes::RoleVerifier do
         ", supported combinations are: Deployment, DaemonSet, Deployment + Service, Job"
     end
 
+    it "reports non-string labels" do
+      role.first[:metadata][:labels][:role_id] = 1
+      errors.must_include "Deployment metadata.labels.role_id must be a String"
+    end
+
+    it "reports invalid labels" do
+      role.first[:metadata][:labels][:role] = 'foo_bar'
+      errors.must_include "Deployment metadata.labels.role must match /\\A[a-z0-9]([-a-z0-9]*[a-z0-9])?\\z/"
+    end
+
     describe 'verify_job_restart_policy' do
       let(:expected) { ["Job spec.template.spec.restartPolicy must be one of Never/OnFailure"] }
       before { role.replace(job_role) }


### PR DESCRIPTION
@zendesk/paas @rata 

atm we pick whatever name is the metadata.name ... which can lead to conflicts.
 -> use role name to generate a unique resource name (for job/deployment/daemonset)

also includes:
 - validate that all labels are strings
 - validate that all labels match dns regex
 - validate that role name matches dns regex

### Risks
 - will make all old deployments need to be manually replaced
