### PR TITLE
make it possible to figure out who create a temp dir

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -98,7 +98,7 @@ class JobExecution
 
     @job.run!
 
-    success = Dir.mktmpdir do |dir|
+    success = Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
       return @job.error! unless setup!(dir)
 
       if @execution_block


### PR DESCRIPTION
@jonmoter 

... test had more uncovered then configured lines, so adding a few unrelated tests to balance that back out