### PR TITLE
do not raise exceptions on bad svg requests, they spam the logs

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -85,9 +85,8 @@ class StagesController < ApplicationController
   end
 
   def check_token
-    unless params[:token] == Rails.application.config.samson.badge_token
-      raise ActiveRecord::RecordNotFound
-    end
+    return if Rack::Utils.secure_compare(params[:token], Rails.application.config.samson.badge_token)
+    head :not_found
   end
 
   def badge?

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -28,9 +28,8 @@ describe StagesController do
     end
 
     it "fails with invalid token" do
-      assert_raises ActiveRecord::RecordNotFound do
-        get :show, params: valid_params.merge(token: 'invalid')
-      end
+      get :show, params: valid_params.merge(token: 'invalid')
+      assert_response :not_found
     end
 
     it "renders none without deploy" do


### PR DESCRIPTION
seeing tons of these in the logs ... let's make them less noisy and cheaper ...
could even do page-caching for them, but I guess this is good enough for now ...
also fixing a timing attack by using secure compare

@zendesk/samson 

```
ActiveRecord::RecordNotFound (Couldn't find Stage):

app/models/concerns/permalinkable.rb:13:in `find_by_param!'
app/controllers/stages_controller.rb:102:in `find_stage'
```