### PR TITLE
Allow specifying a CA cert for Vault clients

### DIFF
--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -35,6 +35,7 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
           writer.token = VaultClient.auth_token(vault_server["vault_address"])
         end
         writer.address = vault_server["vault_address"]
+        writer.ssl_ca_cert = vault_server["ca_cert"] if vault_server["ca_cert"]
         writer
       end
       @reader = @writers.first

--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -3,7 +3,6 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
   Rails.logger.info("Vault Client enabled")
 
   class VaultClient < Vault::Client
-    CONFIG_PATH = 'config/vault.json'.freeze
     CERT_AUTH_PATH = '/v1/auth/cert/login'.freeze
     DEFAULT_CLIENT_OPTIONS = {
       use_ssl: true,
@@ -82,13 +81,17 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
     private
 
     def ensure_config_exists
-      unless File.exist?(Rails.root.join(CONFIG_PATH))
-        raise "#{CONFIG_PATH} is required for #{ENV["SECRET_STORAGE_BACKEND"]}"
+      unless File.exist?(vault_config_file)
+        raise "VAULT_CONFIG_FILE or config/vault.json is required for #{ENV["SECRET_STORAGE_BACKEND"]}"
       end
     end
 
     def vault_hosts
-      JSON.parse(File.read(Rails.root.join("config/vault.json")))
+      JSON.parse(File.read(vault_config_file))
+    end
+
+    def vault_config_file
+      ENV['VAULT_CONFIG_FILE'] || Rails.root.join("config/vault.json")
     end
   end
 end


### PR DESCRIPTION
* Add `ca_cert` attribute to `vault.json` file
* Allow specifying a vault config file via ENV var, rather than hard-coding

/cc @zendesk/samson, @irwaters 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
