### PR TITLE
option in stage to send committers email to jenkins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,4 +112,3 @@ GITHUB_TOKEN=
 # JENKINS_URL= # server_url of jenkins
 # JENKINS_USERNAME= # user id
 # JENKINS_API_KEY= # API Token from user / Configure page
-# JENKINS_NOTIFY_COMMITTERS=1 # optional: send committers to jenkins as 'emails' params (filtered by GOOGLE_DOMAIN)

--- a/db/migrate/20161019034559_add_jenkins_email_committers_to_stage.rb
+++ b/db/migrate/20161019034559_add_jenkins_email_committers_to_stage.rb
@@ -1,0 +1,5 @@
+class AddJenkinsEmailCommittersToStage < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stages, :jenkins_email_committers, :boolean
+  end
+end

--- a/db/migrate/20161019034559_add_jenkins_email_committers_to_stage.rb
+++ b/db/migrate/20161019034559_add_jenkins_email_committers_to_stage.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 class AddJenkinsEmailCommittersToStage < ActiveRecord::Migration[5.0]
   def change
-    add_column :stages, :jenkins_email_committers, :boolean
+    add_column :stages, :jenkins_email_committers, :boolean, default: false, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161019000833) do
+ActiveRecord::Schema.define(version: 20161019034559) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -450,6 +450,7 @@ ActiveRecord::Schema.define(version: 20161019000833) do
     t.boolean  "is_template",                                                default: false, null: false
     t.boolean  "notify_airbrake",                                            default: false, null: false
     t.integer  "template_stage_id"
+    t.boolean  "jenkins_email_committers",                                   default: false, null: false
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id", using: :btree
   end
 

--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -75,7 +75,7 @@ module Samson
       if deploy.buddy
         emails.push(deploy.buddy.email)
       end
-      if ENV["JENKINS_NOTIFY_COMMITTERS"]
+      if deploy.stage.jenkins_email_committers
         emails.concat(deploy.changeset.commits.map(&:author_email))
       end
       emails.map! { |x| Mail::Address.new(x) }

--- a/plugins/jenkins/app/views/samson_jenkins/_fields.html.erb
+++ b/plugins/jenkins/app/views/samson_jenkins/_fields.html.erb
@@ -10,7 +10,7 @@
   <div class="col-lg-6 checkbox col-lg-offset-2">
     <%= form.label :jenkins_email_committers do %>
         <%= form.check_box :jenkins_email_committers %>
-           Should Jenkins send email to all committers?
+        Jenkins sends email to committers
     <% end %>
    </div>
 </fieldset>

--- a/plugins/jenkins/app/views/samson_jenkins/_fields.html.erb
+++ b/plugins/jenkins/app/views/samson_jenkins/_fields.html.erb
@@ -7,4 +7,10 @@
       <%= form.text_field :jenkins_job_names, class: "form-control", placeholder: "Jenkins jobs" %>
     </div>
   </div>
+  <div class="col-lg-6 checkbox col-lg-offset-2">
+    <%= form.label :jenkins_email_committers do %>
+        <%= form.check_box :jenkins_email_committers %>
+           Should Jenkins send email to all committers?
+    <% end %>
+   </div>
 </fieldset>

--- a/plugins/jenkins/lib/samson_jenkins/samson_plugin.rb
+++ b/plugins/jenkins/lib/samson_jenkins/samson_plugin.rb
@@ -8,7 +8,10 @@ Samson::Hooks.view :stage_form, "samson_jenkins/fields"
 Samson::Hooks.view :deploys_header, "samson_jenkins/deploys_header"
 
 Samson::Hooks.callback :stage_permitted_params do
-  :jenkins_job_names
+  [
+    :jenkins_job_names,
+    :jenkins_email_committers
+  ]
 end
 
 Samson::Hooks.callback :after_deploy do |deploy|

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -169,7 +169,7 @@ describe Samson::Jenkins do
         jenkins.build.must_equal 1
       end
 
-      it "includes committer emails when JENKINS_NOTIFY_COMMITTERS is set" do
+      it "includes committer emails when jenkins_email_committers flag is set" do
         deploy.stage.jenkins_email_committers = true
         stub_build_with_parameters("emails": 'super-admin@example.com,author1@example.com,author2@test.com,author3@example.comm,author4@example.co,AUTHOR5@EXAMPLE.COM')
         stub_get_build_id_from_queue(1)
@@ -184,7 +184,7 @@ describe Samson::Jenkins do
         end
       end
 
-      it "filters emails by GOOGLE_DOMAIN when JENKINS_NOTIFY_COMMITTERS is set" do
+      it "filters emails by GOOGLE_DOMAIN when jenkins_email_committers flag is set" do
         with_env 'GOOGLE_DOMAIN': '@example.com' do
           deploy.stage.jenkins_email_committers = true
           stub_build_with_parameters("emails": 'super-admin@example.com,author1@example.com,AUTHOR5@EXAMPLE.COM')

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -170,11 +170,10 @@ describe Samson::Jenkins do
       end
 
       it "includes committer emails when JENKINS_NOTIFY_COMMITTERS is set" do
-        with_env 'JENKINS_NOTIFY_COMMITTERS': "1" do
-          stub_build_with_parameters("emails": 'super-admin@example.com,author1@example.com,author2@test.com,author3@example.comm,author4@example.co,AUTHOR5@EXAMPLE.COM')
-          stub_get_build_id_from_queue(1)
-          jenkins.build.must_equal 1
-        end
+        deploy.stage.jenkins_email_committers = true
+        stub_build_with_parameters("emails": 'super-admin@example.com,author1@example.com,author2@test.com,author3@example.comm,author4@example.co,AUTHOR5@EXAMPLE.COM')
+        stub_get_build_id_from_queue(1)
+        jenkins.build.must_equal 1
       end
 
       it "filters emails by GOOGLE_DOMAIN" do
@@ -186,7 +185,8 @@ describe Samson::Jenkins do
       end
 
       it "filters emails by GOOGLE_DOMAIN when JENKINS_NOTIFY_COMMITTERS is set" do
-        with_env 'GOOGLE_DOMAIN': '@example.com', 'JENKINS_NOTIFY_COMMITTERS': '1' do
+        with_env 'GOOGLE_DOMAIN': '@example.com' do
+          deploy.stage.jenkins_email_committers = true
           stub_build_with_parameters("emails": 'super-admin@example.com,author1@example.com,AUTHOR5@EXAMPLE.COM')
           stub_get_build_id_from_queue(1)
           jenkins.build.must_equal 1


### PR DESCRIPTION
Add an option in edit page of stage to send email of committers to jenkins. Earlier, this option was in .env file, and this changed adds more granularity.

![screen shot 2016-10-20 at 3 36 01 pm](https://cloud.githubusercontent.com/assets/1357270/19550331/923552cc-96db-11e6-8ba6-c866326e600a.png)
![screen shot 2016-10-20 at 3 35 56 pm](https://cloud.githubusercontent.com/assets/1357270/19550330/92351a78-96db-11e6-9c75-d8a9e4bd238f.png)
![screen shot 2016-10-20 at 3 35 21 pm](https://cloud.githubusercontent.com/assets/1357270/19550332/9235ea8e-96db-11e6-9e71-d66eb5389aba.png)
![screen shot 2016-10-20 at 3 35 15 pm](https://cloud.githubusercontent.com/assets/1357270/19550333/923a6118-96db-11e6-8889-0ac1d5d07d13.png)

When the option is true:
![screen shot 2016-10-20 at 3 41 09 pm](https://cloud.githubusercontent.com/assets/1357270/19550357/a51fa8b0-96db-11e6-854d-5ad6e225d654.png)

When not true:
![screen shot 2016-10-20 at 3 41 32 pm](https://cloud.githubusercontent.com/assets/1357270/19550370/b308a8f0-96db-11e6-8a57-899e85c20f46.png)

/cc @zendesk/samson @zendesk/vulcan 

### Tasks
 - [ ] :+1: from team

### References
 - https://zendesk.atlassian.net/browse/SAMSON-292
 - https://zendesk.atlassian.net/browse/VULCAN-197

### Risks
- Level: Low/Med/High

