### PR TITLE
make resource name meaning and validation more obvious

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
@@ -4,6 +4,7 @@ module Kubernetes
     DEPLOYISH = RoleConfigFile::DEPLOY_KINDS
     JOBS = RoleConfigFile::JOB_KINDS
     VALID_LABEL = /\A[a-z0-9]([-a-z0-9]*[a-z0-9])?\z/
+    VALID_LABEL_JS = VALID_LABEL.source.sub!('\\A', '^').sub!('\\z', '$') || raise
 
     SUPPORTED_KINDS = [
       ['Deployment'],

--- a/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
@@ -1,3 +1,4 @@
+<% @role.resource_name ||= @project.permalink.tr('_', '-') + '-' %>
 <%= form_for [@project, @role], html: { class: "form-horizontal" } do |form| %>
   <%= render 'shared/errors', object: @role %>
 
@@ -24,7 +25,7 @@
     </div>
 
     <div class="form-group">
-      <% pattern = Kubernetes::RoleVerifier::VALID_LABEL.source.sub!('\\A', '^').sub!('\\z', '$') || raise %>
+      <% pattern = Kubernetes::RoleVerifier::VALID_LABEL_JS %>
       <%= form.label :resource_name,
           class: "col-lg-2 control-label",
           title: "Name for the resource this role will create (service/job), must match #{pattern}",

--- a/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
@@ -24,9 +24,14 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :resource_name, class: "col-lg-2 control-label" %>
+      <% pattern = Kubernetes::RoleVerifier::VALID_LABEL.source.sub!('\\A', '^').sub!('\\z', '$') || raise %>
+      <%= form.label :resource_name,
+          class: "col-lg-2 control-label",
+          title: "Name for the resource this role will create (service/job), must match #{pattern}",
+          style: "text-decoration: underline"
+      %>
       <div class="col-lg-4">
-        <%= form.text_field :resource_name, class: "form-control" %>
+        <%= form.text_field :resource_name, class: "form-control", pattern: pattern %>
       </div>
     </div>
 

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -64,6 +64,23 @@ describe Kubernetes::Role do
         refute_valid role
       end
     end
+
+    describe "resource_name" do
+      it "is invalid when blank" do
+        role.resource_name = ""
+        refute_valid role
+      end
+
+      it "is valid when filled with a valid name" do
+        role.resource_name = "dfssd"
+        assert_valid role
+      end
+
+      it "is invalid when it cannot be used in kubernetes" do
+        role.resource_name = "sfsdf__F"
+        refute_valid role
+      end
+    end
   end
 
   describe '.seed!' do


### PR DESCRIPTION
before: 

no explanation and no idea why it was wrong
<img width="405" alt="screen shot 2016-09-05 at 6 16 23 pm" src="https://cloud.githubusercontent.com/assets/11367/18259070/eef5da46-7394-11e6-87fc-72c7844e931e.png">

after:
explanation + matching in the UI with pattern help

<img width="441" alt="screen shot 2016-09-05 at 6 08 27 pm" src="https://cloud.githubusercontent.com/assets/11367/18259077/fcc632c4-7394-11e6-9a6b-2b6cd7acd82e.png">
<img width="177" alt="screen shot 2016-09-05 at 6 15 49 pm" src="https://cloud.githubusercontent.com/assets/11367/18259078/fcc9c4b6-7394-11e6-9003-9f50136c7824.png">


@zendesk/samson 