### PR TITLE
take user back after creating a deploy group role via stage UI

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,4 +23,18 @@ class ApplicationController < ActionController::Base
     super
     payload["params"] = request.params
   end
+
+  def redirect_back_or(fallback)
+    if param_location = params[:redirect_to].to_s.presence
+      if param_location.is_a?(String) && param_location.start_with?('/')
+        redirect_to URI("http://nope.nope#{param_location}").request_uri # using URI to silence Brakeman
+      else
+        render status: :bad_request, plain: 'Invalid redirect_to parameter'
+      end
+    elsif request.env['HTTP_REFERER']
+      redirect_to :back
+    else
+      redirect_to fallback
+    end
+  end
 end

--- a/plugins/kubernetes/app/controllers/admin/kubernetes/deploy_group_roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/admin/kubernetes/deploy_group_roles_controller.rb
@@ -14,7 +14,7 @@ class Admin::Kubernetes::DeployGroupRolesController < ApplicationController
   def create
     @deploy_group_role = ::Kubernetes::DeployGroupRole.new(deploy_group_role_params)
     if @deploy_group_role.save
-      redirect_to [:admin, @deploy_group_role]
+      redirect_back_or [:admin, @deploy_group_role]
     else
       render :new, status: 422
     end

--- a/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_for [:admin, @deploy_group_role], html: { class: "form-horizontal" } do |form| %>
+  <%= hidden_field_tag :redirect_to, params[:redirect_to] %>
   <%= render 'shared/errors', object: @deploy_group_role %>
   <% defaults = @deploy_group_role.kubernetes_role.try(:defaults) || {} %>
 

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -39,7 +39,7 @@
             <td>
               <% if current_user.admin_for?(@stage.project) %>
                 <% attributes = {kubernetes_role_id: role.id, project_id: @stage.project_id, deploy_group_id: deploy_group.id} %>
-                <%= link_to "Create", new_admin_kubernetes_deploy_group_role_path(kubernetes_deploy_group_role: attributes) %>
+                <%= link_to "Create", new_admin_kubernetes_deploy_group_role_path(kubernetes_deploy_group_role: attributes, redirect_to: request.path) %>
               <% end %>
             </td>
           <% end %>

--- a/plugins/kubernetes/test/controllers/admin/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/admin/kubernetes/deploy_group_roles_controller_test.rb
@@ -76,6 +76,11 @@ describe Admin::Kubernetes::DeployGroupRolesController do
         assert_redirected_to [:admin, Kubernetes::DeployGroupRole.last]
       end
 
+      it "redirects to param" do
+        post :create, params.merge(redirect_to: '/bar')
+        assert_redirected_to '/bar'
+      end
+
       it "renders when failing to create" do
         params[:kubernetes_deploy_group_role].delete(:cpu)
         post :create, params

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,62 @@
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe ApplicationController do
+  class ApplicationTestController < ApplicationController
+    def test_redirect_back_or
+      redirect_back_or '/fallback'
+    end
+  end
+
+  tests ApplicationTestController
+  use_test_routes
+
+  describe "#redirect_back_or" do
+    as_a_viewer do
+      it "redirects to fallback" do
+        get :test_redirect_back_or, test_route: true
+        assert_redirected_to '/fallback'
+      end
+
+      it "redirects to redirect_to" do
+        get :test_redirect_back_or, test_route: true, redirect_to: '/param'
+        assert_redirected_to '/param'
+      end
+
+      it "redirects to redirect_to with query" do
+        get :test_redirect_back_or, test_route: true, redirect_to: '/param?x=1&y=2'
+        assert_redirected_to '/param?x=1&y=2'
+      end
+
+      it "ignores blank redirect_to which comes from forms blindly filling it" do
+        get :test_redirect_back_or, test_route: true, redirect_to: ''
+        assert_redirected_to '/fallback'
+      end
+
+      describe "with referer" do
+        before { request.env['HTTP_REFERER'] = '/header' }
+
+        it "redirects to referrer" do
+          get :test_redirect_back_or, test_route: true
+          assert_redirected_to '/header'
+        end
+
+        it "prefers params over headers" do
+          get :test_redirect_back_or, test_route: true, redirect_to: '/param'
+          assert_redirected_to '/param'
+        end
+      end
+
+      it "does not redirect to hacky url in redirect_to" do
+        get :test_redirect_back_or, test_route: true, redirect_to: 'http://hacks.com'
+        assert_response :bad_request
+      end
+
+      it "does not redirect to hacky hash in redirect_to" do
+        get :test_redirect_back_or, test_route: true, redirect_to: {host: 'hacks.com', path: 'bar'}
+        assert_response :bad_request
+      end
+    end
+  end
+end

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -86,7 +86,6 @@ describe "cleanliness" do
 
   it "tests all files" do
     untested = [
-      "app/controllers/application_controller.rb",
       "app/controllers/concerns/current_project.rb",
       "app/controllers/concerns/stage_permitted_params.rb",
       "app/mailers/application_mailer.rb",


### PR DESCRIPTION
![screen shot 2016-07-25 at 2 45 11 pm](https://cloud.githubusercontent.com/assets/11367/17118655/6b9a28ee-5276-11e6-8c39-3ec30e7aa531.png)

click create -> new + redirect_to param
create -> success ? redirect-to-param : show error
-> arrive back where you started

@jonmoter 

/cc @zendesk/samson for a generally useful helper
