### PR TITLE
Add JSON response for projects show and attributes to index

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -45,7 +45,10 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    @stages = project.stages
+    respond_to do |format|
+      format.html { @stages = project.stages }
+      format.json { render json: project.to_json(except: [:token, :deleted_at]) }
+    end
   end
 
   def edit

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,5 +1,5 @@
 class ProjectSerializer < ActiveModel::Serializer
-  attributes :id, :name, :url
+  attributes :id, :name, :url, :permalink, :repository_url
 
   def url
     project_url(object)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -318,9 +318,20 @@ describe ProjectsController do
 
   describe "a GET to #show" do
     as_a_viewer do
-      it "does not redirect to the deploys page" do
-        get :show, id: project.to_param
-        assert_response :success
+      describe "as HTML" do
+        it "does not redirect to the deploys page" do
+          get :show, id: project.to_param
+          assert_response :success
+        end
+      end
+
+      describe "as JSON" do
+        it "is json and does not include :token" do
+          get :show, id: project.permalink, format: :json
+          assert_response :success
+          result = JSON.parse(response.body)
+          result.keys.wont_include('token')
+        end
       end
     end
 


### PR DESCRIPTION
* Add json response to Project#show for full object except token and deleted_at
* Add to Project#index json object the repository_url and permalink attributes
* Added tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/projects/SAMSON/issues/SAMSON-241

### Risks
- Level: Low