### PR TITLE
don't crash if showing alerts when user not logged in

### DIFF
--- a/app/helpers/access_request_helper.rb
+++ b/app/helpers/access_request_helper.rb
@@ -3,7 +3,7 @@ module AccessRequestHelper
   def display_access_request_link?(flash_type = :authorization_error)
     flash_type == :authorization_error &&
         AccessRequestsController.feature_enabled? &&
-        !current_user.super_admin?
+        (current_user && !current_user.super_admin?)
   end
 
   def link_to_request_access

--- a/test/helpers/access_request_helper_test.rb
+++ b/test/helpers/access_request_helper_test.rb
@@ -11,6 +11,14 @@ describe AccessRequestHelper do
     after { restore_access_request_settings }
 
     describe 'feature enabled' do
+      describe 'not authed' do
+        let(:current_user) { nil }
+
+        it 'returns false' do
+          refute display_access_request_link?
+        end
+      end
+
       describe 'viewer user' do
         let(:current_user) { users(:viewer) }
 


### PR DESCRIPTION
Getting a crash if showing an alert to a user that's not already logged in.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Airbrake: https://zendesk.airbrake.io/projects/95346/groups/1803890235894343858

### Risks
- Level: Low
