### PR TITLE
annotation values do not have a prefix we need to remove

### DIFF
--- a/lib/samson/secrets/key_resolver.rb
+++ b/lib/samson/secrets/key_resolver.rb
@@ -12,11 +12,9 @@ module Samson
       # expands a key by finding the most specific value for it
       # bar -> production/my_project/pod100/bar
       def expand!(secret_key)
-        key = secret_key.split('/', 2).last
-
         # build a list of all possible ids
         possible_ids = possible_secret_key_parts.map do |id|
-          SecretStorage.generate_secret_key(id.merge(key: key))
+          SecretStorage.generate_secret_key(id.merge(key: secret_key))
         end
 
         # use the value of the first id that exists

--- a/test/lib/samson/secrets/key_resolver_test.rb
+++ b/test/lib/samson/secrets/key_resolver_test.rb
@@ -12,26 +12,26 @@ describe Samson::Secrets::KeyResolver do
     before { SecretStorage.write("global/global/global/bar", value: 'something', user_id: 123) }
 
     it "expands" do
-      key = 'secret/bar'.dup
+      key = 'bar'.dup
       resolver.expand!(key)
       key.must_equal "global/global/global/bar"
     end
 
     it "does nothing when not finding a key" do
-      key = 'secret/baz'.dup
+      key = 'baz'.dup
       resolver.expand!(key)
-      key.must_equal "secret/baz"
+      key.must_equal "baz"
     end
 
     it "looks up by specificity" do
       SecretStorage.write("global/#{project.permalink}/global/bar", value: 'something', user_id: 123)
-      key = 'secret/bar'.dup
+      key = 'bar'.dup
       resolver.expand!(key)
       key.must_equal "global/#{project.permalink}/global/bar"
     end
 
     it "has the correct order of specificity" do
-      key = 'secret/baz'.dup
+      key = 'baz'.dup
       resolver.expand!(key)
       keys = [
         "production/foo/pod1/baz",
@@ -44,7 +44,7 @@ describe Samson::Secrets::KeyResolver do
         "global/global/global/baz"
       ]
       resolver.instance_variable_get(:@errors).must_equal(
-        ["secret/baz (tried: #{keys.join(", ")})"]
+        ["baz (tried: #{keys.join(", ")})"]
       )
     end
   end
@@ -55,8 +55,8 @@ describe Samson::Secrets::KeyResolver do
     end
 
     it "raises all errors for easy debugging" do
-      resolver.expand!('secret/xxx')
-      resolver.expand!('secret/yyy')
+      resolver.expand!('xxx')
+      resolver.expand!('yyy')
       e = assert_raises Samson::Hooks::UserError do
         resolver.verify!
       end


### PR DESCRIPTION
somehow added that in https://github.com/zendesk/samson/pull/1190 ... does not make any sense ...

fixes https://samsontest.zende.sk/projects/lotus_bootstrap_scala/deploys/2837#L16

@irwaters 