### PR TITLE
make lograge+syslog easily testable and not the default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ end
 
 Dotenv.load(Bundler.root.join(Rails.env.test? ? '.env.test' : '.env'))
 
+require "#{Bundler.root}/lib/samson/env_check"
+
 module Samson
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -107,13 +109,11 @@ module Samson
     config.samson.gitlab = ActiveSupport::OrderedOptions.new
     config.samson.gitlab.web_url = deprecated_url.call("GITLAB_URL") || 'https://gitlab.com'
 
-    truthy = ["1", "true"]
-
     config.samson.auth = ActiveSupport::OrderedOptions.new
-    config.samson.auth.github = truthy.include?(ENV["AUTH_GITHUB"])
-    config.samson.auth.google = truthy.include?(ENV["AUTH_GOOGLE"])
-    config.samson.auth.ldap = truthy.include?(ENV["AUTH_LDAP"])
-    config.samson.auth.gitlab = truthy.include?(ENV["AUTH_GITLAB"])
+    config.samson.auth.github = Samson::EnvCheck.set?("AUTH_GITHUB")
+    config.samson.auth.google = Samson::EnvCheck.set?("AUTH_GOOGLE")
+    config.samson.auth.ldap = Samson::EnvCheck.set?("AUTH_LDAP")
+    config.samson.auth.gitlab = Samson::EnvCheck.set?("AUTH_GITLAB")
 
     config.samson.docker = ActiveSupport::OrderedOptions.new
     config.samson.docker.registry = ENV['DOCKER_REGISTRY'].presence

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,9 +29,5 @@ Samson::Application.configure do
   # number of complex assets.
   config.assets.debug = false
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-  end
-
   BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,22 +77,4 @@ Samson::Application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   # config.log_formatter = ::Logger::Formatter.new
-
-  # Lograge
-  config.lograge.enabled = true
-
-  config.lograge.custom_options = lambda do |event|
-    # show params for every request
-    unwanted_keys = %w[format action controller]
-    params = event.payload[:params].reject { |key, _| unwanted_keys.include? key }
-    { params: params }
-  end
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-  else
-    require 'syslog/logger'
-    config.logger = Syslog::Logger.new('samson')
-    config.lograge.formatter = Lograge::Formatters::Logstash.new
-  end
 end

--- a/config/initializers/00_logging.rb
+++ b/config/initializers/00_logging.rb
@@ -1,9 +1,9 @@
 config = Rails.application.config
 
-if ENV["RAILS_LOG_TO_STDOUT"].present?
+if Samson::EnvCheck.set?("RAILS_LOG_TO_STDOUT")
   # heroku and docker: dump everything to stdout
   config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-elsif ENV["RAILS_LOG_TO_SYSLOG"]
+elsif Samson::EnvCheck.set?("RAILS_LOG_TO_SYSLOG")
   # log 1 message per request to syslog in json format
   config.lograge.enabled = true
 

--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -1,0 +1,20 @@
+config = Rails.application.config
+
+if ENV["RAILS_LOG_TO_STDOUT"].present?
+  # heroku and docker: dump everything to stdout
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+elsif ENV["RAILS_LOG_TO_SYSLOG"]
+  # log 1 message per request to syslog in json format
+  config.lograge.enabled = true
+
+  config.lograge.custom_options = lambda do |event|
+    # show params for every request
+    unwanted_keys = %w[format action controller]
+    params = event.payload[:params].reject { |key, _| unwanted_keys.include? key }
+    { params: params }
+  end
+
+  require 'syslog/logger'
+  config.logger = Syslog::Logger.new('samson')
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+end

--- a/lib/samson/env_check.rb
+++ b/lib/samson/env_check.rb
@@ -1,0 +1,9 @@
+module Samson
+  module EnvCheck
+    FALSE = Set.new(['0', 'false', nil, ''])
+
+    def self.set?(k)
+      !FALSE.include?(ENV[k])
+    end
+  end
+end

--- a/test/lib/samson/env_check_test.rb
+++ b/test/lib/samson/env_check_test.rb
@@ -1,0 +1,22 @@
+require_relative '../../test_helper'
+
+SingleCov.covered! unless defined?(Rake) # rake preloads app which loads env check
+
+describe Samson::EnvCheck do
+  describe '.set?' do
+    {
+      '1' => true,
+      '0' => false,
+      nil => false,
+      'true' => true,
+      'false' => false,
+      '' => false
+    }.each do |value, expected|
+      it "is #{expected} when set to #{value}" do
+        with_env('TEST_VALUE' => value) do
+          Samson::EnvCheck.set?('TEST_VALUE').must_equal expected
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
parallel to RAILS_LOG_TO_STDOUT this introduces RAILS_LOG_TO_SYSLOG ... 
when nothing is given we use the default log format 

TODO: rollout env update to set RAILS_LOG_TO_SYSLOG

@jwswj / @jonmoter  looks good ?

/cc @zendesk/samson 

