### PR TITLE
ruby version in Gemfile.lock needs to match .ruby-version or heroku blows up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby File.read('.ruby-version').strip
+ruby '2.3.1'
 
 # gems that have rails engines are are always needed
 group :preload do


### PR DESCRIPTION
"Your Ruby version is 2.2.3, but your Gemfile specified 2.3.1"

@sandlerr 