### PR TITLE
deploy the version of the release to get a descriptive UI

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -21,7 +21,7 @@ class Integrations::BaseController < ApplicationController
     end
 
     stages = project.webhook_stages_for(branch, service_type, service_name)
-    failed = deploy_to_stages(stages)
+    failed = deploy_to_stages(release, stages)
 
     if failed
       head :unprocessable_entity, message: "Failed to start deploy to #{failed.name}"
@@ -58,10 +58,10 @@ class Integrations::BaseController < ApplicationController
   end
 
   # returns stage that failed to deploy or nil
-  def deploy_to_stages(stages)
+  def deploy_to_stages(release, stages)
     deploy_service = DeployService.new(user)
     stages.detect do |stage|
-      deploy_service.deploy!(stage, reference: commit).new_record?
+      deploy_service.deploy!(stage, reference: release&.version || commit).new_record?
     end
   end
 


### PR DESCRIPTION
Currently we show what commit was deployed, which is unhelpful and makes cutting a production release take manual lookup step.

![screen shot 2016-12-19 at 9 38 32 am](https://cloud.githubusercontent.com/assets/11367/21322639/ed06b1f6-c5ce-11e6-80c0-1fc2b8351fc8.png)

/cc @zendesk/samson 
@jcheatham 
