### PR TITLE
Make it so OAuth menu items are only visible to SuperAdmins

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -74,8 +74,10 @@
             <li><%= link_to "Secrets", admin_secrets_path %></li>
           <% end %>
           <li><%= link_to "Reports", csv_exports_path %></li>
-          <li><%= link_to "OAuth Applications", oauth_applications_path %></li>
-          <li><%= link_to "OAuth Authorized Applications", oauth_authorized_applications_path %></li>
+          <% if current_user&.super_admin? %>
+            <li><%= link_to "OAuth Applications", oauth_applications_path %></li>
+            <li><%= link_to "OAuth Authorized Applications", oauth_authorized_applications_path %></li>
+          <% end %>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
* Small fix to remove OAuth menu items for users who can't click on them.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High

