### PR TITLE
ignore minitest `must_equal nil` deprecation

### DIFF
--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -170,7 +170,7 @@ describe EnvironmentVariable do
     end
 
     it "builds from nil so it is matched in rendered selects" do
-      environment_variable.scope_type_and_id.must_equal nil
+      environment_variable.scope_type_and_id.must_be_nil
     end
   end
 end

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -185,7 +185,7 @@ describe Kubernetes::Api::Pod do
         to_raise(KubeException.new('a', 'b', 'c'))
       stub_request(:get, log_url).
         to_raise(KubeException.new('a', 'b', 'c'))
-      pod_with_client.logs('some-container').must_equal nil
+      pod_with_client.logs('some-container').must_be_nil
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -114,7 +114,7 @@ describe Kubernetes::ReleaseDoc do
 
       it "does nothing when service has no clusterIP" do
         doc.send(:raw_template)[1][:spec].delete(:clusterIP)
-        result.must_equal nil
+        result.must_be_nil
       end
 
       it "does nothing when ip prefix is blank" do

--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -51,7 +51,7 @@ describe Kubernetes::RoleConfigFile do
 
     it 'is nil when no service is found' do
       content.replace(read_kubernetes_sample_file('kubernetes_job.yml'))
-      config_file.service.must_equal nil
+      config_file.service.must_be_nil
     end
   end
 
@@ -62,7 +62,7 @@ describe Kubernetes::RoleConfigFile do
     end
 
     it 'is nil when no job is found' do
-      config_file.job.must_equal nil
+      config_file.job.must_be_nil
     end
   end
 end

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -45,7 +45,7 @@ describe Kubernetes::Role do
       it "stores empty as nil to not run into duplication issues" do
         role.service_name = ''
         assert_valid role
-        role.service_name.must_equal nil
+        role.service_name.must_be_nil
       end
 
       it "is invalid with a already used service name" do
@@ -293,12 +293,12 @@ describe Kubernetes::Role do
 
     it "ignores unknown units" do
       assert config_content_yml.sub!('100Mi', '200T')
-      role.defaults.must_equal nil
+      role.defaults.must_be_nil
     end
 
     it "ignores when there is no config" do
       GitRepository.any_instance.stubs(file_content: nil)
-      role.defaults.must_equal nil
+      role.defaults.must_be_nil
     end
 
     it "ignores when config is invalid" do

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -18,7 +18,7 @@ describe Kubernetes::RoleVerifier do
     end
 
     it "works" do
-      errors.must_equal nil
+      errors.must_be_nil
     end
 
     it "allows ConfigMap" do
@@ -53,7 +53,7 @@ describe Kubernetes::RoleVerifier do
 
     it "allows only Job" do
       role.replace(job_role)
-      errors.must_equal nil
+      errors.must_be_nil
     end
 
     it "reports missing name" do
@@ -109,12 +109,12 @@ describe Kubernetes::RoleVerifier do
 
     it "allows valid labels" do
       role.first[:metadata][:labels][:foo] = 'KubeDNS'
-      errors.must_equal nil
+      errors.must_be_nil
     end
 
     it "works with proper annotations" do
       role.first[:spec][:template][:metadata][:annotations] = { 'secret/FOO' => 'bar' }
-      errors.must_equal nil
+      errors.must_be_nil
     end
 
     it "reports invalid annotations" do

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -35,7 +35,7 @@ describe Api::BaseController do
 
   describe "#current_project" do
     it "returns cached @project" do
-      @controller.send(:current_project).must_equal nil
+      @controller.send(:current_project).must_be_nil
       @controller.instance_variable_set(:@project, 1)
       @controller.send(:current_project).must_equal 1
     end

--- a/test/controllers/concerns/current_user_test.rb
+++ b/test/controllers/concerns/current_user_test.rb
@@ -99,7 +99,7 @@ class CurrentUserConcernTest < ActionController::TestCase
       it "unsets the user and logs them out" do
         @controller.send(:current_user=, user)
         @controller.send(:logout!)
-        @controller.send(:current_user).must_equal nil
+        @controller.send(:current_user).must_be_nil
         session.inspect.must_equal({}.inspect)
       end
     end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -92,7 +92,7 @@ describe SessionsController do
 
       it 'does not log in' do
         assert flash[:error]
-        @controller.send(:current_user).must_equal(nil)
+        @controller.send(:current_user).must_be_nil
         assert_redirected_to root_path
       end
     end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -378,12 +378,12 @@ describe ApplicationHelper do
 
       it "does not use referrer from other page since redirect_back_or would not work" do
         assert request.stubs(:referrer, request.referrer.sub(root_url, 'http://hacky.com/'))
-        redirect_to_field.must_equal nil
+        redirect_to_field.must_be_nil
       end
 
       it "is empty when nothing is known" do
         request.stubs(:referrer).returns(nil)
-        redirect_to_field.must_equal nil
+        redirect_to_field.must_be_nil
       end
     end
   end

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -59,7 +59,7 @@ describe DeploysHelper do
       before { deploy.stubs(active?: true) }
 
       it 'does not generate a link' do
-        redeploy_button.must_equal nil
+        redeploy_button.must_be_nil
       end
     end
 

--- a/test/helpers/locks_helper_test.rb
+++ b/test/helpers/locks_helper_test.rb
@@ -24,7 +24,7 @@ describe LocksHelper do
     let(:stage) { stages(:test_staging) }
 
     it "renders nothing when there is no lock" do
-      resource_lock_icon(stage).must_equal nil
+      resource_lock_icon(stage).must_be_nil
     end
 
     it "renders locks" do
@@ -59,8 +59,8 @@ describe LocksHelper do
   describe "#global_lock" do
     it "caches nil" do
       Lock.expects(:global).returns []
-      global_lock.must_equal nil
-      global_lock.must_equal nil
+      global_lock.must_be_nil
+      global_lock.must_be_nil
     end
 
     it "caches values" do
@@ -87,7 +87,7 @@ describe LocksHelper do
     end
 
     it "does not render when there is no locks" do
-      render_lock(stage).must_equal nil
+      render_lock(stage).must_be_nil
     end
   end
 

--- a/test/helpers/stages_helper_test.rb
+++ b/test/helpers/stages_helper_test.rb
@@ -33,7 +33,7 @@ describe StagesHelper do
       end
 
       it "does not show local edit" do
-        edit_command_link(commands(:echo)).must_equal nil
+        edit_command_link(commands(:echo)).must_be_nil
       end
 
       it "links to local edit if command is local and user is project admin" do

--- a/test/lib/omniauth/github_authorization_test.rb
+++ b/test/lib/omniauth/github_authorization_test.rb
@@ -28,7 +28,7 @@ describe GithubAuthorization do
     let(:organization_member) { false }
 
     it 'is not allowed to view' do
-      authorization.role_id.must_equal(nil)
+      authorization.role_id.must_be_nil
     end
   end
 

--- a/test/lib/samson/secrets/db_backend_test.rb
+++ b/test/lib/samson/secrets/db_backend_test.rb
@@ -12,7 +12,7 @@ describe Samson::Secrets::DbBackend do
     end
 
     it "returns nil when it cannot find" do
-      Samson::Secrets::DbBackend.read('production/foo/pod2/noooo').must_equal nil
+      Samson::Secrets::DbBackend.read('production/foo/pod2/noooo').must_be_nil
     end
   end
 

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -23,7 +23,7 @@ describe Samson::Secrets::HashicorpVaultBackend do
 
     it "returns nil when it fails to read" do
       assert_vault_request :get, "production/foo/pod2/bar", status: 404 do
-        Samson::Secrets::HashicorpVaultBackend.read('production/foo/pod2/bar').must_equal nil
+        Samson::Secrets::HashicorpVaultBackend.read('production/foo/pod2/bar').must_be_nil
       end
     end
   end

--- a/test/lib/samson/secrets/key_resolver_test.rb
+++ b/test/lib/samson/secrets/key_resolver_test.rb
@@ -98,7 +98,7 @@ describe Samson::Secrets::KeyResolver do
     end
 
     it "returns nil when it fails to read secrets" do
-      resolver.read("foobar").must_equal nil
+      resolver.read("foobar").must_be_nil
       errors.first.must_include "foobar (tried"
     end
   end

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -352,7 +352,7 @@ describe Changeset::PullRequest do
         # Risks
          - None
       BODY
-      pr.risks.must_equal nil
+      pr.risks.must_be_nil
     end
 
     it "does not find None" do
@@ -360,7 +360,7 @@ describe Changeset::PullRequest do
         # Risks
         None
       BODY
-      pr.risks.must_equal nil
+      pr.risks.must_be_nil
     end
 
     it "finds risks with underline style markdown headers" do
@@ -384,13 +384,13 @@ describe Changeset::PullRequest do
       before { no_risks }
 
       it "finds nothing" do
-        pr.risks.must_equal nil
+        pr.risks.must_be_nil
       end
 
       it "caches nothing" do
         pr.risks
         add_risks
-        pr.risks.must_equal nil
+        pr.risks.must_be_nil
       end
     end
   end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -93,7 +93,7 @@ describe Deploy do
 
     it "does not queue when it can execute in parallel" do
       deploy.stage.run_in_parallel = true
-      deploy.job_execution_queue_name.must_equal nil
+      deploy.job_execution_queue_name.must_be_nil
     end
   end
 

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -166,8 +166,8 @@ describe DockerBuilderService do
       error_message = "A bad thing happened..."
       Docker::Image.unstub(:build_from_tar)
       Docker::Image.expects(:build_from_tar).raises(Docker::Error::DockerError.new(error_message))
-      service.build_image(tmp_dir).must_equal nil
-      build.docker_image_id.must_equal nil
+      service.build_image(tmp_dir).must_be_nil
+      build.docker_image_id.must_be_nil
       service.output.to_s.must_include error_message
     end
 
@@ -175,8 +175,8 @@ describe DockerBuilderService do
       error_message = "Really long output..."
       Docker::Image.unstub(:build_from_tar)
       Docker::Image.expects(:build_from_tar).raises(Docker::Error::UnexpectedResponseError.new(error_message))
-      service.build_image(tmp_dir).must_equal nil
-      build.docker_image_id.must_equal nil
+      service.build_image(tmp_dir).must_be_nil
+      build.docker_image_id.must_be_nil
       service.output.to_s.wont_include error_message
     end
 
@@ -238,7 +238,7 @@ describe DockerBuilderService do
 
     it 'rescues docker error' do
       service.expects(:docker_image_ref).raises(Docker::Error::DockerError)
-      service.push_image('my-test').must_equal nil
+      service.push_image('my-test').must_be_nil
       service.output.to_s.must_equal "Docker push failed: Docker::Error::DockerError\n"
     end
 
@@ -261,7 +261,7 @@ describe DockerBuilderService do
 
     it 'fails when digest cannot be found' do
       assert push_output.reject! { |e| e.first =~ /Digest/ }
-      service.push_image('my-test').must_equal nil
+      service.push_image('my-test').must_be_nil
       service.output.to_s.must_include "Docker push failed: Unable to get repo digest"
     end
 

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -291,17 +291,17 @@ describe GitRepository do
     end
 
     it 'returns nil when file does not exist' do
-      repository.file_content('foox', sha).must_equal nil
+      repository.file_content('foox', sha).must_be_nil
     end
 
     it 'returns nil when sha does not exist' do
-      repository.file_content('foox', 'a' * 40).must_equal nil
+      repository.file_content('foox', 'a' * 40).must_be_nil
     end
 
     it "always updates for non-shas" do
       repository.expects(:sha_exist?).never
       repository.expects(:update!)
-      repository.file_content('foox', 'a' * 41).must_equal nil
+      repository.file_content('foox', 'a' * 41).must_be_nil
     end
 
     it "does not update when sha exists to save time" do
@@ -311,7 +311,7 @@ describe GitRepository do
 
     it "updates when sha is missing" do
       repository.expects(:update!)
-      repository.file_content('foo', 'a' * 40).must_equal nil
+      repository.file_content('foo', 'a' * 40).must_be_nil
     end
 
     describe "pull: false" do
@@ -322,7 +322,7 @@ describe GitRepository do
       end
 
       it "ignores unknown" do
-        repository.file_content('foo', 'aaaaaaaaa', pull: false).must_equal nil
+        repository.file_content('foo', 'aaaaaaaaa', pull: false).must_be_nil
       end
     end
   end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -247,9 +247,9 @@ describe JobExecution do
     job_execution = JobExecution.start_job(JobExecution.new('master', job))
     job_execution.wont_be_nil
 
-    JobExecution.find_by_id(job.id).must_equal(nil)
-    JobExecution.queued?(job.id).must_equal(nil)
-    JobExecution.active?(job.id).must_equal(nil)
+    JobExecution.find_by_id(job.id).must_be_nil
+    JobExecution.queued?(job.id).must_be_nil
+    JobExecution.active?(job.id).must_be_nil
   end
 
   it 'can run with a block' do

--- a/test/models/lock_test.rb
+++ b/test/models/lock_test.rb
@@ -51,7 +51,7 @@ describe Lock do
       it "nils blank resource_type" do
         lock.resource_type = ''
         assert_valid lock
-        lock.resource_type.must_equal nil
+        lock.resource_type.must_be_nil
       end
     end
   end
@@ -109,7 +109,7 @@ describe Lock do
 
   describe "#unlock_summary" do
     it "is emppty when not deleting" do
-      lock.expire_summary.must_equal nil
+      lock.expire_summary.must_be_nil
     end
 
     it "says when unlock is in the future" do

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -196,8 +196,8 @@ describe Project do
     it "does not contain releases after requested time" do
       staging_deploy.update_column(:updated_at, prod_deploy.updated_at - 2.days)
       deploys = project.last_deploy_by_group(prod_deploy.updated_at - 1.day)
-      deploys[pod1.id].must_equal nil
-      deploys[pod2.id].must_equal nil
+      deploys[pod1.id].must_be_nil
+      deploys[pod2.id].must_be_nil
       deploys[pod100.id].must_equal staging_deploy
     end
 
@@ -212,7 +212,7 @@ describe Project do
     it 'contains no non-releases' do
       prod_deploy.update_column(:release, false)
       deploys = project.last_deploy_by_group(Time.now)
-      deploys[pod1.id].must_equal nil
+      deploys[pod1.id].must_be_nil
     end
 
     it 'performs minimal number of queries' do
@@ -269,7 +269,7 @@ describe Project do
     let(:release) { releases(:test) }
 
     it "finds no release before given if there is none" do
-      project.release_prior_to(release).must_equal nil
+      project.release_prior_to(release).must_be_nil
     end
 
     it "finds a release before given" do

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -43,7 +43,7 @@ describe ReleaseService do
       Samson::Hooks.with_callback(:release_deploy_conditions, deployable_condition_check) do |_|
         service.release!(commit: commit, author: author)
 
-        assert_equal nil, stage.deploys.first
+        stage.deploys.first.must_be_nil
       end
     end
 

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -156,7 +156,7 @@ describe SecretStorage do
     it "does not cache when cache did not exist" do
       SecretStorage.backend.expects(:keys).never # block call
       SecretStorage.delete(secret.id)
-      Rails.cache.read(SecretStorage::SECRET_KEYS_CACHE).must_equal nil
+      Rails.cache.read(SecretStorage::SECRET_KEYS_CACHE).must_be_nil
     end
   end
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -99,9 +99,9 @@ describe Stage do
     it 'caches nil' do
       stage
       ActiveRecord::Relation.any_instance.expects(:first).returns nil
-      stage.last_deploy.must_equal nil
+      stage.last_deploy.must_be_nil
       ActiveRecord::Relation.any_instance.expects(:first).never
-      stage.last_deploy.must_equal nil
+      stage.last_deploy.must_be_nil
     end
 
     it 'returns the last deploy for the stage' do
@@ -119,9 +119,9 @@ describe Stage do
     it 'caches nil' do
       subject
       ActiveRecord::Relation.any_instance.expects(:first).returns nil
-      stage.last_successful_deploy.must_equal nil
+      stage.last_successful_deploy.must_be_nil
       ActiveRecord::Relation.any_instance.expects(:first).never
-      stage.last_successful_deploy.must_equal nil
+      stage.last_successful_deploy.must_be_nil
     end
 
     it 'returns the last successful deploy for the stage' do
@@ -188,15 +188,15 @@ describe Stage do
 
   describe "#current_deploy" do
     it "is nil when not deploying" do
-      subject.current_deploy.must_equal nil
+      subject.current_deploy.must_be_nil
     end
 
     it 'caches nil' do
       subject
       ActiveRecord::Relation.any_instance.expects(:first).returns nil
-      subject.current_deploy.must_equal nil
+      subject.current_deploy.must_be_nil
       ActiveRecord::Relation.any_instance.expects(:first).never
-      subject.current_deploy.must_equal nil
+      subject.current_deploy.must_be_nil
     end
 
     it "is there when deploying" do
@@ -293,17 +293,17 @@ describe Stage do
 
     it "is empty when deploy was a success" do
       deploy.job.success!
-      emails.must_equal nil
+      emails.must_be_nil
     end
 
     it "is empty when last deploy was also a failure" do
       previous_deploy.job.fail!
-      emails.must_equal nil
+      emails.must_be_nil
     end
 
     it "is empty when user was human" do
       user.update_attribute(:integration, false)
-      emails.must_equal nil
+      emails.must_be_nil
     end
 
     it "includes committers when there is no previous deploy" do

--- a/test/models/star_test.rb
+++ b/test/models/star_test.rb
@@ -12,14 +12,14 @@ describe Star do
     it "expires on create" do
       Rails.cache.write(key, 1)
       Star.create!(project: project, user: user)
-      Rails.cache.read(key).must_equal nil
+      Rails.cache.read(key).must_be_nil
     end
 
     it "expires on destroy" do
       star = Star.create!(project: project, user: user)
       Rails.cache.write(key, 1)
       star.destroy
-      Rails.cache.read(key).must_equal nil
+      Rails.cache.read(key).must_be_nil
     end
   end
 end

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -72,7 +72,7 @@ describe TerminalExecutor do
 
     it "terminates the program on getpgid failures so we fail fast" do
       Process.expects(:getpgid).raises(Errno::ESRCH)
-      subject.execute!('sleep 0.1').must_equal(nil) # status? of a killed process is 9
+      subject.execute!('sleep 0.1').must_be_nil # status? of a killed process is 9
     end
 
     it "handles the case when getpgid + kill both fail" do
@@ -182,11 +182,11 @@ describe TerminalExecutor do
     end
 
     it 'properly kills the execution' do
-      execute_and_stop('sleep 100', 'INT').must_equal(nil)
+      execute_and_stop('sleep 100', 'INT').must_be_nil
     end
 
     it 'terminates hanging processes with -9' do
-      execute_and_stop('trap "sleep 100" 2; sleep 100', 'KILL').must_equal(nil)
+      execute_and_stop('trap "sleep 100" 2; sleep 100', 'KILL').must_be_nil
     end
   end
 end

--- a/test/models/webhook_recorder_test.rb
+++ b/test/models/webhook_recorder_test.rb
@@ -40,7 +40,7 @@ describe WebhookRecorder do
     end
 
     it "reads missing as nil" do
-      WebhookRecorder.read(project).must_equal nil
+      WebhookRecorder.read(project).must_be_nil
     end
   end
 end

--- a/test/support/must_equal_nil.rb
+++ b/test/support/must_equal_nil.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# https://github.com/seattlerb/minitest/issues/666
+Object.prepend(Module.new do
+  def must_equal(*args)
+    if args.first.nil?
+      must_be_nil(*args[1..-1])
+    else
+      super
+    end
+  end
+end)


### PR DESCRIPTION
@irwaters 
/fyi @zendesk/samson might hit other projects sooner or later ...

`https://github.com/seattlerb/minitest/issues/666` 
Use assert_nil if expecting nil from lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.