### PR TITLE
Add release_deploy_conditions hook.

### DIFF
--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -20,7 +20,7 @@ class ReleaseService
     deploy_service = DeployService.new(release.author)
 
     @project.stages.deployed_on_release.each do |stage|
-      if Samson::Hooks.fire(:release_deploy_conditions, stage, release).reduce(true) { |acc, res| acc && res }
+      if Samson::Hooks.fire(:release_deploy_conditions, stage, release).all?
         deploy_service.deploy!(stage, reference: release.version)
       end
     end

--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -20,7 +20,9 @@ class ReleaseService
     deploy_service = DeployService.new(release.author)
 
     @project.stages.deployed_on_release.each do |stage|
-      deploy_service.deploy!(stage, reference: release.version)
+      if Samson::Hooks.fire(:release_deploy_conditions, stage, release).reduce(true) { |acc, res| acc && res }
+        deploy_service.deploy!(stage, reference: release.version)
+      end
     end
   end
 end

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -19,6 +19,7 @@ Current Plugins:
 * Jenkins
 * Pipelines
 * [ReleaseNumberFromCI](https://github.com/redbubble/samson-release-number-from-ci): A plugin which supports setting specific release number for samson release from CI
+* [Stalemate](https://github.com/redbubble/samson-stalemate): Prevents deployment if a newly created release has commit which is contained in a previously deployed release
 * Slack
 
 ## Enabling Plugins

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -19,7 +19,6 @@ Current Plugins:
 * Jenkins
 * Pipelines
 * [ReleaseNumberFromCI](https://github.com/redbubble/samson-release-number-from-ci): A plugin which supports setting specific release number for samson release from CI
-* [Stalemate](https://github.com/redbubble/samson-stalemate): Prevents deployment if a newly created release has commit which is contained in a previously deployed release
 * Slack
 
 ## Enabling Plugins

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -36,7 +36,8 @@ module Samson
       :job_additional_vars,
       :deploy_group_permitted_params,
       :edit_deploy_group,
-      :buildkite_release_params
+      :buildkite_release_params,
+      :release_deploy_conditions
     ].freeze
 
     INTERNAL_HOOKS = [:class_defined].freeze


### PR DESCRIPTION
We've added a hook in the ReleaseService that allows us to add external logic to decide whether a new release should be deployed.

In terms of the conditions, we are looking at:

1. Do not deploy if the newly created release's commit reference is contained in a previous Samson deploy. 
2. Don't deploy if status of another build is red

/cc @zendesk/samson
