### PR TITLE
show debug info for active and queued jobs

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -285,6 +285,10 @@ class JobExecution
       job_queue.clear
     end
 
+    def debug
+      job_queue.debug
+    end
+
     private
 
     def job_queue

--- a/app/models/job_queue.rb
+++ b/app/models/job_queue.rb
@@ -53,6 +53,10 @@ class JobQueue
     job_execution
   end
 
+  def debug
+    [@active, @queue]
+  end
+
   private
 
   def start_job(job_execution, queue)

--- a/app/views/deploys/_job_executions.html.erb
+++ b/app/views/deploys/_job_executions.html.erb
@@ -1,0 +1,29 @@
+<% if job_executions.any? %>
+  <table class="table">
+    <thead>
+    <tr>
+      <th>Project</th>
+      <th>When</th>
+      <th>Who</th>
+      <th>Stage</th>
+      <th>Status</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% job_executions.each do |queue, job_exs| %>
+      <tr><td colspan="6">Queue <%= queue %></td></tr>
+      <% Array(job_exs).each do |job_ex| %>
+        <% if deploy = job_ex.job.deploy %>
+          <%= render "/projects/deploy", deploy: deploy %>
+        <% else %>
+          <%= link_to job_ex.id, [job_ex.job.project, job_ex.job] %>
+        <% end %>
+      <% end %>
+    <% end %>
+    </tbody>
+  </table>
+</table>
+<% else %>
+  None
+<% end %>

--- a/app/views/deploys/active.erb
+++ b/app/views/deploys/active.erb
@@ -1,5 +1,17 @@
 <%= page_title "Current Deploys" %>
 
-<div class="timeline" ng-controller="currentDeploysCtrl">
-  <%= render 'shared/deploys_table' %>
-</div>
+<% if params[:debug].blank? %>
+  <div class="timeline" ng-controller="currentDeploysCtrl">
+    <%= render 'shared/deploys_table' %>
+  </div>
+  <%= link_to 'job execution debug info', '?debug=1' %>
+<% else %>
+  <% active, queued = JobExecution.debug %>
+  <section class="tabs">
+    <h2>Active</h2>
+    <%= render 'job_executions', job_executions: active %>
+
+    <h2>Queued</h2>
+    <%= render 'job_executions', job_executions: queued %>
+  </section>
+<% end %>

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -6,6 +6,16 @@ SingleCov.covered! uncovered: 7
 describe JobExecution do
   include GitRepoTestHelper
 
+  def execute_job(branch = 'master', **options)
+    execution = JobExecution.new(branch, job, options)
+    execution.on_complete { yield } if block_given?
+    execution.send(:run!)
+  end
+
+  def last_line_of_output
+    job.output.to_s.split("\n").last.strip
+  end
+
   let(:repo_dir) { File.join(GitRepository.cached_repos_dir, project.repository_directory) }
   let(:pod1) { deploy_groups(:pod1) }
   let(:pod2) { deploy_groups(:pod2) }
@@ -371,13 +381,9 @@ describe JobExecution do
     end
   end
 
-  def execute_job(branch = 'master', **options)
-    execution = JobExecution.new(branch, job, options)
-    execution.on_complete { yield } if block_given?
-    execution.send(:run!)
-  end
-
-  def last_line_of_output
-    job.output.to_s.split("\n").last.strip
+  describe "#debug" do
+    it "returns job queue interansl" do
+      JobExecution.debug.must_equal([{}, {}])
+    end
   end
 end

--- a/test/models/job_queue_test.rb
+++ b/test/models/job_queue_test.rb
@@ -165,4 +165,10 @@ describe JobQueue do
       end
     end
   end
+
+  describe "#debug" do
+    it "returns active and queued" do
+      subject.debug.must_equal([{}, {}])
+    end
+  end
 end


### PR DESCRIPTION
<img width="1050" alt="screen shot 2016-12-15 at 11 00 42 pm" src="https://cloud.githubusercontent.com/assets/11367/21254476/81ecf968-c31a-11e6-80b4-f5cb79c8802d.png">

This should come in handy when restarts hang or other weird stuff happens ...

@jonmoter @sandlerr 