### PR TITLE
adding a small sanity check that we do not cache assocations

### DIFF
--- a/test/models/lock_test.rb
+++ b/test/models/lock_test.rb
@@ -301,6 +301,11 @@ describe Lock do
         Lock.send(:all_cached).must_equal []
       end
     end
+
+    it "does not store associations" do
+      lock # trigger create
+      Marshal.dump(Lock.send(:all_cached).first).size.must_be :<, 1500
+    end
   end
 
   describe ".cache_key" do


### PR DESCRIPTION
@jonmoter 

... was worried about size, but it's not an issue since we always cache 'fresh' objects from the db