### PR TITLE
Add "deploy missing" button, and tests.

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -3,3 +3,7 @@
     margin: 0;
   }
 }
+
+.force-form-inline {
+  display: inline-block;
+}

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class Admin::DeployGroupsController < ApplicationController
   before_action :authorize_admin!
-  before_action :authorize_super_admin!, only: [:create, :new, :update, :destroy, :deploy_all, :deploy_missing,
+  before_action :authorize_super_admin!, only: [:create, :new, :update, :destroy, :deploy_all,
                                                 :create_all_stages, :create_all_stages_preview, :edit]
   before_action :deploy_group, only: [:show, :edit, :update, :destroy, :deploy_all, :create_all_stages,
-                                      :create_all_stages_preview, :deploy_missing]
+                                      :create_all_stages_preview]
 
   def index
     @deploy_groups = DeployGroup.all.sort_by(&:natural_order)
@@ -54,11 +54,26 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   def deploy_all
-    deploy_stages(redeploy_successful: true)
-  end
+    environment = deploy_group.environment
+    template_stages = environment.template_stages.all
+    stages_to_deploy = params[:missing_only] == "true" ? deploy_group.stages.reject(&:last_successful_deploy) : deploy_group.stages
+    deploys = stages_to_deploy.map do |stage|
+      template_stage = template_stages.detect { |ts| ts.project_id == stage.project.id }
+      next unless template_stage
 
-  def deploy_missing
-    deploy_stages(redeploy_successful: false)
+      last_success_deploy = template_stage.last_successful_deploy
+      next unless last_success_deploy
+
+      deploy_service = DeployService.new(current_user)
+      deploy_service.deploy!(stage, reference: last_success_deploy.reference)
+    end.compact
+
+    if deploys.empty?
+      flash[:error] = "There were no stages ready for deploy."
+      redirect_to deploys_path
+    else
+      redirect_to deploys_path(ids: deploys.map(&:id))
+    end
   end
 
   def create_all_stages_preview
@@ -94,29 +109,6 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   private
-
-  def deploy_stages(redeploy_successful:)
-    environment = deploy_group.environment
-    template_stages = environment.template_stages.all
-    stages_to_deploy = redeploy_successful ? deploy_group.stages : deploy_group.stages.reject(&:last_successful_deploy)
-    deploys = stages_to_deploy.map do |stage|
-      template_stage = template_stages.detect { |ts| ts.project_id == stage.project.id }
-      next unless template_stage
-
-      last_success_deploy = template_stage.last_successful_deploy
-      next unless last_success_deploy
-
-      deploy_service = DeployService.new(current_user)
-      deploy_service.deploy!(stage, reference: last_success_deploy.reference)
-    end.compact
-
-    if deploys.empty?
-      flash[:error] = "There were no stages ready for deploy."
-      redirect_to deploys_path
-    else
-      redirect_to deploys_path(ids: deploys.map(&:id))
-    end
-  end
 
   # returns nil on success, otherwise the reason this stage was skipped.
   def merge_stage(stage)

--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -56,7 +56,8 @@ class Admin::DeployGroupsController < ApplicationController
   def deploy_all
     environment = deploy_group.environment
     template_stages = environment.template_stages.all
-    stages_to_deploy = params[:missing_only] == "true" ? deploy_group.stages.reject(&:last_successful_deploy) : deploy_group.stages
+    missing_only = params[:missing_only] == "true"
+    stages_to_deploy = missing_only ? deploy_group.stages.reject(&:last_successful_deploy) : deploy_group.stages
     deploys = stages_to_deploy.map do |stage|
       template_stage = template_stages.detect { |ts| ts.project_id == stage.project.id }
       next unless template_stage

--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -61,11 +61,16 @@
                     class: "btn btn-default"
         %>
         <%= link_to "Deploy All Projects", deploy_all_admin_deploy_group_path(@deploy_group), class: "btn btn-default", data: { method: "post" } %>
-        <form style="display: inline-block" method="post" action="<%= deploy_all_admin_deploy_group_path(@deploy_group) %>">
-          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-          <input type="hidden" name="missing_only" value="true">
-          <input type="submit" class="btn btn-default" value="Deploy Missing Projects" title="Deploys will be started for any stages that haven't yet been deployed or have failed all their deploys." >
-        </form>
+        <%= button_to "Deploy Missing Projects",
+                    {
+                      action: :deploy_all,
+                      id: @deploy_group.id
+                    },
+                    class: "btn btn-default",
+                    form_class: "force-form-inline",
+                    params: { missing_only: "true" },
+                    title: "Deploys will be started for any stages that haven't yet been deployed or have failed all their deploys."
+        %>
         <%= link_to "Merge #{@deploy_group.stages.cloned.count} Cloned Stages",
                     merge_all_stages_admin_deploy_group_path(@deploy_group),
                     class: "btn btn-default #{ 'disabled' unless @deploy_group.stages.cloned.exists? }",

--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -61,7 +61,11 @@
                     class: "btn btn-default"
         %>
         <%= link_to "Deploy All Projects", deploy_all_admin_deploy_group_path(@deploy_group), class: "btn btn-default", data: { method: "post" } %>
-        <%= link_to "Deploy Missing Projects", deploy_missing_admin_deploy_group_path(@deploy_group), class: "btn btn-default", data: { method: "post" } %>
+        <form style="display: inline-block" method="post" action="<%= deploy_all_admin_deploy_group_path(@deploy_group) %>">
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <input type="hidden" name="missing_only" value="true">
+          <input type="submit" class="btn btn-default" value="Deploy Missing Projects" title="Deploys will be started for any stages that haven't yet been deployed or have failed all their deploys." >
+        </form>
         <%= link_to "Merge #{@deploy_group.stages.cloned.count} Cloned Stages",
                     merge_all_stages_admin_deploy_group_path(@deploy_group),
                     class: "btn btn-default #{ 'disabled' unless @deploy_group.stages.cloned.exists? }",

--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -67,7 +67,7 @@
                       id: @deploy_group.id
                     },
                     class: "btn btn-default",
-                    form_class: "force-form-inline",
+                    form: {style: "display: inline-block;"},
                     params: { missing_only: "true" },
                     title: "Deploys will be started for any stages that haven't yet been deployed or have failed all their deploys."
         %>

--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -61,6 +61,7 @@
                     class: "btn btn-default"
         %>
         <%= link_to "Deploy All Projects", deploy_all_admin_deploy_group_path(@deploy_group), class: "btn btn-default", data: { method: "post" } %>
+        <%= link_to "Deploy Missing Projects", deploy_missing_admin_deploy_group_path(@deploy_group), class: "btn btn-default", data: { method: "post" } %>
         <%= link_to "Merge #{@deploy_group.stages.cloned.count} Cloned Stages",
                     merge_all_stages_admin_deploy_group_path(@deploy_group),
                     class: "btn btn-default #{ 'disabled' unless @deploy_group.stages.cloned.exists? }",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,7 +131,6 @@ Samson::Application.routes.draw do
     resources :deploy_groups do
       member do
         post :deploy_all
-        post :deploy_missing
         get :create_all_stages_preview
         post :create_all_stages
         post :merge_all_stages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Samson::Application.routes.draw do
     resources :deploy_groups do
       member do
         post :deploy_all
+        post :deploy_missing
         get :create_all_stages_preview
         post :create_all_stages
         post :merge_all_stages

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -192,13 +192,13 @@ describe Admin::DeployGroupsController do
         # Give it a successful deploy
         new_stage = new_deploy_group.reload.stages.first
         new_stage.deploys.create!(
-            reference: 'master',
-            job: Job.create!(
-                project: stage.project,
-                user: User.first,
-                status: "succeeded",
-                command: 'blah'
-            )
+          reference: 'master',
+          job: Job.create!(
+            project: stage.project,
+            user: User.first,
+            status: "succeeded",
+            command: 'blah'
+          )
         )
       end
 

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -17,7 +17,6 @@ describe Admin::DeployGroupsController do
     unauthorized :delete, :destroy, id: 1
     unauthorized :get, :deploy_all, id: 1
     unauthorized :post, :deploy_all, id: 1
-    unauthorized :post, :deploy_missing, id: 1
     unauthorized :post, :create_all_stages, id: 1
   end
 
@@ -46,7 +45,6 @@ describe Admin::DeployGroupsController do
     unauthorized :delete, :destroy, id: 1
     unauthorized :get, :deploy_all, id: 1
     unauthorized :post, :deploy_all, id: 1
-    unauthorized :post, :deploy_missing, id: 1
     unauthorized :post, :create_all_stages, id: 1
   end
 
@@ -181,7 +179,7 @@ describe Admin::DeployGroupsController do
       end
     end
 
-    describe "deploy_missing" do
+    describe "deploy_all for missing deploys" do
       let(:env) { environments(:staging) }
       let(:new_deploy_group) { DeployGroup.create!(name: 'pod102', environment: env) }
 
@@ -206,7 +204,7 @@ describe Admin::DeployGroupsController do
         new_deploy_group.stages.first.deploys.delete_all
 
         assert_difference 'Deploy.count', 1 do
-          post :deploy_missing, params: {id: new_deploy_group}
+          post :deploy_all, params: {id: new_deploy_group, missing_only: "true"}
         end
       end
 
@@ -214,13 +212,13 @@ describe Admin::DeployGroupsController do
         new_deploy_group.stages.first.deploys.last.job.update_column(:status, "failed")
 
         assert_difference 'Deploy.count', 1 do
-          post :deploy_missing, params: {id: new_deploy_group}
+          post :deploy_all, params: {id: new_deploy_group, missing_only: "true"}
         end
       end
 
       it "ignores 'succesfully deployed' stage" do
         refute_difference 'Deploy.count' do
-          post :deploy_missing, params: {id: new_deploy_group}
+          post :deploy_all, params: {id: new_deploy_group, missing_only: "true"}
         end
       end
     end

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -17,6 +17,7 @@ describe Admin::DeployGroupsController do
     unauthorized :delete, :destroy, id: 1
     unauthorized :get, :deploy_all, id: 1
     unauthorized :post, :deploy_all, id: 1
+    unauthorized :post, :deploy_missing, id: 1
     unauthorized :post, :create_all_stages, id: 1
   end
 
@@ -45,6 +46,7 @@ describe Admin::DeployGroupsController do
     unauthorized :delete, :destroy, id: 1
     unauthorized :get, :deploy_all, id: 1
     unauthorized :post, :deploy_all, id: 1
+    unauthorized :post, :deploy_missing, id: 1
     unauthorized :post, :create_all_stages, id: 1
   end
 
@@ -176,6 +178,50 @@ describe Admin::DeployGroupsController do
 
         post :deploy_all, params: {id: deploy_group}
         assert_redirected_to "/deploys" # with no ids  present.
+      end
+    end
+
+    describe "deploy_missing" do
+      let(:env) { environments(:staging) }
+      let(:new_deploy_group) { DeployGroup.create!(name: 'pod102', environment: env) }
+
+      before do
+        # create the new stage to test against
+        Admin::DeployGroupsController.create_all_stages(new_deploy_group)
+
+        # Give it a successful deploy
+        new_stage = new_deploy_group.reload.stages.first
+        new_stage.deploys.create!(
+            reference: 'master',
+            job: Job.create!(
+                project: stage.project,
+                user: User.first,
+                status: "succeeded",
+                command: 'blah'
+            )
+        )
+      end
+
+      it "deploys undeployed stage" do
+        new_deploy_group.stages.first.deploys.delete_all
+
+        assert_difference 'Deploy.count', 1 do
+          post :deploy_missing, params: {id: new_deploy_group}
+        end
+      end
+
+      it "deploys 'failed deploy' stage" do
+        new_deploy_group.stages.first.deploys.last.job.update_column(:status, "failed")
+
+        assert_difference 'Deploy.count', 1 do
+          post :deploy_missing, params: {id: new_deploy_group}
+        end
+      end
+
+      it "ignores 'succesfully deployed' stage" do
+        refute_difference 'Deploy.count' do
+          post :deploy_missing, params: {id: new_deploy_group}
+        end
       end
     end
 


### PR DESCRIPTION

Add a button to the Deploy Groups show page, that lets you deploy only the stage clones that haven't yet been deployed, or have previously failed all deployments.

/cc @zendesk/samson @grosser 

### Screenshot

The button will only deploy the single stage with no successfully deployment.

![samson](https://cloud.githubusercontent.com/assets/933806/19458548/9bf5b010-9481-11e6-9782-6fdc85bc98b1.png)


### References
 - Jira link: https://zendesk.atlassian.net/browse/TOOLS-877

### Risks
- Level: None

