### PR TITLE
show a github icon on the github warning to make it more disinguishable

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
 
         <% unless github_ok? %>
           <div class="alert alert-warning alert-dismissable">
+            <%= image_tag image_url('github.png'), style: 'height: 20px; background: #8a6d3b' %>
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             GitHub may be having problems. Please monitor their <a href="<%= Rails.application.config.samson.github.status_url %>">status page</a> for more details.
           </div>


### PR DESCRIPTION
![screen shot 2016-10-21 at 2 31 19 pm](https://cloud.githubusercontent.com/assets/11367/19612402/2f3f8e60-979b-11e6-917d-1fc952855f17.png)

/fyi @pswadi-zendesk 

@apanzerj 