### PR TITLE
Add deploy id to deploy mail subject

### DIFF
--- a/app/mailers/deploy_mailer.rb
+++ b/app/mailers/deploy_mailer.rb
@@ -33,7 +33,7 @@ class DeployMailer < ApplicationMailer
   private
 
   def deploy_subject(deploy)
-    "[#{Rails.application.config.samson.email.prefix}] #{deploy.summary_for_email}"
+    "[#{Rails.application.config.samson.email.prefix}][#{deploy.id}] #{deploy.summary_for_email}"
   end
 
   def prepare_mail(deploy)

--- a/app/mailers/deploy_mailer.rb
+++ b/app/mailers/deploy_mailer.rb
@@ -33,7 +33,7 @@ class DeployMailer < ApplicationMailer
   private
 
   def deploy_subject(deploy)
-    "[#{Rails.application.config.samson.email.prefix}][#{deploy.id}] #{deploy.summary_for_email}"
+    "[#{Rails.application.config.samson.email.prefix}][##{deploy.id}] #{deploy.summary_for_email}"
   end
 
   def prepare_mail(deploy)

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -78,7 +78,7 @@ describe DeployMailer do
     it "sends" do
       stub_empty_changeset
       DeployMailer.deploy_failed_email(deploy, ["foo@bar.com"]).deliver_now
-      subject.subject.must_equal "[AUTO-DEPLOY][DEPLOY][#{deploy.id}] Super Admin deployed Project to Staging (staging)"
+      subject.subject.must_equal "[AUTO-DEPLOY][DEPLOY][##{deploy.id}] Super Admin deployed Project to Staging (staging)" # rubocop:disable Metrics/LineLength
     end
   end
 end

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -61,8 +61,8 @@ describe DeployMailer do
     end
 
     it 'sets a bypass subject' do
-      subject.subject.must_match /BYPASS/
-      subject.subject.must_match Regexp.new deploy.id.to_s
+      subject.subject.must_include "BYPASS"
+      subject.subject.must_include deploy.id.to_s
     end
 
     describe "with jira address" do

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -62,6 +62,7 @@ describe DeployMailer do
 
     it 'sets a bypass subject' do
       subject.subject.must_match /BYPASS/
+      subject.subject.must_match Regexp.new deploy.id.to_s
     end
 
     describe "with jira address" do
@@ -77,7 +78,7 @@ describe DeployMailer do
     it "sends" do
       stub_empty_changeset
       DeployMailer.deploy_failed_email(deploy, ["foo@bar.com"]).deliver_now
-      subject.subject.must_equal "[AUTO-DEPLOY][DEPLOY] Super Admin deployed Project to Staging (staging)"
+      subject.subject.must_equal "[AUTO-DEPLOY][DEPLOY][#{deploy.id}] Super Admin deployed Project to Staging (staging)"
     end
   end
 end


### PR DESCRIPTION
* Adds the deploy id to the subject of the deploy mails to enable searching through emails/jira tickets for the deploy record.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: N/A

### Risks
- Level: Low
