### PR TITLE
SAMSON-312 allow creating releases manually

### DIFF
--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -4,11 +4,17 @@
 
 <% cache [@project, @releases.current_page, deployer_for_project?] do %>
   <section class="clearfix tabs">
-    <% if @releases.any? %>
-      <p class="pull-right">
-        <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
-      </p>
+    <p class="pull-right">
+      <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
+    </p>
 
+    <% if @project.release_branch.blank? %>
+      <div class="alert alert-warning">
+        <p>Configure a <%= link_to "release branch", edit_project_path(@project, anchor: "project_release_branch") %> to automatically create releases whenever a branch is pushed to.</p>
+      </div>
+    <% end %>
+
+    <% if @releases.any? %>
       <table class="table table-hover release-list">
         <thead>
           <tr>
@@ -25,11 +31,7 @@
       </table>
 
       <%= paginate @releases %>
-    <% elsif @project.release_branch.blank? %>
-      <div class="alert alert-warning">
-        <p>Configure a <%= link_to "release branch", edit_project_path(@project, anchor: "project_release_branch") %> to automatically create releases whenever a branch is pushed to.</p>
-      </div>
-    <% else %>
+    <% elsif @project.release_branch.present? %>
       <div class="alert alert-warning">
         <p>No release created from release branch <%= @project.release_branch %>.</p>
         <p>Add a webhook to samson from your CI to trigger releases on green builds or from your Code hoster to get releases on merge.</p>


### PR DESCRIPTION
@jonmoter 

always allowed to create manually:
<img width="1207" alt="screen shot 2016-11-23 at 6 03 44 pm" src="https://cloud.githubusercontent.com/assets/11367/20584451/7be59e1e-b1a7-11e6-9112-61f3a47260df.png">

still shows warning when branch is not set:
<img width="1176" alt="screen shot 2016-11-23 at 6 05 15 pm" src="https://cloud.githubusercontent.com/assets/11367/20584452/7e35ba32-b1a7-11e6-9d17-1427694b6b3e.png">
