### PR TITLE
PAAS-349 add clair security scanner to kubernets pipeline

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,7 @@ engines:
       - a9e828eeed8e535cc0a9cd801e5ce8c8
       - 828106164429317de33715fe1b5251f2
       - e1924689c6ff87777e6ccbb21a0ed55b
+      - defed7bae9b03c1c2ac1708a1e234d0a
   eslint:
     enabled: true
   fixme:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,7 +14,6 @@ engines:
       - a9e828eeed8e535cc0a9cd801e5ce8c8
       - 828106164429317de33715fe1b5251f2
       - e1924689c6ff87777e6ccbb21a0ed55b
-      - defed7bae9b03c1c2ac1708a1e234d0a
   eslint:
     enabled: true
   fixme:

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -136,3 +136,14 @@ Kubernetes::ReleaseGroup
         |
         -> Kubernetes Pods (how ever many replicas specified)
 ```
+### CLair security scans
+
+To use hyperclair tool (command-line tool for Clair and Docker Registry) for security scans we should supply environment variables:
+
+```
+CLAIR_SCAN_ENABLED = [ true | false ]
+CLAIR_EXEC_SCRIPT = /filesystem/path
+```
+
+CLAIR_EXEC_SCRIPT  - path to shell script that will invoke security scanning. It should be able to return status code. 
+CLAIR_SCAN_EANBLE - should be set to `true` if we want to have clair scans enabled

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -141,9 +141,7 @@ Kubernetes::ReleaseGroup
 To use hyperclair tool (command-line tool for Clair and Docker Registry) for security scans we should supply environment variables:
 
 ```
-CLAIR_SCAN_ENABLED = [ true | false ]
-CLAIR_EXEC_SCRIPT = /filesystem/path
+CLAIR_EXEC_SCRIPT = /filesystem/path/to/hyperclair
 ```
 
 CLAIR_EXEC_SCRIPT  - path to shell script that will invoke security scanning. It should be able to return status code. 
-CLAIR_SCAN_EANBLE - should be set to `true` if we want to have clair scans enabled

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -136,12 +136,13 @@ Kubernetes::ReleaseGroup
         |
         -> Kubernetes Pods (how ever many replicas specified)
 ```
-### CLair security scans
 
-To use hyperclair tool (command-line tool for Clair and Docker Registry) for security scans we should supply environment variables:
+### Clair security scans
+
+To security scan docker images using hyperclair, add:
 
 ```
-CLAIR_EXEC_SCRIPT = /filesystem/path/to/hyperclair
-```
+HYPERCLAIR_PATH=/filesystem/path/to/hyperclair
+``` 
 
-CLAIR_EXEC_SCRIPT  - path to shell script that will invoke security scanning. It should be able to return status code. 
+Must exit with 0 for success and 1 for failure.

--- a/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
@@ -116,7 +116,7 @@ module Kubernetes
     # So far we don't have ruby API for clair scanner and using shell script to wrap hyperclair.
     # Hyperclair will pull the image from registry and run scan against Clair scanner
     def scan_with_clair(project, tag)
-      clair_result = exec_script(ENV['CLAIR_EXEC_SCRIPT'], project, tag)
+      clair_result = exec_script(ENV['CLAIR_EXEC_SCRIPT'], @registry[:serveraddress], project, tag)
       if script_exit_status.success?
         return nil
       else

--- a/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
@@ -138,6 +138,7 @@ describe Kubernetes::BuildJobExecutor do
           Tempfile.open('clair') do |f|
             f.write("#!/bin/bash\n exit 0")
             f.rewind
+            f.close
             File.chmod 0755, f.path
             with_env("CLAIR_EXEC_SCRIPT": f.path) do
               job_api_obj.stubs(:failure?).returns false
@@ -153,6 +154,7 @@ describe Kubernetes::BuildJobExecutor do
           Tempfile.open('clair') do |f|
             f.write("#!/bin/bash\n exit 1")
             f.rewind
+            f.close
             File.chmod 0755, f.path
             with_env("CLAIR_EXEC_SCRIPT": f.path) do
               job_api_obj.stubs(:failure?).returns false

--- a/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
@@ -147,6 +147,7 @@ describe Kubernetes::BuildJobExecutor do
             job_api_obj.stubs(:failure?).returns false
             job_api_obj.stubs(:complete?).returns true
             success, job_log = execute!(registry_info: registry_info)
+
             assert success
             assert_equal(job_pod_log.join("\n") << "\n", job_log)
           end
@@ -166,6 +167,7 @@ describe Kubernetes::BuildJobExecutor do
             job_api_obj.stubs(:failure?).returns false
             job_api_obj.stubs(:complete?).returns true
             success, = execute!(registry_info: registry_info)
+
             refute success
           end
         end


### PR DESCRIPTION
## Description
As a part of PaaS project we are adding to Samson invoking external scanner functionality. This method implies that CLAIR_EXEC_PATH and CLAIR_SCAN_ENABLED environment variables are supplied. Otherwise it will be disabled to allow using Samson without Clair scans.

## Risks
Low

## JIRA ticket number
https://zendesk.atlassian.net/browse/PAAS-349

## Change Request

https://zendesk.atlassian.net/wiki/pages/viewpage.action?pageId=XXXXXXXXXX

## CC list
@zendesk/operations @zendesk/chef @grosser @jonmoter @ashmckenzie 