### PR TITLE
Avoid DataDog spam

### DIFF
--- a/plugins/datadog/app/models/datadog_notification.rb
+++ b/plugins/datadog/app/models/datadog_notification.rb
@@ -37,7 +37,7 @@ class DatadogNotification
   private
 
   def body
-    "@#{@deploy.user.email} deployed #{@deploy.short_reference} to #{@stage.name}"
+    "@#{@deploy.user.name} deployed #{@deploy.short_reference} to #{@stage.name}"
   end
 
   def api_key

--- a/plugins/datadog/app/models/datadog_notification.rb
+++ b/plugins/datadog/app/models/datadog_notification.rb
@@ -37,7 +37,7 @@ class DatadogNotification
   private
 
   def body
-    "@#{@deploy.user.name} deployed #{@deploy.short_reference} to #{@stage.name}"
+    "#{@deploy.user.email} deployed #{@deploy.short_reference} to #{@stage.name}"
   end
 
   def api_key


### PR DESCRIPTION
/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low (imho)

Sending events to DataDog which have an `@` followed by something vaguely email shaped will cause DataDog to send an email to that email account.

On the surface, this isnt so bad, but when you use application specific email addresses you are left in a situation where you are required to create an entirely new DataDog account just to unsubscribe that email address from said spam. 

This, apparently, is a feature.

This change should still allow notifications to be sent, but more importantly, only if it matches a known DataDog account, allowing the individual to manage their spam preferences accordingly.