### PR TITLE
only fail if readiness probe repeatedly fails

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -204,7 +204,7 @@ module Kubernetes
           {live: false, stop: true, details: "Restarted", pod: pod}
         elsif pod.live?
           {live: true, details: "Live", pod: pod}
-        elsif pod.abnormal_events.any?
+        elsif pod.events_indicate_failure?
           {live: false, stop: true, details: "Error", pod: pod}
         else
           {live: false, details: "Waiting (#{pod.phase}, #{pod.reason})", pod: pod}

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -171,7 +171,10 @@ module Kubernetes
 
     def print_events(events)
       events.uniq! { |e| e.message.split("\n").sort }
-      events.each { |e| @output.puts "  #{e.reason}: #{e.message}" }
+      events.each do |e|
+        counter = " x#{e.count}" if e.count != 1
+        @output.puts "  #{e.reason}: #{e.message}#{counter}"
+      end
     end
 
     def unstable!(reason, release_statuses)

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -189,24 +189,51 @@ describe Kubernetes::Api::Pod do
     end
   end
 
-  describe "#abnormal_events" do
+  describe "#events_indicate_failure?" do
     let(:events_url) do
       "http://foobar.server/api/v1/namespaces/the-namespace/events?fieldSelector=involvedObject.name=test_name"
     end
+    let(:readiness_failed) { {type: 'Warning', reason: 'Unhealthy', message: "Readiness probe failed: Get ", count: 1} }
 
-    it "is empty when there are no events" do
+    it "is false when there are no events" do
       stub_request(:get, events_url).to_return(body: {items: []}.to_json)
-      pod_with_client.abnormal_events.must_equal []
+      refute pod_with_client.events_indicate_failure?
     end
 
-    it "is empty when there are Normal events" do
+    it "is false when there are Normal events" do
       stub_request(:get, events_url).to_return(body: {items: [{type: 'Normal'}]}.to_json)
-      pod_with_client.abnormal_events.must_equal []
+      refute pod_with_client.events_indicate_failure?
     end
 
-    it "shows abnormal events" do
+    it "is true with bad events" do
       stub_request(:get, events_url).to_return(body: {items: [{type: 'Warning'}]}.to_json)
-      pod_with_client.abnormal_events.map(&:type).must_equal ['Warning']
+      assert pod_with_client.events_indicate_failure?
+    end
+
+    it "is false with single Readiness event" do
+      stub_request(:get, events_url).to_return(body: {items: [readiness_failed]}.to_json)
+      refute pod_with_client.events_indicate_failure?
+    end
+
+    describe "with multiple Readiness failures" do
+      before do
+        stub_request(:get, events_url).to_return(body: {items: [readiness_failed.merge(count: 20)]}.to_json)
+      end
+
+      it "is true" do
+        assert pod_with_client.events_indicate_failure?
+      end
+
+      it "is false with less then threshold" do
+        pod_attributes[:spec][:containers][0][:readinessProbe] = {failureThreshold: 30}
+        refute pod_with_client.events_indicate_failure?
+      end
+    end
+
+    it "is true with multiple Liveliness events" do
+      readiness_failed[:message] = readiness_failed[:message].sub('Readiness', 'Liveliness')
+      stub_request(:get, events_url).to_return(body: {items: Array.new(20) { readiness_failed }}.to_json)
+      assert pod_with_client.events_indicate_failure?
     end
   end
 end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -486,11 +486,13 @@ describe Kubernetes::DeployExecutor do
               items: [
                 {
                   reason: 'FailedScheduling',
-                  message: "fit failure on node (ip-1-2-3-4)\nfit failure on node (ip-2-3-4-5)"
+                  message: "fit failure on node (ip-1-2-3-4)\nfit failure on node (ip-2-3-4-5)",
+                  count: 4
                 },
                 {
                   reason: 'FailedScheduling',
-                  message: "fit failure on node (ip-2-3-4-5)\nfit failure on node (ip-1-2-3-4)"
+                  message: "fit failure on node (ip-2-3-4-5)\nfit failure on node (ip-1-2-3-4)",
+                  count: 1
                 }
               ]
             }.to_json
@@ -507,7 +509,7 @@ describe Kubernetes::DeployExecutor do
         # correct debugging output
         out.scan(/Pod 100 pod pod-(\S+)/).flatten.uniq.must_equal ["resque-worker:"] # logs and events only for bad pod
         out.must_match(
-          /EVENTS:\s+FailedScheduling: fit failure on node \(ip-1-2-3-4\)\s+fit failure on node \(ip-2-3-4-5\)\n\n/
+          /EVENTS:\s+FailedScheduling: fit failure on node \(ip-1-2-3-4\)\s+fit failure on node \(ip-2-3-4-5\) x4\n\n/
         ) # no repeated events
         out.must_match /LOGS:\s+LOG-1/
         out.must_include "RESOURCE EVENTS staging.some-project:\n  FailedScheduling:"


### PR DESCRIPTION
@zenvdeluca @jonmoter @irwaters 

truth-service failed the deploy because the probe sends a warning

```
"reason": "Unhealthy",
            "message": "Readiness probe failed: Get http://1.2.3.4:4242/: dial tcp 1.2.3.4:4242: getsockopt: connection refused",
```

also made it ignore Liveliness probe just in case ...
I think this gives us 10s time to get ready since the default interval is 1s
... looking deeper into the docs I think we can just set failureThreshold: 100 ... I'll try that next before merging ...