### PR TITLE
look up Vault config from JSON when creating secret sidecar [PAAS-285]

### DIFF
--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -2,6 +2,16 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
   require 'vault'
   Rails.logger.info("Vault Client enabled")
 
+  # Assumes that a vault.json file exists which contains an array of hashes.
+  # Each hash represents an Vault instance Samson can connect to.
+  # The attributes of the hash are:
+  #   - vault_address (string, required) - URL of the vault host
+  #   - deploy_groups (Array, required) - list of deploy groups for that Vault
+  #   - ca_cert (string) - path to CA cert used to verify the Vault server cert
+  #   - vault_token (string) - path to file containing an auth token
+  #   - vault_auth_pem (string) - path to file containing a client certificate
+  #   - tls_verify (boolean) - whether to verify the server's cert
+
   class VaultClient < Vault::Client
     CERT_AUTH_PATH = '/v1/auth/cert/login'.freeze
     DEFAULT_CLIENT_OPTIONS = {
@@ -11,6 +21,21 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
       open_timeout: 3,
       read_timeout: 2
     }.freeze
+
+    def self.auth_token(vault_server)
+      uri = URI.parse(vault_server)
+      @http = Net::HTTP.start(uri.host, uri.port, DEFAULT_CLIENT_OPTIONS)
+      response = @http.request(Net::HTTP::Post.new(CERT_AUTH_PATH))
+      if response.code == "200"
+        JSON.parse(response.body).fetch("auth")["client_token"]
+      else
+        raise "Failed to get auth token from vault server"
+      end
+    end
+
+    def self.client
+      @client ||= new
+    end
 
     def initialize
       return if Rails.env.test?
@@ -68,14 +93,9 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
       end
     end
 
-    def self.auth_token(vault_server)
-      uri = URI.parse(vault_server)
-      @http = Net::HTTP.start(uri.host, uri.port, DEFAULT_CLIENT_OPTIONS)
-      response = @http.request(Net::HTTP::Post.new(CERT_AUTH_PATH))
-      if response.code == "200"
-        JSON.parse(response.body).fetch("auth")["client_token"]
-      else
-        raise "Failed to get auth token from vault server"
+    def config_for(deploy_group_name)
+      vault_hosts.detect do |hash|
+        hash.fetch('deploy_groups', []).include? deploy_group_name
       end
     end
 
@@ -88,7 +108,7 @@ if ENV["SECRET_STORAGE_BACKEND"] == "SecretStorage::HashicorpVault"
     end
 
     def vault_hosts
-      JSON.parse(File.read(vault_config_file))
+      @vault_hosts ||= JSON.parse(File.read(vault_config_file))
     end
 
     def vault_config_file

--- a/plugins/kubernetes/app/models/kubernetes/resource_template.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_template.rb
@@ -200,10 +200,13 @@ module Kubernetes
       end
 
       if needs_secret_sidecar?
+        vault_config = VaultClient.client.config_for(@doc.deploy_group.permalink)
+        raise StandardError, "Could not find Vault config for #{@doc.deploy_group.permalink}" unless vault_config
+
         sidecar_env = (sidecar_container[:env] ||= [])
         {
-          VAULT_ADDR: ENV.fetch("VAULT_ADDR"),
-          VAULT_SSL_VERIFY: ENV.fetch("VAULT_SSL_VERIFY", true)
+          VAULT_ADDR: vault_config['vault_address'],
+          VAULT_SSL_VERIFY: vault_config['tls_verify']
         }.each do |k, v|
           sidecar_env << {
             name: k,

--- a/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
@@ -98,9 +98,13 @@ describe Kubernetes::ResourceTemplate do
     end
 
     describe "secret-sidecar-containers" do
-      with_env(VAULT_ADDR: "somehostontheinternet", VAULT_SSL_VERIFY: "false")
-
       let(:secret_key) { 'production/foo/snafu/bar' }
+      let(:vault_server_config) do
+        {
+          'vault_address' => 'myvault.server',
+          'tls_verify' => false
+        }
+      end
 
       around do |test|
         klass = Kubernetes::ResourceTemplate
@@ -110,6 +114,7 @@ describe Kubernetes::ResourceTemplate do
       end
 
       before do
+        VaultClient.any_instance.stubs(:config_for).returns(vault_server_config)
         old_metadata = "role: some-role\n    "
         new_metadata = "role: some-role\n      annotations:\n        secret/FOO: #{secret_key}\n    "
         assert doc.raw_template.sub!(old_metadata, new_metadata)

--- a/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
@@ -99,12 +99,6 @@ describe Kubernetes::ResourceTemplate do
 
     describe "secret-sidecar-containers" do
       let(:secret_key) { 'production/foo/snafu/bar' }
-      let(:vault_server_config) do
-        {
-          'vault_address' => 'myvault.server',
-          'tls_verify' => false
-        }
-      end
 
       around do |test|
         klass = Kubernetes::ResourceTemplate
@@ -114,7 +108,6 @@ describe Kubernetes::ResourceTemplate do
       end
 
       before do
-        VaultClient.any_instance.stubs(:config_for).returns(vault_server_config)
         old_metadata = "role: some-role\n    "
         new_metadata = "role: some-role\n      annotations:\n        secret/FOO: #{secret_key}\n    "
         assert doc.raw_template.sub!(old_metadata, new_metadata)

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -3,7 +3,6 @@ require_relative '../lib/samson_kubernetes/hash_kuber_selector'
 
 # Mock up vault client
 class VaultClient
-  CONFIG_PATH = 'vault.json'.freeze
   def logical
     @logical ||= Logical.new
   end
@@ -12,8 +11,11 @@ class VaultClient
     Response.new(data)
   end
 
+  def self.client
+    @client ||= new
+  end
+
   def initialize
-    ensure_config_exists
     @expected = {}
     @set = {}
   end
@@ -34,6 +36,14 @@ class VaultClient
   def write(key, body)
     @set[key] = body
     true
+  end
+
+  def config_for(deploy_group_name)
+    {
+      'vault_address' => 'https://test.hvault.server',
+      'deploy_groups' => [deploy_group_name, 'other_deploy_group'],
+      'tls_verify' => false
+    }
   end
 
   # test hooks
@@ -65,12 +75,6 @@ class VaultClient
     def to_h
       instance_values.symbolize_keys
     end
-  end
-
-  private
-
-  def ensure_config_exists
-    raise "vault.json is required for #{CONFIG_PATH}" unless File.exist?(CONFIG_PATH)
   end
 end
 

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -159,26 +159,6 @@ describe SecretStorage do
   describe SecretStorage::HashicorpVault do
     let(:client) { SecretStorage::HashicorpVault.send(:vault_client) }
     let(:secret_namespace) { "secret/apps/" }
-    around do |test|
-      Dir.mktmpdir do |dir|
-        Dir.chdir(dir) do
-          File.write("vault.json", '{foo: bar}')
-          test.call
-        end
-      end
-    end
-
-    describe "config file" do
-      it "cannot create w/o a config" do
-        File.unlink("vault.json")
-        e = assert_raises(RuntimeError) { VaultClient.new }
-        e.message.must_include("vault.json")
-      end
-
-      it "creates a client" do
-        assert_instance_of(::VaultClient, VaultClient.new)
-      end
-    end
 
     before { client.clear }
     after { client.verify! }


### PR DESCRIPTION
* Built on top of #1154 
* Assumes the `vault.json` file has a list of deploy_groups in it. Still need to make that chef change
* Haven't run the tests yet
* We need further refactoring of the Vault/Secret code, but this should unblock us

/cc @zendesk/paas

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-285

### Risks
- Level: Low
