### PR TITLE
solve eager load vs threads issue

### DIFF
--- a/config/initializers/multithreaded_loading.rb
+++ b/config/initializers/multithreaded_loading.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# https://github.com/rails/rails/issues/24028
+# can be removed if a deploy on osx in development mode without eager load works
+ActiveSupport::Dependencies::Interlock.class_eval do
+  def loading
+    yield
+  end
+end


### PR DESCRIPTION
rails 5 thinks it needs to lock while doing autoload ...
then somehow runs into deadlocks because some threads sleep ...
we could spend a bunch of time debugging that or just go back to the way rails 4 handled it
which worked fine for many years ...

https://github.com/rails/rails/issues/24028

@zendesk/samson 

@irwaters 