### PR TITLE
t treat multi reads from deploy groups that have no vault servers like …

### DIFF
--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -23,8 +23,12 @@ module Samson
 
         def read_multi(keys)
           keys.each_with_object({}) do |key, a|
-            if value = read(key)
-              a[key] = value
+            begin
+              if value = read(key)
+                a[key] = value
+              end
+            rescue VaultClient::VaultServerNotConfigured # deploy group has no vault server
+              nil
             end
           end
         end

--- a/lib/samson/secrets/vault_client.rb
+++ b/lib/samson/secrets/vault_client.rb
@@ -4,6 +4,9 @@ module Samson
   module Secrets
     # Vault wrapper that sends requests to all matching vault servers
     class VaultClient
+      class VaultServerNotConfigured < StandardError
+      end
+
       def self.client
         @client ||= new
       end
@@ -40,7 +43,7 @@ module Samson
 
       def client(deploy_group)
         unless id = deploy_group.vault_server_id.presence
-          raise "deploy group #{deploy_group.permalink} has no vault server configured"
+          raise VaultServerNotConfigured, "deploy group #{deploy_group.permalink} has no vault server configured"
         end
         unless client = clients[id]
           raise "no vault server found with id #{id}"

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -50,6 +50,10 @@ describe Samson::Secrets::HashicorpVaultBackend do
         Samson::Secrets::HashicorpVaultBackend.read_multi(['production/foo/pod2/bar']).must_equal({})
       end
     end
+
+    it "leaves out vaules from deploy groups that have no vault server so KeyResolver works" do
+      Samson::Secrets::HashicorpVaultBackend.read_multi(['production/foo/pod100/bar']).must_equal({})
+    end
   end
 
   describe ".delete" do

--- a/test/lib/samson/secrets/vault_client_test.rb
+++ b/test/lib/samson/secrets/vault_client_test.rb
@@ -88,7 +88,7 @@ describe Samson::Secrets::VaultClient do
 
     it "fails descriptively when deploy group has no vault server associated" do
       deploy_groups(:pod2).update_column(:vault_server_id, nil)
-      e = assert_raises(RuntimeError) { client.client(deploy_groups(:pod2)) }
+      e = assert_raises(Samson::Secrets::VaultClient::VaultServerNotConfigured) { client.client(deploy_groups(:pod2)) }
       e.message.must_equal "deploy group pod2 has no vault server configured"
     end
 


### PR DESCRIPTION
@jonmoter @bhouse @irwaters 

https://samson.zende.sk/projects/samson/deploys/222597#L22

…they were not there

so KeyResolver#expand does not fail when trying those keys