### PR TITLE
PAAS-383 show secrets to any user that is a deployer anywhere

### DIFF
--- a/app/controllers/admin/secrets_controller.rb
+++ b/app/controllers/admin/secrets_controller.rb
@@ -10,7 +10,7 @@ class Admin::SecretsController < ApplicationController
   DEPLOYER_ACCESS = [:index, :new].freeze
   before_action :ensure_project_access, except: DEPLOYER_ACCESS
   before_action :authorize_project_admin!, except: DEPLOYER_ACCESS
-  before_action :authorize_deployer!, only: DEPLOYER_ACCESS
+  before_action :authorize_any_deployer!, only: DEPLOYER_ACCESS
 
   def index
     @secret_keys = SecretStorage.keys
@@ -90,5 +90,11 @@ class Admin::SecretsController < ApplicationController
   def current_project
     return if project_permalink == 'global'
     Project.find_by_permalink project_permalink
+  end
+
+  def authorize_any_deployer!
+    if !current_user.deployer? && !current_user.user_project_roles.where('role_id >= ?', Role::DEPLOYER).exists?
+      unauthorized!
+    end
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -70,9 +70,7 @@
             <%= Samson::Hooks.render_views(:admin_menu, self) %>
             <li class="divider"></li>
           <% end %>
-          <% if current_user.try(:deployer?) %>
-            <li><%= link_to "Secrets", admin_secrets_path %></li>
-          <% end %>
+          <li><%= link_to "Secrets", admin_secrets_path %></li>
           <li><%= link_to "Reports", csv_exports_path %></li>
           <% if current_user&.super_admin? %>
             <li><%= link_to "OAuth Applications", oauth_applications_path %></li>

--- a/test/controllers/admin/secrets_controller_test.rb
+++ b/test/controllers/admin/secrets_controller_test.rb
@@ -30,7 +30,7 @@ describe Admin::SecretsController do
     unauthorized :get, :new
   end
 
-  as_a_deployer do
+  as_a_project_deployer do
     unauthorized :post, :create, secret: {
       environment_permalink: 'production',
       project_permalink: 'foo',
@@ -81,6 +81,15 @@ describe Admin::SecretsController do
       it "is unauthorized" do
         delete :destroy, id: secret.id
         assert_unauthorized
+      end
+    end
+  end
+
+  as_a_deployer do
+    describe '#index' do
+      it 'renders template' do
+        get :index
+        assert_template :index
       end
     end
   end


### PR DESCRIPTION
### Risks
- Low: secret access breaking
- Low: users that are deployers on 1 project can see visible secrets for all projects

@zendesk/samson 

