### PR TITLE
lookup secrets only by key

### DIFF
--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -25,32 +25,45 @@ module SecretStorage
       end
     end
 
-    def self.read(key)
-      secret = Secret.find(key)
-      {
-        key: key,
-        updater_id: secret.updater_id,
-        creator_id: secret.creator_id,
-        updated_at: secret.updated_at,
-        created_at: secret.created_at,
-        value: secret.value
-      }
-    end
+    class << self
+      def read(key)
+        return unless secret = Secret.find_by_id(key)
+        secret_to_hash secret
+      end
 
-    def self.write(key, data)
-      secret = Secret.where(id: key).first_or_initialize
-      secret.updater_id = data.fetch(:user_id)
-      secret.creator_id ||= data.fetch(:user_id)
-      secret.value = data.fetch(:value)
-      secret.save
-    end
+      def read_multi(keys)
+        secrets = Secret.where(id: keys).all
+        secrets.each_with_object({}) { |s, a| a[s.id] = secret_to_hash(s) }
+      end
 
-    def self.delete(key)
-      Secret.delete(key)
-    end
+      def write(key, data)
+        secret = Secret.where(id: key).first_or_initialize
+        secret.updater_id = data.fetch(:user_id)
+        secret.creator_id ||= data.fetch(:user_id)
+        secret.value = data.fetch(:value)
+        secret.save
+      end
 
-    def self.keys
-      Secret.order(:id).pluck(:id)
+      def delete(key)
+        Secret.delete(key)
+      end
+
+      def keys
+        Secret.order(:id).pluck(:id)
+      end
+
+      private
+
+      def secret_to_hash(secret)
+        {
+          key: secret.id,
+          updater_id: secret.updater_id,
+          creator_id: secret.creator_id,
+          updated_at: secret.updated_at,
+          created_at: secret.created_at,
+          value: secret.value
+        }
+      end
     end
   end
 
@@ -63,11 +76,20 @@ module SecretStorage
       def read(key)
         key = vault_path(key)
         result = vault_client.read(key)
-        raise ActiveRecord::RecordNotFound if result.data[:vault].nil?
+        return if result.data[:vault].nil?
+
         result = result.to_h
         result = result.merge(result.delete(:data))
         result[:value] = result.delete(:vault)
         result
+      end
+
+      def read_multi(keys)
+        keys.each_with_object({}) do |key, a|
+          if value = read(key)
+            a[key] = value
+          end
+        end
       end
 
       def write(key, data)
@@ -144,9 +166,18 @@ module SecretStorage
       backend.write(key, data)
     end
 
+    # reads a single key and raises ActiveRecord::RecordNotFound if it is not found
     def read(key, include_secret: false)
       data = backend.read(key) || raise(ActiveRecord::RecordNotFound)
       data.delete(:value) unless include_secret
+      data
+    end
+
+    # reads multiple keys from the backend into a hash
+    # [a, b, c] -> {a: 1, c: 2}
+    def read_multi(keys, include_secret: false)
+      data = backend.read_multi(keys)
+      data.each_value { |s| s.delete(:value) } unless include_secret
       data
     end
 

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -76,7 +76,7 @@ module SecretStorage
       def read(key)
         key = vault_path(key)
         result = vault_client.read(key)
-        return if result.data[:vault].nil?
+        return if !result || result.data[:vault].nil?
 
         result = result.to_h
         result = result.merge(result.delete(:data))

--- a/app/views/admin/secrets/index.html.erb
+++ b/app/views/admin/secrets/index.html.erb
@@ -39,7 +39,7 @@
             <% end %>
           </td>
           <td><%= parts.fetch(:deploy_group_permalink) %></td>
-          <td><%= parts.fetch(:key) %></td>
+          <td title="<%= key %>"><%= parts.fetch(:key) %></td>
           <td>
             <%= link_to "Edit", edit_admin_secret_path(key) %> |
             <%= link_to_delete admin_secret_path(key) %>

--- a/app/views/admin/secrets/index.html.erb
+++ b/app/views/admin/secrets/index.html.erb
@@ -14,6 +14,9 @@
   <table class="table table-hover table-condensed">
     <thead>
       <tr>
+        <th>Environment</th>
+        <th>Project</th>
+        <th>Deploy Group</th>
         <th>Key</th>
         <th>Project</th>
         <th></th>
@@ -23,9 +26,10 @@
     <tbody>
       <% @secret_keys.each do |key| %>
         <tr>
-          <td><%= key %></td>
+          <% parts = SecretStorage.parse_secret_key(key) %>
+          <td><%= parts.fetch(:environment_permalink) %></td>
           <td>
-            <% permalink = SecretStorage.parse_secret_key(key).fetch(:project_permalink) %>
+            <% permalink = parts.fetch(:project_permalink) %>
             <% if name = project_list[permalink] %>
               <%= link_to name, project_path(permalink) %>
             <% elsif permalink == 'global' %>
@@ -34,6 +38,8 @@
               Unknown
             <% end %>
           </td>
+          <td><%= parts.fetch(:deploy_group_permalink) %></td>
+          <td><%= parts.fetch(:key) %></td>
           <td>
             <%= link_to "Edit", edit_admin_secret_path(key) %> |
             <%= link_to_delete admin_secret_path(key) %>
@@ -44,7 +50,7 @@
   </table>
 
   <div class="admin-actions">
-    To use in commands, prefix <%= TerminalExecutor::SECRET_PREFIX %>
+    To use a key in commands, prefix <%= TerminalExecutor::SECRET_PREFIX %>
     <div class="pull-right">
       <%= link_to "New Secret", new_admin_secret_path, class: "btn btn-default" %>
     </div>

--- a/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
@@ -98,7 +98,7 @@ describe Kubernetes::ResourceTemplate do
     end
 
     describe "secret-sidecar-containers" do
-      let(:secret_key) { 'production/foo/snafu/bar' }
+      let(:secret_key) { "global/global/global/bar" }
 
       around do |test|
         klass = Kubernetes::ResourceTemplate
@@ -109,7 +109,7 @@ describe Kubernetes::ResourceTemplate do
 
       before do
         old_metadata = "role: some-role\n    "
-        new_metadata = "role: some-role\n      annotations:\n        secret/FOO: #{secret_key}\n    "
+        new_metadata = "role: some-role\n      annotations:\n        secret/FOO: bar\n    "
         assert doc.raw_template.sub!(old_metadata, new_metadata)
 
         SecretStorage.write(secret_key, value: 'something', user_id: 123)
@@ -150,10 +150,16 @@ describe Kubernetes::ResourceTemplate do
 
       it "fails to find a secret needed by the sidecar" do
         SecretStorage.delete(secret_key)
-        e = assert_raises Samson::Hooks::UserError do
-          template.to_hash
-        end
-        e.message.must_include "secret/FOO with key production/foo/snafu/bar could not be found"
+        e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
+        e.message.must_include "Failed to resolve secret keys:\n\tbar (tried: production/foo/pod1/bar"
+      end
+
+      it "fails to find multiple secret needed by the sidecar, but shows them all at once" do
+        assert doc.raw_template.sub!("secret/FOO: bar", "secret/FOO: bar\n        secret/BAR: baz")
+        SecretStorage.delete(secret_key)
+        e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
+        e.message.must_include "bar (tried: production/foo/pod1/bar"
+        e.message.must_include "baz (tried: production/foo/pod1/baz"
       end
 
       describe "scopes" do
@@ -161,45 +167,27 @@ describe Kubernetes::ResourceTemplate do
           SecretStorage.stubs(:read).returns(true)
         end
 
-        describe "deprecated replacement lookup" do
-          it "secret is scoped correctly" do
-            assert doc.raw_template.sub!(secret_key, '${ENV}/foo/${DEPLOY_GROUP}/bar')
-            template.to_hash[:spec][:template][:metadata][:annotations][:'secret/FOO'].
-              must_equal "production/foo/pod1/bar"
-          end
-
-          it "does not effect a non secret annotation" do
-            assert doc.raw_template.sub!(secret_key, "#{secret_key}\n        annotation_key: somevalueforthekey")
-            template.to_hash[:spec][:template][:metadata][:annotations][:annotation_key].
-              must_equal "somevalueforthekey"
-          end
+        it "looks up by only the key" do
+          SecretStorage.expects(:read_multi).returns('global/global/global/bar' => 'xyz')
+          template.to_hash[:spec][:template][:metadata][:annotations][:'secret/FOO'].
+            must_equal "global/global/global/bar"
         end
 
-        describe "key lookup" do
-          before { assert doc.raw_template.sub!(secret_key, 'bar') }
-
-          it "looks up by only the key" do
-            SecretStorage.expects(:read_multi).returns({'global/global/global/bar' => 'xyz'})
-            template.to_hash[:spec][:template][:metadata][:annotations][:'secret/FOO'].
-              must_equal "global/global/global/bar"
-          end
-
-          it "fails when unable to find by onl key" do
-            SecretStorage.expects(:read_multi).returns({})
-            e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
-            # order is important here and should not change
-            priority = [
-              "production/foo/pod1/bar",
-              "global/foo/pod1/bar",
-              "production/global/pod1/bar",
-              "global/global/pod1/bar",
-              "production/foo/global/bar",
-              "global/foo/global/bar",
-              "production/global/global/bar",
-              "global/global/global/bar"
-            ]
-            e.message.must_equal "Key bar could not be resolved, tried #{priority.join(", ")}"
-          end
+        it "fails when unable to find by onl key" do
+          SecretStorage.expects(:read_multi).returns({})
+          e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
+          # order is important here and should not change
+          priority = [
+            "production/foo/pod1/bar",
+            "global/foo/pod1/bar",
+            "production/global/pod1/bar",
+            "global/global/pod1/bar",
+            "production/foo/global/bar",
+            "global/foo/global/bar",
+            "production/global/global/bar",
+            "global/global/global/bar"
+          ]
+          e.message.must_equal "Failed to resolve secret keys:\n\tbar (tried: #{priority.join(", ")})"
         end
       end
     end

--- a/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
@@ -161,16 +161,45 @@ describe Kubernetes::ResourceTemplate do
           SecretStorage.stubs(:read).returns(true)
         end
 
-        it "secret is scoped correctly" do
-          assert doc.raw_template.sub!(secret_key, '${ENV}/foo/${DEPLOY_GROUP}/bar')
-          template.to_hash[:spec][:template][:metadata][:annotations][:'secret/FOO'].
-            must_equal "production/foo/pod1/bar"
+        describe "deprecated replacement lookup" do
+          it "secret is scoped correctly" do
+            assert doc.raw_template.sub!(secret_key, '${ENV}/foo/${DEPLOY_GROUP}/bar')
+            template.to_hash[:spec][:template][:metadata][:annotations][:'secret/FOO'].
+              must_equal "production/foo/pod1/bar"
+          end
+
+          it "does not effect a non secret annotation" do
+            assert doc.raw_template.sub!(secret_key, "#{secret_key}\n        annotation_key: somevalueforthekey")
+            template.to_hash[:spec][:template][:metadata][:annotations][:annotation_key].
+              must_equal "somevalueforthekey"
+          end
         end
 
-        it "does not effect a non secret annotation" do
-          assert doc.raw_template.sub!(secret_key, "#{secret_key}\n        annotation_key: somevalueforthekey")
-          template.to_hash[:spec][:template][:metadata][:annotations][:annotation_key].
-            must_equal "somevalueforthekey"
+        describe "key lookup" do
+          before { assert doc.raw_template.sub!(secret_key, 'bar') }
+
+          it "looks up by only the key" do
+            SecretStorage.expects(:read_multi).returns({'global/global/global/bar' => 'xyz'})
+            template.to_hash[:spec][:template][:metadata][:annotations][:'secret/FOO'].
+              must_equal "global/global/global/bar"
+          end
+
+          it "fails when unable to find by onl key" do
+            SecretStorage.expects(:read_multi).returns({})
+            e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
+            # order is important here and should not change
+            priority = [
+              "production/foo/pod1/bar",
+              "global/foo/pod1/bar",
+              "production/global/pod1/bar",
+              "global/global/pod1/bar",
+              "production/foo/global/bar",
+              "global/foo/global/bar",
+              "production/global/global/bar",
+              "global/global/global/bar"
+            ]
+            e.message.must_equal "Key bar could not be resolved, tried #{priority.join(", ")}"
+          end
         end
       end
     end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -228,7 +228,7 @@ describe JobExecution do
   it 'can access secrets' do
     id = "global/#{project.permalink}/global/bar"
     create_secret id
-    job.update(command: "echo 'secret://#{id}'")
+    job.update(command: "echo 'secret://bar'")
     execute_job("master")
     assert_equal 'MY-SECRET', last_line_of_output
   end

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -97,6 +97,24 @@ describe SecretStorage do
     end
   end
 
+  describe ".read_multi" do
+    it "reads" do
+      data = SecretStorage.read_multi([secret.id], include_secret: true)
+      data.keys.must_equal [secret.id]
+      data[secret.id].fetch(:value).must_equal 'MY-SECRET'
+    end
+
+    it "does not read secrets by default" do
+      data = SecretStorage.read_multi([secret.id])
+      refute data[secret.id].key?(:value)
+    end
+
+    it "returns empty for unknown" do
+      SecretStorage.read_multi([secret.id, 'dfsfsfdsdf']).keys.must_equal [secret.id]
+      SecretStorage.read_multi(['dfsfsfdsdf']).keys.must_equal []
+    end
+  end
+
   describe ".delete" do
     it "deletes" do
       SecretStorage.delete(secret.id)
@@ -187,9 +205,25 @@ describe SecretStorage do
 
       it "fails to read a key" do
         client.expect(secret_namespace + 'production/foo/pod2/bar', vault: nil)
-        assert_raises ActiveRecord::RecordNotFound do
-          SecretStorage::HashicorpVault.read('production/foo/pod2/bar')
-        end
+        SecretStorage::HashicorpVault.read('production/foo/pod2/bar').must_equal nil
+      end
+    end
+
+    describe ".read_multi" do
+      it "gets a value based on a key with /secret" do
+        client.expect(secret_namespace + 'production/foo/pod2/bar', vault: "bar")
+        SecretStorage::HashicorpVault.read_multi(['production/foo/pod2/bar']).must_equal('production/foo/pod2/bar' => {
+          lease_id: nil,
+          lease_duration: nil,
+          renewable: nil,
+          auth: nil,
+          value: "bar"
+        })
+      end
+
+      it "fails to read a key" do
+        client.expect(secret_namespace + 'production/foo/pod2/bar', vault: nil)
+        SecretStorage::HashicorpVault.read_multi(['production/foo/pod2/bar']).must_equal({})
       end
     end
 


### PR DESCRIPTION
solving a few issues:
 - being able to look up production issues in test env
 - needing to hardcode in which env/group/project their secret is
 - being unable to add a specific secret to a deploy-group or project without changing the projects kubernetes file

Implementation details:
 - bar -> find all possible keys (global/global/global/bar, production/global/global/bar etc) -> pick the most specific one
 - showing the users the exact keys in the secrets UI so it's easier to understand
 - adding read_multi for efficient multi-key reads

Followup work:
 - extract resolver to separate file and move the tests that are spread between template and executor there

![screen shot 2016-08-02 at 4 29 01 pm](https://cloud.githubusercontent.com/assets/11367/17349417/69740be0-58d2-11e6-933a-5f86f16459cc.png)

@irwaters @jonmoter 

this will break all existing secrets when deploying ... so needs some manual hand-holding/fixing