### PR TITLE
unify / dry / simplify form elements

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -2,75 +2,17 @@
   <%= render 'shared/errors', object: project %>
 
   <fieldset>
-    <div class="form-group">
-      <%= form.label :name, class: "col-lg-2 control-label" %>
-      <div class="col-lg-4">
-        <%= form.text_field :name, class: "form-control" %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <%= form.label :description, class: "col-lg-2 control-label" %>
-      <div class="col-lg-4">
-        <%= form.text_area :description, class: "form-control" %>
-        <p class="help-block">How would you explain the project to someone new?</p>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <%= form.label :Contact, class: "col-lg-2 control-label" %>
-      <div class="col-lg-4">
-        <%= form.text_field :owner, class: "form-control" %>
-        <p class="help-block">An email or group to contact with questions.</p>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <%= form.label :repository_url, class: "col-lg-2 control-label" %>
-      <div class="col-lg-4">
-        <%= form.text_field :repository_url, class: "form-control" %>
-      </div>
-    </div>
-
-    <% if project.persisted? %>
-      <div class="form-group">
-        <%= form.label :permalink, class: "col-lg-2 control-label" %>
-        <div class="col-lg-4">
-          <%= form.text_field :permalink, class: "form-control" %>
-        </div>
-      </div>
-    <% end %>
-
-    <div class="form-group">
-      <%= form.label :release_branch, class: "col-lg-2 control-label" %>
-      <div class="col-lg-4">
-        <%= form.text_field :release_branch, class: "form-control" %>
-        <p class="help-block">New commits on this branch will cause a release when a webhook arrives.</p>
-      </div>
-    </div>
-
-
+    <%= form.input :name %>
+    <%= form.input :description, as: :text_area, help: 'How would you explain the project to someone new?' %>
+    <%= form.input :owner, label: 'Contact', help: 'An email or group to contact with questions.' %>
+    <%= form.input :repository_url %>
+    <%= form.input :permalink if project.persisted? %>
+    <%= form.input :release_branch, help: 'New commits on this branch will cause a release when a webhook arrives.' %>
     <% if ENV['DOCKER_FEATURE'] %>
-      <div class="form-group">
-        <%= form.label :docker_release_branch, class: "col-lg-2 control-label" %>
-        <div class="col-lg-4">
-          <%= form.text_field :docker_release_branch, class: "form-control" %>
-
-          <p class="help-block">
-            New commits on this branch will cause a docker image to be built when a webhook arrives.
-          </p>
-        </div>
-      </div>
+      <%= form.input :docker_release_branch, help: 'New commits on this branch will cause a docker image to be built when a webhook arrives.' %>
     <% end %>
-
     <% if DeployGroup.enabled? %>
-      <div class="form-group">
-        <div class="col-lg-offset-2 col-lg-4">
-          <%= form.check_box :include_new_deploy_groups %>
-          <%= form.label :include_new_deploy_groups, 'Include in New Deploy Groups'%>
-          <p class="help-block">The "Create all stages" button for a deploy group will create a stage for this project.</p>
-        </div>
-      </div>
+      <%= form.input :include_new_deploy_groups, as: :check_box, label: 'Include in New Deploy Groups', help: 'The "Create all stages" button for a deploy group will create a stage for this project.' %>
     <% end %>
 
     <%= Samson::Hooks.render_views(:project_form, self, form: form) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -138,6 +138,7 @@ module Samson
     }
 
     config.action_controller.action_on_unpermitted_parameters = :raise
+    config.action_view.default_form_builder = 'Samson::FormBuilder' # string so we can auto-reload it
 
     config.active_job.queue_adapter = :sucker_punch
     config.samson.export_job = ActiveSupport::OrderedOptions.new

--- a/lib/samson/form_builder.rb
+++ b/lib/samson/form_builder.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Samson
+  class FormBuilder < ActionView::Helpers::FormBuilder
+    def input(attribute, as: :text_field, help: false, label: false)
+      content_tag :div, class: 'form-group' do
+        content = label(attribute, label, class: "col-lg-2 control-label")
+        content << content_tag(:div, class: 'col-lg-4') do
+          public_send(as, attribute, class: "form-control")
+        end
+        content << @template.additional_info(help) if help
+        content
+      end
+    end
+
+    private
+
+    def content_tag(*args, &block)
+      @template.content_tag(*args, &block)
+    end
+  end
+end

--- a/test/lib/samson/form_builder_test.rb
+++ b/test/lib/samson/form_builder_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::FormBuilder do
+  let(:template) do
+    template = ActionView::Base.new
+    template.extend ApplicationHelper
+    template
+  end
+  let(:builder) { Samson::FormBuilder.new(:user, User.new, template, {}) }
+
+  describe '#input' do
+    it "adds a clickable label" do
+      result = builder.input(:name)
+      result.must_include 'for="user_name">Name</label>'
+      result.must_include 'id="user_name"'
+    end
+
+    it "creates a text field by default" do
+      builder.input(:name).must_include 'type="text"'
+    end
+
+    it "can override label" do
+      builder.input(:name, label: "Ho Ho").must_include 'for="user_name">Ho Ho</label>'
+    end
+
+    it "can change field type" do
+      builder.input(:name, as: :text_area).must_include '<textarea class='
+    end
+
+    it "can show help" do
+      builder.input(:name, help: "Hello!").must_include "title=\"Hello!\"></i>"
+    end
+  end
+end


### PR DESCRIPTION
@zendesk/samson 

WIP, but please take a look and comment on direction / layout ...
planing to re-vamp most forms to use this and cut down on the html noise and make all forms feel the same / have the same usability (clickable checkbox labels / required fields / html validations etc)

future features: 
 - add html limit for column limits / validations
 - add required so we can indicate required fields

before:
<img width="547" alt="screen shot 2016-10-08 at 7 47 15 pm" src="https://cloud.githubusercontent.com/assets/11367/19217445/08d5eca2-8d90-11e6-8eae-f88ec403f394.png">

after:
<img width="588" alt="screen shot 2016-10-08 at 7 43 38 pm" src="https://cloud.githubusercontent.com/assets/11367/19217442/f115abfc-8d8f-11e6-8cf5-4c15a3f70d84.png">
checkbox label and complete empty row are clickable

TODO: tests