### PR TITLE
make env plugin read secrets

### DIFF
--- a/lib/samson/secrets/key_resolver.rb
+++ b/lib/samson/secrets/key_resolver.rb
@@ -38,6 +38,11 @@ module Samson
         found
       end
 
+      def read(key)
+        full_key = expand('unused-param', key).map(&:last).first
+        SecretStorage.read_multi([full_key], include_value: true).values.first&.fetch(:value) # read key without raising
+      end
+
       # raises all errors at once for faster debugging
       def verify!
         if @errors.any?

--- a/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
+++ b/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
@@ -16,6 +16,7 @@ module SamsonAirbrake
         deploy.stage.deploy_groups.group_by(&:environment).each do |environment, deploy_groups|
           rails_env = environment.name.downcase
           next unless rails_env =~ VALID_RAILS_ENV
+
           next unless project_api_key = read_secret(deploy.project, deploy_groups, SECRET_KEY)
 
           # using v1 deploy api since it does not need the project_id to simplify configuration
@@ -34,9 +35,7 @@ module SamsonAirbrake
       private
 
       def read_secret(project, deploy_groups, key)
-        resolver = Samson::Secrets::KeyResolver.new(project, deploy_groups)
-        full_key = resolver.expand('unused-param', key).map(&:last).first
-        SecretStorage.read_multi([full_key], include_value: true).values.first&.fetch(:value) # read key without raising
+        Samson::Secrets::KeyResolver.new(project, deploy_groups).read(key)
       end
     end
   end

--- a/test/lib/samson/secrets/key_resolver_test.rb
+++ b/test/lib/samson/secrets/key_resolver_test.rb
@@ -86,6 +86,19 @@ describe Samson::Secrets::KeyResolver do
     end
   end
 
+  describe "#read" do
+    it "reads secrets" do
+      create_secret "global/global/global/foobar"
+      resolver.read("foobar").must_equal "MY-SECRET"
+      errors.must_equal []
+    end
+
+    it "returns nil when it fails to read secrets" do
+      resolver.read("foobar").must_equal nil
+      errors.first.must_include "foobar (tried"
+    end
+  end
+
   describe "#verify!" do
     it "does nothing when clean" do
       resolver.verify!


### PR DESCRIPTION
@henders @jonmoter @rgueldem @andreionut @sbrnunes @appsan @irwaters 

env value would be `secret://foobar` and that would then lookup the secret

enables us to use secrets in env workflow

for https://zendesk.atlassian.net/wiki/display/ENG/Configuring+projects+from+Samson+-+Proposal

downside would be that secrets will be in the env ... so maybe these should only be for "not so secret secrets" ... maybe "visible" secrets ...


