### PR TITLE
move job execution key logic from deploy service to deploy

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -34,11 +34,11 @@ module DeploysHelper
   end
 
   def deploy_executing?
-    @deploy.active? && JobExecution.active?(@deploy.job_id, key: @deploy.stage_id)
+    @deploy.active? && JobExecution.active?(@deploy.job_id, key: @deploy.job_execution_key)
   end
 
   def deploy_queued?
-    @deploy.pending? && JobExecution.queued?(@deploy.job_id, key: @deploy.stage_id)
+    @deploy.pending? && JobExecution.queued?(@deploy.job_id, key: @deploy.job_execution_key)
   end
 
   def deploy_page_title

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -25,6 +25,11 @@ class Deploy < ActiveRecord::Base
     [super, commit]
   end
 
+  def job_execution_key
+    # if stage can run in parallel - set key to a unique id so it can immediately execute
+    stage.run_in_parallel ? "deploy-#{id}" : "stage-#{stage.id}"
+  end
+
   def summary
     "#{job.user.name} #{deploy_buddy} #{summary_action} #{short_reference} to #{stage.name}"
   end

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -31,9 +31,7 @@ class DeployService
       send_after_notifications(deploy)
     end
 
-    # if stage can run in parallel - set key to a unique id so it can immediately execute
-    key = stage.run_in_parallel ? "deploy-#{deploy.id}" : "stage-#{stage.id}"
-    JobExecution.start_job(job_execution, key: key)
+    JobExecution.start_job(job_execution, key: deploy.job_execution_key)
 
     send_sse_deploy_update('start', deploy)
   end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -86,6 +86,22 @@ describe Deploy do
     end
   end
 
+  describe "#job_execution_key" do
+    describe "stage can run in parallel" do
+      before { stage.update_attributes(run_in_parallel: true) }
+      it "keys on deploy id to run immediately" do
+        deploy.job_execution_key.must_equal "deploy-#{deploy.id}"
+      end
+    end
+
+    describe "stage cannot run in parallel" do
+      before { stage.update_attributes(run_in_parallel: false) }
+      it "keys on its stage id" do
+        deploy.job_execution_key.must_equal "stage-#{stage.id}"
+      end
+    end
+  end
+
   describe "#commit" do
     before { deploy.job.commit = 'abcdef' }
 


### PR DESCRIPTION
Previously the job execution key for deploys logic was in the deploy service. However - the same key needs to be available to check if the deploy is running, queued, etc.


/cc @zendesk/samson @sandlerr 

### Tasks
 - [x] :+1: from team

### References
 - Jira link:

### Risks
- Level: Med. Touches deploys and could break deploy notifications
