### PR TITLE
deploy group UI improvements

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -40,9 +40,14 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   def destroy
-    deploy_group.soft_delete!
-    flash[:notice] = "Successfully deleted deploy group: #{deploy_group.name}"
-    redirect_to action: :index
+    if deploy_group.deploy_groups_stages.empty?
+      deploy_group.soft_delete!
+      flash[:notice] = "Successfully deleted deploy group: #{deploy_group.name}"
+      redirect_to action: :index
+    else
+      flash[:error] = "Deploy group is still in use."
+      redirect_to [:admin, deploy_group]
+    end
   end
 
   def deploy_all

--- a/app/views/admin/deploy_groups/edit.html.erb
+++ b/app/views/admin/deploy_groups/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= @deploy_group.new_record? ? 'New' : 'Edit' %> Deploy Group</h1>
+<h1><%= @deploy_group.new_record? ? 'New' : 'Edit' %> Deploy Group <%= link_to_if @deploy_group.id, @deploy_group.name, [:admin, @deploy_group] %></h1>
 
 <section>
   <%= form_for [:admin, @deploy_group], html: { class: "form-horizontal" } do |form| %>
@@ -11,6 +11,7 @@
     <div class="form-group">
       <div class="col-lg-offset-2 col-lg-10">
         <%= form.submit "Save", class: 'btn btn-default' %>
+        <%= link_to_delete([:admin, @deploy_group]) %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -15,6 +15,20 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <label class="col-lg-2 control-label">Used by</label>
+    <div class="col-lg-4">
+      <p class="form-control-static">
+        <% @deploy_group.deploy_groups_stages.group_by { |dgs| dgs.stage.project }.each do |project, dgs_group| %>
+          <h3><%= link_to project.name, project %></h3>
+          <% dgs_group.each do |dgs| %>
+            <%= link_to dgs.stage.name, [dgs.stage.project, dgs.stage] %><br/>
+          <% end %>
+        <% end %>
+      </p>
+    </div>
+  </div>
+
   <%= Samson::Hooks.render_views(:deploy_group_show, self) %>
 
   <div class="form-group">

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -96,6 +96,7 @@ describe Admin::DeployGroupsController do
 
     describe '#destroy' do
       it 'succeeds' do
+        DeployGroupsStage.delete_all
         delete :destroy, id: deploy_group
         assert_redirected_to admin_deploy_groups_path
         DeployGroup.where(id: deploy_group.id).must_equal []
@@ -105,6 +106,13 @@ describe Admin::DeployGroupsController do
         assert_raises ActiveRecord::RecordNotFound do
           delete :destroy, id: -1
         end
+      end
+
+      it 'fails for used deploy_group and sends user to a page that shows which groups are used' do
+        delete :destroy, id: deploy_group
+        assert_redirected_to [:admin, deploy_group]
+        assert flash[:error]
+        deploy_group.reload
       end
     end
 


### PR DESCRIPTION
 - show delete button on edit
 - show usages in show
 - do not allow to delete a used deploy group
 - link to show from edit page

@apanzerj 
/cc @zendesk/samson 