### PR TITLE
make long webhook content not blow up the page

### DIFF
--- a/app/assets/stylesheets/webhooks.scss
+++ b/app/assets/stylesheets/webhooks.scss
@@ -1,0 +1,5 @@
+// Gets super bloated wih a long param or tokens
+// and pre auto-expands without limits ... cannot use % widths
+#latest_response pre {
+  max-width: 1000px
+}

--- a/app/assets/stylesheets/webhooks.scss
+++ b/app/assets/stylesheets/webhooks.scss
@@ -1,5 +1,5 @@
 // Gets super bloated wih a long param or tokens
 // and pre auto-expands without limits ... cannot use % widths
 #latest_response pre {
-  max-width: 1000px
+  max-width: $container-lg - 170px; // body size minus some room for labels
 }

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -54,7 +54,7 @@
 
   <% if hook = WebhookRecorder.read(@project) %>
     <h2>Latest webhook</h2>
-    <table class="table">
+    <table class="table" id="latest_response">
       <tr><th>Arrived</th><td><%= hook.fetch(:time) %></td></tr>
       <tr>
         <th>Request</th>
@@ -86,7 +86,7 @@
   <% end %>
   <h2></h2>
 
-  <h1>Outbound Webhooks</h1> 
+  <h1>Outbound Webhooks</h1>
   <p>Outbound webhooks POST to an external url after a deploy has finished. The request body will contain deploy, stage, and project information.</p>
   <% if @project.deploys.last %>
     <p><a onclick='toggleSample()'>Click here to see an example payload of this project's latest deploy.</a></p>

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -61,7 +61,7 @@ describe Integrations::BaseController do
       result = WebhookRecorder.read(project)
       result.fetch(:log).must_equal <<-LOG.strip_heredoc
         INFO: Branch master is release branch: true
-        INFO: Starting deploy to all stages
+        INFO: Deploying to 0 stages
       LOG
       result.fetch(:status_code).must_equal 200
       result.fetch(:body).must_equal ""


### PR DESCRIPTION
before:

![screen shot 2016-10-20 at 9 23 49 am](https://cloud.githubusercontent.com/assets/11367/19616915/957d11ea-97d5-11e6-8860-286bba8305f2.png)

after:

<img width="1192" alt="screen shot 2016-10-21 at 9 29 21 pm" src="https://cloud.githubusercontent.com/assets/11367/19616916/9a9dc52a-97d5-11e6-9dec-de3a03e55c64.png">

percentage widths sadly don't work on pre-s since they auto-expand to whatever space is available ... need absolute widths ...

@irwaters 
