### PR TITLE
Irwaters/paas 302 (deploy_group to vault relations)

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -100,7 +100,7 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   def allowed_deploy_group_params
-    ([:name, :environment_id, :env_value] + Samson::Hooks.fire(:deploy_group_permitted_params)).freeze
+    ([:name, :environment_id, :env_value, :vault_instance] + Samson::Hooks.fire(:deploy_group_permitted_params)).freeze
   end
 
   def deploy_group

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -81,6 +81,7 @@ module SecretStorage
       def keys
         keys = vault_client.list(VAULT_SECRET_BACKEND + SAMSON_SECRET_NAMESPACE)
         keys = keys_recursive(keys)
+        keys.uniq! # we read from multiple backends that might have the same keys
         keys.map! do |secret_path|
           convert_path(secret_path, :decode) # FIXME: ideally only decode the key(#4) part
         end

--- a/app/views/admin/deploy_groups/_fields.html.erb
+++ b/app/views/admin/deploy_groups/_fields.html.erb
@@ -13,6 +13,15 @@
     </div>
   </div>
 
+  <% if SecretStorage.backend == SecretStorage::HashicorpVault %>
+    <div class="form-group">
+      <%= form.label :vault_instance, "Vault Instance", class: "col-lg-2 control-label" %>
+      <div class="col-lg-4">
+        <%= form.select(:vault_instance, options_for_select(VaultClient.available_instances, @deploy_group.vault_instance), {}, class: "form-control", required: true) %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="form-group">
     <%= form.label :name, "Environment", class: "col-lg-2 control-label" %>
     <div class="col-lg-4">

--- a/db/migrate/20160726210144_add_vault_instance_to_deploy_groups.rb
+++ b/db/migrate/20160726210144_add_vault_instance_to_deploy_groups.rb
@@ -1,0 +1,5 @@
+class AddVaultInstanceToDeployGroups < ActiveRecord::Migration
+  def change
+    add_column :deploy_groups, :vault_instance, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20160715165508) do
     t.datetime "updated_at",                 null: false
     t.string   "env_value",      limit: 255, null: false
     t.string   "permalink",      limit: 255, null: false
+    t.string   "vault_instance", limit: 255
   end
 
   add_index "deploy_groups", ["environment_id"], name: "index_deploy_groups_on_environment_id", using: :btree

--- a/plugins/kubernetes/app/models/kubernetes/resource_template.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_template.rb
@@ -200,7 +200,7 @@ module Kubernetes
       end
 
       if needs_secret_sidecar?
-        vault_config = VaultClient.client.config_for(@doc.deploy_group.permalink)
+        vault_config = VaultClient.client.config_for(@doc.deploy_group.vault_instance)
         raise StandardError, "Could not find Vault config for #{@doc.deploy_group.permalink}" unless vault_config
 
         sidecar_env = (sidecar_container[:env] ||= [])


### PR DESCRIPTION
Allows for the assoctionan of a given deploy group to a given vault instance.
vault.json now contains a name for the vault instance.  This is picked up by samson UI, and allows you to add that to a deploy group.  This is then used by the vualt client to store secrets for *that* pod.  global secrets are writen to all pods.  specific pod is checked by samson when doing a k8s deployment to make sure that it contains the correct secrets for that stage of the deployment.  UI changes will only  show up WHEN vault is being used for the secret storage backend. 

* Add any screenshots if you are touching the UI
![screen shot 2016-08-01 at 2 51 24 pm](https://cloud.githubusercontent.com/assets/155554/17310159/8b22a0f2-57f7-11e6-9aa7-7e7d57a14e8b.png)


* Remember to add unit tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:
https://zendesk.atlassian.net/browse/PAAS-302

### Risks
- Level: Low