### PR TITLE
Fix: use ternary operator in helper method job_state_class

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -30,11 +30,7 @@ module ProjectsHelper
   end
 
   def job_state_class(job)
-    if job.succeeded?
-      'success'
-    else
-      'failed'
-    end
+    job.succeeded? ? 'success' : 'failed'
   end
 
   def admin_for_project?


### PR DESCRIPTION
Fix code style

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team


