### PR TITLE
Adds a 'hand' mouse pointer to the Warning labels

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -169,3 +169,6 @@ pre.pre-inline {
     margin-right: 10px;
   }
 }
+
+// Labels with tooltips.
+span.label[title] { cursor: help; }


### PR DESCRIPTION
/cc @zendesk/samson

### Description

Adds `?` mouse pointer to any label (with a tooltip) to help indicate there is a descriptive message when the mouse is hover.  

*Before:*
![screen shot 2016-12-14 at 12 42 19 pm](https://cloud.githubusercontent.com/assets/164819/21200056/cfb084e2-c1fa-11e6-81e4-ee277d04fb88.png)

*After:*
![screen shot 2016-12-14 at 12 39 07 pm](https://cloud.githubusercontent.com/assets/164819/21199930/5824c956-c1fa-11e6-9aa3-1e92d1b92565.png)

### Tasks
 - [x] :+1: from team

### Risks
- Level: Low
