### PR TITLE
currently vault token as a newline char

### DIFF
--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -23,7 +23,7 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
       @writers = vault_hosts.map do |vault_server|
         if vault_server["vault_token"].present?
           writer = Vault::Client.new(DEFAULT_CLIENT_OPTIONS.merge(verify_mode: vault_server["tls_verify"]))
-          writer.token = File.read(vault_server["vault_token"])
+          writer.token = File.read(vault_server["vault_token"]).strip
         else
           pemfile = File.read(vault_server["vault_auth_pem"])
           client_cert_options = {


### PR DESCRIPTION
currently vautl token on disk has a newline.

* Add any screenshots if you are touching the UI
* Remember to add unit tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
low
