### PR TITLE
make the test pass no matter how the environment is configured

### DIFF
--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -451,12 +451,16 @@ describe Stage do
       stage.production = true
     end
 
+    after do
+      BuddyCheck.unstub(:enabled?)
+    end
+
     it "requires approval with buddy-check + deploying + production" do
       assert stage.deploy_requires_approval?
     end
 
     it "does not require approval when buddy check is disabled" do
-      BuddyCheck.unstub(:enabled?)
+      BuddyCheck.stubs(enabled?: false)
       refute stage.deploy_requires_approval?
     end
 


### PR DESCRIPTION
This is causing red tests in a private repo because they are run with the buddy check environment variable turned on.

@danielbreves @zendesk/samson 