### PR TITLE
when values are already defined in the env we need to overload them t…

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,11 @@ if ['staging', 'production'].include?(Rails.env)
   require 'airbrake/railtie'
 end
 
-Dotenv.load(Bundler.root.join(Rails.env.test? ? '.env.test' : '.env'))
+if Rails.env.test?
+  Dotenv.overload(Bundler.root.join('.env.test'))
+else
+  Dotenv.load(Bundler.root.join('.env'))
+end
 
 require "#{Bundler.root}/lib/samson/env_check"
 


### PR DESCRIPTION
```
  1) Failure:
BuildSerializer#test_0001_serializes url [/app/test/serializers/deploy_serializer_test.rb:10]:
--- expected
+++ actual
@@ -1 +1 @@
-"http://www.test-url.com/projects/foo/deploys/178003093"
+"https://VALUE_FROM_ENV.com/projects/foo/deploys/178003093"
```

@henders 
/cc @zendesk/samson 