### PR TITLE
fix migration not working when columns have nil values

### DIFF
--- a/db/migrate/20160901175936_prevent_3_state_booleans.rb
+++ b/db/migrate/20160901175936_prevent_3_state_booleans.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 class Prevent3StateBooleans < ActiveRecord::Migration
-  def change
-    [:update_github_pull_requests, :comment_on_zendesk_tickets, :use_github_deployment_api].each do |column|
+  COLUMNS = [:update_github_pull_requests, :comment_on_zendesk_tickets, :use_github_deployment_api].freeze
+
+  def up
+    COLUMNS.each do |column|
+      Stage.where(column => nil).update_all(column => false)
       change_column_default :stages, column, false
       change_column_null :stages, column, false
+    end
+  end
+
+  def down
+    COLUMNS.each do |column|
+      change_column_default :stages, column, nil
+      change_column_null :stages, column, true
     end
   end
 end


### PR DESCRIPTION
was hoping it would set the to false automatically ... did not ...

fix for https://github.com/zendesk/samson/pull/1248

@dragonfax 