### PR TITLE
prevent 3-state booleans

### DIFF
--- a/db/migrate/20160901175936_prevent_3_state_booleans.rb
+++ b/db/migrate/20160901175936_prevent_3_state_booleans.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class Prevent3StateBooleans < ActiveRecord::Migration
+  def change
+    [:update_github_pull_requests, :comment_on_zendesk_tickets, :use_github_deployment_api].each do |column|
+      change_column_default :stages, column, false
+      change_column_null :stages, column, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818210955) do
+ActiveRecord::Schema.define(version: 20160901175936) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -428,16 +428,16 @@ ActiveRecord::Schema.define(version: 20160818210955) do
     t.string   "notify_email_address",                         limit: 255
     t.integer  "order",                                        limit: 4
     t.datetime "deleted_at"
-    t.boolean  "confirm",                                      default: true
+    t.boolean  "confirm",                                                    default: true
     t.string   "datadog_tags",                                 limit: 255
-    t.boolean  "update_github_pull_requests"
-    t.boolean  "deploy_on_release",                            default: false
-    t.boolean  "comment_on_zendesk_tickets"
-    t.boolean  "production",                                   default: false
-    t.boolean  "use_github_deployment_api"
+    t.boolean  "update_github_pull_requests",                                default: false, null: false
+    t.boolean  "deploy_on_release",                                          default: false
+    t.boolean  "comment_on_zendesk_tickets",                                 default: false, null: false
+    t.boolean  "production",                                                 default: false
+    t.boolean  "use_github_deployment_api",                                  default: false, null: false
     t.string   "permalink",                                    limit: 255,                   null: false
     t.text     "dashboard",                                    limit: 65535
-    t.boolean  "email_committers_on_automated_deploy_failure", default: false, null: false
+    t.boolean  "email_committers_on_automated_deploy_failure",               default: false, null: false
     t.string   "static_emails_on_automated_deploy_failure",    limit: 255
     t.string   "datadog_monitor_ids",                          limit: 255
     t.string   "jenkins_job_names",                            limit: 255

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -20,6 +20,11 @@ describe "cleanliness" do
     File.read("db/schema.rb").wont_match /\st\.boolean.*limit: 1/
   end
 
+  it "does not have 3-state booleans (nil/false/true)" do
+    bad = File.read("db/schema.rb").scan(/\st\.boolean.*/).reject { |l| l =~ /default: (false|true)|null: false/ }
+    assert bad.empty?, "Boolean columns missing a default or null: false\n#{bad.join("\n")}"
+  end
+
   it "does not include rails-assets-bootstrap" do
     # make sure rails-assets-bootstrap did not get included by accident (dependency of some other bootstrap thing)
     # if it is not avoidable see http://stackoverflow.com/questions/7163264


### PR DESCRIPTION
@dragonfax 
/cc @zendesk/samson 

previously caught:

```
Boolean columns missing a default or null: false
 t.boolean  "update_github_pull_requests"
 t.boolean  "comment_on_zendesk_tickets"
 t.boolean  "use_github_deployment_api"
```