### PR TITLE
expand wildcard secrets

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -47,7 +47,8 @@ class TerminalExecutor
 
     result = command.gsub(/\b#{SECRET_PREFIX}(#{SecretStorage::SECRET_KEY_REGEX})\b/) do
       key = $1
-      if resolver.expand!(key)
+      if expanded = resolver.expand('unused', key).first&.last
+        key.replace(expanded)
         SecretStorage.read(key, include_secret: true).fetch(:value)
       end
     end

--- a/plugins/kubernetes/app/models/kubernetes/resource_template.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_template.rb
@@ -42,7 +42,7 @@ module Kubernetes
     # look up keys in all possible namespaces by specificity
     def expand_secret_annotations
       resolver = Samson::Secrets::KeyResolver.new(project, [@doc.deploy_group])
-      secret_annotations.each_value { |secret_key| resolver.expand!(secret_key) }
+      secret_annotations.replace(secret_annotations.flat_map { |k, v| resolver.expand(k, v) }.to_h)
       resolver.verify!
     end
 


### PR DESCRIPTION
need to do this in samson to get verification support ... also easier to have all the logic in 1 place

tried using vault.list with * ... but that did not return anything ...

https://github.com/zendesk/samson_secret_puller/pull/20

FOO_* with foo_* -> [[FOO_BAR, a/a/a/foo_bar], [FOO_BAZ, a/a/a/foo_baz]]

@irwaters @jonmoter 