### PR TITLE
cleanup deleted projects permission or creating new permissions fails

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -10,6 +10,7 @@ class Project < ActiveRecord::Base
   after_save :clone_repository, if: :repository_url_changed?
   before_update :clean_old_repository, if: :repository_url_changed?
   after_soft_delete :clean_repository
+  before_soft_delete :destroy_user_project_roles
 
   has_many :builds
   has_many :releases
@@ -19,7 +20,7 @@ class Project < ActiveRecord::Base
   has_many :webhooks
   has_many :commands
   has_many :macros, dependent: :destroy
-  has_many :user_project_roles
+  has_many :user_project_roles, dependent: :destroy
   has_many :users, through: :user_project_roles
 
   # For permission checks on callbacks. Currently used in private plugins.
@@ -208,5 +209,9 @@ class Project < ActiveRecord::Base
   def valid_repository_url
     return if repository.valid_url?
     errors.add(:repository_url, "is not valid or accessible")
+  end
+
+  def destroy_user_project_roles
+    user_project_roles.each(&:destroy)
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -393,4 +393,14 @@ describe Project do
       refute project.create_releases_for_branch?("x")
     end
   end
+
+  describe "#user_project_roles" do
+    it "deletes them on deletion and audits as user change" do
+      assert_difference 'PaperTrail::Version.where(item_type: User).count', +2 do
+        assert_difference 'UserProjectRole.count', -2 do
+          project.soft_delete!
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
@jonmoter @vanchi-zendesk 

alternative would be to make creation not fail ... but I'd rather get rid of the bad data ...