### PR TITLE
do not re-fetch events after we declared failure to preserve whatever caused the failure

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -11,7 +11,7 @@ module Kubernetes
     # TODO: this logic might be able to go directly into Pod, which would simplify the code here a bit
     class ReleaseStatus
       attr_reader :live, :stop, :details, :pod, :role, :group
-      def initialize(live: true, stop: false, details:, pod:, role:, group:)
+      def initialize(stop: false, live:, details:, pod:, role:, group:)
         @live = live
         @stop = stop
         @details = details
@@ -199,7 +199,7 @@ module Kubernetes
           if pod.restarted?
             {live: false, stop: true, details: "Restarted", pod: pod}
           else
-            {details: "Live", pod: pod}
+            {live: true, details: "Live", pod: pod}
           end
         elsif pod.unschedulable?
           {live: false, stop: true, details: "Unschedulable", pod: pod}

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -384,7 +384,7 @@ describe Kubernetes::DeployExecutor do
 
     it "stops when detecting a failure via events" do
       pod_status[:phase] = "Pending"
-      stub_request(:get, %r{http://foobar.server/api/v1/namespaces/staging/events}).
+      request = stub_request(:get, %r{http://foobar.server/api/v1/namespaces/staging/events}).
         to_return(
           body: {
             items: [
@@ -401,6 +401,8 @@ describe Kubernetes::DeployExecutor do
 
       out.must_include "resque-worker: Unschedulable\n"
       out.must_include "UNSTABLE"
+
+      assert_requested request, times: 5 # fetches pod events once and once for 4 different resources
     end
 
     it "stops when taking too long to go live" do


### PR DESCRIPTION
we saw a failure and no events that caused it ... this might be the cause, but even if it is not it gives us a bit more sanity

before we stopped 1 iteration earlier, but then did the pod_status call either way ... so this won't take extra time and print the same result if the user clicks stop during deployment

@jonmoter 