### PR TITLE
fix index length bug

### DIFF
--- a/db/migrate/20161011173842_add_vault_servers.rb
+++ b/db/migrate/20161011173842_add_vault_servers.rb
@@ -9,6 +9,6 @@ class AddVaultServers < ActiveRecord::Migration[5.0]
       t.timestamps
     end
 
-    add_index :vault_servers, :name, unique: true
+    add_index :vault_servers, :name, unique: true, length: { name: 191 }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -502,7 +502,7 @@ ActiveRecord::Schema.define(version: 20161013175858) do
     t.text     "ca_cert",            limit: 65535
     t.datetime "created_at",                                       null: false
     t.datetime "updated_at",                                       null: false
-    t.index ["name"], name: "index_vault_servers_on_name", unique: true, using: :btree
+    t.index ["name"], name: "index_vault_servers_on_name", unique: true, length: {"name"=>191}, using: :btree
   end
 
   create_table "versions", force: :cascade do |t|


### PR DESCRIPTION
the usual index error :/

`Mysql2::Error: Index column size too large. The maximum column size is 767 bytes.: CREATE UNIQUE INDEX `index_vault_servers_on_name`  ON `vault_servers` (`name`)`


@irwaters @jonmoter 