### PR TITLE
remove calls to Kubernetes::Cluster#watch!

### DIFF
--- a/plugins/kubernetes/app/controllers/admin/kubernetes/clusters_controller.rb
+++ b/plugins/kubernetes/app/controllers/admin/kubernetes/clusters_controller.rb
@@ -12,7 +12,6 @@ class Admin::Kubernetes::ClustersController < ApplicationController
   def create
     @cluster = ::Kubernetes::Cluster.new(new_cluster_params)
     success = @cluster.save
-    @cluster.watch! if success
 
     respond_to do |format|
       format.html do
@@ -42,7 +41,6 @@ class Admin::Kubernetes::ClustersController < ApplicationController
   def update
     @cluster.assign_attributes(new_cluster_params)
     success = @cluster.save
-    @cluster.watch! if success
 
     respond_to do |format|
       format.html do

--- a/plugins/kubernetes/test/controllers/admin/kubernetes/clusters_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/admin/kubernetes/clusters_controller_test.rb
@@ -46,14 +46,12 @@ describe Admin::Kubernetes::ClustersController do
       before { Kubernetes::Cluster.any_instance.stubs(connection_valid?: true) } # avoid real connection
 
       it "redirects on success" do
-        Kubernetes::Cluster.any_instance.expects(:watch!) # spawn threads
         post :create, kubernetes_cluster: params
         assert_redirected_to "http://test.host/admin/kubernetes/clusters/#{Kubernetes::Cluster.last.id}"
       end
 
       it "renders when it fails to create" do
         params.delete(:name)
-        Kubernetes::Cluster.any_instance.expects(:watch!).never
         post :create, kubernetes_cluster: params
         assert_template :new
       end


### PR DESCRIPTION
This method no longer exists, and was causing Airbrake errors.

/cc @zendesk/paas

### Tasks
 - [ ] :+1: from team

### References
 - Airbrake: https://zendesk.airbrake.io/projects/95346/groups/1736529205816405742

### Risks
- Level: Low

