### PR TITLE
remove unnecessary created_at from ordering deploys to make sql faster

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -7,7 +7,7 @@ class Deploy < ActiveRecord::Base
   belongs_to :job
   belongs_to :buddy, -> { unscope(where: "deleted_at") }, class_name: 'User'
 
-  default_scope { order(created_at: :desc, id: :desc) }
+  default_scope { order(id: :desc) }
 
   validates_presence_of :reference
   validate :validate_stage_is_unlocked, on: :create


### PR DESCRIPTION
@zendesk/samson 

we don't have an index on that ... and having group + max(id) work means we can save n+1 queries when finding last deploys for multiple stages