### PR TITLE
load New Relic gem before the application, since it creates a Railtie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'vault'
 gem 'docker-api', '>= 1.32'
 gem 'warden-doorkeeper'
 gem 'kubeclient', '~> 1.2.0'
+gem 'newrelic_rpm'
 
 # treat included plugins like gems
 Dir[File.join(Bundler.root, 'plugins/*/')].each { |f| gemspec path: f }
@@ -68,7 +69,6 @@ end
 
 group :production, :staging do
   gem 'airbrake', '~> 4.3.6' # different configuration format on 5.x
-  gem 'newrelic_rpm'
 end
 
 group :assets do

--- a/config/initializers/new_relic.rb
+++ b/config/initializers/new_relic.rb
@@ -1,2 +1,0 @@
-# frozen_string_literal: true
-require 'new_relic/agent/method_tracer'


### PR DESCRIPTION
For some reason the New Relic gem wasn't working, but if I move the `require` here, it loads. I think it has something to do with the Railtie definition.

In development mode, the new relic RPM stores stuff in-memory, rather than sending it to new relic.

/cc @zendesk/samson  

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-285

### Risks
- Level: Low

