### PR TITLE
fail visibly when we somehow did not find a child process

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -69,9 +69,15 @@ class TerminalExecutor
       nil # output was closed ... only happens on linux
     end
 
-    _pid, status = Process.wait2(@pid)
-    input.close
-    status.success?
+    begin
+      _pid, status = Process.wait2(@pid)
+      status.success?
+    rescue Errno::ECHILD
+      @output.puts "#{$!.class}: #{$!.message}"
+      false
+    ensure
+      input.close
+    end
   end
 
   # We need the group pid to cleanly shut down all children

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -36,6 +36,13 @@ describe TerminalExecutor do
       subject.execute!('echo "hi"').must_equal(true)
     end
 
+    it 'shows a nice message when child could not be found' do
+      Process.expects(:wait2).raises(Errno::ECHILD) # No child processes found
+      subject.execute!('blah').must_equal(false)
+      out = output.string.sub(/.*blah: /, '').sub('command ', '') # linux has a different message
+      out.must_equal "not found\r\nErrno::ECHILD: No child processes\n"
+    end
+
     it 'does not expose env secrets' do
       with_env MY_SECRET: 'XYZ' do
         subject.execute!('env')


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/1810464541470303966

atm we just crash, which is not good ...
no idea how to reproduce this, but maybe we are able to find it once it shows up in logs
also making sure input is always getting closed

@jonmoter  @sandlerr 