### PR TITLE
allow me to cancel pending deploys even when job execution is disable…

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -33,7 +33,7 @@ module DeploysHelper
     output << render('shared/output', deployable: @deploy, job: @deploy.job, project: @project, hide: output_hidden)
   end
 
-  def deploy_running?
+  def deploy_executing?
     @deploy.active? && JobExecution.active?(@deploy.job_id, key: @deploy.stage_id)
   end
 

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -16,7 +16,7 @@
   </div>
 </h1>
 
-<% if @deploy.finished? || deploy_running? || JobExecution.enabled %>
+<% if @deploy.finished? || deploy_executing? || JobExecution.enabled %>
   <%= status_panel @deploy %>
   <%= Samson::Hooks.render_views(:deploys_header, self) %>
 <% else %>

--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -37,9 +37,9 @@
   </div>
 </section>
 
-<% if (@deploy.active? && JobExecution.enabled) || deploy_running? %>
-  <%= javascript_tag do %>
+<% if @deploy.active? %>
+  <script>
     toggleOutputToolbar();
     startStream();
-  <% end %>
+  </script>
 <% end %>


### PR DESCRIPTION
…d because samson is restarting

mainly because we somehow have a few jobs alwys hanging around that are pending and also have a pid
weird edge case during restarts, so the extra streaming overhead should be unnoticable ...

also renaming deploy_running since it implies 'state == running' ... but it is checking something different

@jonmoter @sandlerr 