### PR TITLE
make exceptions easier to follow

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -115,7 +115,7 @@ class Job < ActiveRecord::Base
   end
 
   def url
-    deploy.try(:url) || Rails.application.routes.url_helpers.project_job_url(project, self)
+    deploy&.url || Rails.application.routes.url_helpers.project_job_url(project, self)
   end
 
   def pid

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -63,7 +63,7 @@ class JobExecution
 
       @executor.stop! 'KILL'
       @thread.join(stop_timeout) ||
-        (Rails.env.test? ? @thread.join : @thread.kill) # miniest runs before blocks twice when killing thread here
+        (Rails.env.test? ? @thread.join : @thread.kill) # test hangs forever when using .kill here
     end
 
     @job.cancelled!

--- a/app/models/job_execution_subscriber.rb
+++ b/app/models/job_execution_subscriber.rb
@@ -11,7 +11,7 @@ class JobExecutionSubscriber
     Airbrake.notify(
       exception,
       error_message: "JobExecutionSubscriber failed: #{exception.message}",
-      parameters: { job_id: @job.id }
+      parameters: { job_url: @job.url }
     )
   end
 end

--- a/test/models/job_execution_subscriber_test.rb
+++ b/test/models/job_execution_subscriber_test.rb
@@ -4,9 +4,10 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe JobExecutionSubscriber do
-  it 'handles exceptions' do
+  it 'sends exceptions to airbrake so other subscribers can continue' do
+    Airbrake.expects(:notify)
     block = lambda { raise 'Test' }
-    execution = JobExecutionSubscriber.new(stub(id: 1), block)
+    execution = JobExecutionSubscriber.new(stub(url: 1), block)
     execution.call
   end
 end


### PR DESCRIPTION
current `{  "job_id": "243324"}` in airbrake makes it hard to track down where it came from

@irwaters 