### PR TITLE
Correct fix for Slack @here notifications

### DIFF
--- a/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
@@ -18,8 +18,7 @@ class SlackWebhookNotification
 
   def default_buddy_request_message
     project = @deploy.project
-    # https://api.slack.com/docs/message-formatting
-    ":pray: <!here> _#{@deploy.user.name}_ is requesting approval to deploy " \
+    ":pray: @here _#{@deploy.user.name}_ is requesting approval to deploy " \
       "<#{Rails.application.routes.url_helpers.project_deploy_url(project, @deploy)}|" \
       "#{project.name} *#{@deploy.reference}* to #{@deploy.stage.name}>."
   end

--- a/plugins/slack_webhooks/lib/samson_slack_webhooks/slack_webhooks_service.rb
+++ b/plugins/slack_webhooks/lib/samson_slack_webhooks/slack_webhooks_service.rb
@@ -32,7 +32,8 @@ module SamsonSlackWebhooks
     end
 
     def deliver_message_via_webhook(webhook:, message:, attachments:)
-      payload = { text: message, username: 'samson-bot' }
+      # https://api.slack.com/docs/message-formatting#parsing_modes
+      payload = { text: message, username: 'samson-bot', parse: 'full' }
       payload[:channel] = webhook.channel unless webhook.channel.blank?
       payload[:attachments] = attachments if attachments.present?
 

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -100,7 +100,7 @@ describe SlackWebhookNotification do
     it "renders" do
       notification = stub_notification
       message = notification.default_buddy_request_message
-      message.must_include ":pray: <!here> _John Wu_ is requesting approval to deploy "\
+      message.must_include ":pray: @here _John Wu_ is requesting approval to deploy "\
       "<http://www.test-url.com/projects/foo/deploys/123456|Glitter *123abc* to Staging>."\
     end
   end


### PR DESCRIPTION
* I've enabled Slack message full parsing mode
* This way, Slack can deal with the formatting an we just write the messages like in a chat text box

/cc @zendesk/samson @grosser @zehua 

### Tasks
 - [ ] :+1: from team

### References
 - https://api.slack.com/docs/message-formatting#parsing_modes

### Risks
- Level: Low
