### PR TITLE
Remove undockerizable characters from image names

### DIFF
--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -140,7 +140,7 @@ class BinaryBuilder
   end
 
   def image_name
-    "#{@project.send(:permalink_base)}_build:#{@git_reference}".downcase
+    "#{@project.send(:permalink_base)}_build:#{@git_reference.parameterize}".downcase
   end
 
   def create_build_image

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -138,5 +138,13 @@ describe BinaryBuilder do
       image_name = builder.send(:image_name)
       image_name.must_equal(image_name.downcase)
     end
+
+    describe 'with git refs that include slashes' do
+      let(:reference) { 'namespaced/ref' }
+
+      it 'replaces slashes with dashes' do
+        builder.send(:image_name).must_equal 'foo_build:namespaced-ref'
+      end
+    end
   end
 end


### PR DESCRIPTION
This is happening when I try to deploy my project using the ref `ben/my-feature`. Docker tags [cannot have slashes](https://docs.docker.com/engine/reference/commandline/tag/):

> A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.

Happily, Rails’ `parameterize` function will produce results that fit these restrictions.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low. This happens at build time, and should prevent certain classes of poorly-surfaced error.

