### PR TITLE
when user clicks stop then stop doing things

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -21,9 +21,11 @@ class TerminalExecutor
     @output = output
     @verbose = verbose
     @deploy = deploy
+    @stopped = false
   end
 
   def execute!(*commands)
+    return false if @stopped
     if @verbose
       commands.map! { |c| "echo » #{c.shellescape}\n#{resolve_secrets(c)}" }
     else
@@ -35,6 +37,7 @@ class TerminalExecutor
   end
 
   def stop!(signal)
+    @stopped = true
     system('kill', "-#{signal}", "-#{pgid}") if pgid
   end
 

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -188,5 +188,11 @@ describe TerminalExecutor do
     it 'terminates hanging processes with -9' do
       execute_and_stop('trap "sleep 100" 2; sleep 100', 'KILL').must_be_nil
     end
+
+    it 'stops any further execution so current thread can finish' do
+      subject.execute!('echo 1').must_equal true
+      subject.stop! 'INT'
+      subject.execute!('echo 1').must_equal false
+    end
   end
 end


### PR DESCRIPTION
the command that was stopped could be something simple like `git fetch` where
a false response is simply ignored, so do not execute anything else after that
to make the deploy stop immediately

before:
git fetch is being stopped but then we happily start the deploy:

<img width="349" alt="screen shot 2016-12-16 at 5 26 36 pm" src="https://cloud.githubusercontent.com/assets/11367/21283320/47e1f5d4-c3b5-11e6-96c3-f79b90bf6c57.png">



after:
stop means stop ... we are in a bad state, so do not execute more commands:

<img width="484" alt="screen shot 2016-12-16 at 5 26 19 pm" src="https://cloud.githubusercontent.com/assets/11367/21283324/4d700414-c3b5-11e6-9ac8-ac31e344eafe.png">

new code is the `@stopped` logic

@jonmoter @irwaters @sandlerr 
/fyi @zendesk/samson 