### PR TITLE
log more information when a kubernetes deploy is "unstable"

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -60,7 +60,11 @@ module Kubernetes
       end
 
       def error?
-        events.any? { |e| e.type != "Normal" }
+        abnormal_events.any?
+      end
+
+      def abnormal_events
+        events.reject { |e| e.type == 'Normal' }
       end
 
       def events

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -496,7 +496,7 @@ describe Kubernetes::DeployExecutor do
           /EVENTS:\s+FailedScheduling: fit failure on node \(ip-1-2-3-4\)\s+fit failure on node \(ip-2-3-4-5\)\n\n/
         ) # no repeated events
         out.must_match /LOGS:\s+LOG-1/
-        out.must_include "RESOURCE EVENTS some-project:\n  FailedScheduling:"
+        out.must_include "RESOURCE EVENTS staging.some-project:\n  FailedScheduling:"
       end
     end
   end


### PR DESCRIPTION
Currently if a deploy fails for Kubernetes, it says "UNSTABLE", but without a whole lot of info as to what happened.  This adds some.

/cc @zendesk/samson, @zendesk/paas 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low

