### PR TITLE
make sure we produce a clean env when overriding via samson

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_template.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_template.rb
@@ -162,7 +162,7 @@ module Kubernetes
     def set_env
       env = (container[:env] ||= [])
 
-      static_env.each { |k, v| env << {name: k, value: v.to_s} }
+      static_env.each { |k, v| env << {name: k.to_s, value: v.to_s} }
 
       # dynamic lookups for unknown things during deploy
       {
@@ -171,10 +171,15 @@ module Kubernetes
         POD_IP: 'status.podIP'
       }.each do |k, v|
         env << {
-         name: k,
+         name: k.to_s,
          valueFrom: {fieldRef: {fieldPath: v}}
        }
       end
+
+      # unique, but keep last elements
+      env.reverse!
+      env.uniq! { |h| h[:name] }
+      env.reverse!
     end
 
     def static_env


### PR DESCRIPTION
@jonmoter @irwaters 

not sure if it would fail without that or if kubernetes read in the order we want, but trying to remove ambiguity when multiple env vars with the same name got added

/fyi @zendesk/paas in case you want to override settings