### PR TITLE
simplify and dry up job execution logic and queing

### DIFF
--- a/app/controllers/api/automated_deploys_controller.rb
+++ b/app/controllers/api/automated_deploys_controller.rb
@@ -20,7 +20,7 @@ class Api::AutomatedDeploysController < Api::BaseController
       skip_deploy_group_validation: true
     )
 
-    if deploy.persisted? # TODO: also check that the deploy is running and not waiting for buddy
+    if deploy.persisted?
       render json: deploy.to_json, status: :created, location: [@stage.project, deploy]
     else
       failed! "Unable to start deploy: #{deploy.errors.full_messages}"

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -33,12 +33,8 @@ module DeploysHelper
     output << render('shared/output', deployable: @deploy, job: @deploy.job, project: @project, hide: output_hidden)
   end
 
-  def deploy_executing?
-    @deploy.active? && JobExecution.active?(@deploy.job_id, key: @deploy.job_execution_key)
-  end
-
   def deploy_queued?
-    @deploy.pending? && JobExecution.queued?(@deploy.job_id, key: @deploy.job_execution_key)
+    @deploy.pending? && JobExecution.queued?(@deploy.job_id)
   end
 
   def deploy_page_title

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -27,9 +27,9 @@ class Deploy < ActiveRecord::Base
     [super, commit]
   end
 
-  def job_execution_key
-    # if stage can run in parallel - set key to a unique id so it can immediately execute
-    stage.run_in_parallel ? "deploy-#{id}" : "stage-#{stage.id}"
+  # queue deploys on stages that cannot execute in parallel
+  def job_execution_queue_name
+    "stage-#{stage.id}" unless stage.run_in_parallel
   end
 
   def summary

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -31,7 +31,7 @@ class DeployService
       send_after_notifications(deploy)
     end
 
-    JobExecution.start_job(job_execution, key: deploy.job_execution_key)
+    JobExecution.start_job(job_execution, queue: deploy.job_execution_queue_name)
 
     send_sse_deploy_update('start', deploy)
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -98,6 +98,10 @@ class Job < ActiveRecord::Base
     ACTIVE_STATUSES.include?(status)
   end
 
+  def waiting_for_restart?
+    !JobExecution.enabled && !finished? && !active? && !JobExecution.active?(id)
+  end
+
   def output
     super || ""
   end

--- a/app/models/restart_signal_handler.rb
+++ b/app/models/restart_signal_handler.rb
@@ -41,7 +41,7 @@ class RestartSignalHandler
       sleep(5)
     end
 
-    JobExecution.clear_registry
+    JobExecution.clear_queue
 
     output 'Passing SIGUSR2 on.'
 

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -16,15 +16,9 @@
   </div>
 </h1>
 
-<% if @deploy.finished? || deploy_executing? || JobExecution.enabled %>
+<% if @deploy.job.waiting_for_restart? %>
+  <%= render 'jobs/restarting' %>
+<% else %>
   <%= status_panel @deploy %>
   <%= Samson::Hooks.render_views(:deploys_header, self) %>
-<% else %>
-  <div class="alert alert-info">
-    Samson is currently restarting, your deploy has been queued and will be resumed shortly.
-  </div>
-
-  <%= javascript_tag do %>
-    waitUntilEnabled("<%= enabled_jobs_path %>");
-  <% end %>
 <% end %>

--- a/app/views/jobs/_restarting.html.erb
+++ b/app/views/jobs/_restarting.html.erb
@@ -1,0 +1,7 @@
+<div class="alert alert-info">
+  Samson is currently restarting, your deploy has been queued and will be resumed shortly.
+</div>
+
+<%= javascript_tag do %>
+  waitUntilEnabled("<%= enabled_jobs_path %>");
+<% end %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -11,16 +11,10 @@
 </h1>
 
 <div id="header">
-  <% if @job.finished? || @job.running? || JobExecution.enabled %>
-    <%= render 'header' %>
+  <% if @job.waiting_for_restart? %>
+    <%= render 'jobs/restarting' %>
   <% else %>
-    <div class="alert alert-info">
-      Samson is currently restarting, your job has been queued and will be resumed shortly.
-    </div>
-
-    <%= javascript_tag do %>
-      waitUntilEnabled("<%= enabled_jobs_path %>");
-    <% end %>
+    <%= render 'header' %>
   <% end %>
 </div>
 

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -119,7 +119,7 @@ describe DeployService do
       it "immediately starts the job" do
         job_execution
         JobExecution.stubs(:new).returns(job_execution)
-        JobExecution.expects(:start_job).with(job_execution, key: "deploy-#{deploy.id}")
+        JobExecution.expects(:start_job).with(job_execution, queue: nil)
         deploy.buddy = user
         service.confirm_deploy!(deploy)
       end
@@ -129,7 +129,7 @@ describe DeployService do
       it "will be queued on the stage id" do
         job_execution
         JobExecution.stubs(:new).returns(job_execution)
-        JobExecution.expects(:start_job).with(job_execution, key: "stage-#{stage.id}")
+        JobExecution.expects(:start_job).with(job_execution, queue: "stage-#{stage.id}")
         deploy.buddy = user
         service.confirm_deploy!(deploy)
       end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -86,19 +86,14 @@ describe Deploy do
     end
   end
 
-  describe "#job_execution_key" do
-    describe "stage can run in parallel" do
-      before { stage.update_attributes(run_in_parallel: true) }
-      it "keys on deploy id to run immediately" do
-        deploy.job_execution_key.must_equal "deploy-#{deploy.id}"
-      end
+  describe "#job_execution_queue_name" do
+    it "queues base on it's stage when it cannot execute in parallel" do
+      deploy.job_execution_queue_name.must_equal "stage-#{stage.id}"
     end
 
-    describe "stage cannot run in parallel" do
-      before { stage.update_attributes(run_in_parallel: false) }
-      it "keys on its stage id" do
-        deploy.job_execution_key.must_equal "stage-#{stage.id}"
-      end
+    it "does not queue when it can execute in parallel" do
+      deploy.stage.run_in_parallel = true
+      deploy.job_execution_queue_name.must_equal nil
     end
   end
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -18,6 +18,8 @@ describe JobExecution do
   let(:execution) { JobExecution.new('master', job) }
   let(:deploy) { Deploy.create!(stage: stage, job: job, reference: 'master', project: project) }
 
+  with_job_execution
+
   before do
     Project.any_instance.stubs(:valid_repository_url).returns(true)
     create_repo_with_tags('v1')
@@ -25,15 +27,12 @@ describe JobExecution do
     user.email = 'jdoe@test.com'
     project.repository.update_local_cache!
     job.deploy = deploy
-    JobExecution.enabled = true
-    JobExecution.clear_queue
   end
 
   after do
     FileUtils.rm_rf(repo_temp_dir)
     FileUtils.rm_rf(repo_dir)
     project.repository.clean!
-    JobExecution.enabled = false
   end
 
   it "clones the project's repository if it's not already cloned" do

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -26,7 +26,7 @@ describe JobExecution do
     project.repository.update_local_cache!
     job.deploy = deploy
     JobExecution.enabled = true
-    JobExecution.clear_registry
+    JobExecution.clear_queue
   end
 
   after do
@@ -168,7 +168,7 @@ describe JobExecution do
     assert_equal 'hello', last_line_of_output
   end
 
-  it 'removes the job from the registry' do
+  it 'removes the job from the queue' do
     execution = JobExecution.start_job(JobExecution.new('master', job))
 
     JobExecution.find_by_id(job.id).wont_be_nil
@@ -242,15 +242,15 @@ describe JobExecution do
     assert_equal 'MY-SECRET', last_line_of_output
   end
 
-  it 'does not add the job to the registry when JobExecution is disabled' do
+  it 'does not add the job to the queue when JobExecution is disabled' do
     JobExecution.enabled = false
 
     job_execution = JobExecution.start_job(JobExecution.new('master', job))
     job_execution.wont_be_nil
 
-    JobExecution.find_by_id(job.id).must_equal(job_execution)
-    JobExecution.queued?(job.id).must_equal(false)
-    JobExecution.active?(job.id).must_equal(false)
+    JobExecution.find_by_id(job.id).must_equal(nil)
+    JobExecution.queued?(job.id).must_equal(nil)
+    JobExecution.active?(job.id).must_equal(nil)
   end
 
   it 'can run with a block' do

--- a/test/models/job_queue_test.rb
+++ b/test/models/job_queue_test.rb
@@ -23,23 +23,20 @@ describe JobQueue do
   def with_active_job
     job_execution.expects(:start!)
 
-    enable_job_execution { subject.add(job_execution) }
+    with_job_execution do
+      subject.add(job_execution)
+      yield
+    end
   end
 
   def with_a_queued_job
     job_execution.stubs(:start!)
 
-    enable_job_execution do
+    with_job_execution do
       subject.add(job_execution, queue: :x)
       subject.add(queued_job_execution, queue: :x)
+      yield
     end
-  end
-
-  def enable_job_execution
-    JobExecution.enabled = true
-    yield
-  ensure
-    JobExecution.enabled = false
   end
 
   let(:subject) { JobQueue.new }
@@ -52,25 +49,25 @@ describe JobQueue do
 
   describe "#add" do
     it 'immediately starts a job when active is empty' do
-      with_active_job
-      assert subject.active?(1)
-      refute subject.queued?(1)
-      subject.find_by_id(1).must_equal(job_execution)
+      with_active_job do
+        assert subject.active?(1)
+        refute subject.queued?(1)
+        subject.find_by_id(1).must_equal(job_execution)
+      end
     end
 
     it 'starts parallel jobs when they are in different queues' do
       [job_execution, queued_job_execution].each do |job|
         job.expects(:start!)
 
-        enable_job_execution do
-          subject.add(job)
-        end
+        with_job_execution { subject.add(job) }
 
         assert subject.active?(job.id)
       end
     end
 
     it 'does not start a job if job execution is disabled' do
+      JobExecution.enabled = false
       job_execution.expects(:start!).never
 
       subject.add(job_execution)
@@ -81,17 +78,18 @@ describe JobQueue do
     end
 
     it 'does not queue a job if job execution is disabled' do
-      with_active_job
+      with_active_job do
+        JobExecution.enabled = false
+        subject.add(queued_job_execution, queue: :x)
 
-      subject.add(queued_job_execution, queue: :x)
-
-      refute subject.active?(2)
-      refute subject.queued?(2)
-      refute subject.find_by_id(2)
+        refute subject.active?(2)
+        refute subject.queued?(2)
+        refute subject.find_by_id(2)
+      end
     end
 
     describe 'with queued job' do
-      before { with_a_queued_job }
+      around { |t| with_a_queued_job(&t) }
 
       it 'has a queued job' do
         refute subject.active?(2)
@@ -102,7 +100,7 @@ describe JobQueue do
       it 'starts then next job when active job completes' do
         queued_job_execution.expects(:start!)
 
-        enable_job_execution { job_execution.finish }
+        with_job_execution { job_execution.finish }
 
         refute subject.find_by_id(1)
         assert subject.active?(2)
@@ -110,6 +108,7 @@ describe JobQueue do
       end
 
       it 'does not start the next job when job execution is disabled' do
+        JobExecution.enabled = false
         queued_job_execution.expects(:start!).never
 
         job_execution.finish
@@ -122,7 +121,7 @@ describe JobQueue do
       it 'does not start the next job when queue is empty' do
         queued_job_execution.expects(:start!)
 
-        enable_job_execution do
+        with_job_execution do
           job_execution.finish
           queued_job_execution.finish
         end
@@ -139,16 +138,18 @@ describe JobQueue do
 
   describe "#clear" do
     it "removes all queues" do
-      with_a_queued_job
-      queued_job_execution.expects(:close)
-      subject.clear
-      refute subject.queued?(queued_job_execution)
+      with_a_queued_job do
+        queued_job_execution.expects(:close)
+        subject.clear
+        refute subject.queued?(queued_job_execution)
+      end
     end
 
     it "keeps active since they will complete on their own" do
-      with_active_job
-      subject.clear
-      assert subject.active?(1)
+      with_active_job do
+        subject.clear
+        assert subject.active?(1)
+      end
     end
   end
 end

--- a/test/models/job_queue_test.rb
+++ b/test/models/job_queue_test.rb
@@ -1,9 +1,40 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 7
+SingleCov.covered!
 
 describe JobQueue do
+  # JobExecution is very complicated ... so we stub it out
+  fake_execution = Class.new do
+    attr_reader :id
+    def initialize(id)
+      @id = id
+    end
+
+    def on_complete(&block)
+      @on_complete = block
+    end
+
+    def finish
+      @on_complete.call
+    end
+  end
+
+  def with_active_job
+    job_execution.expects(:start!)
+
+    enable_job_execution { subject.add(job_execution) }
+  end
+
+  def with_a_queued_job
+    job_execution.stubs(:start!)
+
+    enable_job_execution do
+      subject.add(job_execution, queue: :x)
+      subject.add(queued_job_execution, queue: :x)
+    end
+  end
+
   def enable_job_execution
     JobExecution.enabled = true
     yield
@@ -12,117 +43,112 @@ describe JobQueue do
   end
 
   let(:subject) { JobQueue.new }
-  let(:job_execution) { stub(id: 1, on_complete: nil) }
-  let(:queued_job_execution) { stub(id: 2, on_complete: nil) }
+  let(:job_execution) { fake_execution.new(1) }
+  let(:queued_job_execution) { fake_execution.new(2) }
 
   before do
     JobExecution.stubs(:new).returns(job_execution).returns(queued_job_execution)
   end
 
-  it 'immediately starts a job when active is empty' do
-    job_execution.expects(:start!)
-
-    enable_job_execution do
-      subject.add(:x, job_execution)
+  describe "#add" do
+    it 'immediately starts a job when active is empty' do
+      with_active_job
+      assert subject.active?(1)
+      refute subject.queued?(1)
+      subject.find_by_id(1).must_equal(job_execution)
     end
 
-    subject.active?(:x, 1).must_equal(true)
-    subject.queued?(:x, 1).must_equal(false)
-    subject.find(1).must_equal(job_execution)
-  end
+    it 'starts parallel jobs when they are in different queues' do
+      [job_execution, queued_job_execution].each do |job|
+        job.expects(:start!)
 
-  it 'queues a job if there is already an active one' do
-    job_execution.stubs(:start!)
+        enable_job_execution do
+          subject.add(job)
+        end
 
-    enable_job_execution do
-      subject.add(:x, job_execution)
-    end
-
-    queued_job_execution.expects(:start!).never
-
-    enable_job_execution do
-      subject.add(:x, queued_job_execution)
-    end
-
-    subject.active?(:x, 2).must_equal(false)
-    subject.queued?(:x, 2).must_equal(true)
-    subject.find(2).must_equal(queued_job_execution)
-  end
-
-  it 'starts two different queues' do
-    job_execution.expects(:start!)
-
-    enable_job_execution do
-      subject.add(:x, job_execution)
-    end
-
-    subject.active?(:x, 1).must_equal(true)
-
-    queued_job_execution.expects(:start!)
-
-    enable_job_execution do
-      subject.add(:y, queued_job_execution)
-    end
-
-    subject.active?(:y, 2).must_equal(true)
-  end
-
-  it 'does not queue a job if job execution is disabled' do
-    job_execution.expects(:start!).never
-
-    subject.add(:x, job_execution)
-
-    subject.active?(:x, 1).must_equal(false)
-    subject.queued?(:x, 1).must_equal(false)
-    subject.find(1).must_equal(job_execution)
-  end
-
-  describe 'with a queue' do
-    before do
-      job_execution.stubs(:start!)
-
-      enable_job_execution do
-        subject.add(:x, job_execution)
-        subject.add(:x, queued_job_execution)
+        assert subject.active?(job.id)
       end
     end
 
-    it 'activates the first execution' do
-      subject.active?(:x, 1).must_equal(true)
+    it 'does not start a job if job execution is disabled' do
+      job_execution.expects(:start!).never
+
+      subject.add(job_execution)
+
+      refute subject.active?(1)
+      refute subject.queued?(1)
+      refute subject.find_by_id(1)
     end
 
-    it 'starts a job when popping the active queue' do
-      queued_job_execution.expects(:start!)
+    it 'does not queue a job if job execution is disabled' do
+      with_active_job
 
-      enable_job_execution do
-        subject.pop(:x, job_execution)
+      subject.add(queued_job_execution, queue: :x)
+
+      refute subject.active?(2)
+      refute subject.queued?(2)
+      refute subject.find_by_id(2)
+    end
+
+    describe 'with queued job' do
+      before { with_a_queued_job }
+
+      it 'has a queued job' do
+        refute subject.active?(2)
+        assert subject.queued?(2)
+        subject.find_by_id(2).must_equal(queued_job_execution)
       end
 
-      subject.find(1).must_equal(nil)
-      subject.active?(:x, 2).must_equal(true)
-      subject.queued?(:x, 2).must_equal(false)
+      it 'starts then next job when active job completes' do
+        queued_job_execution.expects(:start!)
+
+        enable_job_execution { job_execution.finish }
+
+        refute subject.find_by_id(1)
+        assert subject.active?(2)
+        refute subject.queued?(2)
+      end
+
+      it 'does not start the next job when job execution is disabled' do
+        queued_job_execution.expects(:start!).never
+
+        job_execution.finish
+
+        refute subject.find_by_id(1)
+        refute subject.active?(2)
+        assert subject.queued?(2)
+      end
+
+      it 'does not start the next job when queue is empty' do
+        queued_job_execution.expects(:start!)
+
+        enable_job_execution do
+          job_execution.finish
+          queued_job_execution.finish
+        end
+
+        refute subject.find_by_id(1)
+        refute subject.find_by_id(2)
+
+        # make sure we cleaned up nicely
+        subject.instance_variable_get(:@active).must_equal({})
+        subject.instance_variable_get(:@queue).must_equal({})
+      end
+    end
+  end
+
+  describe "#clear" do
+    it "removes all queues" do
+      with_a_queued_job
+      queued_job_execution.expects(:close)
+      subject.clear
+      refute subject.queued?(queued_job_execution)
     end
 
-    it 'does not start a job when job execution is disabled' do
-      queued_job_execution.expects(:start!).never
-
-      subject.pop(:x, job_execution)
-
-      subject.find(1).must_equal(nil)
-      subject.active?(:x, 2).must_equal(false)
-      subject.queued?(:x, 2).must_equal(true)
-    end
-
-    it 'pops the queued job execution off the stack' do
-      queued_job_execution.expects(:start!).never
-
-      subject.pop(:x, queued_job_execution)
-
-      subject.find(1).must_equal(job_execution)
-      subject.active?(:x, 1).must_equal(true)
-
-      subject.find(2).must_equal(nil)
-      subject.queued?(:x, 2).must_equal(false)
+    it "keeps active since they will complete on their own" do
+      with_active_job
+      subject.clear
+      assert subject.active?(1)
     end
   end
 end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -34,17 +34,9 @@ describe Job do
   end
 
   describe "#pid" do
-    around do |test|
-      begin
-        JobExecution.enabled = true
-        test.call
-      ensure
-        JobExecution.enabled = false
-      end
-    end
+    with_job_execution
 
     before do
-      JobExecution.enabled = true
       job_execution = JobExecution.new('master', job)
       job_execution.expects(:start!)
       JobExecution.start_job(job_execution)

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -34,8 +34,20 @@ describe Job do
   end
 
   describe "#pid" do
+    around do |test|
+      begin
+        JobExecution.enabled = true
+        test.call
+      ensure
+        JobExecution.enabled = false
+      end
+    end
+
     before do
-      JobExecution.start_job(JobExecution.new('master', job))
+      JobExecution.enabled = true
+      job_execution = JobExecution.new('master', job)
+      job_execution.expects(:start!)
+      JobExecution.start_job(job_execution)
       JobExecution.any_instance.stubs(:pid).returns(1234)
     end
 

--- a/test/models/multi_lock_test.rb
+++ b/test/models/multi_lock_test.rb
@@ -9,6 +9,8 @@ describe MultiLock do
     MultiLock.send(:unlock, 2)
   end
 
+  after { MultiLock.locks.clear }
+
   describe ".lock" do
     let(:calls) { [] }
 

--- a/test/models/restart_signal_handler_test.rb
+++ b/test/models/restart_signal_handler_test.rb
@@ -26,7 +26,7 @@ describe RestartSignalHandler do
     Signal.expects(:trap).never
     Process.expects(:trap).never
     RestartSignalHandler.any_instance.expects(:sleep).never
-    JobExecution.clear_registry
+    JobExecution.clear_queue
     MultiLock.locks.clear
   end
 
@@ -44,11 +44,11 @@ describe RestartSignalHandler do
     end
 
     it "waits for running jobs" do
-      registry = JobExecution.send(:registry)
+      job_queue = JobExecution.send(:job_queue)
       job_exec = stub(id: 123, pid: 444, pgid: 5555, descriptor: 'Job thingy')
 
       # we call it twice in each iteration
-      registry.expects(:active).times(3).returns [job_exec], [job_exec], []
+      job_queue.expects(:active).times(3).returns [job_exec], [job_exec], []
 
       RestartSignalHandler.any_instance.expects(:sleep).with(5)
       handle

--- a/test/models/restart_signal_handler_test.rb
+++ b/test/models/restart_signal_handler_test.rb
@@ -26,8 +26,6 @@ describe RestartSignalHandler do
     Signal.expects(:trap).never
     Process.expects(:trap).never
     RestartSignalHandler.any_instance.expects(:sleep).never
-    JobExecution.clear_queue
-    MultiLock.locks.clear
   end
 
   describe ".listen" do
@@ -38,9 +36,7 @@ describe RestartSignalHandler do
     end
 
     it "turns job processing off" do
-      JobExecution.enabled = true
-      handle
-      JobExecution.enabled.must_equal false
+      with_job_execution { handle }
     end
 
     it "waits for running jobs" do

--- a/test/support/job_queue_support.rb
+++ b/test/support/job_queue_support.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+ActiveSupport::TestCase.class_eval do
+  # when job execution is on jobs can end up in the queue and that can break future tests
+  # so we clean after using JobExecution
+  def with_job_execution
+    JobExecution.enabled = true
+    yield
+  ensure
+    JobExecution.clear_queue
+    JobExecution.send(:job_queue).instance_variable_get(:@active).clear
+    JobExecution.enabled = false
+  end
+
+  def self.with_job_execution
+    around { |t| with_job_execution(&t) }
+  end
+end


### PR DESCRIPTION
this started as a simple refactor ... but I got drawn deeper and deeper into the rabbit hole ...

 - clearer names
 - JobQueue is responsible for queuing, others do not know about internals
 - fix memory leak in JobQueue
 - reuse 'waiting for restart' logic
 - fix that executing but inactive jobs were not shown
 - fix new jobs during restarts being stored in registry and never getting removed
 - full test coverage for JobQueue

@sandlerr @jonmoter @anthonywoo 