### PR TITLE
reuse previous commit if it was identical but user used short sha or a refrence

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -64,7 +64,7 @@ class Release < ActiveRecord::Base
   def contains_commit?(other_commit)
     return true if other_commit == commit
     # status values documented here: http://stackoverflow.com/questions/23943855/github-api-to-compare-commits-response-status-is-diverged
-    GITHUB.compare(project.github_repo, commit, other_commit).status == 'behind'
+    ['behind', 'identical'].include?(GITHUB.compare(project.github_repo, commit, other_commit).status)
   rescue Octokit::NotFound
     false
   rescue Octokit::Error => e

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -178,6 +178,11 @@ describe Release do
       assert release.contains_commit?("NEW")
     end
 
+    it "is true when it is the same commit but not the same refrence (7 char sha or just wrong usage)" do
+      stub_github_api(url, status: 'identical')
+      assert release.contains_commit?("NEW")
+    end
+
     it "is false if it does not contain commit" do
       stub_github_api(url, status: 'ahead')
       refute release.contains_commit?("NEW")


### PR DESCRIPTION
fixup for #1487 ... noticed while locally testing and submitting short shas to travis integration endpoint, should not normally happen, but better be safe ...

before and after while submitting the same sha
![screen shot 2016-12-19 at 10 33 03 am](https://cloud.githubusercontent.com/assets/11367/21324537/069ae9cc-c5d7-11e6-9a90-0f0c2698a1dc.png)
 