### PR TITLE
Make releases version type agnostic

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -56,7 +56,7 @@ class Integrations::BaseController < ApplicationController
   def create_new_release
     unless project.last_release_contains_commit?(commit)
       release_service = ReleaseService.new(project)
-      release_service.create_release!(release_params)
+      release_service.release!(release_params)
     end
   end
 
@@ -106,7 +106,8 @@ class Integrations::BaseController < ApplicationController
   end
 
   def create_release_and_build_record
-    release = create_new_release || latest_release
+    release = create_new_release
+    release = latest_release unless release && release.persisted?
     create_build(release.version, [release])
   end
 

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -20,11 +20,13 @@ class ReleasesController < ApplicationController
   end
 
   def create
-    @release = ReleaseService.new(@project).create_release!(release_params)
-    redirect_to [@project, @release]
-  rescue ActiveRecord::RecordInvalid => e
-    flash[:error] = e.message
-    redirect_to action: :new
+    @release = ReleaseService.new(@project).release!(release_params)
+    if @release.persisted?
+      redirect_to [@project, @release]
+    else
+      flash[:error] = @release.errors.full_messages.to_sentence
+      render action: :new
+    end
   end
 
   private

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -22,6 +22,9 @@ class ReleasesController < ApplicationController
   def create
     @release = ReleaseService.new(@project).create_release!(release_params)
     redirect_to [@project, @release]
+  rescue ActiveRecord::RecordInvalid => e
+    flash[:error] = e.message
+    redirect_to action: :new
   end
 
   private

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -8,7 +8,7 @@ class Release < ActiveRecord::Base
 
   # DEFAULT_RELEASE_NUMBER is the default value assigned to release#number by the database.
   # This constant is here for convenience - the value that the database uses is in db/schema.rb.
-  DEFAULT_RELEASE_NUMBER = 1
+  DEFAULT_RELEASE_NUMBER = "1"
 
   def self.sort_by_version
     order(number: :desc)
@@ -49,9 +49,14 @@ class Release < ActiveRecord::Base
   def assign_release_number
     # Detect whether the number has been overwritten by params, e.g. using the
     # release-number-from-ci plugin.
-    return if number != DEFAULT_RELEASE_NUMBER && !number.nil?
+    return if number != DEFAULT_RELEASE_NUMBER && number.present?
 
-    latest_release_number = project.releases.last.try(:number) || 0
-    self.number = latest_release_number + 1
+    latest_release_number = project.releases.last.try(:number) || "0"
+
+    # Split and increment the lowest versioning digit
+    split_release_number = latest_release_number.split(".")
+    split_release_number[-1] = (split_release_number[-1].to_i + 1).to_s
+
+    self.number = split_release_number.join(".")
   end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -4,7 +4,9 @@ class Release < ActiveRecord::Base
   belongs_to :author, polymorphic: true
   belongs_to :build
 
-  before_create :assign_release_number
+  before_validation :assign_release_number
+
+  validates :number, format: { with: /\A\d+(.\d+)*\z/, message: "Version number may only be numbers and decimals." }
 
   # DEFAULT_RELEASE_NUMBER is the default value assigned to release#number by the database.
   # This constant is here for convenience - the value that the database uses is in db/schema.rb.
@@ -53,10 +55,6 @@ class Release < ActiveRecord::Base
 
     latest_release_number = project.releases.last.try(:number) || "0"
 
-    # Split and increment the lowest versioning digit
-    split_release_number = latest_release_number.split(".")
-    split_release_number[-1] = (split_release_number[-1].to_i + 1).to_s
-
-    self.number = split_release_number.join(".")
+    raise "Unable to auto bump version" unless self.number = latest_release_number.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
   end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -6,7 +6,7 @@ class Release < ActiveRecord::Base
 
   before_validation :assign_release_number
 
-  validates :number, format: { with: /\A\d+(.\d+)*\z/, message: "Version number may only be numbers and decimals." }
+  validates :number, format: { with: /\A\d+(.\d+)*\z/, message: "may only contain numbers and decimals." }
 
   # DEFAULT_RELEASE_NUMBER is the default value assigned to release#number by the database.
   # This constant is here for convenience - the value that the database uses is in db/schema.rb.

--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -4,10 +4,12 @@ class ReleaseService
     @project = project
   end
 
-  def create_release!(attrs = {})
-    release = @project.releases.create!(attrs)
-    push_tag_to_git_repository(release)
-    start_deploys(release)
+  def release!(attrs = {})
+    release = @project.releases.create(attrs)
+    if release.persisted?
+      push_tag_to_git_repository(release)
+      start_deploys(release)
+    end
     release
   end
 

--- a/app/views/releases/new.html.erb
+++ b/app/views/releases/new.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <%= form.input :commit, required: true, label: "SHA", input_html: { value: @project.deploys.last&.commit } %>
-    <%= form.input :number, as: :number_field, label: "Release number", input_html: { min: 1, step: 1, value: @release.number } %>
+    <%= form.input :number, label: "Release number", input_html: { min: 1, step: 1, value: @release.number } %>
 
     <%= form.actions label: "Create release" %>
   </section>

--- a/db/migrate/20161114194705_releases_number_to_string.rb
+++ b/db/migrate/20161114194705_releases_number_to_string.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 class ReleasesNumberToString < ActiveRecord::Migration[5.0]
   def change
-    change_column :releases, :number, :string, limit: 255, default: "1", null: false
+    change_column :releases, :number, :string, limit: 20, default: "1", null: false
   end
 end

--- a/db/migrate/20161114194705_releases_number_to_string.rb
+++ b/db/migrate/20161114194705_releases_number_to_string.rb
@@ -1,0 +1,5 @@
+class ReleasesNumberToString < ActiveRecord::Migration[5.0]
+  def change
+    change_column :releases, :number, :string, limit: 255, default: "1", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -353,11 +353,11 @@ ActiveRecord::Schema.define(version: 20161115181738) do
   add_index "projects", ["token", "deleted_at"], name: "index_projects_on_token_and_deleted_at", length: {"token"=>191, "deleted_at"=>nil}, using: :btree
 
   create_table "releases", force: :cascade do |t|
-    t.integer  "project_id",  limit: 4,               null: false
-    t.string   "commit",      limit: 255,             null: false
-    t.integer  "number",      limit: 4,   default: 1
-    t.integer  "author_id",   limit: 4,               null: false
-    t.string   "author_type", limit: 255,             null: false
+    t.integer  "project_id",  limit: 4,                 null: false
+    t.string   "commit",      limit: 255,               null: false
+    t.string   "number",      limit: 255, default: "1", null: false
+    t.integer  "author_id",   limit: 4,                 null: false
+    t.string   "author_type", limit: 255,               null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "build_id",    limit: 4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -353,11 +353,11 @@ ActiveRecord::Schema.define(version: 20161115181738) do
   add_index "projects", ["token", "deleted_at"], name: "index_projects_on_token_and_deleted_at", length: {"token"=>191, "deleted_at"=>nil}, using: :btree
 
   create_table "releases", force: :cascade do |t|
-    t.integer  "project_id",  limit: 4,                 null: false
-    t.string   "commit",      limit: 255,               null: false
-    t.string   "number",      limit: 255, default: "1", null: false
-    t.integer  "author_id",   limit: 4,                 null: false
-    t.string   "author_type", limit: 255,               null: false
+    t.integer  "project_id",  limit: 4,                null: false
+    t.string   "commit",      limit: 255,              null: false
+    t.string   "number",      limit: 20, default: "1", null: false
+    t.integer  "author_id",   limit: 4,                null: false
+    t.string   "author_type", limit: 255,              null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "build_id",    limit: 4

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -74,7 +74,7 @@ describe Integrations::BuildkiteController do
         post :create, params: payload.merge(token: project.token), test_route: true
 
         project.releases.size.must_equal 1
-        project.releases.first.number.must_equal 9
+        project.releases.first.number.must_equal "9"
       end
     end
   end

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -35,6 +35,7 @@ describe ReleasesController do
   as_a_project_deployer do
     describe "#create" do
       let(:release_params) { { commit: "abcd" } }
+      let(:bad_release_params) { { commit: "abcd", number: "1A"} }
       before { GITHUB.stubs(:create_release) }
 
       it "creates a new release" do
@@ -42,6 +43,11 @@ describe ReleasesController do
           post :create, params: {project_id: project.to_param, release: release_params}
           assert_redirected_to "/projects/foo/releases/v124"
         end
+      end
+
+      it "rescues bad input and redirects back to new" do
+        post :create, params: {project_id: project.to_param, release: bad_release_params}
+        assert_redirected_to action: :new
       end
     end
 

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -47,7 +47,7 @@ describe ReleasesController do
 
       it "rescues bad input and redirects back to new" do
         post :create, params: {project_id: project.to_param, release: bad_release_params}
-        assert_redirected_to action: :new
+        assert_template :new
       end
     end
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -328,7 +328,7 @@ describe Project do
         [diff, r]
       end
       others.map! do |diff, r|
-        r.update_column(:number, release.number + diff)
+        r.update_column(:number, (release.number.to_i + diff).to_s)
         r
       end
 

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -17,19 +17,19 @@ describe ReleaseService do
   it "creates a new release" do
     count = Release.count
 
-    service.create_release!(commit: commit, author: author)
+    service.release!(commit: commit, author: author)
 
     assert_equal count + 1, Release.count
   end
 
   it "tags the release" do
-    service.create_release!(commit: commit, author: author)
+    service.release!(commit: commit, author: author)
     assert_equal [[project.github_repo, 'v124', target_commitish: commit]], release_params_used
   end
 
   it "deploys the commit to stages if they're configured to" do
     stage = project.stages.create!(name: "production", deploy_on_release: true)
-    release = service.create_release!(commit: commit, author: author)
+    release = service.release!(commit: commit, author: author)
 
     assert_equal release.version, stage.deploys.first.reference
   end
@@ -41,7 +41,7 @@ describe ReleaseService do
       deployable_condition_check = lambda { |_, _| false }
 
       Samson::Hooks.with_callback(:release_deploy_conditions, deployable_condition_check) do |_|
-        service.create_release!(commit: commit, author: author)
+        service.release!(commit: commit, author: author)
 
         assert_equal nil, stage.deploys.first
       end
@@ -51,7 +51,7 @@ describe ReleaseService do
       deployable_condition_check = lambda { |_, _| true }
 
       Samson::Hooks.with_callback(:release_deploy_conditions, deployable_condition_check) do |_|
-        release = service.create_release!(commit: commit, author: author)
+        release = service.release!(commit: commit, author: author)
 
         assert_equal release.version, stage.deploys.first.reference
       end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -11,31 +11,47 @@ describe Release do
 
     it "creates a new release" do
       release = project.releases.create!(commit: commit, author: author)
-      assert_equal 124, release.number
+      assert_equal "124", release.number
     end
 
-    it "increments the release number" do
-      release = project.releases.create!(author: author, commit: "bar")
-      release.update_column(:number, 41)
-      release = project.releases.create!(commit: "foo", author: author)
-      assert_equal 42, release.number
+    describe "when incrementing the release number" do
+      it "correctly increments continuous versions" do
+        release = project.releases.create!(author: author, commit: "bar")
+        release.update_column(:number, "41")
+        release = project.releases.create!(commit: "foo", author: author)
+        assert_equal "42", release.number
+      end
+
+      it "correctly increments major-minor versions" do
+        release = project.releases.create!(author: author, commit: "bar")
+        release.update_column(:number, "4.1")
+        release = project.releases.create!(commit: "foo", author: author)
+        assert_equal "4.2", release.number
+      end
+
+      it "correctly increments semantic versions" do
+        release = project.releases.create!(author: author, commit: "bar")
+        release.update_column(:number, "4.1.6")
+        release = project.releases.create!(commit: "foo", author: author)
+        assert_equal "4.1.7", release.number
+      end
     end
 
     it 'uses the specified release number' do
       release = project.releases.create!(author: author, commit: "bar", number: 1234)
-      assert_equal 1234, release.number
+      assert_equal "1234", release.number
     end
 
     it 'uses the default release number if build number is nil' do
       project.releases.destroy_all
       release = project.releases.create!(author: author, commit: "bar", number: nil)
-      assert_equal 1, release.number
+      assert_equal "1", release.number
     end
 
     it 'uses the build number if build number is not given' do
       project.releases.destroy_all
       release = project.releases.create!(author: author, commit: "bar")
-      assert_equal 1, release.number
+      assert_equal "1", release.number
     end
   end
 


### PR DESCRIPTION
We're looking to switch the Classic versioning system to Major-Minor releases to better match our actual release process.  This adds Samson support for more than just Continuous versioning.  

It's rather naive, and will just increment the last digit of any versioning system.  Examples!

`v1` -> `v2`
`v1.0` -> `v1.1`
`v1.5.7` -> `v1.5.8`

Versioning system changes, as well as any non-least-significant release will require a manual release which is already built into Samson.

/cc @zendesk/samson @zendesk/sustaining 

### Tasks
 - [ ] :+1: from team

### Risks
- Medium:  Could cause errors when tagging releases.

