### PR TITLE
rename old ResourceTemplate to match what it is doing

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -43,7 +43,7 @@ module Kubernetes
     # run on unsaved mock ReleaseDoc to test template and secrets before we save or create a build
     def verify_template
       primary_config = raw_template.detect { |e| Kubernetes::RoleConfigFile::PRIMARY.include?(e.fetch(:kind)) }
-      template = Kubernetes::ResourceTemplate.new(self, primary_config)
+      template = Kubernetes::TemplateFiller.new(self, primary_config)
       template.set_secrets
     end
 
@@ -93,7 +93,7 @@ module Kubernetes
           resource[:spec][:type] = 'NodePort'
           resource
         when *Kubernetes::RoleConfigFile::PRIMARY
-          ResourceTemplate.new(self, resource).to_hash
+          TemplateFiller.new(self, resource).to_hash
         else
           resource
         end

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # fills out Deploy/Job template with dynamic values
 module Kubernetes
-  class ResourceTemplate
+  class TemplateFiller
     attr_reader :template
 
     CUSTOM_UNIQUE_LABEL_KEY = 'rc_unique_identifier'

--- a/plugins/kubernetes/app/views/kubernetes/roles/example.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/example.html.erb
@@ -31,7 +31,7 @@ spec:
       labels:
         project: <%= project_label %>
         role: app-server
-<% if Kubernetes::ResourceTemplate::SIDECAR_IMAGE %>
+<% if Kubernetes::TemplateFiller::SIDECAR_IMAGE %>
       # secrets can be added via https://github.com/zendesk/samson_secret_puller
       # annotations:
       #  secret/RAILS_ENV: ${ENV}/global/global/rails_env

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -100,7 +100,7 @@ describe Kubernetes::DeployExecutor do
         to_return(body: {items: []}.to_json)
       stub_request(:get, /#{Regexp.escape(log_url)}/)
       GitRepository.any_instance.stubs(:file_content).with('Dockerfile', anything).returns "FROM all"
-      Kubernetes::ResourceTemplate.any_instance.stubs(:set_image_pull_secrets)
+      Kubernetes::TemplateFiller.any_instance.stubs(:set_image_pull_secrets)
 
       stub_request(:get, service_url).to_return(body: {metadata: {uid: '123'}}.to_json)
       stub_request(:delete, service_url)
@@ -160,7 +160,7 @@ describe Kubernetes::DeployExecutor do
       end
 
       it "fails before building when secrets are not configured in the backend" do
-        Kubernetes::ResourceTemplate.any_instance.stubs(:needs_secret_sidecar?).returns(true)
+        Kubernetes::TemplateFiller.any_instance.stubs(:needs_secret_sidecar?).returns(true)
 
         # overriding the stubbed value
         template = Kubernetes::ReleaseDoc.new.send(:raw_template)[0]

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -58,7 +58,7 @@ describe Kubernetes::ReleaseDoc do
 
     before do
       kubernetes_fake_raw_template
-      Kubernetes::ResourceTemplate.any_instance.stubs(:set_image_pull_secrets) # makes an extra request we ignore
+      Kubernetes::TemplateFiller.any_instance.stubs(:set_image_pull_secrets) # makes an extra request we ignore
     end
 
     it "stores the template when creating" do

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -47,7 +47,7 @@ describe Kubernetes::Release do
       release
     end
 
-    before { Kubernetes::ResourceTemplate.any_instance.stubs(:set_image_pull_secrets) }
+    before { Kubernetes::TemplateFiller.any_instance.stubs(:set_image_pull_secrets) }
 
     it 'creates with 1 role' do
       expect_file_contents_from_repo

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -3,14 +3,14 @@ require_relative "../../test_helper"
 
 SingleCov.covered!
 
-describe Kubernetes::ResourceTemplate do
+describe Kubernetes::TemplateFiller do
   let(:doc) { kubernetes_release_docs(:test_release_pod_1) }
   let(:raw_template) do
     raw_template = YAML.load(read_kubernetes_sample_file('kubernetes_deployment.yml')).deep_symbolize_keys
     raw_template[:metadata][:namespace] = "pod1"
     raw_template
   end
-  let(:template) { Kubernetes::ResourceTemplate.new(doc, raw_template) }
+  let(:template) { Kubernetes::TemplateFiller.new(doc, raw_template) }
 
   before do
     doc.send(:resource_template=, YAML.load_stream(read_kubernetes_sample_file('kubernetes_deployment.yml')))
@@ -159,7 +159,7 @@ describe Kubernetes::ResourceTemplate do
       let(:secret_key) { "global/global/global/bar" }
 
       around do |test|
-        klass = Kubernetes::ResourceTemplate
+        klass = Kubernetes::TemplateFiller
         silence_warnings { klass.const_set(:SIDECAR_IMAGE, "docker-registry.example.com/foo:bar") }
         test.call
         silence_warnings { klass.const_set(:SIDECAR_IMAGE, nil) }


### PR DESCRIPTION
this used to represent a template, but now it is only used to fill the template

@irwaters @jonmoter 