### PR TITLE
correctly fetch data when it is an ActionController::Parameters object

### DIFF
--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -84,19 +84,19 @@ class Changeset::PullRequest
   end
 
   def sha
-    @data.head.sha
+    @data['head']['sha']
   end
 
   def branch
-    @data.head.ref
+    @data['head']['ref']
   end
 
   def state
-    @data.state
+    @data['state']
   end
 
   def users
-    users = [@data.user, @data.merged_by]
+    users = [@data['user'], @data['merged_by']]
     users.compact.map { |user| Changeset::GithubUser.new(user) }.uniq
   end
 

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -41,7 +41,7 @@ class Changeset::PullRequest
   end
 
   def self.changeset_from_webhook(project, params = {})
-    data = Sawyer::Resource.new(Octokit.agent, params['pull_request'])
+    data = Sawyer::Resource.new(Octokit.agent, params['pull_request'].to_unsafe_h)
     new(project.github_repo, data)
   end
 

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -35,10 +35,20 @@ describe Changeset::PullRequest do
 
   describe ".changeset_from_webhook" do
     it 'finds the pull request' do
-      webhook_data = {'number' => 42, 'pull_request' => {'state' => 'open'}}
-      pr = Changeset::PullRequest.changeset_from_webhook(project, webhook_data)
-
+      params = ActionController::Parameters.new(
+        number: 42,
+        pull_request: {
+          state: 'open',
+          head: ActionController::Parameters.new(
+            ref: 'a/ref',
+            sha: 'abcd123'
+          )
+        }
+      )
+      pr = Changeset::PullRequest.changeset_from_webhook(project, params)
       pr.state.must_equal 'open'
+      pr.branch.must_equal 'a/ref'
+      pr.sha.must_equal 'abcd123'
     end
   end
 


### PR DESCRIPTION
When we moved to rails 5 - `params` is no longer a hash and is now an `ActionController::Parameters` object. Since it is now this object - when we pass in `params` to `Sawyer` (to get `@data`) it preserves the object type and calling method notation on the Sawyer resource no longer works.

I tried to look into converting `params` to a hash before we create the `Sawyer` resource using `params.permit()` however - that proved to be very difficult when dealing with webhook data

I am open to suggestions if anyone has a better idea on how to convert `ActionController::Parameters` to a hash


/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low. Github Pull request Integration may still be broken...

