### PR TITLE
add personal oauth tokens for developers, token UI, usage tracking

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+class AccessTokensController < ApplicationController
+  def index
+    @access_tokens = token_scope
+  end
+
+  def new
+    @access_token = Doorkeeper::AccessToken.new(scopes: 'default', application: ensure_personal_access_app)
+  end
+
+  def create
+    token = Doorkeeper::AccessToken.create!(
+      params.
+        require(:doorkeeper_access_token).
+        permit(:description, :scopes, :application_id).
+        merge(resource_owner_id: current_user.id)
+    )
+    redirect_to(
+      {action: :index},
+      notice: "Token created: copy this token, it will not be shown again: #{token.token}"
+    )
+  end
+
+  def destroy
+    token_scope.find(params.require(:id)).destroy!
+    redirect_to(
+      {action: :index},
+      notice: "Token deleted"
+    )
+  end
+
+  private
+
+  def token_scope
+    Doorkeeper::AccessToken.where(resource_owner_id: current_user.id)
+  end
+
+  def ensure_personal_access_app
+    Doorkeeper::Application.where(name: 'Personal Access Token').first_or_create!(
+      scopes: '', # by default nothing is allowed ... scopes will come from access tokens
+      redirect_uri: 'http://example.com' # this app will never redirect
+    )
+  end
+end

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -1,0 +1,33 @@
+<%= page_title 'OAuth Access Tokens' %>
+
+<section class="tabs">
+  <p class="pull-right">
+    <%= link_to "Create Token", new_access_token_path, class: "btn btn-default" %>
+  </p>
+
+  <table class="table">
+    <thead>
+    <tr>
+      <th>Application</th>
+      <th>Description</th>
+      <th>Scope</th>
+      <th>Last used</th>
+      <th>Created</th>
+      <th></th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <% @access_tokens.each do |token| %>
+    <tr>
+      <td><%= link_to_if current_user.super_admin?, token.application.name, oauth_application_path(token.application) %></td>
+      <td><%= token.description %></td>
+      <td><%= token.scopes.to_a.join(", ") %></td>
+      <td><%= token.last_used_at ? relative_time(token.last_used_at) : "Never" %></td>
+      <td><%= relative_time token.created_at %></td>
+      <td><%= link_to_delete(access_token_path(token)) %></td>
+    </tr>
+    <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -1,0 +1,13 @@
+<%= page_title "New Access Token" %>
+
+<section>
+  <%= form_for @access_token, url: access_tokens_path, html: { class: "form-horizontal" } do |form| %>
+    <%= form.input :application_id do %>
+      <%= form.select :application_id, options_for_select(Doorkeeper::Application.all.map { |a| [a.name, a.id] }), {}, {class: 'form-control'} %>
+    <% end %>
+    <%= form.input :description %>
+    <%= form.input :scopes, help: I18n.t('doorkeeper.applications.help.scopes') %>
+
+    <%= form.actions %>
+  <% end %>
+</section>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -77,7 +77,6 @@
           <li><%= link_to "Reports", csv_exports_path %></li>
           <% if current_user&.super_admin? %>
             <li><%= link_to "OAuth Applications", oauth_applications_path %></li>
-            <li><%= link_to "OAuth Authorized Applications", oauth_authorized_applications_path %></li>
           <% end %>
         </ul>
       </li>
@@ -93,6 +92,7 @@
           </a>
           <ul class="dropdown-menu">
             <li><%= link_to "Profile", profile_path %></li>
+            <li><%= link_to "OAuth", access_tokens_path %></li>
             <li><%= link_to "Logout", logout_path %></li>
           </ul>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,8 @@ Samson::Application.routes.draw do
 
   resource :profile, only: [:show, :update]
 
+  resources :access_tokens, only: [:index, :new, :create, :destroy]
+
   resources :versions, only: [:index]
 
   get '/auth/github/callback', to: 'sessions#github'

--- a/db/migrate/20161102201243_add_metadata_to_access_tokens.rb
+++ b/db/migrate/20161102201243_add_metadata_to_access_tokens.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddMetadataToAccessTokens < ActiveRecord::Migration[5.0]
+  def change
+    add_column :oauth_access_tokens, :description, :string
+    add_column :oauth_access_tokens, :last_used_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161026004331) do
+ActiveRecord::Schema.define(version: 20161102201243) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -305,6 +305,8 @@ ActiveRecord::Schema.define(version: 20161026004331) do
     t.datetime "created_at",                                      null: false
     t.string   "scopes",                 limit: 255
     t.string   "previous_refresh_token", limit: 255, default: "", null: false
+    t.string   "description"
+    t.datetime "last_used_at"
   end
 
   add_index "oauth_access_tokens", ["application_id"], name: "fk_rails_732cb83ab7", using: :btree

--- a/lib/warden/strategies/doorkeeper_strategy.rb
+++ b/lib/warden/strategies/doorkeeper_strategy.rb
@@ -24,6 +24,7 @@ class Warden::Strategies::Doorkeeper < ::Warden::Strategies::Base
       elsif !(user = User.find_by_id(token.resource_owner_id))
         halt_json "OAuth token belongs to deleted user #{token.resource_owner_id}"
       else
+        token.update_column(:last_used_at, Time.now) unless token.last_used_at&.> 1.minutes.ago
         request.session_options[:skip] = true # do not store user in session
         success! user
       end

--- a/test/controllers/access_tokens_controller_test.rb
+++ b/test/controllers/access_tokens_controller_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe AccessTokensController do
+  as_a_viewer do
+    let(:application) { Doorkeeper::Application.create!(name: 'Foobar', redirect_uri: 'http://example.com') }
+
+    describe "#index" do
+      let!(:token) { Doorkeeper::AccessToken.create!(application: application, resource_owner_id: user.id) }
+      let!(:other_token) { Doorkeeper::AccessToken.create!(application: application, resource_owner_id: 123) }
+
+      it "lists my tokens" do
+        get :index
+        assert_response :success
+        assigns[:access_tokens].must_equal [token]
+      end
+    end
+
+    describe "#new" do
+      it "prefills with default scope so users does not create useless tokens" do
+        get :new
+        assert_response :success
+        assigns[:access_token].scopes.to_a.must_equal ['default']
+      end
+
+      it "ensures the personal token exists" do
+        get :new
+        Doorkeeper::Application.pluck(:name).must_equal ["Personal Access Token"]
+      end
+
+      it "does not create multiple personal tokens" do
+        get :new
+        get :new
+        Doorkeeper::Application.pluck(:name).must_equal ["Personal Access Token"]
+      end
+    end
+
+    describe "#create" do
+      it "creates a token for the current user" do
+        assert_difference 'Doorkeeper::AccessToken.count', +1 do
+          post :create, params: {
+            doorkeeper_access_token: {description: 'D', scopes: 'locks, projects', application_id: application.id}
+          }
+          assert_redirected_to '/access_tokens'
+        end
+        token = Doorkeeper::AccessToken.last
+        token.resource_owner_id.must_equal user.id # scoped to current user
+        flash[:notice].must_include token.token # user was able to copy the token
+      end
+    end
+
+    describe "#destroy" do
+      it "destroys" do
+        token = Doorkeeper::AccessToken.create!(application: application, resource_owner_id: user.id)
+        assert_difference 'Doorkeeper::AccessToken.count', -1 do
+          delete :destroy, params: {id: token.id}
+        end
+        assert_redirected_to '/access_tokens'
+      end
+
+      it "does not destroy other peoples tokens" do
+        token = Doorkeeper::AccessToken.create!(application: application, resource_owner_id: 123)
+        refute_difference 'Doorkeeper::AccessToken.count', -1 do
+          assert_raises ActiveRecord::RecordNotFound do
+            delete :destroy, params: {id: token.id}
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@zendesk/samson 

@abmartinr @apanzerj 

we previously reused the doorkeeper UI, but it was unusable and only available for admins

<img width="1181" alt="screen shot 2016-11-02 at 1 53 31 pm" src="https://cloud.githubusercontent.com/assets/11367/19949755/d1c73e7a-a110-11e6-9fcc-87b972d2bbb6.png">
<img width="194" alt="screen shot 2016-11-02 at 2 06 47 pm" src="https://cloud.githubusercontent.com/assets/11367/19949756/d1cb9344-a110-11e6-87f6-8bda10ea2640.png">
<img width="812" alt="screen shot 2016-11-02 at 1 49 23 pm" src="https://cloud.githubusercontent.com/assets/11367/19949757/d1cf9318-a110-11e6-92de-17e08b3a13c3.png">
<img width="1169" alt="screen shot 2016-11-02 at 1 51 33 pm" src="https://cloud.githubusercontent.com/assets/11367/19949758/d1d2a86e-a110-11e6-8140-01bc7b3608bc.png">
