### PR TITLE
Add Auto-created Stages to the Pipeline

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -92,12 +92,18 @@ class Admin::DeployGroupsController < ApplicationController
 
   private
 
-  def create_stage_with_group(stage)
-    stage = Stage.build_clone(stage)
+  def create_stage_with_group(template_stage)
+    stage = Stage.build_clone(template_stage)
     stage.deploy_groups << deploy_group
     stage.name = deploy_group.name
     stage.is_template = false
     stage.save!
+
+    if template_stage.respond_to?(:next_stage_ids) # pipeline plugin was installed
+      template_stage.next_stage_ids << stage.id
+      template_stage.save!
+    end
+
     stage
   end
 

--- a/app/helpers/stages_helper.rb
+++ b/app/helpers/stages_helper.rb
@@ -28,6 +28,8 @@ module StagesHelper
   end
 
   def stage_template_icon
-    content_tag :span, '', class: "glyphicon glyphicon-duplicate", title: "Template stage, this stage will be used when copying to new Deploy Groups"
+    content_tag :span, '',
+      class: "glyphicon glyphicon-duplicate",
+      title: "Template stage, this stage will be used when copying to new Deploy Groups"
   end
 end

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -198,6 +198,14 @@ describe Admin::DeployGroupsController do
 
         refute_empty deploy_group.stages.where(project: template_stage.project)
       end
+
+      it 'adds the new stage to the end of the deploy pipeline' do
+        post :create_all_stages, params: {id: deploy_group}
+
+        # the new stage is at the end of the pipeline
+        stage = deploy_group.stages.last
+        template_stage.next_stage_ids.must_equal([stage.id])
+      end
     end
   end
 end


### PR DESCRIPTION

When auto-creating new stages (from templates) for a new deploy group (pod), add those new stages to the end of the deploy pipeline. I.e. add them as "next stages" for the template stage. That way, they won't get missed during proper deployment workflows.

/cc @zendesk/samson @grosser 

### References

* JIRA https://zendesk.atlassian.net/browse/TOOLS-875

### Risks

Low

