### PR TITLE
allow merging users that were created by accident when using differen…

### DIFF
--- a/app/controllers/admin/user_merges_controller.rb
+++ b/app/controllers/admin/user_merges_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class Admin::UserMergesController < ApplicationController
+  before_action :authorize_super_admin!
+  before_action :find_user
+
+  def new
+  end
+
+  def create
+    target = User.find(params[:merge_target_id])
+    @user.update_attributes!(external_id: target.external_id)
+    target.soft_delete!
+    redirect_to [:admin, @user], notice: "Merge successful."
+  end
+
+  private
+
+  def find_user
+    @user = User.find(params[:user_id])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,7 +82,7 @@ class User < ActiveRecord::Base
   end
 
   def name_and_email
-    "#{name} (#{email})"
+    name == email ? name : "#{name} (#{email})"
   end
 
   def gravatar_url

--- a/app/views/admin/user_merges/new.html.erb
+++ b/app/views/admin/user_merges/new.html.erb
@@ -1,0 +1,26 @@
+<h1>Merge other users into <%= @user.name_and_email %></h1>
+
+Should be used when a user changed their login provider and created a new empty user in the process.
+<br/>
+Delete selected empty user and change #<%= @user.id %> <%= @user.name_and_email %> login credentials to that of the selected user.
+
+<% if candidates = (User.where(email: @user.email) + (@user.name.present? ? User.where(name: @user.name) : []) - [@user]).presence %>
+  <h2>Users with the same name or email</h2>
+  <ul>
+    <% candidates.each do |user| %>
+      <li>ID <%= user.id %> <%= link_to user.name_and_email, [:admin, user] %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_for @user, url: admin_user_user_merges_path(@user), method: :post do |f| %>
+  <div class="form-group">
+    <label class="col-lg-2 control-label">Destroy and take login credentials from user id</label>
+    <div class="col-lg-4">
+      <%= text_field_tag :merge_target_id, '', class: 'form-control' %>
+    </div>
+  </div>
+  <br/>
+  <br/>
+  <%= f.actions label: 'Merge' %>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,12 +1,17 @@
 <h1><%= @user.name %></h1>
 
 <section id="user-description" class="clearfix">
+  <div class="pull-right">
+    <%= link_to "Merge", new_admin_user_user_merges_path(@user) %>
+  </div>
+
   <dl class="dl-horizontal">
     <dt>Name:</dt>
     <dd><%= @user.name %></dd>
     <dt>System Role:</dt>
     <dd><%= @user.role.display_name %></dd>
   </dl>
+
   <%= link_to_history @user %>
 </section>
 <section id="user-project-roles" class="clearfix">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,9 @@ Samson::Application.routes.draw do
   end
 
   namespace :admin do
-    resources :users, only: [:index, :show, :update, :destroy]
+    resources :users, only: [:index, :show, :update, :destroy] do
+      resource :user_merges, only: [:new, :create]
+    end
     resources :projects, only: [:index, :destroy]
     resources :commands, except: [:edit]
     resources :secrets, except: [:edit]

--- a/test/controllers/admin/user_merges_controller_test.rb
+++ b/test/controllers/admin/user_merges_controller_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Admin::UserMergesController do
+  as_a_admin do
+    unauthorized :get, :new, user_id: 1
+    unauthorized :post, :create, user_id: 1
+  end
+
+  as_a_super_admin do
+    describe "#new" do
+      it "renders" do
+        get :new, params: {user_id: users(:admin).id}
+        assert_response :success
+      end
+    end
+
+    describe "#create" do
+      it "merges the users and lets the original now log in with new credentials" do
+        assert_difference 'User.count', -1 do
+          post :create, params: {user_id: user.id, merge_target_id: users(:deployer).id}
+          assert_redirected_to [:admin, user]
+        end
+        user.reload.external_id.must_equal users(:deployer).external_id
+      end
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -119,11 +119,7 @@ describe User do
         }
       end
 
-      let(:existing_user) do
-        User.create!(name: "Test", external_id: 9)
-      end
-
-      before { existing_user }
+      let!(:existing_user) { User.create!(name: "Test", external_id: 9) }
 
       it "does not update the user" do
         user.name.must_equal("Test")
@@ -457,8 +453,15 @@ describe User do
   end
 
   describe "#name_and_email" do
+    let(:user) { users(:admin) }
+
     it "is name and email" do
-      users(:admin).name_and_email.must_equal "Admin (admin@example.com)"
+      user.name_and_email.must_equal "Admin (admin@example.com)"
+    end
+
+    it "is email without name" do
+      user.name = ''
+      user.name_and_email.must_equal "admin@example.com"
     end
   end
 end


### PR DESCRIPTION
https://zendesk.atlassian.net/browse/TOOLS-979

We support multiple auth providers, but we cannot trust all of them to properly verify their emails (github for example allows user to enter a bogus email)
So if we had unique users by email then they could either not sign up with a new provider or we would have to merge them with existing users, which would lead to them being able to take over existing users.

So instead of fixing this mess which would be complicated hard to do securely we add a merge button so admins can sort things out manually.

The user needs to be a super-admin since otherwise an admin could merge themselves into a super-admin user.


![screen shot 2016-10-25 at 2 55 25 pm](https://cloud.githubusercontent.com/assets/11367/19706171/55b2db88-9ac5-11e6-89f1-19a4387f2bb8.png)

![screen shot 2016-10-25 at 3 08 11 pm](https://cloud.githubusercontent.com/assets/11367/19706168/50b01ad8-9ac5-11e6-97b4-347fd48aef53.png)
![screen shot 2016-10-25 at 2 55 21 pm](https://cloud.githubusercontent.com/assets/11367/19706173/57abb1c6-9ac5-11e6-839f-93ad5f0efce0.png)

@jonmoter @stewi2 
