### PR TITLE
dont use cached pull request for issue_comment events

### DIFF
--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -34,6 +34,7 @@ class Changeset::IssueComment
   private
 
   def pull_request
-    @pull_request ||= Changeset::PullRequest.find(repo, data['number'])
+    pr_data = GITHUB.pull_request(repo, data['number'])
+    @pull_request ||= Changeset::PullRequest.new(repo, pr_data)
   end
 end

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 class Changeset::IssueComment
-  attr_reader :repo, :data
+  attr_reader :repo, :data, :comment
   VALID_ACTIONS = ['created'].freeze
 
   def initialize(repo, data)
     @repo = repo
     @body = data['body']
+    @comment = data['comment']
     @data = data['issue']
   end
 
@@ -34,7 +35,9 @@ class Changeset::IssueComment
   private
 
   def pull_request
-    pr_data = GITHUB.pull_request(repo, data['number'])
+    pr_data = Rails.cache.fetch(['IssueComment', repo, comment['id']].join("-")) do
+      GITHUB.pull_request(repo, data['number'])
+    end
     @pull_request ||= Changeset::PullRequest.new(repo, pr_data)
   end
 end

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -29,4 +29,33 @@ describe Changeset::IssueComment do
       Changeset::IssueComment.valid_webhook?(webhook_data).must_equal false
     end
   end
+
+  describe '#sha' do
+    let(:issue_data) { {issue: {number: 1}}.with_indifferent_access }
+
+    let(:pr_data) do
+      {
+        head: {
+          sha: 'abcd123',
+          ref: 'a/test'
+        }
+      }.with_indifferent_access
+    end
+
+    let(:cached_pr_data) do
+      {
+        head: {
+          sha: 'cach123',
+          ref: 'a/test'
+        }
+      }.with_indifferent_access
+    end
+
+    it 'does not read from cached PullRequest' do
+      Rails.cache.write(['Changeset::PullRequest', 'foo/bar', 1].join("-"), cached_pr_data)
+      GITHUB.stubs(:pull_request).with("foo/bar", 1).returns(pr_data)
+      issue = Changeset::IssueComment.new('foo/bar', issue_data)
+      issue.sha.must_equal 'abcd123'
+    end
+  end
 end

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -31,7 +31,16 @@ describe Changeset::IssueComment do
   end
 
   describe '#sha' do
-    let(:issue_data) { {issue: {number: 1}}.with_indifferent_access }
+    let(:issue_data) do
+      {
+        issue: {
+          number: 1
+        },
+        comment: {
+          id: 123
+        }
+      }.with_indifferent_access
+    end
 
     let(:pr_data) do
       {
@@ -51,8 +60,9 @@ describe Changeset::IssueComment do
       }.with_indifferent_access
     end
 
-    it 'does not read from cached PullRequest' do
+    it 'shows the latest sha when a new comment is made' do
       Rails.cache.write(['Changeset::PullRequest', 'foo/bar', 1].join("-"), cached_pr_data)
+      Rails.cache.write(['IssueComment', 'foo/bar', 1].join("-"), cached_pr_data)
       GITHUB.stubs(:pull_request).with("foo/bar", 1).returns(pr_data)
       issue = Changeset::IssueComment.new('foo/bar', issue_data)
       issue.sha.must_equal 'abcd123'


### PR DESCRIPTION
Issue comment events should trigger a deploy for the latest commit in the PR. There was an bug where issue comments would find a cached version of the same pull request and deploy an older commit - this happens because the cache key is based on repo and PR number which will be the same for multiple issue comments on the same PR.

Now when finding a pull request associated with an issue comment - it will always send a github request to find the PR data

/cc @zendesk/samson @mwerner @alanhogan 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/HAR-929

### Risks
- Level: Low

