### PR TITLE
blanked add imagePullSecrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,8 +107,6 @@ GITHUB_TOKEN=
 
 ## Kubernetes
 # SECRET_SIDECAR_IMAGE= # optional, path to the docker image that built from the secret_puller service.  service will be disabled w/o it
-# KUBERNETES_IMAGE_PULL_SECRETS="ecr-auth-us-west-1,..." # override imagePullSecrets before deploying to make docker authenticate to your repository
-
 
 ## Jenkins, optional, for triggering Jenkins builds after deployment
 # JENKINS_URL= # server_url of jenkins

--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,9 @@ GITHUB_TOKEN=
 ## Secret storage
 # SECRET_STORAGE_BACKEND= # optional, should be one of: SecretStorage::DbBackend (default) or SecretStorage::HashicorpVault
 
-## Kubernets sidecar
+## Kubernetes
 # SECRET_SIDECAR_IMAGE= # optional, path to the docker image that built from the secret_puller service.  service will be disabled w/o it
+# KUBERNETES_IMAGE_PULL_SECRETS="ecr-auth-us-west-1,..." # override imagePullSecrets before deploying to make docker authenticate to your repository
 
 
 ## Jenkins, optional, for triggering Jenkins builds after deployment

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -129,6 +129,10 @@ module Kubernetes
       end
     end
 
+    def namespace
+      deploy_group.kubernetes_namespace
+    end
+
     private
 
     def resource_name
@@ -242,10 +246,6 @@ module Kubernetes
       parsed_config_file
     rescue Samson::Hooks::UserError
       errors.add(:kubernetes_release, $!.message)
-    end
-
-    def namespace
-      deploy_group.kubernetes_namespace
     end
 
     def loop_sleep

--- a/plugins/kubernetes/app/models/kubernetes/resource_template.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_template.rb
@@ -19,6 +19,7 @@ module Kubernetes
         set_resource_usage
         set_secrets
         set_env
+        set_image_pull_secrets
 
         hash = template
         Rails.logger.info "Created Kubernetes hash: #{hash.to_json}"
@@ -199,6 +200,12 @@ module Kubernetes
 
       # env from plugins
       env.merge!(Samson::Hooks.fire(:deploy_group_env, project, @doc.deploy_group).inject({}, :merge!))
+    end
+
+    def set_image_pull_secrets
+      return unless secrets = ENV['KUBERNETES_IMAGE_PULL_SECRETS']
+      template[:spec].fetch(:template, {}).fetch(:spec, {})[:imagePullSecrets] =
+        secrets.split(",").map { |s| {name: s} }
     end
 
     def needs_secret_sidecar?

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -100,6 +100,7 @@ describe Kubernetes::DeployExecutor do
         to_return(body: {items: []}.to_json)
       stub_request(:get, /#{Regexp.escape(log_url)}/)
       GitRepository.any_instance.stubs(:file_content).with('Dockerfile', anything).returns "FROM all"
+      Kubernetes::ResourceTemplate.any_instance.stubs(:set_image_pull_secrets)
     end
 
     it "succeeds" do

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -14,6 +14,8 @@ describe Kubernetes::ReleaseDoc do
   end
 
   describe "#store_resource_template" do
+    before { Kubernetes::ResourceTemplate.any_instance.stubs(:set_image_pull_secrets) }
+
     it "stores the template when creating" do
       created = Kubernetes::ReleaseDoc.create!(doc.attributes.except('id', 'resource_template'))
       created.resource_template['kind'].must_equal 'Deployment'

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -47,6 +47,8 @@ describe Kubernetes::Release do
       release
     end
 
+    before { Kubernetes::ResourceTemplate.any_instance.stubs(:set_image_pull_secrets) }
+
     it 'creates with 1 role' do
       expect_file_contents_from_repo
       release = assert_create_succeeds(release_params)

--- a/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_template_test.rb
@@ -57,6 +57,14 @@ describe Kubernetes::ResourceTemplate do
       template.to_hash[:metadata][:name].must_equal 'test-app-server'
     end
 
+    it "sets imagePullSecrets" do
+      with_env KUBERNETES_IMAGE_PULL_SECRETS: 'a,b,c' do
+        template.to_hash[:spec][:template][:spec][:imagePullSecrets].must_equal(
+          [{"name" => 'a'}, {"name" => 'b'}, {"name" => 'c'}]
+        )
+      end
+    end
+
     describe "containers" do
       let(:result) { template.to_hash }
       let(:container) { result.fetch(:spec).fetch(:template).fetch(:spec).fetch(:containers).first }


### PR DESCRIPTION
@jonmoter @irwaters 

at least until kubernetes 1.3 we need to add imagePullSecrets ... so add a nice way to add them to all projects we deploy so we don't have to change that everywhere

https://github.com/zendesk/chef_zendesk_samson/pull/193/files