### PR TITLE
SAMSON-299 avoid giant commits params we get from github ... they break syslog

### DIFF
--- a/lib/samson/logging.rb
+++ b/lib/samson/logging.rb
@@ -12,6 +12,7 @@ elsif Samson::EnvCheck.set?("RAILS_LOG_TO_SYSLOG")
     # show params for every request
     unwanted_keys = %w[format action controller]
     params = event.payload[:params].reject { |key, _| unwanted_keys.include? key }
+    params['commits'] = '... truncated ...' if params['commits']
     { params: params, thread_count: Thread.list.size }
   end
 


### PR DESCRIPTION
simple/cheap solution ... ideally compare size and truncate as needed, but maybe this is good enough ?

https://zendesk.atlassian.net/browse/SAMSON-299

@jonmoter @murat1985 