### PR TITLE
Add Rails version to migration

### DIFF
--- a/db/migrate/20160827172550_add_deploy_to_new_pods_to_projects.rb
+++ b/db/migrate/20160827172550_add_deploy_to_new_pods_to_projects.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddDeployToNewPodsToProjects < ActiveRecord::Migration
+class AddDeployToNewPodsToProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :include_new_deploy_groups, :boolean, default: false, null: false
   end

--- a/db/migrate/20160831151133_add_is_template_to_stage.rb
+++ b/db/migrate/20160831151133_add_is_template_to_stage.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddIsTemplateToStage < ActiveRecord::Migration
+class AddIsTemplateToStage < ActiveRecord::Migration[4.2]
   def change
     add_column :stages, :is_template, :boolean, default: false, null: false
   end


### PR DESCRIPTION
Attempting to run migrations complained that some were missing the Rails version. This fixes that issue.

/cc @zendesk/samson

### Tasks
 - [x] :+1: from team

### Risks
- Level: Low

