### PR TITLE
remove redundant info

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -25,10 +25,3 @@
     </tbody>
   </table>
 </section>
-
-<br>
-
-<p>
-  <%= stage_template_icon %>
-  Is a Template Stage for new Deploy Groups.
-</p>


### PR DESCRIPTION
@dragonfax icon has a hover ... don't need this text on every page ...

<img width="443" alt="screen shot 2016-09-21 at 10 10 00 am" src="https://cloud.githubusercontent.com/assets/11367/18721110/ca856dd8-7fe3-11e6-96e8-620c05b9c6fe.png">
