### PR TITLE
allow slack to only notify on failure

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012161509) do
+ActiveRecord::Schema.define(version: 20161013175858) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -405,9 +405,10 @@ ActiveRecord::Schema.define(version: 20161012161509) do
     t.integer  "stage_id",    limit: 4,     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "before_deploy",               default: false, null: false
-    t.boolean  "after_deploy",                default: true,  null: false
-    t.boolean  "for_buddy",                   default: false, null: false
+    t.boolean  "before_deploy",                 default: false, null: false
+    t.boolean  "after_deploy",                  default: true,  null: false
+    t.boolean  "for_buddy",                     default: false, null: false
+    t.boolean  "only_on_failure",               default: false, null: false
   end
 
   add_index "slack_webhooks", ["stage_id"], name: "index_slack_webhooks_on_stage_id", using: :btree

--- a/plugins/slack_webhooks/app/decorators/stage_decorator.rb
+++ b/plugins/slack_webhooks/app/decorators/stage_decorator.rb
@@ -3,16 +3,16 @@ Stage.class_eval do
   has_many :slack_webhooks
   accepts_nested_attributes_for :slack_webhooks, allow_destroy: true, reject_if: :no_webhook_url?
 
-  def send_slack_webhook_notifications?
-    slack_webhooks.any?
-  end
-
   def slack_buddy_channels
     @slack_buddy_channels ||= slack_webhooks.for_buddy.pluck(:channel)
   end
 
   def send_slack_buddy_request?
     slack_buddy_channels.any?
+  end
+
+  def send_slack_webhook_notifications?
+    slack_webhooks.any?
   end
 
   private

--- a/plugins/slack_webhooks/app/models/slack_webhook.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook.rb
@@ -6,6 +6,15 @@ class SlackWebhook < ActiveRecord::Base
 
   scope :for_buddy, -> { where(for_buddy: true) }
 
+  def deliver_for?(deploy_phase, deploy)
+    case deploy_phase
+    when :for_buddy then for_buddy?
+    when :before_deploy then before_deploy?
+    when :after_deploy then after_deploy? && (!only_on_failure? || !deploy.succeeded?)
+    else raise
+    end
+  end
+
   private
 
   def validate_url

--- a/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
@@ -33,7 +33,7 @@ class SlackWebhookNotification
 
   def _deliver(deploy_phase:, message:, attachments: nil)
     @stage.slack_webhooks.each do |webhook|
-      next unless webhook.public_send(deploy_phase)
+      next unless webhook.deliver_for?(deploy_phase, @deploy)
       SamsonSlackWebhooks::SlackWebhooksService.new.deliver_message_via_webhook(
         webhook: webhook,
         message: message,

--- a/plugins/slack_webhooks/app/views/samson_slack_webhooks/_fields.html.erb
+++ b/plugins/slack_webhooks/app/views/samson_slack_webhooks/_fields.html.erb
@@ -1,5 +1,5 @@
 <fieldset>
-  <legend>Slack</legend>
+  <legend>Slack Webhooks</legend>
 
   <% stage = form.object %>
   <% stage.slack_webhooks.build %>
@@ -10,7 +10,7 @@
     <%= form.fields_for :slack_webhooks do |slack_fields| %>
       <div class="form-group">
         <div class="col-lg-4">
-          <%= slack_fields.text_field :webhook_url, class: "form-control", placeholder: "Webhook URL" %>
+          <%= slack_fields.url_field :webhook_url, class: "form-control", placeholder: "Webhook URL" %>
         </div>
 
         <div class="col-lg-3">
@@ -29,6 +29,13 @@
 
       <div class="form-group">
         <div class="col-lg-2 checkbox">
+          <%= slack_fields.label :for_buddy do %>
+            <%= slack_fields.check_box :for_buddy%>
+            Buddy Approval
+          <% end %>
+        </div>
+
+        <div class="col-lg-2 checkbox">
           <%= slack_fields.label :before_deploy do %>
             <%= slack_fields.check_box :before_deploy%>
             Before Deploy
@@ -43,9 +50,9 @@
         </div>
 
         <div class="col-lg-3 checkbox">
-          <%= slack_fields.label :for_buddy do %>
-            <%= slack_fields.check_box :for_buddy%>
-            For Buddy Approval
+          <%= slack_fields.label :only_on_failure do %>
+            <%= slack_fields.check_box :only_on_failure %>
+            Only on failure <%= additional_info "... for After Deploy" %>
           <% end %>
         </div>
       </div>

--- a/plugins/slack_webhooks/db/migrate/20161013175858_add_only_on_failure_to_slack_webhooks.rb
+++ b/plugins/slack_webhooks/db/migrate/20161013175858_add_only_on_failure_to_slack_webhooks.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddOnlyOnFailureToSlackWebhooks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :slack_webhooks, :only_on_failure, :boolean, default: false, null: false
+  end
+end

--- a/plugins/slack_webhooks/lib/samson_slack_webhooks/samson_plugin.rb
+++ b/plugins/slack_webhooks/lib/samson_slack_webhooks/samson_plugin.rb
@@ -16,12 +16,16 @@ Samson::Hooks.callback :stage_clone do |old_stage, new_stage|
 end
 
 Samson::Hooks.callback :stage_permitted_params do
-  { slack_webhooks_attributes: [:id, :webhook_url, :channel, :before_deploy, :after_deploy, :for_buddy, :_destroy] }
+  {
+    slack_webhooks_attributes: [
+      :id, :webhook_url, :channel, :before_deploy, :after_deploy, :for_buddy, :only_on_failure, :_destroy
+    ]
+  }
 end
 
 [:before_deploy, :after_deploy].each do |callback|
   Samson::Hooks.callback callback do |deploy, _buddy|
-    if deploy.stage.send_slack_webhook_notifications?
+    if deploy.stage.send_slack_webhook_notifications? # avoid rendering overhead when disabled
       SlackWebhookNotification.new(deploy).deliver(callback)
     end
   end

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -19,14 +19,20 @@ describe SlackWebhookNotification do
   let(:risks) { payload.fetch('attachments')[0].fetch('fields')[1] }
 
   def stub_notification(before_deploy: false, after_deploy: true, for_buddy: false, risks: true, prs: true)
-    pr_stub = stub url: 'https://github.com/foo/bar/pulls/1', number: 1, title: 'PR 1',
-                   risks: risks ? 'abc' : nil
+    pr_stub = stub(
+      url: 'https://github.com/foo/bar/pulls/1',
+      number: 1,
+      title: 'PR 1',
+      risks: risks ? 'abc' : nil
+    )
     changeset = stub "changeset"
     changeset.stubs(:pull_requests).returns(prs ? [pr_stub] : [])
 
-    webhook = stub(
-      webhook_url: endpoint, channel: nil,
-      before_deploy: before_deploy, after_deploy: after_deploy, for_buddy: for_buddy
+    webhook = SlackWebhook.new(
+      webhook_url: endpoint,
+      before_deploy: before_deploy,
+      after_deploy: after_deploy,
+      for_buddy: for_buddy
     )
     stage = stub(name: "Staging", slack_webhooks: [webhook], project: project)
     deploy = stub(
@@ -36,64 +42,59 @@ describe SlackWebhookNotification do
     SlackWebhookNotification.new(deploy)
   end
 
-  before do
-    SlackWebhookNotificationRenderer.stubs(:render).returns("foo")
-    @delivery = stub_request(:post, endpoint)
-  end
+  describe "#deliver" do
+    before do
+      SlackWebhookNotificationRenderer.stubs(:render).returns("foo")
+      @delivery = stub_request(:post, endpoint)
+    end
 
-  it "notifies slack channels configured for the stage when the deploy_phase is configured" do
-    notification = stub_notification
-    notification.deliver :after_deploy
+    it "notifies slack channels configured for the stage when the deploy_phase is enabled" do
+      stub_notification.deliver :after_deploy # column defaults to true
+      assert_requested @delivery
+    end
 
-    assert_requested @delivery
-  end
+    it "does not notify slack channels configured for the stage when the deploy_phase is disabled" do
+      stub_notification.deliver :before_deploy
+      assert_not_requested @delivery
+    end
 
-  it "does not notify slack channels configured for the stage when the deploy_phase is not configured" do
-    notification = stub_notification
-    notification.deliver :before_deploy
+    it "renders a notification" do
+      stub_notification(before_deploy: true).deliver :before_deploy
+      payload.fetch("text").must_equal "foo"
+    end
 
-    assert_not_requested @delivery
-  end
+    it "sends buddy request with the specified message" do
+      notification = stub_notification(for_buddy: true)
+      notification.buddy_request "buddy approval needed"
 
-  it "renders a nicely formatted notification" do
-    notification = stub_notification(before_deploy: true)
-    SlackWebhookNotificationRenderer.stubs(:render).returns("bar")
-    notification.deliver :before_deploy
+      payload.fetch('text').must_equal "buddy approval needed"
+      payload.fetch('attachments').length.must_equal 1
+      prs['title'].must_equal 'PRs'
+      prs['value'].must_equal '<https://github.com/foo/bar/pulls/1|#1> - PR 1'
+      risks['title'].must_equal 'Risks'
+      risks['value'].must_equal "<https://github.com/foo/bar/pulls/1|#1>:\nabc"
+    end
 
-    payload.fetch("text").must_equal "bar"
-  end
+    it 'tells the user if there are no PRs' do
+      notification = stub_notification(for_buddy: true, prs: false)
+      notification.buddy_request "no PRs"
+      prs['value'].must_equal '(no PRs)'
+      risks['value'].must_equal "(no risks)"
+    end
 
-  it "sends buddy request with the specified message" do
-    notification = stub_notification(for_buddy: true)
-    notification.buddy_request "buddy approval needed"
+    it 'says if there are no risks' do
+      notification = stub_notification(for_buddy: true, risks: false)
+      notification.buddy_request "PRs but no risks"
+      prs['value'].must_equal '<https://github.com/foo/bar/pulls/1|#1> - PR 1'
+      risks['value'].must_equal "(no risks)"
+    end
 
-    payload.fetch('text').must_equal "buddy approval needed"
-    payload.fetch('attachments').length.must_equal 1
-    prs['title'].must_equal 'PRs'
-    prs['value'].must_equal '<https://github.com/foo/bar/pulls/1|#1> - PR 1'
-    risks['title'].must_equal 'Risks'
-    risks['value'].must_equal "<https://github.com/foo/bar/pulls/1|#1>:\nabc"
-  end
-
-  it 'tells the user if there are no PRs' do
-    notification = stub_notification(for_buddy: true, prs: false)
-    notification.buddy_request "no PRs"
-    prs['value'].must_equal '(no PRs)'
-    risks['value'].must_equal "(no risks)"
-  end
-
-  it 'says if there are no risks' do
-    notification = stub_notification(for_buddy: true, risks: false)
-    notification.buddy_request "PRs but no risks"
-    prs['value'].must_equal '<https://github.com/foo/bar/pulls/1|#1> - PR 1'
-    risks['value'].must_equal "(no risks)"
-  end
-
-  it "fails silently on error" do
-    notification = stub_notification
-    stub_request(:post, endpoint).to_timeout
-    Rails.logger.expects(:error)
-    notification.deliver :after_deploy
+    it "fails silently on error" do
+      notification = stub_notification
+      stub_request(:post, endpoint).to_timeout
+      Rails.logger.expects(:error)
+      notification.deliver :after_deploy
+    end
   end
 
   describe "#default_buddy_request_message" do

--- a/plugins/slack_webhooks/test/models/slack_webhook_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_test.rb
@@ -4,9 +4,9 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe SlackWebhook do
-  let(:webhook) { SlackWebhook.new }
+  let(:webhook) { SlackWebhook.new(after_deploy: false) }
 
-  describe '#validate_url' do
+  describe "#validate_url" do
     it "is valid with a valid url" do
       webhook.webhook_url = 'http://example.com'
       assert_valid webhook
@@ -20,6 +20,55 @@ describe SlackWebhook do
     it "is invalid with garbadge" do
       webhook.webhook_url = 'ddsfdsfds'
       refute_valid webhook
+    end
+  end
+
+  describe "#deliver_for?" do
+    let(:deploy) { deploys(:succeeded_test) }
+
+    it "does not deliver when everything is disabled" do
+      refute webhook.deliver_for?(:before_deploy, deploy)
+      refute webhook.deliver_for?(:after_deploy, deploy)
+      refute webhook.deliver_for?(:for_buddy, deploy)
+    end
+
+    it "deliver before when before hook is enabled" do
+      webhook.before_deploy = true
+      assert webhook.deliver_for?(:before_deploy, deploy)
+    end
+
+    it "deliver after when after hook is enabled" do
+      webhook.after_deploy = true
+      assert webhook.deliver_for?(:after_deploy, deploy)
+    end
+
+    it "delivers for for_buddy when for_buddy hooks is enabled" do
+      webhook.for_buddy = true
+      assert webhook.deliver_for?(:for_buddy, deploy)
+    end
+
+    it "fails with unknown hook" do
+      assert_raises { webhook.deliver_for?(:foobar, deploy) }
+    end
+
+    describe "with only_on_failure" do
+      before do
+        webhook.before_deploy = true
+        webhook.after_deploy = true
+        webhook.only_on_failure = true
+      end
+
+      it "deliver after for failed deploy" do
+        assert webhook.deliver_for?(:after_deploy, deploys(:failed_staging_test))
+      end
+
+      it "does not deliver after for successful deploy" do
+        refute webhook.deliver_for?(:after_deploy, deploy)
+      end
+
+      it "delivers before for all deploys" do
+        assert webhook.deliver_for?(:before_deploy, deploy)
+      end
     end
   end
 end

--- a/plugins/slack_webhooks/test/samson_slack_webhooks/samson_plugin_test.rb
+++ b/plugins/slack_webhooks/test/samson_slack_webhooks/samson_plugin_test.rb
@@ -47,7 +47,8 @@ describe SamsonSlackWebhooks do
         "updated_at" => nil,
         "before_deploy" => false,
         "after_deploy" => true,
-        "for_buddy" => false
+        "for_buddy" => false,
+        "only_on_failure" => false
       }]
     end
   end
@@ -55,7 +56,9 @@ describe SamsonSlackWebhooks do
   describe :stage_permitted_params do
     it "includes our params" do
       Samson::Hooks.fire(:stage_permitted_params).must_include(
-        slack_webhooks_attributes: [:id, :webhook_url, :channel, :before_deploy, :after_deploy, :for_buddy, :_destroy]
+        slack_webhooks_attributes: [
+          :id, :webhook_url, :channel, :before_deploy, :after_deploy, :for_buddy, :only_on_failure, :_destroy
+        ]
       )
     end
   end


### PR DESCRIPTION
@pswadi-zendesk @liulikun @ben 

 - removing send_slack_webhook_notifications since deiver is a noop if there are not hooks
 - ordering check boxes per deploy workflow order
 - adding browser input validation for url
 - renaming tab so it's more obvious which plugin that is