### PR TITLE
kill job execution threads that are hanging

### DIFF
--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -336,6 +336,7 @@ describe JobExecution do
         TerminalExecutor.any_instance.expects(:stop!).with('INT')
         TerminalExecutor.any_instance.expects(:stop!).with('KILL')
         execution.stop!
+        job.reload.status.must_equal 'cancelled'
       ensure
         JobExecution.stop_timeout = old
       end


### PR DESCRIPTION
/cc @zendesk/samson

ran into this when deploying kubernetes and an api call would not complete ... I think we should kill threads if they misbehave instead of letting them hang forever

was unable to test this because of some internal minitest bug that makes before blocks run twice when the thread was killed ...