### PR TITLE
Additional checks for a valid pull request

### DIFF
--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -50,7 +50,7 @@ class Changeset::PullRequest
   # should only be when the edit is related to adding the text [samson review]
   def self.valid_webhook?(params)
     data = params['pull_request'] || {}
-    action = params.fetch('github').fetch('action')
+    action = params.dig('github', 'action')
     return false unless data['state'] == 'open' && (VALID_ACTIONS.include? action)
 
     if action == 'edited'

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -58,10 +58,23 @@ describe Integrations::GithubController do
     let(:user_name) { 'Github' }
     let(:payload) do
       {
-        ref: 'refs/heads/dev',
         after: commit,
         number: '42',
-        pull_request: {state: 'open', body: 'imafixwolves [samson]'}
+        pull_request: {
+          head: {
+            ref: 'refs/heads/dev'
+          },
+          state: 'open',
+          body: 'imafixwolves [samson review]'
+        },
+        github: {
+          action: 'edited',
+          changes: {
+            body: {
+              from: 'something'
+            }
+          }
+        }
       }.with_indifferent_access
     end
     let(:api_response) do
@@ -77,7 +90,7 @@ describe Integrations::GithubController do
       payload.deep_merge!(pull_request: {state: 'closed'})
     end
 
-    does_not_deploy 'without "[samson]" in the body' do
+    does_not_deploy 'without "[samson review]" in the body' do
       payload.deep_merge!(pull_request: {body: 'imafixwolves'})
     end
   end


### PR DESCRIPTION
When using [samson review] - we're inspecting github `pull_request` events. However - we would sometimes get multiple deploys with the same `sha`.

<img width="287" alt="screen shot 2016-07-22 at 11 39 59 am" src="https://cloud.githubusercontent.com/assets/1566114/17067525/eeb90772-5000-11e6-8557-c6ab439138dc.png">

This happens because github will send a pull request event to samson if the pr description gets updated, if someone adds a label, and much more. 

We only want samson to trigger a deploy when there is a new code push, or if someone explicitly adds the text [samson review]. To achieve this - the only events we will now consider are:  `opened`, `edited` or `synchronized`. In addition, if it's an edit event - we'll make sure the previous description did not have `[samson review]` in the description.


/cc @zendesk/samson @mwerner 

### Tasks
 - [x] :+1: from team


### Risks
- Level: Low. Samson could potentially not deploy the pull requests we expect
