### PR TITLE
make the excluded namespace default+service ... since datadog needs t…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -28,7 +28,7 @@ module Kubernetes
     end
 
     # optimization to not do multiple queries to the same cluster+namespace because we have many roles
-    # ... needs to check doc namespace too since it might be kube-system
+    # ... needs to check doc namespace too since it might be not overwritten
     # ... assumes that there is only 1 namespace per release_doc
     def clients
       scopes = release_docs.map do |release_doc|

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -73,9 +73,7 @@ module Kubernetes
     # dynamically fill out the templates and store the result
     def store_resource_template
       self.resource_template = raw_template.map do |resource|
-        unless resource[:metadata][:namespace] == "kube-system"
-          resource[:metadata][:namespace] = deploy_group.kubernetes_namespace
-        end
+        update_namespace resource
 
         case resource[:kind]
         when 'Service'
@@ -98,6 +96,12 @@ module Kubernetes
           resource
         end
       end
+    end
+
+    def update_namespace(resource)
+      return if resource[:metadata][:namespace] == "default" &&
+        (resource[:metadata][:labels] || {})[:'kubernetes.io/cluster-service'] == 'true'
+      resource[:metadata][:namespace] = deploy_group.kubernetes_namespace
     end
 
     def validate_config_file

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -82,7 +82,7 @@ module Kubernetes
       end
 
       def loop_sleep
-        sleep 2 unless ENV.fetch('RAILS_ENV') == 'test'
+        sleep 2 unless Rails.env == 'test'
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -42,7 +42,7 @@ describe Kubernetes::Cluster do
   end
 
   describe "#namespaces" do
-    it 'ignores kube-system' do
+    it 'ignores kube-system because it is internal and should not be deployed too' do
       items = [{metadata: {name: 'N1'}}, {metadata: {name: 'N2'}}, {metadata: {name: 'kube-system'}}]
       stub_request(:get, "http://foobar.server/api/v1/namespaces").
         to_return(body: {items: items, }.to_json)

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -84,9 +84,10 @@ describe Kubernetes::ReleaseDoc do
       e.message.must_equal "Service name for role app-server was generated and needs to be changed before deploying."
     end
 
-    it "keeps kube-system namespace because it is a unique system namespace" do
-      doc.send(:raw_template)[0][:metadata][:namespace] = "kube-system"
-      create!.resource_template[0][:metadata][:namespace].must_equal 'kube-system'
+    it "keeps default service namespace because it is a unique system namespace" do
+      doc.send(:raw_template)[0][:metadata][:namespace] = "default"
+      doc.send(:raw_template)[0][:metadata][:labels] = {"kubernetes.io/cluster-service": 'true'}
+      create!.resource_template[0][:metadata][:namespace].must_equal 'default'
     end
 
     it "configures ConfigMap" do

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -116,8 +116,8 @@ describe Kubernetes::Release do
 
     it "can scope queries by resource namespace" do
       release = kubernetes_releases(:test_release)
-      Kubernetes::Resource::Deployment.any_instance.stubs(namespace: "kube-system")
-      stub_request(:get, %r{http://foobar.server/api/v1/namespaces/kube-system/pods}).to_return(body: {
+      Kubernetes::Resource::Deployment.any_instance.stubs(namespace: "default")
+      stub_request(:get, %r{http://foobar.server/api/v1/namespaces/default/pods}).to_return(body: {
         resourceVersion: "1",
         items: [{}, {}]
       }.to_json)

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -62,7 +62,7 @@ describe Kubernetes::RoleVerifier do
     end
 
     it "reports non-unique namespaces since that would break pod fetching" do
-      role.first[:metadata][:namespace] = "kube-system"
+      role.first[:metadata][:namespace] = "default"
       errors.to_s.must_include "Namespaces need to be unique"
     end
 


### PR DESCRIPTION
@morten @irwaters 

apps now need this to not be moved to the actual namespace

https://github.com/zendesk/zendesk_kubernetes/pull/104

```
namespace: default
labels:
  kubernetes.io/cluster-service: 'true'
```