### PR TITLE
Always show the redeploy button

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery-ujs
 //= require jquery-cookie
+//= require jquery-ui
 //= require datatables.net
 //= require datatables.net-bs
 //= require datatables.net-fixedcolumns
@@ -31,7 +32,6 @@
 //= require bootstrap/tooltip
 //= require bootstrap/popover
 //= require bootstrap-select
-//= require jquery-ui
 //= require x-editable/dist/bootstrap3-editable/js/bootstrap-editable
 //= require message-center
 //= require rickshaw/vendor/d3.min

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -339,6 +339,8 @@ $(function () {
 
     highlightAndScroll();
   }());
+
+  $('[data-toggle="tooltip"]').tooltip();
 });
 
 function toggleOutputToolbar() {

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -99,12 +99,13 @@ module DeploysHelper
     end
   end
 
-  def redeploy_button(already_succeeded = false)
+  def redeploy_button
+    return if @deploy.active?
     html_options = {
       class: 'btn btn-danger',
       method: :post
     }
-    if already_succeeded
+    if @deploy.succeeded?
       html_options[:class] = 'btn btn-default'
       html_options[:data] = {
         toggle: 'tooltip',

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -99,6 +99,28 @@ module DeploysHelper
     end
   end
 
+  def redeploy_button(already_succeeded = false)
+    html_options = {
+      class: 'btn btn-danger',
+      method: :post
+    }
+    if already_succeeded
+      html_options[:class] = 'btn btn-default'
+      html_options[:data] = {
+        toggle: 'tooltip',
+        placement: 'auto bottom'
+      }
+      html_options[:title] = 'Why? This deploy succeeded.'
+    end
+    link_to "Redeploy",
+      project_stage_deploys_path(
+        @project,
+        @deploy.stage,
+        deploy: { reference: @deploy.reference }
+      ),
+      html_options
+  end
+
   def stop_button(deploy: @deploy, **options)
     return unless @project && deploy
     link_to(

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -3,8 +3,10 @@
 
   <div class="pull-right">
     <% if deployer_for_project? %>
-      <% unless @deploy.succeeded? || @deploy.active? %>
-        <%= link_to "Redeploy", project_stage_deploys_path(@project, @deploy.stage, deploy: { reference: @deploy.reference }), method: :post, class: "btn btn-danger" %>
+      <% if @deploy.succeeded? %>
+        <%= redeploy_button(true) %>
+      <% elsif !@deploy.active? %>
+        <%= redeploy_button %>
       <% end %>
 
       <% if @deploy.succeeded? && next_stage = @deploy.stage.next_stage %>

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -3,7 +3,7 @@
 
   <div class="pull-right">
     <% if deployer_for_project? %>
-        <%= redeploy_button %>
+      <%= redeploy_button %>
 
       <% if @deploy.succeeded? && next_stage = @deploy.stage.next_stage %>
         <% unless next_stage.locked? %>

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -3,11 +3,7 @@
 
   <div class="pull-right">
     <% if deployer_for_project? %>
-      <% if @deploy.succeeded? %>
-        <%= redeploy_button(true) %>
-      <% elsif !@deploy.active? %>
         <%= redeploy_button %>
-      <% end %>
 
       <% if @deploy.succeeded? && next_stage = @deploy.stage.next_stage %>
         <% unless next_stage.locked? %>

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -34,4 +34,42 @@ describe DeploysHelper do
       assert_raises(KeyError) { file_status_label('wut') }
     end
   end
+
+  describe '#redeploy_button' do
+    before do
+      @deploy = deploys(:succeeded_test)
+      @project = projects(:test)
+    end
+
+    describe 'when the deploy already succeeded' do
+      it 'generates a link' do
+        link = '<a class="btn btn-default" data-toggle="tooltip" data-placement="auto bottom" title="Why? This deploy'\
+               ' succeeded." rel="nofollow" data-method="post" href="/projects/foo/stages/staging/deploys?deploy%5Bre'\
+               'ference%5D=staging">Redeploy</a>'
+        redeploy_button.must_equal link
+      end
+    end
+
+    describe 'when the deploy is still running' do
+      around do |t|
+        @deploy.stub(:active?, true) { t.call }
+      end
+
+      it 'does not generate a link' do
+        redeploy_button.must_equal nil
+      end
+    end
+
+    describe 'when the deploy failed' do
+      around do |t|
+        @deploy = deploys(:succeeded_test)
+        @deploy.stub(:succeeded?, false) { t.call }
+      end
+
+      it 'generates a red link' do
+        redeploy_button.must_equal '<a class="btn btn-danger" rel="nofollow" data-method="post" href="/projects/foo/'\
+                                   'stages/staging/deploys?deploy%5Breference%5D=staging">Redeploy</a>'
+      end
+    end
+  end
 end


### PR DESCRIPTION
@zendesk/samson @timbertson 

- move `jquery-ui` higher so its tooltip method doesn't conflict with bootstrap
- show a redeploy button with different styling on successful deploys