### PR TITLE
DRY up logic for building docker images

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -66,7 +66,7 @@ class DockerBuilderService
 
     success, build_log = k8s_job.execute!(build, project,
       tag: docker_ref, push: push,
-      registry: registry_credentials, tag_as_latest: tag_as_latest)
+      registry: DockerBuilderService.registry_credentials, tag_as_latest: tag_as_latest)
 
     build.docker_ref = docker_ref
     build.docker_repo_digest = nil
@@ -110,7 +110,7 @@ class DockerBuilderService
 
     build.docker_image.tag(repo: project.docker_repo, tag: build.docker_ref, force: true)
 
-    build.docker_image.push(registry_credentials) do |chunk|
+    build.docker_image.push(DockerBuilderService.registry_credentials) do |chunk|
       parsed_chunk = output.write_docker_chunk(chunk)
       if (status = parsed_chunk['status']) && sha = status[DIGEST_SHA_REGEX, 1]
         build.docker_repo_digest = "#{project.docker_repo}@#{sha}"
@@ -152,7 +152,7 @@ class DockerBuilderService
   def push_latest
     output.puts "### Pushing the 'latest' tag for this image"
     build.docker_image.tag(repo: project.docker_repo, tag: 'latest', force: true)
-    build.docker_image.push(registry_credentials, tag: 'latest', force: true) do |chunk|
+    build.docker_image.push(DockerBuilderService.registry_credentials, tag: 'latest', force: true) do |chunk|
       output.write_docker_chunk(chunk)
     end
   end

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -147,14 +147,11 @@ class BinaryBuilder
   end
 
   def create_build_image
-    @output_stream.puts 'Now building the build container...'
     build_options = {
       'dockerfile' => DOCKER_BUILD_FILE,
       't' => image_name
     }
-    Docker::Image.build_from_dir(@dir, build_options) do |chunk|
-      @output_stream.write_docker_chunk(chunk)
-    end
+    DockerBuilderService.build_docker_image(@dir, build_options, @output_stream)
   end
 
   def docker_api_version

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -35,7 +35,8 @@ describe BinaryBuilder do
       builder.build
       output.string.must_equal [
         "Connecting to Docker host with Api version: 1.19 ...\n",
-        "Now building the build container...\n",
+        "### Running Docker build\n",
+        "### Docker build complete\n",
         "Now starting Build container...\n",
         "Grabbing '/app/artifacts.tar' from build container...\n",
         "Continuing docker build...\n",
@@ -59,7 +60,8 @@ describe BinaryBuilder do
         output.string.must_equal [
           "Running pre build script...\n",
           "Connecting to Docker host with Api version: 1.19 ...\n",
-          "Now building the build container...\n",
+          "### Running Docker build\n",
+          "### Docker build complete\n",
           "Now starting Build container...\n",
           "Grabbing '/app/artifacts.tar' from build container...\n",
           "Continuing docker build...\n",

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -256,7 +256,7 @@ describe DockerBuilderService do
 
         mock_docker_image.expects(:tag).with(has_entry(tag: 'my-test')).with(has_entry(tag: 'latest'))
         mock_docker_image.expects(:push).
-          with(service.send(:registry_credentials), tag: 'latest', force: true).
+          with(DockerBuilderService.registry_credentials, tag: 'latest', force: true).
           multiple_yields(*push_output)
         service.push_image('my-test', tag_as_latest: true)
       end


### PR DESCRIPTION
currently Samson doesn't fork when building a docker image. this means that all that work (git etc) happens in the ruby thread, really gumming up the works.

The issue is that when you call Docker::Image.build_from_dir, that creates a tarfile in ruby code, which does a whole mess of disk IO.

So far I'm just refactoring some code before I add the forking logic.

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low

@grosser 