### PR TITLE
plugin fixutres cleanup

### DIFF
--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -167,7 +167,7 @@ module Samson
           each(&:add_decorators)
       end
 
-      def plugin_test_setup
+      def symlink_plugin_fixtures
         fixture_path = ActiveSupport::TestCase.fixture_path
         plugins.each do |plugin|
           fixtures = Dir.glob(File.join(plugin.folder, 'test', 'fixtures', '*'))
@@ -177,11 +177,6 @@ module Samson
             File.symlink(fixture, new_path) unless File.exist?(new_path)
             Minitest.after_run { File.delete(new_path) if File.symlink?(new_path) }
           end
-
-          # Load test_helper.rb if it exists
-          # TODO maybe not necessary ...
-          test_helper_file = File.join(plugin.folder, 'test', 'test_helper.rb')
-          require test_helper_file if File.exist?(test_helper_file)
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,11 +63,7 @@ class ActiveSupport::TestCase
 
   ActiveRecord::Migration.check_pending!
 
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  #
-  # Note: You'll currently still have to declare fixtures explicitly in integration tests
-  # -- they do not yet inherit this setting
-  Samson::Hooks.plugin_test_setup
+  Samson::Hooks.symlink_plugin_fixtures
   fixtures :all
 
   before do


### PR DESCRIPTION
fixes fixtures cleanup vs spring and removes unnecessary test helper loading

@sandlerr 