### PR TITLE
Revert  "update dependencies, refactor dockerfile" changes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ruby:2.3.1-slim
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get update && apt-get install -y nodejs build-essential libmysqlclient-dev libpq-dev libsqlite3-dev git
-RUN npm install -g npm
+RUN apt-get update && apt-get install -y wget apt-transport-https git
+RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN echo 'deb https://deb.nodesource.com/node_0.12 jessie main' > /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs build-essential libmysqlclient-dev libpq-dev libsqlite3-dev
 
 WORKDIR /app
 


### PR DESCRIPTION

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low

This reverts the part of that commit that changed the Dockerfile, except for the
change to ruby 2.3.1, that is of course needed. The bug hit it is this:
https://github.com/npm/npm/issues/9863 (although reported to an older version,
it still applies and bug reports to newer versions of npm where closed as
duplicates of this bug).

This fixes the build that is not working since that change and docker hub fails
to build images automatically since then.