### PR TITLE
improve the output when deploying Kubernetes stages

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -120,7 +120,7 @@ module Kubernetes
             "No logs found"
           end
         end
-        logs.split("\n").each { |line| @output.puts "  #{line}"}
+        logs.split("\n").each { |line| @output.puts "  #{line}" }
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -2,7 +2,7 @@
 # finishes when cluster is "Ready"
 module Kubernetes
   class DeployExecutor
-    WAIT_FOR_LIVE = 10.minutes
+    WAIT_FOR_LIVE = ENV.fetch('KUBE_WAIT_FOR_LIVE', 10).to_i.minutes
     CHECK_STABLE = 1.minute
     TICK = 2.seconds
     RESTARTED = "Restarted".freeze
@@ -180,7 +180,7 @@ module Kubernetes
     end
 
     def print_statuses(status_groups)
-      return if @last_status_output && @last_status_output < 10.seconds.ago
+      return if @last_status_output && @last_status_output > 10.seconds.ago
 
       @last_status_output = Time.now
       @output.puts "Deploy status after #{seconds_waiting} seconds:"

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -101,15 +101,16 @@ module Kubernetes
         print_events(client, pod)
         @output.puts
         print_logs(client, pod)
+        @output.puts "\n------------------------------------------\n"
       end
     end
 
     # logs - container fails to boot
     def print_logs(client, pod)
-      @output.puts "  LOGS:"
+      @output.puts "LOGS:"
 
       pod.containers.map(&:name).each do |container|
-        @output.puts "  Container #{container}" if pod.containers.size > 1
+        @output.puts "Container #{container}" if pod.containers.size > 1
 
         logs = begin
           client.get_pod_log(pod.name, pod.namespace, previous: pod.restarted?, container: container)
@@ -120,12 +121,13 @@ module Kubernetes
             "No logs found"
           end
         end
-        logs.split("\n").each { |line| @output.puts "  #{line}" }
+        # Don't display hundreds of log lines
+        logs.split("\n").last(50).each { |line| @output.puts "  #{line}" }
       end
     end
 
     def print_events(client, pod)
-      @output.puts "  EVENTS:"
+      @output.puts "EVENTS:"
       events = client.get_events(
         namespace: pod.namespace,
         field_selector: "involvedObject.name=#{pod.name}"

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -302,7 +302,7 @@ describe Kubernetes::DeployExecutor do
       Kubernetes::ReleaseDoc.any_instance.stubs(:desired_pod_count).returns(1.5)
       pod_reply[:items] << pod_reply[:items].first
       assert execute!
-      out.must_include "resque-worker: Live\n  resque-worker: Live"
+      out.scan(/resque-worker: Live/).count.must_equal 2
       out.must_include "SUCCESS"
     end
 
@@ -408,10 +408,10 @@ describe Kubernetes::DeployExecutor do
 
         # correct debugging output
         out.scan(/Pod 100 pod pod-(\S+)/).flatten.uniq.must_equal ["resque-worker:"] # logs and events only for bad pod
-        out.must_include(
-          "EVENTS:\nFailedScheduling: fit failure on node (ip-1-2-3-4)\nfit failure on node (ip-2-3-4-5)\n\n"
+        out.must_match(
+          /EVENTS:\s+FailedScheduling: fit failure on node \(ip-1-2-3-4\)\s+fit failure on node \(ip-2-3-4-5\)\n\n/
         ) # no repeated events
-        out.must_include "LOGS:\nLOG-1\n"
+        out.must_match /LOGS:\s+LOG-1/
       end
 
       it "requests regular logs when previous logs are not available" do
@@ -424,7 +424,7 @@ describe Kubernetes::DeployExecutor do
 
         refute execute!
 
-        out.must_include "LOGS:\nLOG-1\n"
+        out.must_match /LOGS:\s+LOG-1/
       end
 
       it "does not crash when both log endpoints fails with a 404" do
@@ -437,7 +437,7 @@ describe Kubernetes::DeployExecutor do
 
         refute execute!
 
-        out.must_include "LOGS:\nNo logs found\n"
+        out.must_match /LOGS:\s+No logs found/
       end
     end
   end


### PR DESCRIPTION
* Don't write output every 2 seconds
* Make the output of each line different, so you can tell it's outputting new info
* Limit output of container logs to last 50 lines

(Will create screenshots after I test it out.)

/cc @zendesk/paas

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low

