### PR TITLE
Slack UX improvements

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,6 +13,7 @@ engines:
       - 66e8b888d5f032420a906b6210ecf8e1
       - a9e828eeed8e535cc0a9cd801e5ce8c8
       - 828106164429317de33715fe1b5251f2
+      - e1924689c6ff87777e6ccbb21a0ed55b
   eslint:
     enabled: true
   fixme:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,6 +8,11 @@ engines:
       languages:
         - ruby
         - javascript
+    exclude_fingerprints:
+      - f9a562b3551e820a22595fb5008b5823
+      - 66e8b888d5f032420a906b6210ecf8e1
+      - a9e828eeed8e535cc0a9cd801e5ce8c8
+      - 828106164429317de33715fe1b5251f2
   eslint:
     enabled: true
   fixme:

--- a/app/assets/javascripts/jquery-mentions-input/jquery.mentionsInput.js
+++ b/app/assets/javascripts/jquery-mentions-input/jquery.mentionsInput.js
@@ -470,7 +470,7 @@
     //Resets the text area
     function resetInput(currentVal) {
       mentionsCollection = [];
-      var mentionText = utils.htmlEncode(currentVal);
+      var mentionText = currentVal;
       var regex = new RegExp("(" + settings.triggerChar + ")\\[(.*?)\\]\\((.*?):(.*?)\\)", "gi");
       var match, newMentionText = mentionText;
       while ((match = regex.exec(mentionText)) !== null) {

--- a/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
@@ -13,7 +13,7 @@ class SlackWebhookNotification
   end
 
   def buddy_request(message)
-    _deliver(deploy_phase: :for_buddy, message: message)
+    _deliver(deploy_phase: :for_buddy, message: message, attachments: [pr_and_risk_attachment])
   end
 
   def default_buddy_request_message
@@ -31,11 +31,44 @@ class SlackWebhookNotification
     @content ||= SlackWebhookNotificationRenderer.render(@deploy, subject)
   end
 
-  def _deliver(deploy_phase:, message:)
+  def _deliver(deploy_phase:, message:, attachments: nil)
     @stage.slack_webhooks.each do |webhook|
-      if webhook.public_send(deploy_phase)
-        SamsonSlackWebhooks::SlackWebhooksService.new.deliver_message_via_webhook(webhook: webhook, message: message)
-      end
+      next unless webhook.public_send(deploy_phase)
+      SamsonSlackWebhooks::SlackWebhooksService.new.deliver_message_via_webhook(
+        webhook: webhook,
+        message: message,
+        attachments: attachments
+      )
     end
+  end
+
+  def pr_and_risk_attachment
+    {
+      fields: [pr_field, risks_field]
+    }
+  end
+
+  def pr_field
+    prs_string = @deploy.changeset.pull_requests.map do |pr|
+      "<#{pr.url}|##{pr.number}> - #{pr.title}"
+    end.join("\n")
+    prs_string = '(no PRs)' if prs_string.empty?
+    {
+      title: 'PRs',
+      value: prs_string,
+      short: true
+    }
+  end
+
+  def risks_field
+    risks_string = @deploy.changeset.pull_requests.each_with_object([]) do |pr, result|
+      result << "<#{pr.url}|##{pr.number}>:\n#{pr.risks}" if pr.risks
+    end.join("\n")
+    risks_string = '(no risks)' if risks_string.empty?
+    {
+      title: 'Risks',
+      value: risks_string,
+      short: true
+    }
   end
 end

--- a/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
@@ -19,9 +19,9 @@ class SlackWebhookNotification
   def default_buddy_request_message
     project = @deploy.project
     # https://api.slack.com/docs/message-formatting
-    ":pray: <!here> _#{@deploy.user.name}_ is requesting approval" \
-      " to deploy #{project.name} *#{@deploy.reference}* to #{@deploy.stage.name}.\n"\
-      "Review this deploy: #{Rails.application.routes.url_helpers.project_deploy_url(project, @deploy)}"
+    ":pray: <!here> _#{@deploy.user.name}_ is requesting approval to deploy " \
+      "<#{Rails.application.routes.url_helpers.project_deploy_url(project, @deploy)}|" \
+      "#{project.name} *#{@deploy.reference}* to #{@deploy.stage.name}>."
   end
 
   private

--- a/plugins/slack_webhooks/app/models/slack_webhook_notification_renderer.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification_renderer.rb
@@ -3,7 +3,25 @@ class SlackWebhookNotificationRenderer
   def self.render(deploy, subject)
     controller = ActionController::Base.new
     view = ActionView::Base.new(File.expand_path("../../views/samson_slack_webhooks", __FILE__), {}, controller)
-    locals = { deploy: deploy, changeset: deploy.changeset, subject: subject }
+    status_emoji = if deploy.pending?
+      ':stopwatch:'
+    elsif deploy.running?
+      ':truck::dash:'
+    elsif deploy.errored?
+      ':x:'
+    elsif deploy.failed?
+      ':x:'
+    elsif deploy.succeeded?
+      ':white_check_mark:'
+    else
+      ''
+    end
+    locals = {
+      deploy: deploy,
+      status_emoji: status_emoji,
+      changeset: deploy.changeset,
+      subject: subject
+    }
     view.render(template: 'notification', locals: locals).chomp
   end
 end

--- a/plugins/slack_webhooks/app/views/samson_slack_webhooks/notification.text.erb
+++ b/plugins/slack_webhooks/app/views/samson_slack_webhooks/notification.text.erb
@@ -1,4 +1,4 @@
-:point_right: *<%= subject %>* (<<%= deploy.url %>|view the deploy>) :point_left:
+<%= status_emoji %> *<%= subject %>* (<<%= deploy.url %>|view the deploy>)
 <% if changeset.commits.count == 0 %>
 There are no new commits since last time.
 <% else %>

--- a/plugins/slack_webhooks/lib/samson_slack_webhooks/slack_webhooks_service.rb
+++ b/plugins/slack_webhooks/lib/samson_slack_webhooks/slack_webhooks_service.rb
@@ -31,9 +31,10 @@ module SamsonSlackWebhooks
       end
     end
 
-    def deliver_message_via_webhook(webhook:, message:)
+    def deliver_message_via_webhook(webhook:, message:, attachments:)
       payload = { text: message, username: 'samson-bot' }
       payload[:channel] = webhook.channel unless webhook.channel.blank?
+      payload[:attachments] = attachments if attachments.present?
 
       Faraday.post(webhook.webhook_url, payload: payload.to_json)
     rescue Faraday::ClientError => e

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
@@ -4,23 +4,21 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe SlackWebhookNotificationRenderer do
+  let(:subject) { 'Deploy starting' }
+  let(:changeset) do
+    stub "changeset",
+      commits: stub("commits", count: 3),
+      github_url: "https://github.com/url",
+      pull_requests: stub("pull_requests", count: 2),
+      author_names: ['author1', 'author2']
+  end
+
   it "renders a nicely formatted notification" do
-    changeset = stub("changeset")
     deploy = stub("deploy",
       short_reference: "xyz",
       changeset: changeset,
       pending?: true,
       url: "http://sams.on/url")
-
-    changeset.stubs(:commits).returns(stub("commits", count: 3))
-    changeset.stubs(:github_url).returns("https://github.com/url")
-    changeset.stubs(:pull_requests).returns(stub("pull_requests", count: 2))
-
-    author1 = "author1"
-    author2 = "author2"
-    changeset.stubs(:author_names).returns([author1, author2])
-
-    subject = "Deploy starting"
 
     result = SlackWebhookNotificationRenderer.render(deploy, subject)
 
@@ -28,5 +26,59 @@ describe SlackWebhookNotificationRenderer do
       :stopwatch: *Deploy starting* (<http://sams.on/url|view the deploy>)
       _<https://github.com/url|3 commits> and 2 pull requests by author1 and author2._
     RESULT
+  end
+
+  it 'uses a truck emoji for a running deploy' do
+    deploy = stub("deploy",
+      short_reference: "xyz",
+      changeset: changeset,
+      pending?: false,
+      running?: true,
+      url: "http://sams.on/url")
+
+    result = SlackWebhookNotificationRenderer.render(deploy, subject)
+    result.must_include ':truck::dash:'
+  end
+
+  it 'uses an X emoji for an errored deploy' do
+    deploy = stub("deploy",
+      short_reference: "xyz",
+      changeset: changeset,
+      pending?: false,
+      running?: false,
+      errored?: true,
+      url: "http://sams.on/url")
+
+    result = SlackWebhookNotificationRenderer.render(deploy, subject)
+    result.must_include ':x:'
+  end
+
+  it 'uses an X emoji for a failed deploy' do
+    deploy = stub("deploy",
+      short_reference: "xyz",
+      changeset: changeset,
+      pending?: false,
+      running?: false,
+      errored?: false,
+      failed?: true,
+      url: "http://sams.on/url")
+
+    result = SlackWebhookNotificationRenderer.render(deploy, subject)
+    result.must_include ':x:'
+  end
+
+  it 'uses a checkmark emoji for a successful deploy' do
+    deploy = stub("deploy",
+      short_reference: "xyz",
+      changeset: changeset,
+      pending?: false,
+      running?: false,
+      errored?: false,
+      failed?: false,
+      succeeded?: true,
+      url: "http://sams.on/url")
+
+    result = SlackWebhookNotificationRenderer.render(deploy, subject)
+    result.must_include ':white_check_mark:'
   end
 end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
@@ -6,7 +6,11 @@ SingleCov.covered!
 describe SlackWebhookNotificationRenderer do
   it "renders a nicely formatted notification" do
     changeset = stub("changeset")
-    deploy = stub("deploy", short_reference: "xyz", changeset: changeset, url: "http://sams.on/url")
+    deploy = stub("deploy",
+      short_reference: "xyz",
+      changeset: changeset,
+      pending?: true,
+      url: "http://sams.on/url")
 
     changeset.stubs(:commits).returns(stub("commits", count: 3))
     changeset.stubs(:github_url).returns("https://github.com/url")
@@ -21,7 +25,7 @@ describe SlackWebhookNotificationRenderer do
     result = SlackWebhookNotificationRenderer.render(deploy, subject)
 
     result.must_equal <<-RESULT.strip_heredoc.chomp
-      :point_right: *Deploy starting* (<http://sams.on/url|view the deploy>) :point_left:
+      :stopwatch: *Deploy starting* (<http://sams.on/url|view the deploy>)
       _<https://github.com/url|3 commits> and 2 pull requests by author1 and author2._
     RESULT
   end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
@@ -81,4 +81,19 @@ describe SlackWebhookNotificationRenderer do
     result = SlackWebhookNotificationRenderer.render(deploy, subject)
     result.must_include ':white_check_mark:'
   end
+
+  it 'omits emoji for any other situation' do
+    deploy = stub("deploy",
+      short_reference: "xyz",
+      changeset: changeset,
+      pending?: false,
+      running?: false,
+      errored?: false,
+      failed?: false,
+      succeeded?: false,
+      url: "http://sams.on/url")
+
+    result = SlackWebhookNotificationRenderer.render(deploy, subject)
+    result.wont_match /:.*:/
+  end
 end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -15,8 +15,8 @@ describe SlackWebhookNotification do
     end
     payload
   end
-  let(:prs) { attachment.fetch('fields')[0] }
-  let(:risks) { attachment.fetch('fields')[1] }
+  let(:prs) { payload.fetch('attachments')[0].fetch('fields')[0] }
+  let(:risks) { payload.fetch('attachments')[0].fetch('fields')[1] }
 
   def stub_notification(before_deploy: false, after_deploy: true, for_buddy: false, risks: true, prs: true)
     pr_stub = stub url: 'https://github.com/foo/bar/pulls/1', number: 1, title: 'PR 1',
@@ -75,10 +75,9 @@ describe SlackWebhookNotification do
     risks['value'].must_equal "<https://github.com/foo/bar/pulls/1|#1>:\nabc"
   end
 
-  it 'says if there are no PRs' do
+  it 'tells the user if there are no PRs' do
     notification = stub_notification(for_buddy: true, prs: false)
     notification.buddy_request "no PRs"
-
     prs['value'].must_equal '(no PRs)'
     risks['value'].must_equal "(no risks)"
   end
@@ -86,7 +85,6 @@ describe SlackWebhookNotification do
   it 'says if there are no risks' do
     notification = stub_notification(for_buddy: true, risks: false)
     notification.buddy_request "PRs but no risks"
-
     prs['value'].must_equal '<https://github.com/foo/bar/pulls/1|#1> - PR 1'
     risks['value'].must_equal "(no risks)"
   end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -15,6 +15,8 @@ describe SlackWebhookNotification do
     end
     payload
   end
+  let(:prs) { attachment.fetch('fields')[0] }
+  let(:risks) { attachment.fetch('fields')[1] }
 
   def stub_notification(before_deploy: false, after_deploy: true, for_buddy: false, risks: true, prs: true)
     pr_stub = stub url: 'https://github.com/foo/bar/pulls/1', number: 1, title: 'PR 1',
@@ -67,8 +69,6 @@ describe SlackWebhookNotification do
 
     payload.fetch('text').must_equal "buddy approval needed"
     payload.fetch('attachments').length.must_equal 1
-    attachment = payload.fetch('attachments')[0]
-    prs, risks = attachment.fetch('fields')
     prs['title'].must_equal 'PRs'
     prs['value'].must_equal '<https://github.com/foo/bar/pulls/1|#1> - PR 1'
     risks['title'].must_equal 'Risks'
@@ -79,7 +79,6 @@ describe SlackWebhookNotification do
     notification = stub_notification(for_buddy: true, prs: false)
     notification.buddy_request "no PRs"
 
-    prs, risks = payload.fetch('attachments')[0].fetch('fields')
     prs['value'].must_equal '(no PRs)'
     risks['value'].must_equal "(no risks)"
   end
@@ -88,7 +87,6 @@ describe SlackWebhookNotification do
     notification = stub_notification(for_buddy: true, risks: false)
     notification.buddy_request "PRs but no risks"
 
-    prs, risks = payload.fetch('attachments')[0].fetch('fields')
     prs['value'].must_equal '<https://github.com/foo/bar/pulls/1|#1> - PR 1'
     risks['value'].must_equal "(no risks)"
   end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -21,7 +21,8 @@ describe SlackWebhookNotification do
     )
     stage = stub(name: "Staging", slack_webhooks: [webhook], project: project)
     deploy = stub(
-      to_s: 123456, summary: "hello world!", user: user, stage: stage, project: project, changeset: changeset, reference: '123abc'
+      to_s: 123456, summary: "hello world!", user: user, stage: stage, project: project,
+      changeset: changeset, reference: '123abc'
     )
     SlackWebhookNotification.new(deploy)
   end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -9,13 +9,19 @@ describe SlackWebhookNotification do
   let(:endpoint) { "https://slack.com/api/chat.postMessage" }
 
   def stub_notification(before_deploy: false, after_deploy: true, for_buddy: false)
+    changeset = stub("changeset",
+      pull_requests: [
+        stub(url: 'https://github.com/foo/bar/pulls/1', number: 1, title: 'PR 1',
+             risks: 'abc')
+      ])
+
     webhook = stub(
       webhook_url: endpoint, channel: nil,
       before_deploy: before_deploy, after_deploy: after_deploy, for_buddy: for_buddy
     )
     stage = stub(name: "Staging", slack_webhooks: [webhook], project: project)
     deploy = stub(
-      to_s: 123456, summary: "hello world!", user: user, stage: stage, project: project, reference: '123abc'
+      to_s: 123456, summary: "hello world!", user: user, stage: stage, project: project, changeset: changeset, reference: '123abc'
     )
     SlackWebhookNotification.new(deploy)
   end
@@ -82,8 +88,8 @@ describe SlackWebhookNotification do
     it "renders" do
       notification = stub_notification
       message = notification.default_buddy_request_message
-      message.must_include ":pray: <!here> _John Wu_ is requesting approval to deploy Glitter *123abc*"\
-        " to Staging.\nReview this deploy: http://www.test-url.com/projects/foo/deploys/123456"
+      message.must_include ":pray: <!here> _John Wu_ is requesting approval to deploy "\
+      "<http://www.test-url.com/projects/foo/deploys/123456|Glitter *123abc* to Staging>."\
     end
   end
 end


### PR DESCRIPTION
Quick: which one of these deploys failed?

![image](https://cloud.githubusercontent.com/assets/39902/17685672/194f3236-631b-11e6-8097-db953309f452.png)

Hard to tell from a glance. This PR improves the Slack UX for Samson in a few key ways:

- Adds easy-to-recognize status emoji to deploy notifications
- Improves our use of Slack markup
- Fixes the `@here` mention when requesting a buddy
- Adds the nice attachment feature from the [slack_app plugin](https://github.com/zendesk/samson/pull/1130) to the buddy-request message

Now it's easy to tell when a deploy succeeds:

![image](https://cloud.githubusercontent.com/assets/39902/17685744/c939d2a0-631b-11e6-98ce-b0606aa74121.png)

/cc @zendesk/samson

### Tasks
 - [x] Status emoji in hook notifications
 - [x] Linkify deploy name in hook notification
 - [x] Fix the `@here` mention on the buddy request
 - [x] Add the PRs/Risks attachment to the buddy request
 - [ ] :+1: from team

### Risks
- Level: Low. This is just a tweak to the output when sending things to Slack.
