### PR TITLE
use with_connection to avoid "Cannot lease connection"

### DIFF
--- a/lib/samson/clair.rb
+++ b/lib/samson/clair.rb
@@ -12,6 +12,7 @@ module Samson
       def append_job_with_scan(job, docker_tag)
         return unless clair = ENV['HYPERCLAIR_PATH']
 
+        ActiveRecord::Base.clear_active_connections!
         Thread.new do
           sleep 0.1 if Rails.env.test? # in test we reuse the same connection, so we cannot use it at the same time
           success, output, time = scan(clair, job.project, docker_tag)


### PR DESCRIPTION
@sandlerr @jonmoter 

After adding clair this old friend popped up again:

https://zendesk.airbrake.io/projects/95346/groups/1794866641583417835/notices/1840523327485950109
Cannot lease connection, it is already in use by a different thread

per discussion in https://github.com/rails/rails/issues/25585
ActiveRecord::Base.connection_pool.with_connection is preferred and seems cleaner to me too
so let's give that a try ...