### PR TITLE
Conditional --recursive flag for git submodule sync based on git version

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -134,11 +134,17 @@ class GitRepository
 
   def checkout_submodules!(pwd)
     return true unless File.exist? "#{pwd}/.gitmodules"
+
+    recursive_flag = " --recursive" if git_supports_recursive_flag?
     executor.execute!(
       "cd #{pwd}",
-      "git submodule sync",
+      "git submodule sync#{recursive_flag}",
       "git submodule update --init --recursive"
     )
+  end
+
+  def git_supports_recursive_flag?
+    Gem::Version.new($git_version) >= Gem::Version.new("1.8.1")
   end
 
   def locally_cached?

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -144,7 +144,7 @@ class GitRepository
   end
 
   def git_supports_recursive_flag?
-    Gem::Version.new(GitInfo.version) >= Gem::Version.new("1.8.1")
+    GitInfo.version >= Gem::Version.new("1.8.1")
   end
 
   def locally_cached?

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -144,7 +144,7 @@ class GitRepository
   end
 
   def git_supports_recursive_flag?
-    Gem::Version.new($git_version) >= Gem::Version.new("1.8.1")
+    Gem::Version.new(GitInfo.version) >= Gem::Version.new("1.8.1")
   end
 
   def locally_cached?

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -136,7 +136,7 @@ class GitRepository
     return true unless File.exist? "#{pwd}/.gitmodules"
     executor.execute!(
       "cd #{pwd}",
-      "git submodule sync --recursive",
+      "git submodule sync",
       "git submodule update --init --recursive"
     )
   end

--- a/config/initializers/git_info.rb
+++ b/config/initializers/git_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class GitInfo
-  @version = `git --version`.scan(/\d+/).join('.')
+  @version = Gem::Version.new(`git --version`.scan(/\d+/).join('.'))
 
   class << self
     attr_reader :version

--- a/config/initializers/git_info.rb
+++ b/config/initializers/git_info.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class GitInfo
+  @version = `git --version`.scan(/\d+/).join('.')
+
+  class << self
+    attr_reader :version
+  end
+end

--- a/config/initializers/git_version.rb
+++ b/config/initializers/git_version.rb
@@ -1,1 +1,0 @@
-$git_version = `git --version`.scan(/\d+/).join('.')

--- a/config/initializers/git_version.rb
+++ b/config/initializers/git_version.rb
@@ -1,0 +1,1 @@
+$git_version = `git --version`.scan(/\d+/).join('.')


### PR DESCRIPTION
Conditionally adds the `--recursive` flag to the `git submodule sync` command if the git version is  1.8.1 or higher. It was not an option in older versions.

/cc @zendesk/samson

### Tasks
 - [x] :+1: from team

### Risks
- Low, change to a newly added method that fixes a bug due to an old version of git

