### PR TITLE
use body of cached 304 response

### DIFF
--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -11,7 +11,7 @@ class Octokit::RedirectAsError < Faraday::Response::Middleware
   private
 
   def on_complete(response)
-    if response[:status].to_i.between?(300, 399)
+    if [301, 302].include?(response[:status].to_i)
       raise Octokit::RepositoryUnavailable, response
     end
   end

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -53,6 +53,13 @@ describe Changeset do
       stub_github_api("repos/foo/bar/branches/master", {}, 301)
       Changeset.new("foo/bar", "a", "master").comparison.class.must_equal Changeset::NullComparison
     end
+
+    # tests config/initializers/octokit.rb Octokit::RedirectAsError
+    it "uses the cached body of a 304" do
+      stub_github_api("repos/foo/bar/branches/master", {commit: { sha: "bar"}}, 304)
+      stub_github_api("repos/foo/bar/compare/a...bar", "x" => "z")
+      Changeset.new("foo/bar", "a", "master").comparison.to_h.must_equal x: "z"
+    end
   end
 
   describe "#github_url" do


### PR DESCRIPTION
atm 304 is shown as github error ... which is wrong ...

<img width="238" alt="screen shot 2016-06-29 at 9 59 56 am" src="https://cloud.githubusercontent.com/assets/11367/16461213/4786ab12-3de0-11e6-821c-16a7d22bf3ad.png">

@jonmoter 