### PR TITLE
Refuse to merge a stage into template, if commands changed.

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -110,7 +110,7 @@ class Admin::DeployGroupsController < ApplicationController
     return unless template_stage
     return if stage.is_template
     return if stage.deploy_groups.count != 1
-    return if (stage.commands.to_a <=> template_stage.commands.to_a).nonzero?
+    return if stage.commands.to_a != template_stage.commands.to_a
 
     unless template_stage.deploy_groups.include?(stage.deploy_groups.first)
       template_stage.deploy_groups += stage.deploy_groups

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -110,6 +110,7 @@ class Admin::DeployGroupsController < ApplicationController
     return unless template_stage
     return if stage.is_template
     return if stage.deploy_groups.count != 1
+    return if (stage.commands.to_a <=> template_stage.commands.to_a).nonzero?
 
     unless template_stage.deploy_groups.include?(stage.deploy_groups.first)
       template_stage.deploy_groups += stage.deploy_groups

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -93,11 +93,11 @@ class Admin::DeployGroupsController < ApplicationController
       [reason, stage]
     end
 
-    failures = failures.reject { |reason,| reason.nil? }
+    failures = failures.select(&:first)
 
     message = failures.map { |reason, stage| "#{stage.project.name} #{stage.name} #{reason}" }.join(", ")
 
-    redirect_to [:admin, deploy_group], notice: (failures.empty? ? nil : "Some stages were skipped: #{message}")
+    redirect_to [:admin, deploy_group], alert: (failures.empty? ? nil : "Some stages were skipped: #{message}")
   end
 
   def self.create_all_stages(deploy_group)

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -91,11 +91,13 @@ class Admin::DeployGroupsController < ApplicationController
     failures = deploy_group.stages.cloned.map do |stage|
       reason = merge_stage(stage)
       [reason, stage]
-    end.reject { |reason,| reason.nil? }
+    end
+
+    failures = failures.reject { |reason,| reason.nil? }
 
     message = failures.map { |reason, stage| "#{stage.project.name} #{stage.name} #{reason}" }.join(", ")
 
-    redirect_to [:admin, deploy_group], notice: ( failures.empty? ? nil : "Some stages were skipped: #{message}" )
+    redirect_to [:admin, deploy_group], notice: (failures.empty? ? nil : "Some stages were skipped: #{message}")
   end
 
   def self.create_all_stages(deploy_group)
@@ -113,7 +115,7 @@ class Admin::DeployGroupsController < ApplicationController
 
     return "has no template stage to merge into" unless template_stage
     return "is a template stage" if stage.is_template
-    return "has no deploy groups" if stage.deploy_groups.count == 0
+    return "has no deploy groups" if stage.deploy_groups.count.zero?
     return "has more than one deploy group" if stage.deploy_groups.count > 1
     return "commands in template stage differ" if stage.commands.to_a != template_stage.commands.to_a
 

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -262,10 +262,10 @@ describe Admin::DeployGroupsController do
           end
         end
 
-        it "success sets no the reason for skipping" do
+        it "success sets no alert for skipping" do
           post :merge_all_stages, params: {id: deploy_group}
 
-          refute flash.notice
+          refute flash.alert
         end
 
         it "removes the next_stage_id" do
@@ -316,9 +316,9 @@ describe Admin::DeployGroupsController do
             refute template_stage.deploy_groups.include?(deploy_group)
           end
 
-          it "sets warning in notice" do
+          it "sets warning in alert" do
             post :merge_all_stages, params: {id: deploy_group}
-            assert flash.notice
+            assert flash.alert
           end
         end
 
@@ -337,10 +337,10 @@ describe Admin::DeployGroupsController do
           end
 
           # non-cloned stages are naturally ignored as part of the merge process
-          # no notice is necessary
-          xit "sets warning in notice" do
+          # no alert is necessary
+          xit "sets warning in alert" do
             post :merge_all_stages, params: {id: deploy_group}
-            assert flash.notice
+            assert flash.alert
           end
         end
 
@@ -358,9 +358,9 @@ describe Admin::DeployGroupsController do
             refute template_stage.deploy_groups.include?(deploy_group)
           end
 
-          it "sets warning in notice" do
+          it "sets warning in alert" do
             post :merge_all_stages, params: {id: deploy_group}
-            assert flash.notice
+            assert flash.alert
           end
         end
 
@@ -378,9 +378,9 @@ describe Admin::DeployGroupsController do
             refute template_stage.deploy_groups.include?(deploy_group)
           end
 
-          it "sets warning in notice" do
+          it "sets warning in alert" do
             post :merge_all_stages, params: {id: deploy_group}
-            assert flash.notice
+            assert flash.alert
           end
         end
       end

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -299,7 +299,7 @@ describe Admin::DeployGroupsController do
           StageCommand.create!(command: command, stage: stage, position: 2)
 
           # doesn't remove the old stage
-          assert_difference 'Stage.count', 0 do
+          refute_difference 'Stage.count' do
             post :merge_all_stages, params: {id: deploy_group}
           end
 

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -293,6 +293,19 @@ describe Admin::DeployGroupsController do
 
           assert DeployGroupsStage.where(stage_id: template_stage.id, deploy_group_id: deploy_group.id).first
         end
+
+        it "ignores a stage with changed commands" do
+          command = Command.create!(command: "flooboop")
+          StageCommand.create!(command: command, stage: stage, position: 2)
+
+          # doesn't remove the old stage
+          assert_difference 'Stage.count', 0 do
+            post :merge_all_stages, params: {id: deploy_group}
+          end
+
+          # doesn't merge the deploy group
+          refute template_stage.deploy_groups.include?(deploy_group)
+        end
       end
 
       describe "with multiple stages to remove" do


### PR DESCRIPTION
We can't trust merging the stage into its source template if it no longer has the same commands. 

Either the template changes to something "more modern" or someone had to change the clone to get it to work. Either situation is a no-merge.

/cc @zendesk/samson @grosser 

### Screenshot

![samson](https://cloud.githubusercontent.com/assets/933806/19287951/c69b0838-8fb8-11e6-8ca6-a7a81abac9f5.png)


### References
 - Jira link: https://zendesk.atlassian.net/browse/TOOLS-939

### Risks

None

