### PR TITLE
show aibrake url in build logs

### DIFF
--- a/app/models/output_buffer.rb
+++ b/app/models/output_buffer.rb
@@ -30,7 +30,7 @@ class OutputBuffer
   end
 
   def puts(line = "")
-    write(line.rstrip + "\n")
+    write(line.to_s.rstrip << "\n")
   end
 
   def write(data, event = :message)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -4,16 +4,18 @@ if from_cap || defined?(Airbrake)
     config.api_key = ENV['AIRBRAKE_API_KEY']
     config.user_information = # replaces <!-- AIRBRAKE ERROR --> on 500 pages
       "<br/><br/>Error number: <a href='https://airbrake.io/locate/{{error_id}}'>{{error_id}}</a>"
-    # config.development_environments = ['test'] # uncomment to report in development
+    # config.development_environments = [:test] # uncomment to report in development
   end
 else
   module Airbrake
     def self.notify(ex, *_args)
       Rails.logger.error "AIRBRAKE: #{ex.class} - #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
+      nil
     end
 
     def self.notify_or_ignore(ex, *_args)
       notify(ex)
+      nil
     end
   end
 end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -304,6 +304,18 @@ describe JobExecution do
         execution.output.to_s.wont_include model_file
       end
     end
+
+    it "shows airbrake error location" do
+      with_hidden_errors do
+        Airbrake.expects(:notify).returns("12345")
+        Airbrake.expects(:configuration).returns(stub(user_information: 'href="http://foo.com/{{error_id}}"'))
+        job.expects(:run!).raises("Oh boy")
+        execution.start!
+        execution.wait!
+        execution.output.to_s.must_include "JobExecution failed: Oh boy"
+        execution.output.to_s.must_include "http://foo.com/12345"
+      end
+    end
   end
 
   describe "#stop!" do

--- a/test/models/output_buffer_test.rb
+++ b/test/models/output_buffer_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 3
+SingleCov.covered! uncovered: 2
 
 describe OutputBuffer do
   include OutputBufferSupport
@@ -42,11 +42,32 @@ describe OutputBuffer do
     build_listener.value.must_equal ["hello"]
   end
 
+  describe "#puts" do
+    it "writes a newline without argument" do
+      listen(&:puts).must_equal ["\n"]
+    end
+
+    it "writes nil as newline" do
+      listen { |o| o.puts nil }.must_equal ["\n"]
+    end
+
+    it "rstrips content" do # not sure why we do this, just documenting
+      listen { |o| o.puts " x " }.must_equal [" x\n"]
+    end
+  end
+
   def build_listener
     Thread.new do
       content = []
       buffer.each { |_event, chunk| content << chunk }
       content
     end
+  end
+
+  def listen
+    listener = build_listener
+    yield buffer
+    buffer.close
+    listener.value
   end
 end

--- a/test/support/timeout.rb
+++ b/test/support/timeout.rb
@@ -13,4 +13,4 @@ module TimeoutEveryTestCase
     end
   end
 end
-# Minitest::Test.prepend TimeoutEveryTestCase
+Minitest::Test.prepend TimeoutEveryTestCase


### PR DESCRIPTION
when an error happens in production / when backtraces are hidden we still want users to be able to talk to developers efficiently

<img width="567" alt="screen shot 2016-07-22 at 7 33 20 pm" src="https://cloud.githubusercontent.com/assets/11367/17075268/74ce18ec-5043-11e6-862c-32ffe74009dd.png">

@zendesk/samson 
