### PR TITLE
add ecr seed button to kubernetes cluster

### DIFF
--- a/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
+++ b/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
@@ -31,8 +31,14 @@ module SamsonAwsEcr
           ENV['DOCKER_REGISTRY_USER'] = user
           ENV['DOCKER_REGISTRY_PASS'] = pass
         end
+
+        [ENV['DOCKER_REGISTRY_USER'], ENV['DOCKER_REGISTRY_PASS']]
       rescue Aws::ECR::Errors::InvalidSignatureException
         raise Samson::Hooks::UserError, "Invalid AWS credentials"
+      end
+
+      def active?
+        !!ecr_client
       end
 
       private

--- a/plugins/kubernetes/app/views/admin/kubernetes/clusters/edit.html.erb
+++ b/plugins/kubernetes/app/views/admin/kubernetes/clusters/edit.html.erb
@@ -21,7 +21,11 @@
           help: "First 1 to 3 sections of an IPv4 address to replace Service clusterIP, for example 123.231"
       %>
 
-      <%= form.actions %>
+      <%= form.actions do %>
+        <% if Samson::Hooks.active_plugin?('aws_ecr') && SamsonAwsEcr::Engine.active? %>
+          <%= link_to "Seed ECR", seed_ecr_admin_kubernetes_cluster_path(@cluster), class: "btn btn-default", data: {method: :post} %>
+        <% end %>
+      <% end %>
     </fieldset>
   <% end %>
 </section>

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -18,7 +18,11 @@ Samson::Application.routes.draw do
 
   namespace :admin do
     namespace :kubernetes do
-      resources :clusters, except: :destroy
+      resources :clusters, except: :destroy do
+        member do
+          post :seed_ecr
+        end
+      end
       resources :deploy_group_roles do
         collection do
           post :seed


### PR DESCRIPTION
@irwaters @jonmoter 

<img width="542" alt="screen shot 2016-11-22 at 6 27 44 pm" src="https://cloud.githubusercontent.com/assets/11367/20550204/28053634-b0e8-11e6-9231-ed1651eb6ade.png">
<img width="289" alt="screen shot 2016-11-22 at 7 16 06 pm" src="https://cloud.githubusercontent.com/assets/11367/20550206/2a130bea-b0e8-11e6-9483-43af170ae667.png">

adding created to annotations or otherwise it breaks the request for not being base64 encoded
tested on sandbox cluster ... master/staging did not work ...