### PR TITLE
PAAS-292 run secret and role verifications before we create a slow build or even a release

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -51,8 +51,8 @@ module Kubernetes
       params.fetch(:deploy_groups).each do |dg|
         dg.fetch(:roles).to_a.each do |role|
           release_docs.create!(
-            deploy_group_id: dg.fetch(:id),
-            kubernetes_role_id: role.fetch(:id),
+            deploy_group: dg.fetch(:deploy_group),
+            kubernetes_role: role.fetch(:role),
             replica_target: role.fetch(:replicas),
             cpu: role.fetch(:cpu),
             ram: role.fetch(:ram)

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -148,10 +148,10 @@ describe Kubernetes::Release do
       project: project,
       deploy_groups: [
         {
-          id: deploy_group.id,
+          deploy_group: deploy_group,
           roles: [
             {
-              id: app_server.id,
+              role: app_server,
               replicas: 1,
               cpu: 1,
               ram: 50
@@ -165,7 +165,7 @@ describe Kubernetes::Release do
   def multiple_roles_release_params
     release_params.tap do |params|
       params[:deploy_groups].each do |dg|
-        dg[:roles].push(id: resque_worker.id, replicas: 2, cpu: 2, ram: 100)
+        dg[:roles].push(role: resque_worker, replicas: 2, cpu: 2, ram: 100)
       end
     end
   end


### PR DESCRIPTION
@jonmoter @irwaters 

creating builds / releases / release docs is slow and pollutes our DB with invalid and unnecessary rows ... so run validations before we try to start a build

ideally this would not duplicate the validation runs, but that's a bit harder to achieve / cheap ...