### PR TITLE
after being create a job is pending for a short amount of time

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -197,7 +197,7 @@ module Kubernetes
     end
 
     def wait_for_build(build)
-      if !build.docker_repo_digest && build.docker_build_job.try(:running?)
+      if !build.docker_repo_digest && build.docker_build_job.try(:active?)
         @output.puts("Waiting for Build #{build.url} to finish.")
         loop do
           break if @stopped


### PR DESCRIPTION
we don't want to declare it failed just to see it pass right after

```
# Executing deploy
# Deploy URL: xxx/projects/kube_service_watcher/deploys/2638
Creating Build for 4ac1814dea5dde130352763c9eb6b95cc46c6e53.
JobExecution failed: Build xxx/projects/kube_service_watcher/builds/40 is pending, rerun it manually.
```