### PR TITLE
output more useful information (in JSON) when waiting for jobs

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -77,6 +77,10 @@ class JobExecution
     @subscribers << JobExecutionSubscriber.new(job, block)
   end
 
+  def descriptor
+    "#{job.project.name} - #{reference}"
+  end
+
   private
 
   def stage

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -19,6 +19,7 @@ class JobExecution
   attr_reader :output, :reference, :job, :viewers, :executor
 
   delegate :id, to: :job
+  delegate :pid, :pgid, to: :executor
 
   def initialize(reference, job, env = {}, &block)
     @output = OutputBuffer.new
@@ -49,10 +50,6 @@ class JobExecution
 
   def wait!
     @thread.join
-  end
-
-  def pid
-    @executor.pid
   end
 
   # Used on queued jobs when shutting down

--- a/app/models/restart_signal_handler.rb
+++ b/app/models/restart_signal_handler.rb
@@ -31,7 +31,7 @@ class RestartSignalHandler
             job_id: job_exec.id,
             pid: job_exec.pid,
             pgid: job_exec.pgid,
-            project: job_exec.job.project.name
+            descriptor: job_exec.descriptor
           }
         end,
         locks: MultiLock.locks
@@ -55,10 +55,6 @@ class RestartSignalHandler
       message: message
     }.merge(data).to_json
 
-    if Rails.logger
-      Rails.logger.info(output)
-    else
-      puts output
-    end
+    Rails.logger.info(output)
   end
 end

--- a/test/models/restart_signal_handler_test.rb
+++ b/test/models/restart_signal_handler_test.rb
@@ -45,9 +45,10 @@ describe RestartSignalHandler do
 
     it "waits for running jobs" do
       registry = JobExecution.send(:registry)
+      job_exec = stub(id: 123, pid: 444, pgid: 5555, descriptor: 'Job thingy')
 
       # we call it twice in each iteration
-      registry.expects(:active).times(3).returns [stub(id: 123)], [stub(id: 123)], []
+      registry.expects(:active).times(3).returns [job_exec], [job_exec], []
 
       RestartSignalHandler.any_instance.expects(:sleep).with(5)
       handle


### PR DESCRIPTION
Gives more useful information, like which project, the process id, and the process group id.

Old:
```
Waiting for jobs: [866444028]
```

New:
```
{"time":"2016-11-04 18:11:36 +0000","message":"waiting for jobs to complete","jobs":[{"job_id":866444028,"pid":84869,"pgid":84869,"project":"Truth Service"}],"locks":{}}
```

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low