### PR TITLE
delete deploy_group_stages once a stage is deleted so they do not bec…

### DIFF
--- a/app/models/deploy_groups_stage.rb
+++ b/app/models/deploy_groups_stage.rb
@@ -2,4 +2,8 @@
 class DeployGroupsStage < ActiveRecord::Base
   belongs_to :stage, touch: true
   belongs_to :deploy_group
+
+  def destroy
+    self.class.where(stage_id: stage_id, deploy_group_id: deploy_group_id).delete_all
+  end
 end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -18,7 +18,7 @@ class Stage < ActiveRecord::Base
   has_many :commands, -> { order('stage_commands.position ASC') },
     through: :command_associations, auto_include: false
 
-  has_many :deploy_groups_stages
+  has_many :deploy_groups_stages, dependent: :destroy
   has_many :deploy_groups, through: :deploy_groups_stages
 
   default_scope { order(:order) }

--- a/test/models/deploy_groups_stage_test.rb
+++ b/test/models/deploy_groups_stage_test.rb
@@ -4,4 +4,17 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe DeployGroupsStage do
+  describe "#destroy" do
+    let(:deploy_groups_stage) do
+      stages(:test_staging).deploy_groups_stages.first
+    end
+
+    it "destroys" do
+      DeployGroupsStage.create!(stage: deploy_groups_stage.stage, deploy_group: deploy_groups(:pod2))
+      DeployGroupsStage.create!(stage: stages(:test_production), deploy_group: deploy_groups_stage.deploy_group)
+      assert_difference 'DeployGroupsStage.count', -1 do
+        deploy_groups_stage.destroy
+      end
+    end
+  end
 end


### PR DESCRIPTION
…ome invalid / blow up when rendering

https://zendesk.airbrake.io/projects/95346/groups/1760289710393468921/notices/1760290139726124697

Downside: restoring a stage will lose it's deploy_groups ... but that's not too bad ...

@jcheatham 