### PR TITLE
start all deploys even if one in the beginning fails

### DIFF
--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../../test_helper'
 
-SingleCov.covered! uncovered: 5
+SingleCov.covered!
 
 describe Integrations::BaseController do
   class BaseTestController < Integrations::BaseController
@@ -13,31 +13,38 @@ describe Integrations::BaseController do
   let(:sha) { "dc395381e650f3bac18457909880829fc20e34ba" }
   let(:project) { projects(:test) }
   let(:stage) { stages(:test_staging) }
+  let(:token) { project.token }
 
   before do
     project.releases.destroy_all
     project.builds.destroy_all
     Integrations::BaseController.any_instance.stubs(:deploy?).returns(true)
-    Integrations::BaseController.any_instance.stubs(:project).returns(project)
     Integrations::BaseController.any_instance.stubs(:commit).returns(sha)
     Integrations::BaseController.any_instance.stubs(:branch).returns('master')
     Project.any_instance.stubs(:create_releases_for_branch?).returns(true)
     Build.any_instance.stubs(:validate_git_reference).returns(true)
-    stub_request(:post, "https://api.github.com/repos/bar/foo/releases").
-      to_return(status: 200, body: "", headers: {})
+    stub_request(:post, "https://api.github.com/repos/bar/foo/releases")
   end
 
   describe "#create" do
     it 'creates release and build' do
-      post :create, params: {test_route: true}
+      post :create, params: {test_route: true, token: token}
       assert_response :success
       project.releases.count.must_equal 1
       project.builds.count.must_equal 1
     end
 
+    it 'does not create a release when latest already includes the commit' do
+      GITHUB.expects(:compare).returns(stub(status: 'behind'))
+      project.releases.create!(commit: sha, author: users(:admin))
+      post :create, params: {test_route: true, token: token}
+      assert_response :success
+      project.releases.count.must_equal 1
+    end
+
     it 'returns :ok if this is not a merge' do
       Integrations::BaseController.any_instance.stubs(:deploy?).returns(false)
-      post :create, params: {test_route: true}
+      post :create, params: {test_route: true, token: token}
       assert_response :success
       project.releases.count.must_equal 0
       project.builds.count.must_equal 0
@@ -45,18 +52,18 @@ describe Integrations::BaseController do
 
     it 're-uses last release if commit already present' do
       stub_github_api("repos/bar/foo/compare/#{sha}...#{sha}", status: 'identical')
-      post :create, params: {test_route: true}
+      post :create, params: {test_route: true, token: token}
       assert_response :success
 
       @controller.expects(:latest_release).once.returns(Minitest::Mock.new.expect(:version, nil))
-      post :create, params: {test_route: true}
+      post :create, params: {test_route: true, token: token}
       assert_response :success
       project.releases.count.must_equal 1
       project.builds.count.must_equal 1
     end
 
     it 'records the request' do
-      post :create, params: {test_route: true}
+      post :create, params: {test_route: true, token: token}
       assert_response :success
       result = WebhookRecorder.read(project)
       result.fetch(:log).must_equal <<-LOG.strip_heredoc
@@ -76,7 +83,7 @@ describe Integrations::BaseController do
         mocked_method = MiniTest::Mock.new
         mocked_method.expect :call, MiniTest::Mock.new.expect(:run!, nil, [Hash]), [Build]
         DockerBuilderService.stub :new, mocked_method do
-          post :create, params: {test_route: true}
+          post :create, params: {test_route: true, token: token}
         end
         assert_response :success
         project.releases.count.must_equal 1
@@ -93,7 +100,7 @@ describe Integrations::BaseController do
           mocked_method = MiniTest::Mock.new
           mocked_method.expect :call, MiniTest::Mock.new.expect(:run!, nil, [Hash]), [Build]
           DockerBuilderService.stub :new, mocked_method do
-            post :create, params: {test_route: true}
+            post :create, params: {test_route: true, token: token}
           end
           assert_response :success
           project.releases.count.must_equal 0
@@ -102,10 +109,49 @@ describe Integrations::BaseController do
         end
       end
     end
+
+    it "stops deploy to further stages when first fails" do
+      DeployService.any_instance.expects(:deploy!).times(1).returns(Deploy.new)
+      project.webhooks.create!(branch: 'master', stage: stage, source: 'any')
+      project.webhooks.create!(branch: 'master', stage: stages(:test_production), source: 'any')
+
+      post :create, params: {test_route: true, token: token}
+      assert_response :unprocessable_entity
+    end
+
+    it "fails with invalid token" do
+      post :create, params: {test_route: true, token: token + 'x'}
+      assert_response :unauthorized
+    end
+  end
+
+  describe "#commit" do
+    it "raises when not implemented" do
+      Integrations::BaseController.any_instance.unstub(:commit)
+      assert_raises(NotImplementedError) { @controller.send(:commit) }
+    end
+  end
+
+  describe "#deploy?" do
+    it "raises when not implemented" do
+      Integrations::BaseController.any_instance.unstub(:deploy?)
+      assert_raises(NotImplementedError) { @controller.send(:deploy?) }
+    end
+  end
+
+  describe "#contains_skip_token?" do
+    it "recognizes skips" do
+      assert @controller.send(:contains_skip_token?, "[skip deploy] docs change")
+      assert @controller.send(:contains_skip_token?, "[deploy skip] docs change")
+    end
+
+    it "does not recognize normal deploys" do
+      refute @controller.send(:contains_skip_token?, "do not skip deploy")
+    end
   end
 
   it "does not use Rails.logger, but record_log in all subclasses so logs are always visible to end users" do
-    bad = Dir['app/controllers/integrations/*'].select do |file|
+    bad = Dir['{,plugins/*/}app/controllers/integrations/*'].select do |file|
       File.read(file) =~ /\blogger\b/
     end
     bad.delete('app/controllers/integrations/base_controller.rb')

--- a/test/controllers/integrations/travis_controller_test.rb
+++ b/test/controllers/integrations/travis_controller_test.rb
@@ -45,12 +45,6 @@ describe Integrations::TravisController do
       @request.headers["Authorization"] = authorization if authorization
     end
 
-    it "fails with unknown project" do
-      assert_raises ActiveRecord::RecordNotFound do
-        create token: 'sdasda'
-      end
-    end
-
     describe "with no authorization" do
       let(:authorization) { nil }
 

--- a/test/support/integration_controller_test_helper.rb
+++ b/test/support/integration_controller_test_helper.rb
@@ -34,26 +34,23 @@ module IntegrationsControllerTestHelper
 
       it "creates the ci user if it does not exist" do
         post :create, params: payload.deep_merge(token: project.token)
-
-        User.find_by_name(user_name).wont_be_nil
+        assert User.find_by_name(user_name)
       end
 
       it "responds with 200 OK if the request is valid" do
         post :create, params: payload.deep_merge(token: project.token)
-
-        response.status.must_equal 200
+        assert_response :success
       end
 
       it "responds with 422 OK if deploy cannot be started" do
-        DeployService.stubs(new: stub(deploy!: stub(persisted?: false)))
+        DeployService.stubs(new: stub(deploy!: Deploy.new))
         post :create, params: payload.deep_merge(token: project.token)
-        response.status.must_equal 422
+        assert_response :unprocessable_entity
       end
 
-      it "responds with 404 Not Found if the token is invalid" do
-        assert_raises ActiveRecord::RecordNotFound do
-          post :create, params: payload.deep_merge(token: "foobar")
-        end
+      it "responds with 401 Unauthorized if the token is invalid" do
+        post :create, params: payload.deep_merge(token: "foobar")
+        assert_response :unauthorized
       end
     end
   end


### PR DESCRIPTION
@jonmoter @sandlerr 

 - make missing token not render as 404, but unauthorized
 - test untested codez
 - show which stages failed to deploy