### PR TITLE
Add job index on user_id

### DIFF
--- a/db/migrate/20161012161509_add_user_id_index_to_jobs.rb
+++ b/db/migrate/20161012161509_add_user_id_index_to_jobs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddUserIdIndexToJobs < ActiveRecord::Migration[5.0]
+  def change
+    add_index :jobs, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161007231901) do
+ActiveRecord::Schema.define(version: 20161012161509) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -164,6 +164,7 @@ ActiveRecord::Schema.define(version: 20161007231901) do
 
   add_index "jobs", ["project_id"], name: "index_jobs_on_project_id", using: :btree
   add_index "jobs", ["status"], name: "index_jobs_on_status", length: {"status"=>191}, using: :btree
+  add_index "jobs", ["user_id"], name: "index_jobs_on_user_id", using: :btree
 
   create_table "kubernetes_cluster_deploy_groups", force: :cascade do |t|
     t.integer  "kubernetes_cluster_id", limit: 4,   null: false


### PR DESCRIPTION
* During the audit, the performance of deploys/search was extremely slow and often timed out with a 404 due to the volume of deploys/jobs we have.
* Adding a jobs table index on user_id (deployer) so the search queries would run faster.

Added rubocop fix that #1361 needed and travis had a delayed start and odd test results that resulted in reverting in #1362.  

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: N/A

### Risks
- Level: Low