### PR TITLE
Irwaters/paas 268

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,10 +99,6 @@ GITHUB_TOKEN=
 
 ## Secret storage
 # SECRET_STORAGE_BACKEND= # optional, should be one of: SecretStorage::DbBackend (default) or SecretStorage::HashicorpVault
-# VAULT_ADDR= # optinal, comma/space seperated list of urls to vault servers if it is being used for secret storage.
-#   The first server listed will be used for reads
-# VAULT_SSL_CERT= # required if using vault secret backend, path to pem file used for client ssl auth wiht vault server
-# VAULT_SSL_VERIFY= # optional, wether or not to verify ssl certs when using ssl with vault.  defaults to true
 
 ## Kubernets sidecar
 # SECRET_SIDECAR_IMAGE= # optional, path to the docker image that built from the secret_puller service.  service will be disabled w/o it

--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -15,7 +15,7 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
 
     def initialize
       return if Rails.env.test?
-      config_valid?
+      ensure_config_exists
       # since we have a bunch of servers, don't use the client singlton to
       # talk to them
       # as we configure each client, check to see if the config has a token in it,
@@ -81,9 +81,9 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
 
     private
 
-    def config_valid?
+    def ensure_config_exists
       unless File.exist?(Rails.root.join(CONFIG_PATH))
-        raise "config/vault.json is required for #{ENV["SECRET_STORAGE_BACKEND"]}"
+        raise "#{CONFIG_PATH} is required for #{ENV["SECRET_STORAGE_BACKEND"]}"
       end
     end
 

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -13,7 +13,7 @@ class VaultClient
   end
 
   def initialize
-    config_valid?
+    ensure_config_exists
     @expected = {}
     @set = {}
   end
@@ -69,7 +69,7 @@ class VaultClient
 
   private
 
-  def config_valid?
+  def ensure_config_exists
     raise "vault.json is required for #{CONFIG_PATH}" unless File.exist?(CONFIG_PATH)
   end
 end

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -3,6 +3,7 @@ require_relative '../lib/samson_kubernetes/hash_kuber_selector'
 
 # Mock up vault client
 class VaultClient
+  CONFIG_PATH = 'vault.json'.freeze
   def logical
     @logical ||= Logical.new
   end
@@ -12,6 +13,7 @@ class VaultClient
   end
 
   def initialize
+    config_valid?
     @expected = {}
     @set = {}
   end
@@ -63,6 +65,12 @@ class VaultClient
     def to_h
       instance_values.symbolize_keys
     end
+  end
+
+  private
+
+  def config_valid?
+    raise "vault.json is required for #{ENV["SECRET_STORAGE_BACKEND"]}" unless File.exist?("vault.json")
   end
 end
 

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -70,7 +70,7 @@ class VaultClient
   private
 
   def config_valid?
-    raise "vault.json is required for #{ENV["SECRET_STORAGE_BACKEND"]}" unless File.exist?("vault.json")
+    raise "vault.json is required for #{CONFIG_PATH}" unless File.exist?(CONFIG_PATH)
   end
 end
 

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -159,6 +159,26 @@ describe SecretStorage do
   describe SecretStorage::HashicorpVault do
     let(:client) { SecretStorage::HashicorpVault.send(:vault_client) }
     let(:secret_namespace) { "secret/apps/" }
+    around do |test|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("vault.json", '{foo: bar}')
+          test.call
+        end
+      end
+    end
+
+    describe "config file" do
+      it "cannot create w/o a config" do
+        File.unlink("vault.json")
+        e = assert_raises(RuntimeError) { VaultClient.new }
+        e.message.must_include("vault.json")
+      end
+
+      it "creates a client" do
+        assert_instance_of(::VaultClient, VaultClient.new)
+      end
+    end
 
     before { client.clear }
     after { client.verify! }


### PR DESCRIPTION
re-factor the vault client so that it can use a token or a cert/key-pair.  also change it so that it can consume a config file.  this is required so that we can have multile vault servers each with their own configs/tokens/certs etc.

* Add any screenshots if you are touching the UI
* Remember to add unit tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:
https://zendesk.atlassian.net/browse/PAAS-268
### Risks
Low