### PR TITLE
fix docker output so it can handle multiple lines

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -112,8 +112,10 @@ class DockerBuilderService
 
     build.docker_image.push(DockerBuilderService.registry_credentials) do |chunk|
       parsed_chunk = output.write_docker_chunk(chunk)
-      if (status = parsed_chunk['status']) && sha = status[DIGEST_SHA_REGEX, 1]
-        build.docker_repo_digest = "#{project.docker_repo}@#{sha}"
+      parsed_chunk.each do |output_hash|
+        if (status = output_hash['status']) && sha = status[DIGEST_SHA_REGEX, 1]
+          build.docker_repo_digest = "#{project.docker_repo}@#{sha}"
+        end
       end
     end
 

--- a/test/models/output_buffer_test.rb
+++ b/test/models/output_buffer_test.rb
@@ -59,27 +59,27 @@ describe OutputBuffer do
 
   describe "#write_docker_chunk" do
     it "nicely formats complete chunk" do
-      buffer.write_docker_chunk('{"foo": 1, "bar": 2}').must_equal("foo" => 1, "bar" => 2)
+      buffer.write_docker_chunk('{"foo": 1, "bar": 2}').first.must_equal("foo" => 1, "bar" => 2)
       buffer.to_s.must_equal("foo: 1 | bar: 2\n")
     end
 
     it "ignores blank values" do
-      buffer.write_docker_chunk('{"foo": " ", "bar": null}').must_equal("foo" => " ", "bar" => nil)
+      buffer.write_docker_chunk('{"foo": " ", "bar": null}').first.must_equal("foo" => " ", "bar" => nil)
       buffer.to_s.must_equal("")
     end
 
     it "writes partial chunks" do # ideally piece together multiple partial chunks
-      buffer.write_docker_chunk('{"foo": ').must_equal('message' => '{"foo": ')
+      buffer.write_docker_chunk('{"foo": ').first.must_equal('message' => '{"foo":')
       buffer.to_s.must_equal "{\"foo\":\n"
     end
 
     it "does not print spammy progressDetail" do
-      buffer.write_docker_chunk('{"progressDetail": 1}').must_equal("progressDetail" => 1)
+      buffer.write_docker_chunk('{"progressDetail": 1}').first.must_equal("progressDetail" => 1)
       buffer.to_s.must_equal ""
     end
 
     it "simplifies stream only responses" do
-      buffer.write_docker_chunk('{"stream": 123}').must_equal("stream" => 123)
+      buffer.write_docker_chunk('{"stream": 123}').first.must_equal("stream" => 123)
       buffer.to_s.must_equal("123\n")
     end
 
@@ -98,6 +98,17 @@ describe OutputBuffer do
       buffer.to_s.must_equal "foo\"\\255\"}\n---\\u003e 6c9a006fd38a\\n\nfoo\"\\255\"}\n"
       build_listener.value.map(&:encoding).uniq.must_equal([Encoding::UTF_8])
       build_listener.value.map(&:valid_encoding?).uniq.must_equal([true])
+    end
+
+    it "handles multiple lines in one chunk" do
+      lines = [
+        { 'foo' => 1, 'bar' => 2 },
+        { 'foo' => 3, 'bar' => 4 }
+      ]
+
+      output = lines.map(&:to_json).join("\n")
+      buffer.write_docker_chunk(output).must_equal(lines)
+      buffer.to_s.must_equal "foo: 1 | bar: 2\nfoo: 3 | bar: 4\n"
     end
   end
 


### PR DESCRIPTION
When I was building docker images locally (using Docker for Mac), I'd get a bunch of JSON errors when displaying the Docker output.

I did some digging, and sometimes I would get "chunks" back from docker that contained multiple lines, each line with a separate JSON hash.  So this adds some logic to handle that scenario, and also re-encodes the string first.

/cc @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low

