### PR TITLE
very few projects need binary builder and having it active for new stages is confusing

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927223306) do
+ActiveRecord::Schema.define(version: 20160929161911) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -442,7 +442,7 @@ ActiveRecord::Schema.define(version: 20160927223306) do
     t.string   "jenkins_job_names",                            limit: 255
     t.string   "next_stage_ids"
     t.boolean  "no_code_deployed",                                           default: false
-    t.boolean  "docker_binary_plugin_enabled",                               default: true
+    t.boolean  "docker_binary_plugin_enabled",                               default: false, null: false
     t.boolean  "kubernetes",                                                 default: false, null: false
     t.boolean  "is_template",                                                default: false, null: false
     t.boolean  "notify_airbrake",                                            default: false, null: false

--- a/plugins/docker_binary_builder/db/migrate/20160929161911_disable_binary_by_default.rb
+++ b/plugins/docker_binary_builder/db/migrate/20160929161911_disable_binary_by_default.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class DisableBinaryByDefault < ActiveRecord::Migration[5.0]
+  class Stage < ActiveRecord::Base
+  end
+
+  def change
+    change_column_default :stages, :docker_binary_plugin_enabled, false
+    change_column_null :stages, :docker_binary_plugin_enabled, false, false
+  end
+end


### PR DESCRIPTION
@zendesk/samson @henders 

every new/existing stage has:

![screen shot 2016-09-29 at 9 34 39 am](https://cloud.githubusercontent.com/assets/11367/18963011/f8f34bb4-8627-11e6-9295-dd38f6af7e43.png)

which every time makes me think "what is this ... do we use/need that" ... lets remove this mental overhead and only enable it when we need it ...