### PR TITLE
make 404 and other errors render json ... also show that user is unauthorized

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,7 +2,10 @@
 class Api::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token, if: :using_per_request_auth?
 
+  prepend_before_action :enforce_json_format
   before_action :require_project
+
+  protected
 
   def paginate(scope)
     if scope.is_a?(Array)
@@ -20,8 +23,6 @@ class Api::BaseController < ApplicationController
     @project
   end
 
-  protected
-
   def require_project
     @project = (Project.find_by_id(params[:project_id]) if params[:project_id])
   end
@@ -31,5 +32,13 @@ class Api::BaseController < ApplicationController
       Warden::Strategies::BasicStrategy::KEY,
       Warden::Strategies::Doorkeeper::KEY
     ].include? request.env['warden']&.winning_strategy
+  end
+
+  # without json format 404/500 pages are rendered in html and auth will redirect
+  # can be tested by turning consider_all_requests_local = false in development
+  # and raising an error somewhere ... cannot be tested with an integration test
+  def enforce_json_format
+    return if request.format == :json
+    render status: 415, json: {error: 'JSON only api. Use json extension or set content type application/json'}
   end
 end

--- a/app/controllers/unauthorized_controller.rb
+++ b/app/controllers/unauthorized_controller.rb
@@ -18,14 +18,14 @@ class UnauthorizedController < ActionController::Metal
   end
 
   def respond
-    if request.path.start_with?('/api/') || request.format == :json
-      render json: {}, status: 404
-    else
-      respond_to do |format|
-        format.html do
-          flash[:authorization_error] = "You are not authorized to view this page."
-          redirect_back_or(login_path)
-        end
+    message = "You are not authorized to view this page."
+    respond_to do |format|
+      format.json do
+        render json: {error: message}, status: :unauthorized
+      end
+      format.html do
+        flash[:authorization_error] = message
+        redirect_back_or(login_path)
       end
     end
   end

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -9,6 +9,8 @@ describe Api::BaseController do
       head :ok
     end
 
+    private
+
     # turned off in test ... but we want to simulate it
     def allow_forgery_protection
       true
@@ -20,12 +22,20 @@ describe Api::BaseController do
 
   describe "#paginate" do
     it 'paginates array' do
-      @controller.paginate(Array.new(1000).fill('a')).size.must_equal 1000
+      @controller.send(:paginate, Array.new(1000).fill('a')).size.must_equal 1000
     end
 
     it 'paginates scope' do
       Deploy.stubs(:page).with(1).returns('foo')
-      @controller.paginate(Deploy).must_equal 'foo'
+      @controller.send(:paginate, Deploy).must_equal 'foo'
+    end
+  end
+
+  describe "#current_project" do
+    it "returns cached @project" do
+      @controller.send(:current_project).must_equal nil
+      @controller.instance_variable_set(:@project, 1)
+      @controller.send(:current_project).must_equal 1
     end
   end
 
@@ -35,20 +45,38 @@ describe Api::BaseController do
 
     it "allows posts without auth token for basic auth" do
       request.env['warden'].winning_strategy = :basic
-      post :test_render, params: {test_route: true}
+      post :test_render, params: {test_route: true, format: :json}
       assert_response :success
     end
 
     it "allows posts without auth token for oauth auth" do
       request.env['warden'].winning_strategy = :doorkeeper
-      post :test_render, params: {test_route: true}
+      post :test_render, params: {test_route: true, format: :json}
       assert_response :success
     end
 
     it "does not allows posts without auth token for sessions" do
       assert_raises ActionController::InvalidAuthenticityToken do
-        post :test_render, params: {test_route: true}
+        post :test_render, params: {test_route: true, format: :json}
       end
+    end
+  end
+
+  describe "#enforce_json_format" do
+    it "fails without json" do
+      get :test_render, params: {test_route: true}
+      assert_response :unsupported_media_type
+    end
+
+    it "passes with json" do
+      get :test_render, params: {test_route: true}, format: :json
+      assert_response :unauthorized
+    end
+
+    it "does not pass with only json header" do
+      json!
+      get :test_render, params: {test_route: true}
+      assert_response :unsupported_media_type
     end
   end
 end

--- a/test/controllers/api/deploy_groups_controller_test.rb
+++ b/test/controllers/api/deploy_groups_controller_test.rb
@@ -15,13 +15,13 @@ describe Api::DeployGroupsController do
 
   it 'returns precondition_failed when deploy_groups are disabled' do
     DeployGroup.unstub(:enabled?)
-    get :index
+    get :index, format: :json
     assert_response :precondition_failed
   end
 
   describe '#index' do
     before do
-      get :index
+      get :index, format: :json
     end
 
     subject { JSON.parse(response.body) }
@@ -38,7 +38,7 @@ describe Api::DeployGroupsController do
 
   describe '#index with project and stage' do
     before do
-      get :index, params: {project_id: project.id, id: stage.id}
+      get :index, params: {project_id: project.id, id: stage.id}, format: :json
     end
 
     let(:project) { projects(:test) }

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -12,7 +12,7 @@ describe Api::DeploysController do
   describe '#active_count' do
     before do
       Deploy.stubs(:active).returns(['a'])
-      get :active_count
+      get :active_count, format: :json
     end
 
     it 'responds successfully' do
@@ -93,7 +93,7 @@ describe Api::DeploysController do
 
     describe 'for a project' do
       before do
-        get :index, params: {project_id: project.id}
+        get :index, params: {project_id: project.id}, format: :json
       end
 
       subject { JSON.parse(response.body) }
@@ -111,7 +111,7 @@ describe Api::DeploysController do
 
       describe 'with filter parameter' do
         subject do
-          get :index, params: params
+          get :index, params: params, format: :json
         end
 
         let(:deploy_response) { JSON.parse(response.body)['deploys'] }

--- a/test/controllers/api/projects_controller_test.rb
+++ b/test/controllers/api/projects_controller_test.rb
@@ -10,7 +10,7 @@ describe Api::ProjectsController do
 
   describe '#index' do
     before do
-      get :index
+      get :index, format: :json
     end
 
     subject { JSON.parse(response.body) }

--- a/test/controllers/api/stages_controller_test.rb
+++ b/test/controllers/api/stages_controller_test.rb
@@ -10,7 +10,7 @@ describe Api::StagesController do
 
   describe 'get #index' do
     before do
-      get :index, params: {project_id: project.id}
+      get :index, params: {project_id: project.id}, format: :json
     end
 
     subject { JSON.parse(response.body) }
@@ -47,7 +47,7 @@ describe Api::StagesController do
     end
 
     it 'renders a cloned stage' do
-      post :clone, params: {stage_id: stages.first.permalink}
+      post :clone, params: {stage_id: stages.first.permalink}, format: :json
       assert_response :created
     end
 
@@ -60,7 +60,9 @@ describe Api::StagesController do
 
       before do
         stage.deploy_groups_stages.delete_all
-        post :clone, params: {stage_id: stage.permalink, deploy_group_ids: [dg.id], stage_name: 'NewProduction'}
+        post :clone, format: :json, params: {
+          stage_id: stage.permalink, deploy_group_ids: [dg.id], stage_name: 'NewProduction'
+        }
       end
 
       let(:stage) { stages.first }
@@ -90,24 +92,24 @@ describe Api::StagesController do
 
     describe 'when the cloned stage is invalid' do
       before do
-        post :clone, params: {stage_id: stages.first.permalink, stage_name: stages.first.name}
+        post :clone, params: {stage_id: stages.first.permalink, stage_name: stages.first.name}, format: :json
       end
 
       it 'does not clone' do
         assert_difference('Stage.count', 0) do
-          post :clone, params: {stage_id: stages.first.permalink, stage_name: stages.first.name}
+          post :clone, params: {stage_id: stages.first.permalink, stage_name: stages.first.name}, format: :json
         end
       end
 
       it 'includes the errors' do
-        post :clone, params: {stage_id: stages.first.permalink, stage_name: stages.first.name}
+        post :clone, params: {stage_id: stages.first.permalink, stage_name: stages.first.name}, format: :json
         response.body.must_include "already been taken"
       end
     end
 
     it 'creates a new stage' do
       assert_difference('Stage.count', 1) do
-        post :clone, params: {stage_id: stages.first.permalink}
+        post :clone, params: {stage_id: stages.first.permalink}, format: :json
       end
     end
   end

--- a/test/controllers/unauthorized_controller_test.rb
+++ b/test/controllers/unauthorized_controller_test.rb
@@ -27,8 +27,8 @@ describe 'Unauthorized' do
       describe "with api" do
         let(:path) { "/api/deploys/active_count.json" }
 
-        it 'responds not found' do
-          last_response.status.must_equal 404
+        it 'responds unauthorized' do
+          last_response.status.must_equal 401
         end
 
         it 'responds with json' do
@@ -60,8 +60,8 @@ describe 'Unauthorized' do
         get '/', format: :json
       end
 
-      it 'responds not found' do
-        last_response.status.must_equal 404
+      it 'responds unauthorized' do
+        last_response.status.must_equal 401
       end
 
       it 'responds with json' do

--- a/test/lib/warden/strategies/doorkeeper_strategy_test.rb
+++ b/test/lib/warden/strategies/doorkeeper_strategy_test.rb
@@ -25,23 +25,23 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
 
   it "does not check and fails without header" do
     assert_sql_queries(0) { perform_get nil }
-    assert_response :not_found
+    assert_response :unauthorized
   end
 
   it "checks and fails with invalid header" do
     assert_sql_queries(1) { perform_get(valid_header + Base64.encode64('foo')) }
-    assert_response :not_found
+    assert_response :unauthorized
   end
 
   it "checks and fails with unfound user" do
     user.delete
     assert_sql_queries(3) { perform_get(valid_header) } # FYI queries are: find token, revoke token, find user
-    assert_response :not_found
+    assert_response :unauthorized
   end
 
   it "does not check and fails with non matching header" do
     assert_sql_queries(0) { perform_get "oops" + valid_header }
-    assert_response :not_found
+    assert_response :unauthorized
   end
 
   it "does not check and fails with non-api resource to show users they are doing it wrong" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -245,11 +245,7 @@ class ActionController::TestCase
         app.scopes = :default
       end
     end
-
-    let(:user) do
-      users(:admin)
-    end
-
+    let(:user) { users(:admin) }
     let(:token) do
       oauth_app.access_tokens.new do |token|
         token.resource_owner_id = user.id


### PR DESCRIPTION
@apanzerj 

basically forcing json so that any errors also are rendered as json by rails ... this makes the /api detection hack obsolete since the request will fail before auth happens

also making json unauthorized behave like the html part and actually tell the user that auth failed ...