### PR TITLE
Always redirect to login path when unauthorized

### DIFF
--- a/app/controllers/unauthorized_controller.rb
+++ b/app/controllers/unauthorized_controller.rb
@@ -25,14 +25,8 @@ class UnauthorizedController < ActionController::Metal
       end
       format.html do
         flash[:authorization_error] = message
-        redirect_back_or(login_path)
+        redirect_to login_path
       end
     end
-  end
-
-  private
-
-  def redirect_back_or(path)
-    redirect_back fallback_location: path
   end
 end

--- a/test/controllers/unauthorized_controller_test.rb
+++ b/test/controllers/unauthorized_controller_test.rb
@@ -55,9 +55,11 @@ describe 'Unauthorized' do
       describe 'with a referer' do
         let(:headers) { { 'HTTP_REFERER' => '/hello' } }
 
-        it 'redirects to the referer' do
+        it 'redirects to the login path' do
           last_response.status.must_equal 302
-          last_response.headers['Location'].must_equal("http://example.org/hello")
+
+          # Really just '/', but Rack insists on using the full SERVER_NAME
+          last_response.headers['Location'].must_equal('http://example.org/login')
         end
       end
     end


### PR DESCRIPTION
Not sure why it was set to redirect back to the referrer at the first place, but since Ledger contains links to Samson, and if the user is not logged into Samson, it redirects the user back to Ledger which is confusing. I think we should always redirect the user to login page if unauthorized.

/cc @zendesk/samson @zendesk/tools @grosser 

### Tasks
 - [x] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/TOOLS-1038

### Risks
- Level: Low
