### PR TITLE
show an error when kubernetes is unable to terminate pods instead of …

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,9 @@ Style/DoubleNegation:
 Style/Documentation:
   Enabled: false
 
+Style/Next:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Enabled: false
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -146,6 +146,17 @@ describe Kubernetes::ReleaseDoc do
         client.expects(:create_daemon_set)
         doc.deploy
       end
+
+      it "tells the user what is wrong when the pods never get terminated" do
+        client.expects(:update_daemon_set)
+        client.expects(:get_daemon_set).times(31).returns(daemonset_stub(0, 1))
+        client.expects(:delete_daemon_set).never
+        client.expects(:create_daemon_set).never
+        e = assert_raises Samson::Hooks::UserError do
+          doc.deploy
+        end
+        e.message.must_include "misscheduled"
+      end
     end
 
     describe "job" do


### PR DESCRIPTION
@jonmoter @irwaters 

... happened when deploying translation daemon and it was confusing as to why it could not finish