### PR TITLE
add endpoint to destroy lock without knowing the id

### DIFF
--- a/app/controllers/api/locks_controller.rb
+++ b/app/controllers/api/locks_controller.rb
@@ -15,4 +15,13 @@ class Api::LocksController < Api::BaseController
     Lock.find(params.require(:id)).soft_delete!
     head :ok
   end
+
+  def destroy_via_resource
+    lock = Lock.where(
+      resource_id: params.fetch(:resource_id).presence,
+      resource_type: params.fetch(:resource_type).presence
+    ).first!
+    lock.soft_delete!
+    head :ok
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Samson::Application.routes.draw do
     end
 
     resources :locks, only: [:index, :create, :destroy]
+    delete '/locks', to: 'locks#destroy_via_resource'
   end
 
   resources :projects, except: [:destroy] do

--- a/test/controllers/api/locks_controller_test.rb
+++ b/test/controllers/api/locks_controller_test.rb
@@ -45,5 +45,43 @@ describe Api::LocksController do
         assert_response :success
       end
     end
+
+    describe "#destroy_via_resource" do
+      before { Lock.create!(user: users(:admin)) }
+
+      it "unlocks global" do
+        assert_difference "Lock.count", -1 do
+          delete :destroy_via_resource,
+            params: {resource_id: nil, resource_type: nil},
+            format: :json
+        end
+        assert_response :success
+      end
+
+      it "unlocks resource" do
+        stage = stages(:test_staging)
+        Lock.create!(user: users(:admin), resource: stage)
+        assert_difference "Lock.count", -1 do
+          delete :destroy_via_resource,
+            params: {resource_id: stage.id, resource_type: 'Stage'},
+            format: :json
+        end
+        assert_response :success
+      end
+
+      it "fails with unfound lock" do
+        assert_raises ActiveRecord::RecordNotFound do
+          delete :destroy_via_resource,
+            params: {resource_id: 333223, resource_type: 'Stage'},
+            format: :json
+        end
+      end
+
+      it "fails without parameters" do
+        assert_raises ActionController::ParameterMissing do
+          delete :destroy_via_resource, format: :json
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
@abmartinr @apanzerj  

`DELETE /api/locks` resource_id=x resource_type=y ... set to '' for global