### PR TITLE
make stopping an execution call hooks once

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Job < ActiveRecord::Base
   belongs_to :project
-  belongs_to :user, -> { unscope(where: 'deleted_at') }
+  belongs_to :user, -> { unscope(where: :deleted_at) }
 
   has_one :deploy
 
@@ -20,7 +20,7 @@ class Job < ActiveRecord::Base
   end
 
   def self.non_deploy
-    includes(:deploy).where(deploys: { id: nil })
+    joins('left join deploys on deploys.job_id = jobs.id').where(deploys: { id: nil })
   end
 
   def self.pending

--- a/test/lib/samson/clair_test.rb
+++ b/test/lib/samson/clair_test.rb
@@ -4,13 +4,13 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Samson::Clair do
+  share_database_connection_in_all_threads
+
   def execute!
     Samson::Clair.append_job_with_scan(job, 'latest')
   end
 
   let(:job) { jobs(:succeeded_test) }
-
-  before { ActiveRecord::Base.stubs(connection: ActiveRecord::Base.connection) } # we update in another thread
 
   around do |t|
     Tempfile.open('clair') do |f|

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 36
+SingleCov.covered! uncovered: 32
 
 describe Job do
   include GitRepoTestHelper
@@ -9,9 +9,38 @@ describe Job do
   let(:url) { "git://foo.com:hello/world.git" }
   let(:user) { users(:admin) }
   let(:project) { Project.create!(name: 'jobtest', repository_url: url) }
-  let(:job) { project.jobs.create!(command: 'cat foo', user: user, project: project) }
+  let(:job) { project.jobs.create!(command: 'cat foo', user: user, project: project, commit: 'master') }
 
   before { Project.any_instance.stubs(:valid_repository_url).returns(true) }
+
+  describe ".valid_status?" do
+    it "is valid with known status" do
+      assert Job.valid_status?('pending')
+    end
+
+    it "is invalid with unknown status" do
+      refute Job.valid_status?('foo')
+    end
+  end
+
+  describe ".non_deploy" do
+    it "finds jobs without deploys" do
+      Job.non_deploy.must_equal [jobs(:running_test)]
+    end
+  end
+
+  describe ".pending" do
+    it "finds pending jobs" do
+      jobs(:running_test).update_column(:status, 'pending')
+      Job.pending.must_equal [jobs(:running_test)]
+    end
+  end
+
+  describe ".running" do
+    it "finds running jobs" do
+      Job.running.must_equal [jobs(:running_test)]
+    end
+  end
 
   describe "#validate_globally_unlocked" do
     def create
@@ -33,23 +62,41 @@ describe Job do
     end
   end
 
+  describe "#summary" do
+    it "renders" do
+      job.summary.must_equal "Admin is about to execute against master"
+    end
+  end
+
+  describe "#user" do
+    it "finds regular user" do
+      job.user.must_equal user
+    end
+
+    it "returns deleted user when user was soft deleted" do
+      job.user.soft_delete!
+      job.reload.user.must_equal user
+    end
+
+    it "returns placeholder user when user was deleted" do
+      job.user.delete
+      job.reload.user.class.must_equal NullUser
+    end
+  end
+
   describe "#pid" do
     with_job_execution
 
-    before do
+    it "has a pid when running" do
       job_execution = JobExecution.new('master', job)
       job_execution.expects(:start!)
       JobExecution.start_job(job_execution)
       JobExecution.any_instance.stubs(:pid).returns(1234)
-    end
-
-    it "has a pid when running" do
       job.run!
       job.pid.wont_be_nil
     end
 
-    it "has no pid when stopped" do
-      job.stop!
+    it "has no pid when not running" do
       job.pid.must_be_nil
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -180,6 +180,11 @@ class ActiveSupport::TestCase
   def self.with_paper_trail
     around { |t| PaperTrail.with_logging(&t) }
   end
+
+  # we update in multiple thread, to rollback changes we need to share a single transaction
+  def self.share_database_connection_in_all_threads
+    before { ActiveRecord::Base.stubs(connection: ActiveRecord::Base.connection) }
+  end
 end
 
 Mocha::Expectation.class_eval do


### PR DESCRIPTION
 - only call finish from either ensure or stop!
 - avoid db updates from possibly killed thread that might have a borked db connection
 - do not call finish twice when stopping multiple times
 - do not mark job as cancelled when it finished regularly

This should solve the bugs we saw with active threads being unable to be found
(see JobQueue#delete_and_enqueue_next)

@sandlerr @jonmoter @irwaters 