### PR TITLE
Remove static_render method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,12 +140,6 @@ module ApplicationHelper
     link_to_delete(path, icon_tag('remove') + ' Delete', class: 'btn btn-danger')
   end
 
-  # render collections without making brakeman trigger a dynamic render alert
-  # like `render collection` does
-  def static_render(collection)
-    render partial: collection.first.to_partial_path, collection: collection if collection.any?
-  end
-
   # Flash type -> Bootstrap alert class
   def flash_messages
     flash.flat_map do |type, messages|

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -11,7 +11,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= static_render @jobs %>
+      <%= render partial: 'job', collection: @jobs %>
     </tbody>
   </table>
 

--- a/app/views/macros/index.html.erb
+++ b/app/views/macros/index.html.erb
@@ -2,7 +2,7 @@
 
 <section class="tabs">
   <ul id="macros">
-    <%= static_render @macros %>
+    <%= render partial: 'macro', collection: @macros %>
   </ul>
 
   <% if admin_for_project? %>

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -20,7 +20,7 @@
         </thead>
 
         <tbody>
-          <%= static_render @releases %>
+          <%= render partial: 'release', collection: @releases %>
         </tbody>
       </table>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -40,7 +40,7 @@
         <td>No users found.</td>
       </tr>
     <% else %>
-        <%= static_render @users %>
+        <%= render partial: 'user', collection: @users %>
     <% end %>
     </tbody>
   </table>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -285,17 +285,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#static_render" do
-    it "can render nothing" do
-      static_render([]).must_equal nil
-    end
-
-    it "can render objects via their partials" do
-      ActionView::Base.any_instance.stubs(job_path: 'X')
-      static_render([jobs(:succeeded_test)]).must_include "cap staging deploy"
-    end
-  end
-
   describe "#environments" do
     it "loads all environments" do
       environments.size.must_equal Environment.all.size


### PR DESCRIPTION
The `static_render` method was added (909f74e71b4483b600db843194cad35bbf36e1fa) only to avoid warnings from Brakeman. Instead of working around the problem, we can just use explicit `render` calls just like Brakeman was trying to tell us.

/cc @zendesk/samson

### Tasks
 - [x] :+1: from team

### Risks
- Level: Low

