### PR TITLE
Add routing support for releases with dots

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -3,6 +3,7 @@ class Release < ActiveRecord::Base
   NUMBER = '\d+(:?\.\d+)*'
   NUMBER_REGEX = /\A#{NUMBER}\z/
   VERSION_REGEX = /\Av(#{NUMBER})\z/
+  ROUTE_REGEX = /v(#{NUMBER})/
 
   belongs_to :project, touch: true
   belongs_to :author, polymorphic: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Samson::Application.routes.draw do
       end
     end
 
-    resources :releases, only: [:show, :index, :new, :create], id: /v(\d+(:?\.\d+)*)/, format: /json/
+    resources :releases, only: [:show, :index, :new, :create], id: Release::ROUTE_REGEX
 
     resources :stages do
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Samson::Application.routes.draw do
       end
     end
 
-    resources :releases, only: [:show, :index, :new, :create]
+    resources :releases, only: [:show, :index, :new, :create], id: /v(\d+(:?\.\d+)*)/, format: /json/
 
     resources :stages do
       collection do

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -6,14 +6,20 @@ SingleCov.covered!
 describe ReleasesController do
   let(:project) { projects(:test) }
   let(:release) { releases(:test) }
+  let(:release_dot) { releases(:test_dot) }
 
   as_a_viewer do
     unauthorized :get, :new, project_id: :foo
     unauthorized :post, :create, project_id: :foo
 
     describe "#show" do
-      it "renders" do
+      it "renders continuous versions" do
         get :show, params: {project_id: project.to_param, id: release.version}
+        assert_response :success
+      end
+
+      it "renders major-minor versions" do
+        get :show, params: {project_id: project.to_param, id: release_dot.version}
         assert_response :success
       end
 

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -18,15 +18,14 @@ describe ReleasesController do
       end
 
       it "renders major-minor versions" do
-        release.number = "12.3"
-        release.save!
+        release.update_column :number, '12.3'
         get :show, params: {project_id: project.to_param, id: release.version}
         assert_response :success
       end
 
       it "fails to render unknown release" do
         assert_raises ActiveRecord::RecordNotFound do
-          get :show, params: {project_id: project.to_param, id: 123}
+          get :show, params: {project_id: project.to_param, id: "v321"}
         end
       end
     end

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -6,7 +6,6 @@ SingleCov.covered!
 describe ReleasesController do
   let(:project) { projects(:test) }
   let(:release) { releases(:test) }
-  let(:release_dot) { releases(:test_dot) }
 
   as_a_viewer do
     unauthorized :get, :new, project_id: :foo
@@ -19,7 +18,9 @@ describe ReleasesController do
       end
 
       it "renders major-minor versions" do
-        get :show, params: {project_id: project.to_param, id: release_dot.version}
+        release.number = "12.3"
+        release.save!
+        get :show, params: {project_id: project.to_param, id: release.version}
         assert_response :success
       end
 

--- a/test/fixtures/releases.yml
+++ b/test/fixtures/releases.yml
@@ -1,5 +1,11 @@
 test:
   project: test
   commit: abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd
-  number: 123
+  number: "123"
+  author: deployer (User)
+
+test_dot:
+  project: test
+  commit: abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd
+  number: "12.3"
   author: deployer (User)

--- a/test/fixtures/releases.yml
+++ b/test/fixtures/releases.yml
@@ -3,9 +3,3 @@ test:
   commit: abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd
   number: "123"
   author: deployer (User)
-
-test_dot:
-  project: test
-  commit: abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd
-  number: "12.3"
-  author: deployer (User)


### PR DESCRIPTION
After the changes from https://github.com/zendesk/samson/pull/1482, we allow releases with dots (ex v1.0).  The routing didn't support this, and it interpreted the `v1` as the `id`, and the `0` as the `format`.  This adds an explicit regex for the `id`, and restricts the format to json.

/cc @zendesk/samson @zendesk/sustaining 

### Tasks
 - [ ] :+1: from team

### References
 - https://github.com/zendesk/samson/pull/1482

### Risks
- Level: Low:  Could cause release failures.

