### PR TITLE
trigger deploys only on new github issue comments

### DIFF
--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Changeset::IssueComment
   attr_reader :repo, :data
+  VALID_ACTIONS = ['created'].freeze
 
   def initialize(repo, data)
     @repo = repo
@@ -13,6 +14,7 @@ class Changeset::IssueComment
   end
 
   def self.valid_webhook?(params)
+    return false unless VALID_ACTIONS.include? params['action']
     comment = params['comment'] || {}
     !(comment['body'] =~ Changeset::PullRequest::WEBHOOK_FILTER).nil?
   end

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -96,7 +96,6 @@ describe "cleanliness" do
       "app/controllers/concerns/stage_permitted_params.rb",
       "app/mailers/application_mailer.rb",
       "app/models/changeset/code_push.rb",
-      "app/models/changeset/issue_comment.rb",
       "app/models/changeset/jira_issue.rb",
       "app/models/concerns/has_commands.rb",
       "app/models/concerns/has_role.rb",

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered! uncovered: 8
+
+describe Changeset::IssueComment do
+  describe ".valid_webhook" do
+    let(:webhook_data) do
+      {
+        comment: {
+          body: '[samson review]'
+        },
+      }.with_indifferent_access
+    end
+
+    it 'is valid for new comments' do
+      webhook_data[:action] = 'created'
+      Changeset::IssueComment.valid_webhook?(webhook_data).must_equal true
+    end
+
+    it 'is not valid for deleted comments' do
+      webhook_data[:action] = 'deleted'
+      Changeset::IssueComment.valid_webhook?(webhook_data).must_equal false
+    end
+
+    it 'is not valid for edited comments' do
+      webhook_data[:action] = 'edited'
+      Changeset::IssueComment.valid_webhook?(webhook_data).must_equal false
+    end
+  end
+end


### PR DESCRIPTION
Deploys were being triggered when issue comments with `[samson review]` were being deleted. Github will send all issue comment event types (new, edit, delete) - and we only need a deploy when someone adds a new comment with `[samson review]`

/cc @zendesk/samson @shajith @mwerner @craig-day 

### Tasks
 - [x] :+1: from team

### Risks
- Low. Auto deploys may not be triggered correctly from github comments

