### PR TITLE
remove Project#deploy_with_docker? and fix docker binary builder

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -77,11 +77,7 @@ class Project < ActiveRecord::Base
   #
   # Returns true if new releases should be created, false otherwise.
   def build_docker_image_for_branch?(branch)
-    deploy_with_docker? && docker_release_branch == branch
-  end
-
-  def deploy_with_docker?
-    docker_release_branch.present?
+    docker_release_branch == branch
   end
 
   # The user/repo part of the repository URL.

--- a/app/views/shared/_project_tabs.html.erb
+++ b/app/views/shared/_project_tabs.html.erb
@@ -5,7 +5,7 @@
   <li class="<%= 'active' if active == 'releases' %>">
     <%= link_to "Releases", project_releases_path(project) %>
   </li>
-  <% if project.deploy_with_docker? %>
+  <% if ENV['DOCKER_FEATURE'] %>
     <li class="<%= 'active' if active == 'builds' %>">
       <%= link_to "Builds", project_builds_path(project) %>
     </li>

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -18,7 +18,7 @@ class BinaryBuilder
   end
 
   def build
-    return unless @project.try(:deploy_with_docker?) && build_file_exist?
+    return unless build_file_exist?
 
     run_pre_build_script
 

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -43,12 +43,6 @@ describe BinaryBuilder do
       ].join
     end
 
-    it 'does nothing if docker flag is not set for project' do
-      project.update_attributes(docker_release_branch: nil)
-      builder.expects(:create_build_image).never
-      builder.build
-    end
-
     it 'does nothing if docker flag is set for project but no dockerfile.build exists' do
       builder.unstub(:build_file_exist?)
       builder.expects(:create_build_image).never


### PR DESCRIPTION
The `deploy_with_docker` column on the Project model was intended to say whether docker was "enabled" for a given project. That would cause the "Builds" tab to appear, and enable the user of docker binary builder.  It was intended to be a distinct flag from whether to automatically build a docker image on merge to a branch.

When the column was removed in #1264, that screwed up some of that logic.

This PR changes the functionality to assume that Docker is now just a built-in feature of Samson, rather than enabled on a per-project basis.  This means that if the docker_binary_builder plugin is enabled, and checked for a given stage, it will automatically run as intended.

/cc @zendesk/samson, @sandlerr, @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low (this is already broken in production)

