### PR TITLE
Allow specifying the release number

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -46,7 +46,7 @@ class Integrations::BaseController < ApplicationController
   end
 
   def release_params
-    {commit: commit, author: user}
+    { commit: commit, author: user }
   end
 
   def create_new_release

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -45,10 +45,14 @@ class Integrations::BaseController < ApplicationController
     raise NotImplementedError, "#deploy? must be overridden in a subclass"
   end
 
+  def release_params
+    {commit: commit, author: user}
+  end
+
   def create_new_release
     unless project.last_release_contains_commit?(commit)
       release_service = ReleaseService.new(project)
-      release_service.create_release!(commit: commit, author: user)
+      release_service.create_release!(release_params)
     end
   end
 

--- a/app/controllers/integrations/buildkite_controller.rb
+++ b/app/controllers/integrations/buildkite_controller.rb
@@ -31,6 +31,6 @@ class Integrations::BuildkiteController < Integrations::BaseController
 
   def release_params
     extra_params = Samson::Hooks.fire(:release_params, project, build_param)
-    { commit: commit, author: user }.merge( Hash[*extra_params.flatten]  )
+    { commit: commit, author: user }.merge(Hash[*extra_params.flatten])
   end
 end

--- a/app/controllers/integrations/buildkite_controller.rb
+++ b/app/controllers/integrations/buildkite_controller.rb
@@ -31,6 +31,6 @@ class Integrations::BuildkiteController < Integrations::BaseController
 
   def release_params
     extra_params = Samson::Hooks.fire(:buildkite_release_params, project, build_param)
-    { commit: commit, author: user }.merge(Hash[*extra_params.flatten])
+    super.merge(Hash[*extra_params.flatten])
   end
 end

--- a/app/controllers/integrations/buildkite_controller.rb
+++ b/app/controllers/integrations/buildkite_controller.rb
@@ -30,7 +30,7 @@ class Integrations::BuildkiteController < Integrations::BaseController
   end
 
   def release_params
-    extra_params = Samson::Hooks.fire(:release_params, project, build_param)
+    extra_params = Samson::Hooks.fire(:buildkite_release_params, project, build_param)
     { commit: commit, author: user }.merge(Hash[*extra_params.flatten])
   end
 end

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -37,7 +37,7 @@ class Lock < ActiveRecord::Base
   end
 
   def self.remove_expired_locks
-    Lock.where("delete_at IS NOT NULL and delete_at < CURRENT_TIMESTAMP").find_each(&:soft_delete!)
+    Lock.where("delete_at IS NOT NULL and delete_at < ?", Time.now.to_s(:db)).find_each(&:soft_delete!)
   end
 
   def delete_in=(seconds)

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -37,7 +37,7 @@ class Lock < ActiveRecord::Base
   end
 
   def self.remove_expired_locks
-    Lock.where("delete_at IS NOT NULL and delete_at < ?", Time.now.to_s(:db)).find_each(&:soft_delete!)
+    Lock.where("delete_at IS NOT NULL and delete_at < CURRENT_TIMESTAMP").find_each(&:soft_delete!)
   end
 
   def delete_in=(seconds)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -44,6 +44,9 @@ class Release < ActiveRecord::Base
   private
 
   def assign_release_number
+    default_number = 1
+    return if self.number != default_number
+
     latest_release_number = project.releases.last.try(:number) || 0
     self.number = latest_release_number + 1
   end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -45,7 +45,7 @@ class Release < ActiveRecord::Base
 
   def assign_release_number
     default_number = 1
-    return if number != default_number
+    return if number != default_number && !number.nil?
 
     latest_release_number = project.releases.last.try(:number) || 0
     self.number = latest_release_number + 1

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -45,7 +45,7 @@ class Release < ActiveRecord::Base
 
   def assign_release_number
     default_number = 1
-    return if self.number != default_number
+    return if number != default_number
 
     latest_release_number = project.releases.last.try(:number) || 0
     self.number = latest_release_number + 1

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -5,6 +5,10 @@ class Release < ActiveRecord::Base
 
   before_create :assign_release_number
 
+  # DEFAULT_RELEASE_NUMBER is the default value assigned to release#number by the database.
+  # This constant is here for convenience - the value that the database uses is in db/schema.rb.
+  DEFAULT_RELEASE_NUMBER = 1
+
   def self.sort_by_version
     order(number: :desc)
   end
@@ -46,9 +50,7 @@ class Release < ActiveRecord::Base
   def assign_release_number
     # Detect whether the number has been overwritten by params, e.g. using the
     # release-number-from-ci plugin.
-    # DefaultNumber is the default value assigned to release#number by ActiveRecord.
-    DefaultNumber = 1
-    return if number != DefaultNumber && !number.nil?
+    return if number != DEFAULT_RELEASE_NUMBER && !number.nil?
 
     latest_release_number = project.releases.last.try(:number) || 0
     self.number = latest_release_number + 1

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -44,8 +44,11 @@ class Release < ActiveRecord::Base
   private
 
   def assign_release_number
-    default_number = 1
-    return if number != default_number && !number.nil?
+    # Detect whether the number has been overwritten by params, e.g. using the
+    # release-number-from-ci plugin.
+    # DefaultNumber is the default value assigned to release#number by ActiveRecord.
+    DefaultNumber = 1
+    return if number != DefaultNumber && !number.nil?
 
     latest_release_number = project.releases.last.try(:number) || 0
     self.number = latest_release_number + 1

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -18,6 +18,7 @@ Current Plugins:
 * [Hipchat](https://github.com/listia/samson_hipchat): Clone of Slack plugin
 * Jenkins
 * Pipelines
+* [ReleaseNumberFromCI](https://github.com/redbubble/samson-release-number-from-ci): A plugin which supports setting specific release number for samson release from CI
 * Slack
 
 ## Enabling Plugins

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -34,7 +34,7 @@ module Samson
       :job_additional_vars,
       :deploy_group_permitted_params,
       :edit_deploy_group,
-      :release_params
+      :buildkite_release_params
     ].freeze
 
     INTERNAL_HOOKS = [:class_defined].freeze

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -76,7 +76,7 @@ describe Integrations::BuildkiteController do
       Build.any_instance.stubs(:validate_git_reference).returns(true)
       stub_request(:post, "https://api.github.com/repos/bar/foo/releases").
         to_return(status: 200, body: "", headers: {})
-      Samson::Hooks.callback :release_params do |project, build_param|
+      Samson::Hooks.callback :release_params do |_|
         [[:number, 9]]
       end
     end

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -64,7 +64,7 @@ describe Integrations::BuildkiteController do
     end
   end
 
-  context 'when the release_params hook gets trigger' do
+  context 'when the buildkite_release_params hook gets trigger' do
     before do
       project.releases.destroy_all
       project.builds.destroy_all
@@ -76,7 +76,7 @@ describe Integrations::BuildkiteController do
       Build.any_instance.stubs(:validate_git_reference).returns(true)
       stub_request(:post, "https://api.github.com/repos/bar/foo/releases").
         to_return(status: 200, body: "", headers: {})
-      Samson::Hooks.callback :release_params do |_|
+      Samson::Hooks.callback :buildkite_release_params do |_|
         [[:number, 9]]
       end
     end

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -65,27 +65,24 @@ describe Integrations::BuildkiteController do
   end
 
   context 'when the buildkite_release_params hook gets trigger' do
+    let(:buildkite_build_number) { lambda { |_, _| [[:number, 9]] } }
     before do
       project.releases.destroy_all
       project.builds.destroy_all
-      Integrations::BuildkiteController.any_instance.stubs(:deploy?).returns(true)
       Integrations::BuildkiteController.any_instance.stubs(:project).returns(project)
-      Integrations::BuildkiteController.any_instance.stubs(:commit).returns(commit)
-      Integrations::BuildkiteController.any_instance.stubs(:branch).returns('master')
-      Project.any_instance.stubs(:create_releases_for_branch?).returns(true)
+      project.stubs(:create_releases_for_branch?).returns(true)
       Build.any_instance.stubs(:validate_git_reference).returns(true)
       stub_request(:post, "https://api.github.com/repos/bar/foo/releases").
         to_return(status: 200, body: "", headers: {})
-      Samson::Hooks.callback :buildkite_release_params do |_|
-        [[:number, 9]]
-      end
     end
 
     it 'creates the release with the buildkite build number' do
-      post :create, payload.merge(token: project.token), test_route: true
+      Samson::Hooks.with_callback(:buildkite_release_params, buildkite_build_number) do |_|
+        post :create, payload.merge(token: project.token), test_route: true
 
-      project.releases.size.must_equal 1
-      project.releases.first.number.must_equal 9
+        project.releases.size.must_equal 1
+        project.releases.first.number.must_equal 9
+      end
     end
   end
 end

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -82,8 +82,8 @@ describe Integrations::BuildkiteController do
     end
 
     it 'creates the release with the buildkite build number' do
-
       post :create, payload.merge(token: project.token), test_route: true
+
       project.releases.size.must_equal 1
       project.releases.first.number.must_equal 9
     end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -25,6 +25,12 @@ describe Release do
       assert_equal 1234, release.number
     end
 
+    it 'uses the default release number if build number is nil' do
+      project.releases.destroy_all
+      release = project.releases.create!(author: author, commit: "bar", number:nil )
+      assert_equal 1, release.number
+    end
+
     it 'uses the build number if build number is 1' do
       project.releases.destroy_all
       release = project.releases.create!(author: author, commit: "bar")

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -27,7 +27,7 @@ describe Release do
 
     it 'uses the default release number if build number is nil' do
       project.releases.destroy_all
-      release = project.releases.create!(author: author, commit: "bar", number:nil )
+      release = project.releases.create!(author: author, commit: "bar", number: nil)
       assert_equal 1, release.number
     end
 

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -31,7 +31,7 @@ describe Release do
       assert_equal 1, release.number
     end
 
-    it 'uses the build number if build number is 1' do
+    it 'uses the build number if build number is not given' do
       project.releases.destroy_all
       release = project.releases.create!(author: author, commit: "bar")
       assert_equal 1, release.number

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -19,6 +19,17 @@ describe Release do
       release = project.releases.create!(commit: "foo", author: author)
       assert_equal 42, release.number
     end
+
+    it 'uses the specified release number' do
+      release = project.releases.create!(author: author, commit: "bar", number: 1234)
+      assert_equal 1234, release.number
+    end
+
+    it 'uses the build number if build number is 1' do
+      project.releases.destroy_all
+      release = project.releases.create!(author: author, commit: "bar")
+      assert_equal 1, release.number
+    end
   end
 
   describe "#currently_deploying_stages" do


### PR DESCRIPTION
We've made some small changes that will allow us to write a plugin that will use the build number from our CI pipeline as our release number, as opposed to having it auto-increment. These changes include some tests to make sure we've not broken existing behaviour.

Our plugin is over at https://github.com/redbubble/samson-release-number-from-ci if you'd like to take a look to see what we're attempting to do (it is a little rough around the edges, since we were able to implement it as a plugin rather than trying to shove into the core). Nice plugin architecture btw!

We also made a small change to a test that was flaky on our setup - we hope this makes the suite a little more reliable on different setups.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
