### PR TITLE
do not fail when a deleted role still exists in the repo

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -78,18 +78,13 @@ module Kubernetes
       end
     end
 
+    # roles for which a config file exists in the repo
+    # ... we ignore those without to allow users to deploy a branch that changes roles
     def self.configured_for_project(project, git_sha)
-      known = project.kubernetes_roles.not_deleted
-
-      necessary_role_configs = kubernetes_config_files_in_repo(project, git_sha).map(&:path)
-      necessary_role_configs.map do |path|
-        known.detect { |r| r.config_file == path } || begin
-          url = Rails.application.routes.url_helpers.project_kubernetes_roles_url(project)
-          raise(
-            Samson::Hooks::UserError,
-            "No role for #{path} is configured. Add it on kubernetes Roles tab #{url}"
-          )
-        end
+      project.kubernetes_roles.not_deleted.select do |role|
+        path = role.config_file
+        next unless file_contents = project.repository.file_content(path, git_sha)
+        Kubernetes::RoleConfigFile.new(file_contents, path) # run validations
       end
     end
 
@@ -123,20 +118,14 @@ module Kubernetes
     end
 
     class << self
-      # this is a little conflicted code because it tries to solve:
-      # - allow adding a new role for a branch without making all deploys fail
-      # - make deploys fail that do not serve all kubernetes/ files in the repo
-      # - make deploys fail that do not serve one-off kubernetes files in the repo
+      # all configs in kubernetes/* at given ref
       def kubernetes_config_files_in_repo(project, git_ref)
         folder = 'kubernetes'
-        files = project.repository.file_content(folder, git_ref) || []
+        files = project.repository.file_content(folder, git_ref).
+          to_s.split("\n").
+          map { |f| "#{folder}/#{f}" }
 
-        files = files.split("\n").grep(/\.(yml|yaml|json)$/).map { |f| "#{folder}/#{f}" }
-
-        files.concat project.kubernetes_roles.not_deleted.map(&:config_file).
-          reject { |f| f.start_with?("#{folder}/") }
-
-        files.map do |path|
+        files.grep(/\.(yml|yaml|json)$/).map do |path|
           next unless file_contents = project.repository.file_content(path, git_ref)
           Kubernetes::RoleConfigFile.new(file_contents, path)
         end.compact

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -238,7 +238,7 @@ describe Kubernetes::Role do
     end
 
     it "raises when a role is in the repo, but not configured" do
-      role.soft_delete!
+      role.destroy!
       assert_raises Samson::Hooks::UserError do
         Kubernetes::Role.configured_for_project(project, 'HEAD')
       end
@@ -251,6 +251,16 @@ describe Kubernetes::Role do
       assert_raises Samson::Hooks::UserError do
         Kubernetes::Role.configured_for_project(project, 'HEAD')
       end
+    end
+
+    it "ignores deleted roles" do
+      other = project.kubernetes_roles.create!(
+        config_file: 'foobar/foo.yml', name: 'xasdasd', resource_name: 'dsfsfsdf'
+      )
+      write_config other.config_file, config_content_yml
+      other.soft_delete!
+
+      Kubernetes::Role.configured_for_project(project, 'HEAD').must_equal [role]
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -230,18 +230,14 @@ describe Kubernetes::Role do
         Kubernetes::Role.configured_for_project(project, 'HEAD').must_equal [role]
       end
 
-      it "raises when a role is configured but not in the repo" do
-        assert_raises Samson::Hooks::UserError do
-          Kubernetes::Role.configured_for_project(project, 'HEAD')
-        end
+      it "ignores when the role is configured but not in the repo" do
+        Kubernetes::Role.configured_for_project(project, 'HEAD').must_equal []
       end
     end
 
-    it "raises when a role is in the repo, but not configured" do
+    it "ignores when a role is in the repo, but not configured" do
       role.destroy!
-      assert_raises Samson::Hooks::UserError do
-        Kubernetes::Role.configured_for_project(project, 'HEAD')
-      end
+      Kubernetes::Role.configured_for_project(project, 'HEAD').must_equal []
     end
 
     it "raises when a role is invalid so the deploy is stopped" do


### PR DESCRIPTION
@irwaters @jonmoter 

this code is kind of messy ... I think it would be simpler if we change the logic to "require all roles that exist in the repo" ... and remove the 'kubernetes/' lookup ... so everything is treated with the same logic ...

implemented that in the second commit ...