### PR TITLE
fail nicely when commit resultion fails, but checkout works

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -159,7 +159,7 @@ class JobExecution
   end
 
   def setup!(dir)
-    resolve_ref_to_commit
+    return unless resolve_ref_to_commit
     stage.try(:kubernetes) || checkout_workspace(dir)
   end
 
@@ -180,8 +180,14 @@ class JobExecution
     @repository.update_local_cache!
     commit = @repository.commit_from_ref(@reference)
     tag = @repository.tag_from_ref(@reference)
-    @job.update_git_references!(commit: commit, tag: tag)
-    @output.puts("Commit: #{commit}")
+    if commit
+      @job.update_git_references!(commit: commit, tag: tag)
+      @output.puts("Commit: #{commit}")
+      true
+    else
+      @output.puts("Could not find commit for #{@reference}")
+      false
+    end
   end
 
   def commands(dir)

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -213,6 +213,14 @@ describe JobExecution do
   it 'errors if job setup fails' do
     execute_job('nope')
     assert_equal 'errored', job.status
+    job.output.to_s.must_include "Could not find commit for nope"
+  end
+
+  it 'errors if job commit resultion fails, but checkout works' do
+    GitRepository.any_instance.expects(:commit_from_ref).returns nil
+    execute_job('master')
+    assert_equal 'errored', job.status
+    job.output.to_s.must_include "Could not find commit for master"
   end
 
   it 'cannot setup project if project is locked' do


### PR DESCRIPTION
@zendesk/samson @craig-day 

race condition where resoltuion would fail and leave the commit as nil, which leaads to the command building failing

https://samson.zende.sk/projects/rosetta/deploys/204926
https://zendesk.airbrake.io/projects/95346/groups/1775176321342056248/notices/1776228355397618438?tab=occurrences

NoMethodError: undefined method `shellescape' for nil:NilClass