### PR TITLE
more cleanup

### DIFF
--- a/plugins/kubernetes/test/fixtures/kubernetes/release_docs.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/release_docs.yml
@@ -5,4 +5,4 @@ test_release_pod_1:
   replica_target: 2
   cpu: 1
   ram: 100
-  resource_template: '{"kind":"Deployment", "metadata":{"name":"app-server"}}'
+  resource_template: '{"kind":"Deployment", "metadata":{"name":"app-server", "namespace":"pod1"}}'


### PR DESCRIPTION
@irwaters @jonmoter 

... remove methods we no longer need or makes them private
... prepares for kube-system namespace being special by making everything use the resource_template as source of truth