### PR TITLE
Api::DeploysController

### DIFF
--- a/app/controllers/api/deploys_controller.rb
+++ b/app/controllers/api/deploys_controller.rb
@@ -1,16 +1,39 @@
 # frozen_string_literal: true
 class Api::DeploysController < Api::BaseController
-  include CurrentProject
-
   skip_before_action :require_project, only: [:active_count]
+  before_action :ensure_filter, only: :index
 
   def index
-    scope = current_project.try(:deploys) || Deploy
-    @deploys = paginate(params[:ids].present? ? [scope.find(params[:ids])].flatten : scope)
-    render json: @deploys
+    render json: paginate(Deploy.joins(:job).where(search_params))
   end
 
   def active_count
     render json: Deploy.active.count
+  end
+
+  protected
+
+  def job_filter
+    params[:filter]
+  end
+
+  def search_params
+    if stage_id = params[:stage_id]
+      search_params = {deploys: {stage_id: stage_id}}
+    elsif project_id = params[:project_id]
+      stage_ids = Project.find(project_id).stages.pluck(:id)
+      search_params = {deploys: {stage_id: stage_ids}}
+    end
+
+    search_params[:jobs] = {status: job_filter} if job_filter
+
+    search_params
+  end
+
+  def ensure_filter
+    return unless job_filter
+    unless Job.valid_status?(job_filter)
+      render json: { error: "Filter is not valid. Please use " + Job::VALID_STATUSES.join(", ") }, status: :bad_request
+    end
   end
 end

--- a/app/controllers/api/deploys_controller.rb
+++ b/app/controllers/api/deploys_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Api::DeploysController < Api::BaseController
   skip_before_action :require_project, only: [:active_count]
-  before_action :ensure_filter, only: :index
+  before_action :validate_filter, only: :index
 
   def index
     render json: paginate(Deploy.joins(:job).where(search_params))
@@ -30,7 +30,7 @@ class Api::DeploysController < Api::BaseController
     search_params
   end
 
-  def ensure_filter
+  def validate_filter
     return unless job_filter
     unless Job.valid_status?(job_filter)
       render json: { error: "Filter is not valid. Please use " + Job::VALID_STATUSES.join(", ") }, status: :bad_request

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -74,8 +74,10 @@
             <li><%= link_to "Secrets", admin_secrets_path %></li>
           <% end %>
           <li><%= link_to "Reports", csv_exports_path %></li>
-          <li><%= link_to "OAuth Applications", oauth_applications_path %></li>
-          <li><%= link_to "OAuth Authorized Applications", oauth_authorized_applications_path %></li>
+          <% if current_user&.super_admin? %>
+            <li><%= link_to "OAuth Applications", oauth_applications_path %></li>
+            <li><%= link_to "OAuth Authorized Applications", oauth_authorized_applications_path %></li>
+          <% end %>
         </ul>
       </li>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,20 @@ Samson::Application.routes.draw do
   root to: 'projects#index'
 
   namespace :api do
-    resources :deploys, only: [:index, :active_count] do
+    resources :deploys, only: [:index] do
       collection do
         get :active_count
       end
     end
 
+    resources :deploy_groups, only: [:index]
+
+    resources :projects, only: [:index] do
+      resources :deploys, only: [:index]
+    end
+
     resources :stages, only: [:index] do
+      get :deploys, to: 'deploys#index'
       post :clone, to: 'stages#clone'
     end
   end

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -4,6 +4,24 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Api::BaseController do
+  describe 'paginate array' do
+    subject { n = []; 2000.times { n << ['a'] }; n }
+
+    it 'paginates' do
+      @controller.paginate(subject).size.must_equal 1000
+    end
+  end
+
+  describe 'paginate scope' do
+    subject { Deploy }
+    let(:junk) { n = []; 2000.times { n << ['a'] }; n }
+
+    it 'calls #page' do
+      Deploy.stubs(:page).with(1).returns('foo')
+      @controller.paginate(subject).must_equal 'foo'
+    end
+  end
+
   describe 'Doorkeeper Auth Status' do
     subject { Api::BaseController }
     it 'is allowed' do

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -3,9 +3,9 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Api::DeploysController do
-  assert_route verb: "GET", path: "/api/deploys/active_count", to: 'api/deploys#active_count'
-  assert_route verb: "GET", path: "/api/projects/1/deploys", to: 'api/deploys#index', params: {project_id: '1'}
-  assert_route verb: "GET", path: "/api/stages/2/deploys", to: 'api/deploys#index', params: {stage_id: '2'}
+  assert_route :get, "/api/deploys/active_count", to: 'api/deploys#active_count'
+  assert_route :get, "/api/projects/1/deploys", to: 'api/deploys#index', params: {project_id: '1'}
+  assert_route :get, "/api/stages/2/deploys", to: 'api/deploys#index', params: {stage_id: '2'}
 
   oauth_setup!
 

--- a/test/controllers/api/stages_controller_test.rb
+++ b/test/controllers/api/stages_controller_test.rb
@@ -10,7 +10,7 @@ describe Api::StagesController do
 
   describe 'get #index' do
     before do
-      get :index, project_id: project.permalink
+      get :index, project_id: project.id
     end
 
     subject { JSON.parse(response.body) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -175,13 +175,14 @@ class ActiveSupport::TestCase
     around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir) { test.call } } }
   end
 
-  def self.assert_route(verb:, path:, to:, params: {})
+  def self.assert_route(verb, path, to:, params: {})
     controller, action = to.split("#", 2)
     it_name = "routes to #{controller} #{action}"
     it_name += params.keys.empty? ? " with no parameters" : " with parameters #{params}"
 
     describe "a #{verb} to #{path}" do
       it it_name do
+        verb = verb.to_s.upcase
         assert_routing({method: verb, path: path}, {controller: controller, action: action}.merge(params))
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -174,6 +174,18 @@ class ActiveSupport::TestCase
   def self.run_inside_of_temp_directory
     around { |test| Dir.mktmpdir { |dir| Dir.chdir(dir) { test.call } } }
   end
+
+  def self.assert_route(verb:, path:, to:, params: {})
+    controller, action = to.split("#", 2)
+    it_name = "routes to #{controller} #{action}"
+    it_name += params.keys.empty? ? " with no parameters" : " with parameters #{params}"
+
+    describe "a #{verb} to #{path}" do
+      it it_name do
+        assert_routing({method: verb, path: path}, {controller: controller, action: action}.merge(params))
+      end
+    end
+  end
 end
 
 Mocha::Expectation.class_eval do
@@ -286,7 +298,6 @@ class ActionController::TestCase
     before do
       Rails.application.routes.draw do
         match "/test/:test_route/:controller/:action", via: [:get, :post, :put, :patch, :delete]
-        # get "testing/foo" => "testing#foo"
       end
     end
 


### PR DESCRIPTION
* Creates the DeploysController for the API

Routes Added:

```
>                         api_deploy_groups GET    /api/deploy_groups(.:format)                                     api/deploy_groups#index
>                       api_project_deploys GET    /api/projects/:project_id/deploys(.:format)                      api/deploys#index
>                              api_projects GET    /api/projects(.:format)                                          api/projects#index
>                         api_stage_deploys GET    /api/stages/:stage_id/deploys(.:format)                          api/deploys#index
```
/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High

