### PR TITLE
include tag in parameters to jenkins

### DIFF
--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -37,6 +37,7 @@ module Samson
         buildStartedBy: deploy.user.name,
         originatedFrom: originated_from,
         commit: deploy.job.commit,
+        tag: deploy.job.tag,
         deployUrl: deploy.url,
         emails: notify_emails
       }, opts).to_i

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -20,7 +20,7 @@ describe Samson::Jenkins do
   def stub_build_with_parameters(update_params)
     stub_request(:post, "http://www.test-url.com/job/test_job/buildWithParameters").
       with(
-        body: {"buildStartedBy" => "Super Admin", "originatedFrom" => "Project_Staging_staging", "commit" => "abcabc1", "deployUrl" => "http://www.test-url.com/projects/foo/deploys/#{deploy.id}", "emails" => "super-admin@example.com"}.merge(update_params),
+        body: {"buildStartedBy" => "Super Admin", "originatedFrom" => "Project_Staging_staging", "commit" => "abcabc1", "deployUrl" => "http://www.test-url.com/projects/foo/deploys/#{deploy.id}", "emails" => "super-admin@example.com", "tag" => nil}.merge(update_params),
         headers: {'Authorization' => 'Basic dXNlckB0ZXN0LmNvbTpqYXBpa2V5'}
       ).
       to_return(status: 200, body: "", headers: {}).to_timeout


### PR DESCRIPTION
Include commit tag in the parameters sent to Jenkins when starting a Jenkins job after a successful deploy.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Medium: Jenkins integration could stop working

