### PR TITLE
Remove the stage from next_stage_ids immediately, instead of erroring.

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -123,7 +123,6 @@ class Admin::DeployGroupsController < ApplicationController
 
     unless template_stage.deploy_groups.include?(stage.deploy_groups.first)
       template_stage.deploy_groups += stage.deploy_groups
-      template_stage.next_stage_ids.delete(stage.id.to_s)
       template_stage.save!
     end
 

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -195,7 +195,7 @@ class Stage < ActiveRecord::Base
 
   def destroy_stage_pipeline
     project.stages.each do |s|
-      if s.next_stage_ids.delete(id.to_s).present?
+      if s.next_stage_ids.delete(id.to_s)
         s.save!
       end
     end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -194,9 +194,9 @@ class Stage < ActiveRecord::Base
   end
 
   def destroy_stage_pipeline
-    project.stages.each do |s|
+    (project.stages - [self]).each do |s|
       if s.next_stage_ids.delete(id.to_s)
-        s.save!
+        s.save(validate: false)
       end
     end
   end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -194,12 +194,8 @@ class Stage < ActiveRecord::Base
   end
 
   def destroy_stage_pipeline
-    puts
-    puts "destroying pipeline"
-    puts
     project.stages.each do |s|
       if s.next_stage_ids.delete(id.to_s).present?
-        puts "found a pipeline to destroy"
         s.save!
       end
     end

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -8,5 +8,4 @@ Stage.class_eval do
   # duplicate call from models/stage.rb, but this is needed
   # to load the soft delete methods
   has_soft_deletion default_scope: true
-  before_soft_delete :verify_not_part_of_pipeline
 end

--- a/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
+++ b/plugins/pipelines/app/models/concerns/samson_pipelines/stage_concern.rb
@@ -31,15 +31,4 @@ module SamsonPipelines::StageConcern
     end
     true
   end
-
-  # Make sure that this stage isn't referenced by another stage in a pipeline.
-  # This will stop soft_deletion of the stage.
-  def verify_not_part_of_pipeline
-    project.stages.each do |s|
-      if s.next_stage_ids.include?(id)
-        errors[:base] << "Stage #{name} is in a pipeline from #{s.name} and cannot be deleted"
-        throw :abort
-      end
-    end
-  end
 end

--- a/plugins/pipelines/test/decorators/stage_decorator_test.rb
+++ b/plugins/pipelines/test/decorators/stage_decorator_test.rb
@@ -108,16 +108,4 @@ describe Stage do
       stage1.valid?.must_equal true
     end
   end
-
-  describe '#verify_not_part_of_pipeline' do
-    it 'allows soft delete if the stage is not part of a pipeline' do
-      stage1.soft_delete.must_equal true
-    end
-
-    it 'returns false if this stage is referenced by another' do
-      stage1.update!(next_stage_ids: [stage2.id])
-      stage2.soft_delete.must_equal false
-      stage2.errors.messages.must_equal base: ["Stage stage2 is in a pipeline from stage1 and cannot be deleted"]
-    end
-  end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -455,6 +455,13 @@ describe Stage do
         stage.soft_undelete!
       end
     end
+
+    it "removes the stage from the pipeline of other stages" do
+      other_stage = Stage.create!(project: stage.project, name: 'stage1', next_stage_ids: [stage.id.to_s])
+      assert other_stage.next_stage_ids.include?(stage.id.to_s)
+      stage.soft_delete!
+      refute other_stage.reload.next_stage_ids.include?(stage.id.to_s)
+    end
   end
 
   describe "#command_updated_at" do


### PR DESCRIPTION
For pod-o-matic. 

@dawbs was having issues deleting stages. It turns out the pipeline was keeping the stage from deleting. 

In the past, deleting stages was a rare thing. But now, with pod-o-matic, we expect it to happen a lot more often. So lets fix pain point and just auto-delete the stage in question, from the pipelines its in.

/cc @zendesk/samson @grosser @jonmoter 

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-288

### Risks
- Level: None

We don't delete stages we simply soft delete them.

