### PR TITLE
do not blow up when directory was removed during deploy

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -96,7 +96,7 @@ class JobExecution
 
     @job.run!
 
-    success = Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
+    success = make_temp_directory do |dir|
       return @job.error! unless setup!(dir)
 
       if @execution_block
@@ -247,6 +247,17 @@ class JobExecution
 
   def puts_if_present(message)
     @output.puts message if message
+  end
+
+  def make_temp_directory
+    Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
+      begin
+        yield dir
+      ensure
+        # make the mktmpdir ensure not blow up if the directory was removed
+        Dir.mkdir(dir) unless Dir.exist?(dir)
+      end
+    end
   end
 
   class << self

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -255,8 +255,13 @@ describe JobExecution do
   it 'can run with a block' do
     x = :not_called
     execution = JobExecution.new('master', job) { x = :called }
-    execution.send(:run!)
+    assert execution.send(:run!)
     x.must_equal :called
+  end
+
+  it 'can finish when temp directory is cleaned up during the run' do
+    execution = JobExecution.new('master', job) { |_, dir| Dir.delete(dir) }
+    assert execution.send(:run!)
   end
 
   describe "kubernetes" do


### PR DESCRIPTION
this pops up once every day or so, reduce airbrake spam a bit and confusion from a weird error

https://zendesk.airbrake.io/projects/95346/groups/1744273568143190802?tab=notice-list

@irwaters 