### PR TITLE
show what version the console is on and add helper for fake login

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,0 +1,4 @@
+Rails.application.console do
+  Rails::ConsoleMethods.send(:prepend, Samson::ConsoleExtensions)
+  puts "Samson version: #{Rails.application.config.samson.revision.to_s.first(7)}"
+end

--- a/lib/samson/console_extensions.rb
+++ b/lib/samson/console_extensions.rb
@@ -1,0 +1,19 @@
+module Samson
+  module ConsoleExtensions
+    # used to fake a login while debugging in a `rails c` console session
+    # so app.get 'http://xyz.com/protected/resource' works
+    def login(user)
+      CurrentUser.class_eval do
+        define_method :current_user do
+          user
+        end
+
+        # this would call warden and cause a redirect
+        define_method :login_user do |&block|
+          block.call
+        end
+        "logged in as #{user.name}"
+      end
+    end
+  end
+end

--- a/test/lib/samson/console_extensions_test.rb
+++ b/test/lib/samson/console_extensions_test.rb
@@ -1,0 +1,43 @@
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::ConsoleExtensions do
+  describe "#login" do
+    include Samson::ConsoleExtensions
+
+    class ConsoleExtensionTestController < ApplicationController
+      include CurrentUser
+      before_filter :authorize_super_admin!
+
+      def secret
+        render plain: 'OK'
+      end
+
+      private
+
+      def verified_request?
+        true
+      end
+    end
+
+    let(:request) { {'rack.input' => StringIO.new, 'REQUEST_METHOD' => 'GET'} }
+    let(:user) { users(:super_admin) }
+
+    # modify our fake class and not the original to not break all other tests
+    before { Samson::ConsoleExtensions.const_set(:CurrentUser, ConsoleExtensionTestController) }
+    after { Samson::ConsoleExtensions.send(:remove_const, :CurrentUser) }
+
+    it "sets user to given user" do
+      login(user)
+      ConsoleExtensionTestController.new.current_user.must_equal(user)
+    end
+
+    it "makes controller requests pass through" do
+      login(user)
+      status, _headers, body = ConsoleExtensionTestController.action(:secret).call(request)
+      status.must_equal 200
+      body.body.to_s.must_equal 'OK'
+    end
+  end
+end


### PR DESCRIPTION
@zendesk/samson 

```
rails c
Samson version: 4ba837f
Loading development environment (Rails 4.2.6)
>> login
=> "logged in as Michael Grosser"
>> app.get '/'
=> 200
```