### PR TITLE
Fix: next stage_ids should always be strings

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -121,7 +121,7 @@ class Admin::DeployGroupsController < ApplicationController
 
     unless template_stage.deploy_groups.include?(stage.deploy_groups.first)
       template_stage.deploy_groups += stage.deploy_groups
-      template_stage.next_stage_ids.delete(stage.id)
+      template_stage.next_stage_ids.delete(stage.id.to_s)
       template_stage.save!
     end
 
@@ -161,7 +161,7 @@ class Admin::DeployGroupsController < ApplicationController
       stage.save!
 
       if template_stage.respond_to?(:next_stage_ids) # pipeline plugin was installed
-        template_stage.next_stage_ids << stage.id
+        template_stage.next_stage_ids << stage.id.to_s
         template_stage.save!
       end
 

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 Stage.class_eval do
   prepend SamsonPipelines::StageConcern
-  serialize :next_stage_ids, Array
+  serialize :next_stage_ids, Array # array of string ids.
 
   validate :valid_pipeline?, if: :next_stage_ids_changed?
 

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -204,7 +204,7 @@ describe Admin::DeployGroupsController do
 
         # the new stage is at the end of the pipeline
         stage = deploy_group.stages.last
-        template_stage.next_stage_ids.must_equal([stage.id])
+        template_stage.next_stage_ids.must_equal([stage.id.to_s])
       end
     end
 
@@ -269,11 +269,11 @@ describe Admin::DeployGroupsController do
         end
 
         it "removes the next_stage_id" do
-          assert template_stage.reload.next_stage_ids.include?(stage.id)
+          assert template_stage.reload.next_stage_ids.include?(stage.id.to_s)
 
           post :merge_all_stages, params: {id: deploy_group}
 
-          refute template_stage.reload.next_stage_ids.include?(stage.id)
+          refute template_stage.reload.next_stage_ids.include?(stage.id.to_s)
         end
 
         it "adds the deploy group to the template stage" do

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -207,6 +207,18 @@ describe StagesController do
         end
       end
 
+      it 'checks the appropriate next_stage_ids checkbox' do
+        next_stage = Stage.create!(name: 'food', project: subject.project)
+        subject.next_stage_ids = [next_stage.id.to_s]
+        subject.save!
+
+        get :edit, params: {project_id: subject.project.to_param, id: subject.to_param }
+
+        checkbox = css_select('#stage_next_stage_ids_').
+            detect { |node| node.attribute('value')&.value == next_stage.id.to_s }
+        assert_equal 'checked', checkbox.attribute('checked').value
+      end
+
       it "fails with unknown project" do
         assert_raises ActiveRecord::RecordNotFound do
           get :edit, params: {project_id: :foo23123, id: 1}


### PR DESCRIPTION
Lets standardize on strings for Stage ids in the Stage.next_stage_ids field.

Without this, the Stage Edit form can't show the correct list of "next stages" already selected.

### References

 - Jira link: https://zendesk.atlassian.net/browse/TOOLS-961

### Risks
- Level: None

