### PR TITLE
ignore when 1 deploy group has no vault server set up ... reading and…

### DIFF
--- a/lib/samson/secrets/vault_client.rb
+++ b/lib/samson/secrets/vault_client.rb
@@ -80,7 +80,7 @@ module Samson
             unless environment = Environment.find_by_permalink(environment_permalink)
               raise "no environment with permalink #{environment_permalink} found"
             end
-            environment.deploy_groups.map { |deploy_group| client(deploy_group) }.uniq
+            environment.deploy_groups.select(&:vault_server_id).map { |deploy_group| client(deploy_group) }.uniq
           end
         else
           unless deploy_group = DeployGroup.find_by_permalink(deploy_group_permalink)

--- a/test/lib/samson/secrets/vault_client_test.rb
+++ b/test/lib/samson/secrets/vault_client_test.rb
@@ -86,8 +86,8 @@ describe Samson::Secrets::VaultClient do
         end
       end
 
-      it "fails when not all deploy groups in that environment have a vault server" do
-        assert_raises Samson::Secrets::VaultClient::VaultServerNotConfigured do
+      it "ignores when not all deploy groups in that environment have a vault server" do
+        assert_vault_request :put, 'production/global/global/foo' do
           client.write('production/global/global/foo', foo: :bar)
         end
       end


### PR DESCRIPTION


… writing will still work fine

@irwaters 