### PR TITLE
Validate annotations and catch docker error

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -75,6 +75,11 @@ class DockerBuilderService
         output.write_docker_chunk(chunk)
       end
     output.puts('### Docker build complete')
+  rescue Docker::Error::UnexpectedResponseError
+    # If the docker library isn't able to find an image id, it returns the
+    # entire output of the "docker build" command, which we've already captured
+    output.puts("Docker build failed (image id not found in response)")
+    nil
   rescue Docker::Error::DockerError => e
     # If a docker error is raised, consider that a "failed" job instead of an "errored" job
     output.puts("Docker build failed: #{e.message}")

--- a/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
@@ -133,7 +133,7 @@ module Kubernetes
     def verify_annotations
       path = [:spec, :template, :metadata, :annotations]
       annotations = map_attributes(path)
-      @errors << "Annotations must be a hash" if annotations.any? { |a| a && !a.kind_of?(Hash) }
+      @errors << "Annotations must be a hash" if annotations.any? { |a| a && !a.is_a?(Hash) }
     end
 
     def verify_env_values

--- a/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
@@ -28,6 +28,7 @@ module Kubernetes
       verify_job_restart_policy
       verify_numeric_limits
       verify_project_and_role_consistent
+      verify_annotations
       verify_env_values
       @errors.presence
     end
@@ -127,6 +128,12 @@ module Kubernetes
       names = map_attributes(path, elements: jobs)
       return if names - allowed == []
       @errors << "Job #{path.join('.')} must be one of #{allowed.join('/')}"
+    end
+
+    def verify_annotations
+      path = [:spec, :template, :metadata, :annotations]
+      annotations = map_attributes(path)
+      @errors << "Annotations must be a hash" if annotations.any? { |a| a && !a.kind_of?(Hash) }
     end
 
     def verify_env_values

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -102,6 +102,11 @@ describe Kubernetes::RoleVerifier do
       errors.must_include "Deployment metadata.labels.role must match /\\A[a-z0-9]([-a-z0-9]*[a-z0-9])?\\z/"
     end
 
+    it "reports invalid annotations" do
+      role.first[:spec][:template][:metadata][:annotations] = ['foo', 'bar']
+      errors.must_include "Annotations must be a hash"
+    end
+
     it "reports non-string env values" do
       role.first[:spec][:template][:spec][:containers][0][:env] = {
         name: 'XYZ_PORT',

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -102,6 +102,11 @@ describe Kubernetes::RoleVerifier do
       errors.must_include "Deployment metadata.labels.role must match /\\A[a-z0-9]([-a-z0-9]*[a-z0-9])?\\z/"
     end
 
+    it "works with proper annotations" do
+      role.first[:spec][:template][:metadata][:annotations] = { 'secret/FOO' => 'bar' }
+      errors.must_equal nil
+    end
+
     it "reports invalid annotations" do
       role.first[:spec][:template][:metadata][:annotations] = ['foo', 'bar']
       errors.must_include "Annotations must be a hash"

--- a/plugins/kubernetes/test/samples/kubernetes_deployment.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_deployment.yml
@@ -18,9 +18,6 @@ spec:
       labels:
         project: some-project
         role: some-role
-      annotations:
-        secret/API_KEY: api_key
-        secret/DB_PASS: database/password
     spec:
       containers:
       - name: some-project

--- a/plugins/kubernetes/test/samples/kubernetes_deployment.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_deployment.yml
@@ -18,6 +18,9 @@ spec:
       labels:
         project: some-project
         role: some-role
+      annotations:
+        secret/API_KEY: api_key
+        secret/DB_PASS: database/password
     spec:
       containers:
       - name: some-project

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -146,10 +146,21 @@ describe DockerBuilderService do
     end
 
     it 'catches docker errors' do
+      error_message = "A bad thing happened..."
       Docker::Image.unstub(:build_from_dir)
-      Docker::Image.expects(:build_from_dir).raises(Docker::Error::DockerError.new("XYZ"))
+      Docker::Image.expects(:build_from_dir).raises(Docker::Error::DockerError.new(error_message))
       service.build_image(tmp_dir).must_equal nil
       build.docker_image_id.must_equal nil
+      service.output.to_s.must_include error_message
+    end
+
+    it 'catches UnexpectedResponseErrors' do
+      error_message = "Really long output..."
+      Docker::Image.unstub(:build_from_dir)
+      Docker::Image.expects(:build_from_dir).raises(Docker::Error::UnexpectedResponseError.new(error_message))
+      service.build_image(tmp_dir).must_equal nil
+      build.docker_image_id.must_equal nil
+      service.output.to_s.wont_include error_message
     end
 
     it 'catches JSON errors' do


### PR DESCRIPTION
Two things here:

1. Validate that the annotations are a hash, rather than an array
2. If a docker build fails, don't output the entire stream twice

/cc @grosser 

### References
 - Failed deploy: https://samsontest.zende.sk/projects/product_data_warehouse/deploys/3253
 - Airbrake: https://zendesk.airbrake.io/projects/95346/groups/1778521175384075883
 - Failed docker build with extra output: https://samsontest.zende.sk/projects/product_data_warehouse/builds/237#L701

### Risks
- Level: Low