### PR TITLE
make sure all release commits are proper shas and not refs that can c…

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -98,10 +98,7 @@ class BuildsController < ApplicationController
   def git_sha
     @git_sha ||= begin
       # Create/update local cache to avoid getting a stale reference
-      current_project.repository.exclusive(holder: 'BuildsController#create') do
-        current_project.repository.update_local_cache!
-      end
-
+      current_project.repository.exclusive(holder: 'BuildsController#create', &:update_local_cache!)
       current_project.repository.commit_from_ref(new_build_params[:git_ref])
     end
   end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -5,9 +5,10 @@ class Release < ActiveRecord::Base
   belongs_to :build # direct association is not necessary since the release commit is the same as the build sha
 
   before_validation :assign_release_number
+  before_validation :covert_ref_to_sha
 
   validates :number, format: { with: /\A\d+(.\d+)*\z/, message: "may only contain numbers and decimals." }
-  # TODO: commit must be a sha
+  validates :commit, format: { with: Build::SHA1_REGEX, message: "can only be a full sha"}, on: :create
 
   # DEFAULT_RELEASE_NUMBER is the default value assigned to release#number by the database.
   # This constant is here for convenience - the value that the database uses is in db/schema.rb.
@@ -60,5 +61,15 @@ class Release < ActiveRecord::Base
   rescue Octokit::Error => e
     Airbrake.notify(e, parameters: { github_repo: project.github_repo, commit: commit, other_commit: other_commit})
     false # Err on side of caution and cause a new release to be created.
+  end
+
+  private
+
+  def covert_ref_to_sha
+    return if commit.blank? || commit =~ Build::SHA1_REGEX
+
+    # Create/update local cache to avoid getting a stale reference
+    project.repository.exclusive(holder: 'Release#covert_ref_to_sha', &:update_local_cache!)
+    self.commit = project.repository.commit_from_ref(commit)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ project.stages.create!(
 )
 
 project.releases.create!(
-  commit: "123456",
+  commit: "1234" * 10,
   author_id: 1,
   author_type: "User"
 )

--- a/test/fixtures/releases.yml
+++ b/test/fixtures/releases.yml
@@ -1,5 +1,5 @@
 test:
   project: test
-  commit: abc
+  commit: abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd
   number: 123
   author: deployer (User)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -276,7 +276,7 @@ describe Project do
       others = [-2, -1, 1]
       others.map! do |diff|
         r = Release.create!(
-          commit: 'aba',
+          commit: 'abab' * 10,
           author: release.author,
           project: project
         )

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -7,7 +7,7 @@ describe ReleaseService do
   let(:project) { projects(:test) }
   let(:author) { users(:deployer) }
   let(:service) { ReleaseService.new(project) }
-  let(:commit) { "abcd" }
+  let(:commit) { "abcd" * 10 }
   let(:release_params_used) { [] }
 
   before do

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -138,7 +138,7 @@ describe Stage do
     let(:stage) { stages(:test_staging) }
     let(:author) { users(:deployer) }
     let(:job) { project.jobs.create!(user: author, commit: "x", command: "echo", status: "succeeded") }
-    let(:releases) { Array.new(3).map { project.releases.create!(author: author, commit: "A") } }
+    let(:releases) { Array.new(3).map { project.releases.create!(author: author, commit: "a" * 40) } }
 
     before do
       stage.deploys.create!(reference: "v124", job: job)


### PR DESCRIPTION
…hange later

followup to https://github.com/zendesk/samson/pull/1487

the 99% case is creating releases via integration controller ... and they already use shas, so making the manual creation do the same so we can do cheap compares like we do in `contains_commit?` and know what exactly was deployed even if `master` later changes

@henders @jonmoter 