### PR TITLE
github action determines webhook validity

### DIFF
--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -14,7 +14,7 @@ class Changeset::IssueComment
   end
 
   def self.valid_webhook?(params)
-    return false unless VALID_ACTIONS.include? params['action']
+    return false unless VALID_ACTIONS.include? params.dig('github', 'action')
     comment = params['comment'] || {}
     !(comment['body'] =~ Changeset::PullRequest::WEBHOOK_FILTER).nil?
   end

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -7,6 +7,7 @@ describe Changeset::IssueComment do
   describe ".valid_webhook" do
     let(:webhook_data) do
       {
+        github: {},
         comment: {
           body: '[samson review]'
         },
@@ -14,17 +15,17 @@ describe Changeset::IssueComment do
     end
 
     it 'is valid for new comments' do
-      webhook_data[:action] = 'created'
+      webhook_data[:github][:action] = 'created'
       Changeset::IssueComment.valid_webhook?(webhook_data).must_equal true
     end
 
     it 'is not valid for deleted comments' do
-      webhook_data[:action] = 'deleted'
+      webhook_data[:github][:action] = 'deleted'
       Changeset::IssueComment.valid_webhook?(webhook_data).must_equal false
     end
 
     it 'is not valid for edited comments' do
-      webhook_data[:action] = 'edited'
+      webhook_data[:github][:action] = 'edited'
       Changeset::IssueComment.valid_webhook?(webhook_data).must_equal false
     end
   end


### PR DESCRIPTION
We were looking at the wrong `action` key...

The correct one is within `github` to match the payload documented here: https://developer.github.com/v3/activity/events/types/#issuecommentevent

/cc @zendesk/samson @mwerner @alanhogan 

### Tasks
 - [ ] :+1: from team


### Risks
- Level: Low. Webhook deploys from issue comments may still not work

