### PR TITLE
jenkins job name changes tracked by paper trail

### DIFF
--- a/plugins/jenkins/app/models/jenkins_job.rb
+++ b/plugins/jenkins/app/models/jenkins_job.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 class JenkinsJob < ActiveRecord::Base
+  has_paper_trail only:  [:name]
   belongs_to :deploy
 end

--- a/test/controllers/versions_controller_test.rb
+++ b/test/controllers/versions_controller_test.rb
@@ -22,6 +22,15 @@ describe VersionsController do
         assert_template :index
       end
 
+      it "renders with jenkins job name" do
+        create_version user.id
+        stage.update_attribute(:jenkins_job_names, 'jenkins-job-1')
+        stage.update_attribute(:jenkins_job_names, 'jenkins-job-2')
+        get :index, params: {item_id: stage.id, item_type: stage.class.name}
+        assert_template :index
+        assert_select 'p', text: /jenkins-job-1/
+      end
+
       it "renders with unfound user" do
         create_version '1211212'
         get :index, params: {item_id: stage.id, item_type: stage.class.name}


### PR DESCRIPTION
* Presently, jekins job name change is not tracked. As such, we do not know who changed the job name and when. This change tries to remedy that.
* 
![screen shot 2016-10-18 at 12 39 54 pm](https://cloud.githubusercontent.com/assets/1357270/19464604/5066a9ba-9530-11e6-8fce-f4e64b93d332.png)
![screen shot 2016-10-18 at 12 40 02 pm](https://cloud.githubusercontent.com/assets/1357270/19464605/506a3d82-9530-11e6-9548-c148dcace6ea.png)


* Remember to add unit tests

/cc @zendesk/samson @zendesk/vulcan 

### Tasks
 - [ ] :+1: from team

### References
 - https://zendesk.atlassian.net/browse/VULCAN-188
 - https://zendesk.atlassian.net/projects/SAMSON/issues/SAMSON-289

### Risks
- Level: Low/Med/High

