### PR TITLE
use actual user for whodunnit

### DIFF
--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -29,7 +29,7 @@ module CurrentUser
 
   def login_user
     warden.authenticate || unauthorized!
-    PaperTrail.with_whodunnit(current_user.id) { yield }
+    PaperTrail.with_whodunnit_user(current_user) { yield }
   end
 
   def warden

--- a/app/controllers/oauth_test_controller.rb
+++ b/app/controllers/oauth_test_controller.rb
@@ -6,6 +6,11 @@ class OauthTestController < ActionController::Base
 
   before_action :ensure_application
 
+  # no user here ... so no tracking needed
+  skip_before_action :set_paper_trail_enabled_for_controller
+  skip_before_action :set_paper_trail_whodunnit
+  skip_before_action :set_paper_trail_controller_info
+
   def index
     redirect_to oauth_client.auth_code.authorize_url(redirect_uri: token_url)
   end

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -8,12 +8,19 @@ PaperTrail.whodunnit =
   end
 
 class << PaperTrail
-  def with_whodunnit(user)
-    old = whodunnit
-    self.whodunnit = user
+  undef_method :whodunnit= # nobody uses this directly and we should never use the default papertrail before_actions
+  attr_reader :whodunnit_user
+
+  def with_whodunnit_user(user)
+    old = @whodunnit_user
+    @whodunnit_user = user
     yield
   ensure
-    self.whodunnit = old
+    @whodunnit_user = old
+  end
+
+  def whodunnit
+    @whodunnit_user&.id
   end
 
   def with_logging

--- a/test/controllers/concerns/current_user_test.rb
+++ b/test/controllers/concerns/current_user_test.rb
@@ -9,7 +9,7 @@ class CurrentUserConcernTest < ActionController::TestCase
     include CurrentProject
 
     def whodunnit
-      render plain: PaperTrail.whodunnit.to_s.dup
+      render plain: "#{PaperTrail.whodunnit} -- #{PaperTrail.whodunnit_user.name}"
     end
 
     def change
@@ -64,11 +64,11 @@ class CurrentUserConcernTest < ActionController::TestCase
   end
 
   as_a_viewer do
-    around { |t| PaperTrail.with_whodunnit(nil, &t) }
+    around { |t| PaperTrail.with_whodunnit_user(nil, &t) }
 
     it "knows who did something" do
       get :whodunnit, params: {test_route: true}
-      response.body.must_equal users(:viewer).id.to_s
+      response.body.must_equal "#{users(:viewer).id} -- #{users(:viewer).name}"
     end
 
     it "does not assign to different users by accident" do

--- a/test/controllers/versions_controller_test.rb
+++ b/test/controllers/versions_controller_test.rb
@@ -4,8 +4,8 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe VersionsController do
-  def create_version(id)
-    PaperTrail.with_whodunnit(id) do
+  def create_version(user)
+    PaperTrail.with_whodunnit_user(user) do
       PaperTrail.with_logging do
         stage.update_attribute(:name, 'Fooo')
       end
@@ -16,7 +16,7 @@ describe VersionsController do
 
   as_a_viewer do
     describe "#index" do
-      before { create_version user.id }
+      before { create_version user }
 
       it "renders" do
         get :index, params: {item_id: stage.id, item_type: stage.class.name}
@@ -32,7 +32,7 @@ describe VersionsController do
       end
 
       it "renders with unfound user" do
-        create_version '1211212'
+        create_version(User.new { |u| u.id = 1211212 })
         get :index, params: {item_id: stage.id, item_type: stage.class.name}
         assert_template :index
       end


### PR DESCRIPTION
it's silly that we only have the id available ... might as well keep the full object to do all kinds of reporting

/cc @zendesk/samson

will make https://github.com/zendesk/samson/pull/1460 less hacky