### PR TITLE
uppercase label values are valid

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_verifier.rb
@@ -3,7 +3,7 @@ module Kubernetes
   class RoleVerifier
     DEPLOYISH = RoleConfigFile::DEPLOY_KINDS
     JOBS = RoleConfigFile::JOB_KINDS
-    VALID_LABEL = /\A[a-z0-9]([-a-z0-9]*[a-z0-9])?\z/
+    VALID_LABEL = /\A[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?\z/ # cannot use /i since it is not supported in js patterns
     VALID_LABEL_JS = VALID_LABEL.source.sub!('\\A', '^').sub!('\\z', '$') || raise
 
     SUPPORTED_KINDS = [

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -99,7 +99,12 @@ describe Kubernetes::RoleVerifier do
 
     it "reports invalid labels" do
       role.first[:metadata][:labels][:role] = 'foo_bar'
-      errors.must_include "Deployment metadata.labels.role must match /\\A[a-z0-9]([-a-z0-9]*[a-z0-9])?\\z/"
+      errors.must_include "Deployment metadata.labels.role must match /\\A[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?\\z/"
+    end
+
+    it "allows valid labels" do
+      role.first[:metadata][:labels][:foo] = 'KubeDNS'
+      errors.must_equal nil
     end
 
     it "works with proper annotations" do


### PR DESCRIPTION
@jonmoter @irwaters ... we use `KubeDNS` for example