### PR TITLE
TOOLS-1024 automated deploys

### DIFF
--- a/app/controllers/api/automated_deploys_controller.rb
+++ b/app/controllers/api/automated_deploys_controller.rb
@@ -9,7 +9,7 @@ class Api::AutomatedDeploysController < Api::BaseController
 
   def create
     deploy_service = DeployService.new(current_user)
-    env = params.require(:env).to_unsafe_hash.map { |k, v| "export PARAM_#{k}=#{v.shellescape}" }
+    env = params.require(:env).to_unsafe_hash.map { |k, v| "export PARAM_#{k}=#{v.gsub("\n", "\\n").shellescape}" }
     env << "export DEPLOY_GROUPS=#{@deploy_group.env_value}"
 
     deploy = deploy_service.deploy!(

--- a/app/controllers/api/automated_deploys_controller.rb
+++ b/app/controllers/api/automated_deploys_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+# deploys that automatically get triggered when new hosts come up or are restarted
+class Api::AutomatedDeploysController < Api::BaseController
+  STAGE_NAME = 'Automated Deploys'
+
+  before_action :find_or_create_stage
+  before_action :find_deploy_group
+  before_action :find_last_deploy
+
+  def create
+    deploy_service = DeployService.new(current_user)
+    env = params.require(:env).to_unsafe_hash.map { |k, v| "export PARAM_#{k}=#{v.shellescape}" }
+    env << "export DEPLOY_GROUPS=#{@deploy_group.env_value}"
+
+    deploy = deploy_service.deploy!(
+      @stage,
+      reference: @last_deploy.reference,
+      buddy_id: @last_deploy.buddy_id,
+      before_command: env.join("\n") << "\n",
+      skip_deploy_group_validation: true
+    )
+
+    if deploy.persisted? # TODO: also check that the deploy is running and not waiting for buddy
+      render json: deploy.to_json, status: :created, location: [@stage.project, deploy]
+    else
+      failed! "Unable to start deploy: #{deploy.errors.full_messages}"
+    end
+  end
+
+  private
+
+  def find_or_create_stage
+    project = Project.find_by_permalink!(params.require(:project_id))
+    @stage = project.stages.where(name: STAGE_NAME).first || begin
+      unless template = project.stages.where(is_template: true).first
+        return failed! "Unable to find template for #{project.name}"
+      end
+
+      @stage = Stage.build_clone(template)
+      @stage.name = STAGE_NAME
+      @stage.dashboard = "Automatically created stage from Api::AutomatedDeploysController<br>" \
+        "that will deploy to individual deploy groups or hosts when called via api."
+      unless @stage.save
+        failed!("Unable to save stage: #{@stage.errors.full_messages}")
+      end
+      @stage
+    end
+  end
+
+  def find_deploy_group
+    @deploy_group = DeployGroup.find_by_permalink!(params.require(:deploy_group))
+  end
+
+  def find_last_deploy
+    influencing_stages = DeployGroupsStage.where(deploy_group: @deploy_group).pluck(:stage_id)
+    unless @last_deploy = Deploy.where(stage_id: influencing_stages).successful.first
+      failed!("Unable to find successful deploy for #{@stage.name}")
+    end
+  end
+
+  def failed!(message)
+    render json: {error: message}, status: :bad_request
+  end
+end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -21,6 +21,8 @@ class Deploy < ActiveRecord::Base
 
   before_validation :trim_reference
 
+  attr_accessor :skip_deploy_group_validation
+
   def cache_key
     [super, commit]
   end
@@ -181,13 +183,15 @@ class Deploy < ActiveRecord::Base
   # commands and deploy groups can change via many different paths,
   # so we validate once a user actually tries to execute the command
   def validate_stage_uses_deploy_groups_properly
-    if DeployGroup.enabled? && stage.deploy_groups.none? && stage.script.include?("$DEPLOY_GROUPS")
-      errors.add(
-        :stage,
-        "contains at least one command using the $DEPLOY_GROUPS environment variable," \
-        " but there are no Deploy Groups associated with this stage."
-      )
-    end
+    return unless DeployGroup.enabled?
+    return if skip_deploy_group_validation
+    return if stage.deploy_groups.any?
+    return unless stage.script.include?("$DEPLOY_GROUPS")
+    errors.add(
+      :stage,
+      "contains at least one command using the $DEPLOY_GROUPS environment variable," \
+      " but there are no Deploy Groups associated with this stage."
+    )
   end
 
   def deploy_buddy

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -83,8 +83,10 @@ class Stage < ActiveRecord::Base
   end
 
   def create_deploy(user, attributes = {})
+    before_command = attributes.delete(:before_command)
     deploys.create(attributes.merge(release: !no_code_deployed, project: project)) do |deploy|
-      deploy.build_job(project: project, user: user, command: script, commit: deploy.reference)
+      commands = before_command.to_s.dup << script
+      deploy.build_job(project: project, user: user, command: commands, commit: deploy.reference)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,4 +26,4 @@ en:
       help:
         # Ideally make dynamic https://github.com/doorkeeper-gem/doorkeeper/issues/896
         # and enforce inclusion ... for now keep in sync with api controllers
-        scopes: "Separate scopes with spaces. Possible: deploy_groups, deploys, locks, projects, stages, default (everything)"
+        scopes: "Separate scopes with spaces. Possible: automated_deploys, deploy_groups, deploys, locks, projects, stages, default (everything)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Samson::Application.routes.draw do
       end
 
       resources :deploys, only: [:index]
+
+      resources :automated_deploys, only: [:create]
     end
 
     resources :stages, only: [] do

--- a/test/controllers/api/automated_deploys_controller_test.rb
+++ b/test/controllers/api/automated_deploys_controller_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Api::AutomatedDeploysController do
+  def post_create
+    post :create, params: {project_id: :foo, deploy_group: 'pod100', env: {'FOO' => 'bar'}}, format: :json
+  end
+
+  before do
+    # trigger deploy validation error we saw in staging ... validate_stage_uses_deploy_groups_properly
+    # we set $DEPLOY_GROUPS via before_command but do not select any deploy group
+    DeployGroup.stubs(enabled?: true)
+    commands(:echo).update_column(:command, 'cap $DEPLOY_GROUPS deploy')
+  end
+
+  oauth_setup!
+
+  describe "#create" do
+    let(:template) { stages(:test_staging) }
+    let(:copied_deploy) { deploys(:failed_staging_test) }
+
+    before do
+      copied_deploy.update_column(:buddy_id, users(:admin).id) # buddy so we can test for it
+      Job.update_all(status: 'succeeded') # multiple deploys so we know ordering works
+    end
+
+    it "creates a new stage and deploys" do
+      assert_difference 'Stage.count', +1 do
+        assert_difference 'Deploy.count', +1 do
+          post_create
+          assert_response :created
+        end
+      end
+
+      # copies over the buddy id and uses current user as use
+      Deploy.first.user.must_equal user
+      Deploy.first.buddy_id.must_equal copied_deploy.buddy_id
+    end
+
+    it "reuses an existing stage and deploys" do
+      template.update_column(:name, Api::AutomatedDeploysController::STAGE_NAME)
+
+      refute_difference 'Stage.count' do
+        assert_difference 'Deploy.count', +1 do
+          post_create
+          assert_response :created
+        end
+      end
+    end
+
+    it "fails when no template was found" do
+      template.update_column(:is_template, false)
+      post_create
+      assert_response :bad_request
+      response.body.must_equal "{\"error\":\"Unable to find template for Project\"}"
+    end
+
+    it "fails when new stage could not be saved" do
+      Stage.any_instance.expects(:valid?).returns(false)
+      post_create
+      assert_response :bad_request
+      response.body.must_equal "{\"error\":\"Unable to save stage: []\"}"
+    end
+
+    it "fails when no deploy could be found" do
+      Job.update_all(status: 'cancelled')
+      post_create
+      assert_response :bad_request
+      response.body.must_equal "{\"error\":\"Unable to find successful deploy for Automated Deploys\"}"
+    end
+
+    it "fails when deploy could not be started" do
+      Deploy.any_instance.expects(:valid?).returns(false) # validation fails
+      post_create
+      assert_response :bad_request
+      response.body.must_equal "{\"error\":\"Unable to start deploy: []\"}"
+    end
+  end
+end

--- a/test/controllers/api/automated_deploys_controller_test.rb
+++ b/test/controllers/api/automated_deploys_controller_test.rb
@@ -5,7 +5,7 @@ SingleCov.covered!
 
 describe Api::AutomatedDeploysController do
   def post_create
-    post :create, params: {project_id: :foo, deploy_group: 'pod100', env: {'FOO' => 'bar'}}, format: :json
+    post :create, params: {project_id: :foo, deploy_group: 'pod100', env: {'FOO' => "bar\nba$"}}, format: :json
   end
 
   before do
@@ -37,6 +37,9 @@ describe Api::AutomatedDeploysController do
       # copies over the buddy id and uses current user as use
       Deploy.first.user.must_equal user
       Deploy.first.buddy_id.must_equal copied_deploy.buddy_id
+
+      # env vars are correctly encoded
+      Job.last.command.must_include "export PARAM_FOO=bar\\\\nba\\$\n"
     end
 
     it "reuses an existing stage and deploys" do


### PR DESCRIPTION
@ubootda @jonmoter @bcolferzd 

https://zendesk.atlassian.net/browse/TOOLS-1024

a rough draft of what I think it should look like ... just wanted to type it all out to not forget the corner cases ... please let me know what you think / if thats the right place to put it

```
curl -X POST -H 'Authorization: Bearer TOKEN-GOES-HERE' 'http://localhost:3000/api/projects/kube_translation_daemon/automated_deploys.json?deploy_group=pod1&env[host]=app1.foo.bar'
{"id":12,"stage_id":5,"job_id":13,"reference":"master","created_at":"2016-11-22T00:26:44.000Z","updated_at":"2016-11-22T00:26:44.000Z","buddy_id":null,"started_at":null,"deleted_at":null,"build_id":null,"release":true,"kubernetes":true}
```

```
curl -X POST -H 'Authorization: Bearer INSERT_TOKEN_HERE' 'https://samsontest.zende.sk/api/projects/rosetta/automated_deploys.json?deploy_group=pod99&env%5BHOST%5D=app1.foo.bar'
{"id":4002,"stage_id":240,"job_id":4521,"reference":"master","created_at":"2016-12-01T20:32:24.000Z","updated_at":"2016-12-01T20:32:24.000Z","buddy_id":null,"started_at":null,"deleted_at":null,"build_id":null,"release":true,"kubernetes":false,"project_id":95}

...

» cd /data/samson/tmp/samson-rosetta-452120161201-2417-137es6p
» export PARAM_HOST=app1.foo.bar
» export DEPLOY_GROUPS=master99
```

this will not be able to be re-deployed ... but fail nicely when it is done

TODO:
 - [x] tests
 - [ ] check with compliance
 - [x] try on staging