### PR TITLE
redirect back to overview page after editing a deploy role

### DIFF
--- a/plugins/kubernetes/app/controllers/admin/kubernetes/deploy_group_roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/admin/kubernetes/deploy_group_roles_controller.rb
@@ -42,7 +42,7 @@ class Admin::Kubernetes::DeployGroupRolesController < ApplicationController
       deploy_group_role_params.except(:project_id, :deploy_group_id, :kubernetes_role_id)
     )
     if @deploy_group_role.save
-      redirect_to [:admin, @deploy_group_role]
+      redirect_back_or [:admin, @deploy_group_role]
     else
       render :edit, status: 422
     end

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -31,7 +31,7 @@
             <td><%= dg_role.ram %></td>
             <td>
               <% if current_user.admin_for?(@stage.project) %>
-                <%= link_to 'Edit', edit_admin_kubernetes_deploy_group_role_path(dg_role) %>
+                <%= link_to 'Edit', edit_admin_kubernetes_deploy_group_role_path(dg_role, redirect_to: request.path) %>
               <% end %>
             </td>
           <% else %>

--- a/plugins/kubernetes/test/controllers/admin/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/admin/kubernetes/deploy_group_roles_controller_test.rb
@@ -121,10 +121,18 @@ describe Admin::Kubernetes::DeployGroupRolesController do
     end
 
     describe "#update" do
+      let(:valid_params) { {id: deploy_group_role.id, kubernetes_deploy_group_role: {cpu: 3.1}} }
+
       it "updates" do
-        put :update, params: {id: deploy_group_role.id, kubernetes_deploy_group_role: {cpu: 3.1}}
+        put :update, params: valid_params
         deploy_group_role.reload.cpu.must_equal 3.1
         assert_redirected_to [:admin, deploy_group_role]
+      end
+
+      it "can redirect back" do
+        valid_params[:redirect_to] = "/test"
+        put :update, params: valid_params
+        assert_redirected_to "/test"
       end
 
       it "does not allow to circumvent project admin protection" do
@@ -135,7 +143,7 @@ describe Admin::Kubernetes::DeployGroupRolesController do
 
       it "does not allow updates for non-admins" do
         user.user_project_roles.delete_all
-        put :update, params: {id: deploy_group_role.id, kubernetes_deploy_group_role: {cpu: 3.1}}
+        put :update, params: valid_params
         assert_unauthorized
       end
 


### PR DESCRIPTION
@jonmoter @irwaters 

nice to easily go back and forth when editing replicas/cpu/memory