### PR TITLE
show when automatic unlock is broken instead of showing negative time…

### DIFF
--- a/app/views/locks/_lock.html.erb
+++ b/app/views/locks/_lock.html.erb
@@ -5,5 +5,5 @@
     <%= lock_icon %> Deployments to <%= lock.global? ? "ALL STAGES" : "this stage" %> were locked
   <% end %>
   <%= lock.reason %> by <%= lock.locked_by %> <%= time_ago_in_words(lock.created_at) %>
-  ago<%= lock.unlock_at %>.
+  ago<%= lock.unlock_summary %>.
 </div>

--- a/test/lib/samson/tasks/lock_cleaner_test.rb
+++ b/test/lib/samson/tasks/lock_cleaner_test.rb
@@ -1,44 +1,33 @@
 require_relative '../../../test_helper'
 
-SingleCov.covered! uncovered: 2
+SingleCov.covered!
 
 describe Samson::Tasks::LockCleaner do
-  subject { Samson::Tasks::LockCleaner.new }
-
-  describe "#start" do
+  describe ".start" do
     it "starts the timer task" do
-      subject.task.expects(:execute).once
-      subject.start
+      Concurrent::TimerTask.any_instance.expects(:execute)
+      Samson::Tasks::LockCleaner.start
     end
   end
 
-  describe "#task" do
-    it 'sets the timeout interval' do
-      subject.task.timeout_interval.must_equal 10
-    end
-
-    it "sets the execution interval" do
-      subject.task.execution_interval.must_equal 60
-    end
-
-    it "adds an observer" do
-      subject.task.count_observers.must_equal 1
-    end
-  end
-
-  describe "#update" do
-    let(:exp) { Exception.new("test").tap { |e| e.set_backtrace([]) } }
-
-    it "does nothing without an exception" do
+  # we cannot really execute this since it leaves the Thread from Concurrent.global_timer_set behind
+  # and killing that would break following tests
+  describe "execution" do
+    it "does nothing on normal execution" do
       Rails.logger.expects(:error).never
       Airbrake.expects(:notify).never
-      subject.update(Time.now, nil, nil)
+      Samson::Tasks::LockCleaner.new.send(:update, Time.now, nil, nil)
     end
 
     it "logs when given an exception" do
       Rails.logger.expects(:error).twice
-      Airbrake.expects(:notify).with(exp, error_message: 'Samson::Tasks::LockCleaner failed').once
-      subject.update(Time.now, nil, exp)
+      Airbrake.expects(:notify).with(instance_of(ArgumentError), error_message: 'Samson::Tasks::LockCleaner failed')
+      e = begin; raise ArgumentError; rescue; $!; end
+      Samson::Tasks::LockCleaner.new.send(:update, Time.now, nil, e)
+    end
+
+    it "can run" do
+      Samson::Tasks::LockCleaner.new.send(:run)
     end
   end
 end

--- a/test/models/lock_test.rb
+++ b/test/models/lock_test.rb
@@ -1,54 +1,70 @@
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered!
 
 describe Lock do
-  describe 'global locks' do
-    let(:global_lock) { Lock.create!(user: user) }
+  let(:lock) { Lock.create!(user: users(:deployer), stage: stages(:test_staging)) }
 
-    describe 'with a user' do
-      let(:user) { users(:admin) }
-      before { global_lock }
-
-      it 'is unique' do
-        Lock.create(user: user).persisted?.must_equal(false)
-      end
-
-      it 'is global' do
-        global_lock.global?.must_equal(true)
-      end
-
-      it 'is globalled' do
-        Lock.global.first.must_equal(global_lock)
-      end
-
-      it 'lists the user who created the lock' do
-        global_lock.summary.must_include('Locked by Admin')
-      end
-
-      describe 'soft deleted' do
-        before { global_lock.soft_delete! }
-
-        it 'is not globalled' do
-          Lock.global.must_be_empty
-        end
-      end
+  describe "#summary" do
+    it 'says who created the lock' do
+      lock.summary.must_include('by Deployer')
     end
 
-    describe 'without a user' do
-      let(:user) { nil }
+    describe 'global locks' do
+      let(:lock) { Lock.create!(user: user) }
 
-      it 'is invalid' do
-        lambda { global_lock }.must_raise(ActiveRecord::RecordInvalid)
+      describe 'with a user' do
+        let(:user) { users(:admin) }
+        before { lock }
+
+        it 'is unique' do
+          refute_valid Lock.new(user: user)
+        end
+
+        it 'is global' do
+          lock.global?.must_equal(true)
+        end
+
+        it 'is globalled' do
+          Lock.global.first.must_equal(lock)
+        end
+
+        it 'lists the user who created the lock' do
+          lock.summary.must_include('by Admin')
+        end
+
+        describe 'soft deleted' do
+          before { lock.soft_delete! }
+
+          it 'is not globalled' do
+            Lock.global.must_be_empty
+          end
+        end
+      end
+
+      describe 'without a user' do
+        let(:user) { nil }
+
+        it 'is invalid' do
+          lambda { lock }.must_raise(ActiveRecord::RecordInvalid)
+        end
       end
     end
   end
 
-  describe 'individual locks' do
-    let(:user_lock) { Lock.create!(user: users(:deployer), stage: stages(:test_staging)) }
+  describe "#unlock_summary" do
+    it "is emppty when not deleting" do
+      lock.unlock_summary.must_equal nil
+    end
 
-    it 'says who created the lock' do
-      user_lock.summary.must_include('Locked by Deployer')
+    it "says when unlock is in the future" do
+      lock.delete_at = 5.minutes.from_now + 2
+      lock.unlock_summary.must_equal " and will unlock in 5 minutes"
+    end
+
+    it "says when unlock failed" do
+      lock.delete_at = 5.minutes.ago
+      lock.unlock_summary.must_equal " and automatic unlock is not working"
     end
   end
 
@@ -72,7 +88,7 @@ describe Lock do
     end
   end
 
-  describe 'remove_expired_locks' do
+  describe '.remove_expired_locks' do
     before do
       expired = 2.hour.ago
       Lock.create!(user: users(:deployer), stage: stages(:test_staging), created_at: expired, delete_in: 3600)


### PR DESCRIPTION
![screen shot 2016-07-07 at 2 08 32 pm](https://cloud.githubusercontent.com/assets/11367/16669838/4fd76c62-444c-11e6-9db4-9ffb72f3643b.png)

when lock service is busted atm it shows negative time as relative time ... which is confusing ...

@zendesk/samson 