### PR TITLE
rename confirm to more meaningful review before deploying

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -96,7 +96,7 @@ module DeploysHelper
 
   def stages_select_options
     @project.stages.unlocked_for(current_user).map do |stage|
-      [stage.name, stage.id, 'data-confirmation' => stage.confirm?]
+      [stage.name, stage.id, 'data-confirmation' => stage.review_before_deploying?]
     end
   end
 

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -24,7 +24,7 @@ module ReleasesHelper
   def link_to_deploy_stage(stage, release)
     deploy_params = { reference: release.version }
 
-    if stage.confirm?
+    if stage.review_before_deploying?
       link_to stage.name, new_project_stage_deploy_path(@project, stage, deploy_params)
     else
       link_to stage.name, project_stage_deploys_path(@project, stage, deploy: deploy_params), method: :post

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -3,7 +3,7 @@
 <%= render_global_lock %>
 
 <section>
-  <%= form_for [@project, @stage, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_stage_deploys_path(@project, @stage), 'confirmation' => @stage.confirm? } do |form| %>
+  <%= form_for [@project, @stage, @deploy], html: { class: "form-horizontal" }, data: { 'commit-status-url' => project_commit_statuses_path(@project), 'confirm-url' => confirm_project_stage_deploys_path(@project, @stage), 'confirmation' => @stage.review_before_deploying? } do |form| %>
     <fieldset>
       <%= render 'shared/errors', object: @deploy %>
 

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -53,9 +53,9 @@
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <div class="checkbox">
-        <%= form.label :confirm do %>
-          <%= form.check_box :confirm %>
-          Confirm before deployment
+        <%= form.label :review_before_deploying do %>
+          <%= form.check_box :review_before_deploying %>
+          Review before deployment
         <% end %>
       </div>
     </div>

--- a/db/migrate/20160929165757_rename_confirm.rb
+++ b/db/migrate/20160929165757_rename_confirm.rb
@@ -1,0 +1,6 @@
+class RenameConfirm < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :stages, :confirm, :review_before_deploying
+    change_column_default :stages, :review_before_deploying, false
+  end
+end


### PR DESCRIPTION
@zendesk/samson 

"Confirm" sounds like useless overhead ... "Review" is closer to what it is used for ... also making the column name more descriptive ... sounds good ?

![screen shot 2016-09-29 at 10 11 31 am](https://cloud.githubusercontent.com/assets/11367/18964300/1eb488c2-862d-11e6-83e4-ad1e6ce0aaab.png)

![screen shot 2016-09-29 at 10 12 01 am](https://cloud.githubusercontent.com/assets/11367/18964314/2dd09bb6-862d-11e6-99e1-0d034305c299.png)
