### PR TITLE
Show the airbrake ID to end-users for easier debugging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ GITHUB_TOKEN=
 
 # DEPLOY_GROUP_FEATURE=1 # optional, enable Environments and DeployGroups
 
+# AIRBRAKE_API_KEY= # optional, report errors to airbrake
+
 ## Docker
 # DOCKER_FEATURE=1 # optional, experimental docker support
 # DOCKER_REGISTRY= # required, where to push/pull your docker images

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,9 +4,14 @@ require 'rails/all'
 
 Bundler.require(:preload)
 Bundler.require(:assets) if Rails.env.development? || ENV["PRECOMPILE"]
+
 if ['development', 'staging'].include?(Rails.env)
   require 'better_errors'
   require 'rack-mini-profiler'
+end
+
+if ['staging', 'production'].include?(Rails.env)
+  require 'airbrake/railtie'
 end
 
 Dotenv.load(Bundler.root.join(Rails.env.test? ? '.env.test' : '.env'))

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,8 +1,10 @@
 from_cap = !defined?(Rails)
-if from_cap || Rails.env.staging? || Rails.env.production?
-  require 'airbrake'
+if from_cap || defined?(Airbrake)
   Airbrake.configure do |config|
     config.api_key = ENV['AIRBRAKE_API_KEY']
+    config.user_information = # replaces <!-- AIRBRAKE ERROR --> on 500 pages
+      "<br/><br/>Error number: <a href='https://airbrake.io/locate/{{error_id}}'>{{error_id}}</a>"
+    # config.development_environments = ['test'] # uncomment to report in development
   end
 else
   module Airbrake

--- a/public/500.html
+++ b/public/500.html
@@ -52,6 +52,9 @@
   <div class="dialog">
     <h1>We're sorry, but something went wrong.</h1>
   </div>
-  <p>If you are the application owner check the logs for more information.</p>
+  <p>
+    If you are the application owner check the logs for more information.
+    <!-- AIRBRAKE ERROR -->
+  </p>
 </body>
 </html>


### PR DESCRIPTION
Loads airbrake and insert middleware on staging/production

![screen shot 2016-07-21 at 11 31 12 am](https://cloud.githubusercontent.com/assets/11367/17034243/a7aefcd0-4f36-11e6-958b-955fdb75fbd4.png)

To test locally:
 - set AIRBRAKE_API_KEY
 - remove if staging/production checks in application.rb
 - uncomment config.development_environments
 - raise an exception in a controller
 - set config.consider_all_requests_local = false

@zendesk/samson 

users without airbrake account will see a login message ... but I think that's fine and not crazy confusing but gives us the great benefit of being able to click right through to the backtrace