### PR TITLE
write out .env before running a docker build

### DIFF
--- a/plugins/dockerb/lib/samson_dockerb/samson_plugin.rb
+++ b/plugins/dockerb/lib/samson_dockerb/samson_plugin.rb
@@ -4,7 +4,7 @@ module SamsonDockerb
   end
 end
 
-Samson::Hooks.callback :after_deploy_setup do |dir, _|
+Samson::Hooks.callback :after_deploy_setup do |dir|
   if File.exist?("#{dir}/Dockerfile.erb") && !File.exist?("#{dir}/Dockerfile")
     require 'dockerb'
     Dir.chdir(dir) do

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -152,6 +152,30 @@ describe SamsonEnv do
     end
   end
 
+  describe :before_docker_build do
+    def fire
+      build = Build.new(project: project)
+      Samson::Hooks.fire(:before_docker_build, Dir.pwd, build, StringIO.new)
+    end
+
+    run_inside_of_temp_directory
+
+    before do
+      project.environment_variables.create!(name: "HELLO", value: "world")
+    end
+
+    it "writes to .env" do
+      fire
+      File.read(".env").must_equal "HELLO=\"world\"\n"
+    end
+
+    it "does not include deploy group level variables" do
+      EnvironmentVariable.create!(name: "HELLO", value: "world", parent: deploy_groups(:pod1))
+      fire
+      File.read(".env").must_equal "HELLO=\"world\"\n"
+    end
+  end
+
   describe :deploy_group_env do
     it "adds env variables" do
       deploy_group = deploy_groups(:pod1)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-ENV["RAILS_ENV"] ||= "test"
+ENV["RAILS_ENV"] = "test"
 
 require 'bundler/setup'
 


### PR DESCRIPTION
the build will ADD the .env and then source it to get credentials

downside / danger would be that the secrets stay in the container ... either as file or as env variables ... which is bad :(

@prudhvi @jonmoter 
