### PR TITLE
Human readable job/deploy duration

### DIFF
--- a/app/assets/javascripts/streams.js
+++ b/app/assets/javascripts/streams.js
@@ -36,6 +36,7 @@ function startStream() {
       var data = JSON.parse(e.data);
 
       $('#header').html(data.html);
+      timeAgoFormat();
       window.document.title = data.title;
       if (doNotify && data.notification !== undefined) {
         var notification = new Notification(data.notification, {icon: '/favicon.ico'});

--- a/app/assets/javascripts/streams.js
+++ b/app/assets/javascripts/streams.js
@@ -8,7 +8,10 @@ function timeAgoFormat() {
   });
 }
 
-$(document).ready(timeAgoFormat);
+$(document).ready(function() {
+  timeAgoFormat();
+  setInterval(timeAgoFormat, 60000); // update times every 60s
+});
 
 function startStream() {
   $(document).ready(function() {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,24 +49,6 @@ module ApplicationHelper
     render '/locks/lock', lock: global_lock if global_lock
   end
 
-  def relative_time(time)
-    content_tag(:span, time.rfc822, data: { time: datetime_to_js_ms(time) }, class: "mouseover")
-  end
-
-  def render_time(time, format)
-    # grab the time format that the user has in their profile
-    format ||= current_user.time_format
-    if format == 'local'
-      local_time = time.in_time_zone(cookies[:timezone] || 'UTC').to_s
-      content_tag(:time, local_time, datetime: local_time)
-    elsif format == 'utc'
-      utc_time = time.in_time_zone('UTC')
-      content_tag(:time, utc_time.to_s, datetime: utc_time)
-    else
-      relative_time(time)
-    end
-  end
-
   def sortable(column, title = nil)
     title ||= column.titleize
     direction = (column == params[:sort] && params[:direction] == "asc") ? "desc" : "asc"

--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -2,4 +2,22 @@ module DateTimeHelper
   def datetime_to_js_ms(utc_string)
     utc_string.to_i * 1000
   end
+
+  def relative_time(time)
+    content_tag(:span, time.rfc822, data: { time: datetime_to_js_ms(time) }, class: "mouseover")
+  end
+
+  def render_time(time, format)
+    # grab the time format that the user has in their profile
+    format ||= current_user.time_format
+    if format == 'local'
+      local_time = time.in_time_zone(cookies[:timezone] || 'UTC').to_s
+      content_tag(:time, local_time, datetime: local_time)
+    elsif format == 'utc'
+      utc_time = time.in_time_zone('UTC')
+      content_tag(:time, utc_time.to_s, datetime: utc_time)
+    else
+      relative_time(time)
+    end
+  end
 end

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -22,7 +22,16 @@ module StatusHelper
   def status_panel(deploy)
     content = h deploy.summary
     if deploy.active?
-      content << content_tag(:ul, content_tag(:li, deploy.summary_for_process))
+      content << content_tag(:br)
+      content << "Started "
+      content << content_tag(
+        :span,
+        deploy.start_time.rfc822,
+        data: { time: datetime_to_js_ms(deploy.start_time) },
+        class: 'mouseover'
+      )
+      job = deploy.respond_to?(:job) ? deploy.job : deploy
+      content << " [Process ID: #{job.pid}]"
     end
 
     if deploy.finished?

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -24,24 +24,14 @@ module StatusHelper
     if deploy.active?
       content << content_tag(:br)
       content << "Started "
-      content << content_tag(
-        :span,
-        deploy.start_time.rfc822,
-        data: { time: datetime_to_js_ms(deploy.start_time) },
-        class: 'mouseover'
-      )
+      content << relative_time(deploy.start_time)
       job = deploy.respond_to?(:job) ? deploy.job : deploy
       content << " [Process ID: #{job.pid}]"
     end
 
     if deploy.finished?
       content << " "
-      content << content_tag(
-        :span,
-        deploy.start_time.rfc822,
-        data: { time: datetime_to_js_ms(deploy.start_time) },
-        class: 'mouseover'
-      )
+      content << render_time(deploy.start_time, current_user.time_format)
       content << ", it took #{duration_text(deploy)}."
     end
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -27,11 +27,6 @@ class Deploy < ActiveRecord::Base
     "#{job.user.name} #{deploy_buddy} #{summary_action} #{short_reference} to #{stage.name}"
   end
 
-  def summary_for_process
-    t = (Time.now.to_i - start_time.to_i)
-    "ProcessID: #{job.pid} Running: #{t} seconds"
-  end
-
   def summary_for_timeline
     "#{short_reference}#{' was' if job.succeeded?} #{summary_action} to #{stage.name}"
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -34,11 +34,6 @@ class Job < ActiveRecord::Base
     "#{user.name} #{summary_action} against #{short_reference}"
   end
 
-  def summary_for_process
-    t = (Time.now.to_i - start_time.to_i)
-    "ProcessID: #{pid} Running: #{t} seconds"
-  end
-
   def user
     super || NullUser.new(user_id)
   end

--- a/app/views/jobs/_job.html.erb
+++ b/app/views/jobs/_job.html.erb
@@ -1,6 +1,6 @@
 <% cache job do %>
   <tr>
-    <td><span class="mouseover" data-time="<%= datetime_to_js_ms(job.created_at) %>"><%= job.created_at.rfc822 %></span></td>
+    <td><%= relative_time(job.created_at) %></td>
     <td>
       <%= link_to "#{job.user.name} executed:", [@project, job] %>
       <pre class="pre-command"><%= job.command %></pre>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -245,37 +245,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#render_time" do
-    let(:ts) { Time.parse("2016-04-18T17:46:10.337+00:00") }
-    let(:current_user) { users(:admin) }
-
-    it "formats time in the uesrs default preference" do
-      render_time(ts, nil).must_equal "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
-    end
-
-    it "formats time in utc" do
-      render_time(ts, 'utc').must_equal "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
-    end
-
-    it "formats time in utc if no timezone cookie is set" do
-      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
-    end
-
-    it "formats local time in America/Los_Angeles via cookie set by JS" do
-      cookies[:timezone] = 'America/Los_Angeles'
-      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 10:46:10 -0700\">2016-04-18 10:46:10 -0700</time>"
-    end
-
-    it "formats local time in America/New_York via cookie set by JS" do
-      cookies[:timezone] = 'America/New_York'
-      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 13:46:10 -0400\">2016-04-18 13:46:10 -0400</time>"
-    end
-
-    it "formats time relative" do
-      render_time(ts, 'foobar').must_equal "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
-    end
-  end
-
   describe "#static_render" do
     it "can render nothing" do
       static_render([]).must_equal nil

--- a/test/helpers/date_time_helper_test.rb
+++ b/test/helpers/date_time_helper_test.rb
@@ -16,29 +16,41 @@ describe DateTimeHelper do
     let(:current_user) { users(:admin) }
 
     it "formats time in the uesrs default preference" do
-      render_time(ts, nil).must_equal "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
+      render_time(ts, nil).must_equal(
+        "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
+      )
     end
 
     it "formats time in utc" do
-      render_time(ts, 'utc').must_equal "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
+      render_time(ts, 'utc').must_equal(
+        "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
+      )
     end
 
     it "formats time in utc if no timezone cookie is set" do
-      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
+      render_time(ts, 'local').must_equal(
+        "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
+      )
     end
 
     it "formats local time in America/Los_Angeles via cookie set by JS" do
       cookies[:timezone] = 'America/Los_Angeles'
-      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 10:46:10 -0700\">2016-04-18 10:46:10 -0700</time>"
+      render_time(ts, 'local').must_equal(
+        "<time datetime=\"2016-04-18 10:46:10 -0700\">2016-04-18 10:46:10 -0700</time>"
+      )
     end
 
     it "formats local time in America/New_York via cookie set by JS" do
       cookies[:timezone] = 'America/New_York'
-      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 13:46:10 -0400\">2016-04-18 13:46:10 -0400</time>"
+      render_time(ts, 'local').must_equal(
+        "<time datetime=\"2016-04-18 13:46:10 -0400\">2016-04-18 13:46:10 -0400</time>"
+      )
     end
 
     it "formats time relative" do
-      render_time(ts, 'foobar').must_equal "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
+      render_time(ts, 'foobar').must_equal(
+        "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
+      )
     end
   end
 end

--- a/test/helpers/date_time_helper_test.rb
+++ b/test/helpers/date_time_helper_test.rb
@@ -10,4 +10,35 @@ describe DateTimeHelper do
       datetime_to_js_ms(t).must_equal t.to_i * 1000
     end
   end
+
+  describe "#render_time" do
+    let(:ts) { Time.parse("2016-04-18T17:46:10.337+00:00") }
+    let(:current_user) { users(:admin) }
+
+    it "formats time in the uesrs default preference" do
+      render_time(ts, nil).must_equal "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
+    end
+
+    it "formats time in utc" do
+      render_time(ts, 'utc').must_equal "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
+    end
+
+    it "formats time in utc if no timezone cookie is set" do
+      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 17:46:10 UTC\">2016-04-18 17:46:10 UTC</time>"
+    end
+
+    it "formats local time in America/Los_Angeles via cookie set by JS" do
+      cookies[:timezone] = 'America/Los_Angeles'
+      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 10:46:10 -0700\">2016-04-18 10:46:10 -0700</time>"
+    end
+
+    it "formats local time in America/New_York via cookie set by JS" do
+      cookies[:timezone] = 'America/New_York'
+      render_time(ts, 'local').must_equal "<time datetime=\"2016-04-18 13:46:10 -0400\">2016-04-18 13:46:10 -0400</time>"
+    end
+
+    it "formats time relative" do
+      render_time(ts, 'foobar').must_equal "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
+    end
+  end
 end

--- a/test/helpers/status_helper_test.rb
+++ b/test/helpers/status_helper_test.rb
@@ -6,6 +6,8 @@ describe StatusHelper do
   include ERB::Util
   include DateTimeHelper
 
+  let(:current_user) { users(:viewer) }
+
   describe "#status_panel" do
     it "accepts a deploy" do
       refute_nil status_panel(deploys(:succeeded_production_test))

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -67,13 +67,6 @@ describe Deploy do
     end
   end
 
-  describe "#summary_for_process" do
-    it "renders" do
-      deploy.job.stubs(pid: 123)
-      deploy.summary_for_process.gsub(/\d+/, "DD").must_equal "ProcessID: DD Running: DD seconds"
-    end
-  end
-
   describe "#summary_for_timeline" do
     it "renders" do
       deploy.summary_for_timeline.must_equal "staging was deployed to Staging"


### PR DESCRIPTION
:v:

/cc @sandlerr @danielbreves @zendesk/samson

### Description
Replace process duration with human-readable started time, updated every minute (client side).

**before**:
![screen shot 2016-07-15 at 2 46 27 pm](https://cloud.githubusercontent.com/assets/153219/16863904/efd18c80-4a9a-11e6-810d-7fbcbd898b58.png)

**after**:
![screen shot 2016-07-15 at 2 43 49 pm](https://cloud.githubusercontent.com/assets/153219/16863879/94a284e0-4a9a-11e6-8653-cb318e565ff6.png)
![screen shot 2016-07-15 at 2 44 49 pm](https://cloud.githubusercontent.com/assets/153219/16863888/b439a66c-4a9a-11e6-91e1-360c727d91d0.png)


### Tasks
 - [ ] :+1: from team

### References
 - Jira link: 

### Risks
- Level: Low - UI change