### PR TITLE
make timeout errors easier to debug

### DIFF
--- a/test/support/timeout.rb
+++ b/test/support/timeout.rb
@@ -1,11 +1,17 @@
 # tests sometimes hang locally or on ci and with this we can actually debug the cause instead of just hanging forever
 module TimeoutEveryTestCase
-  def capture_exceptions(*args, &block)
+  class TestCaseTimeout < StandardError
+    def message
+      "Test took too long to finish, aborting. To use a debugger: disable timeouts in #{__FILE__}."
+    end
+  end
+
+  def capture_exceptions(*, &block)
     super do
       rescued = false
       begin
-        Timeout.timeout(5, &block)
-      rescue Timeout::Error => e
+        Timeout.timeout(5, TestCaseTimeout, &block)
+      rescue TestCaseTimeout => e
         raise e if rescued
         rescued = true
         retry


### PR DESCRIPTION
also makes it less likely to be caught by and unrelated rescue

```
  1) Error:
BuildSerializer#test_0001_serializes create at to milliseconds:
TimeoutEveryTestCase::TestCaseTimeout: Test took too long to finish, aborting. To use a debugger: disable timeouts in /Users/mgrosser/Code/zendesk/samson/test/support/timeout.rb.
    test/serializers/build_serializer_test.rb:10:in `sleep'
    test/serializers/build_serializer_test.rb:10:in `block (2 levels) in <main>'
    test/support/timeout.rb:13:in `block in capture_exceptions'
    test/support/timeout.rb:10:in `capture_exceptions'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips

Focus on failing tests:
mtest test/serializers/build_serializer_test.rb:9
```

@apanzerj 