### PR TITLE
copy all deploy params on redeploy so the rollback param stays persisted

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -92,10 +92,8 @@ module DeploysHelper
 
   def redeploy_button
     return if @deploy.active?
-    html_options = {
-      class: 'btn btn-danger',
-      method: :post
-    }
+
+    html_options = {method: :post}
     if @deploy.succeeded?
       html_options[:class] = 'btn btn-default'
       html_options[:data] = {
@@ -103,12 +101,18 @@ module DeploysHelper
         placement: 'auto bottom'
       }
       html_options[:title] = 'Why? This deploy succeeded.'
+    else
+      html_options[:class] = 'btn btn-danger'
     end
+
+    deploy_params = {reference: @deploy.reference}
+    Samson::Hooks.fire(:deploy_permitted_params).each { |p| deploy_params[p] = @deploy.public_send(p) }
+
     link_to "Redeploy",
       project_stage_deploys_path(
         @project,
         @deploy.stage,
-        deploy: { reference: @deploy.reference }
+        deploy: deploy_params
       ),
       html_options
   end

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -25,7 +25,7 @@ module Samson
     EVENT_HOOKS = [
       :stage_clone,
       :stage_permitted_params,
-      :deploy_permitted_params, # for external plugin
+      :deploy_permitted_params,
       :project_permitted_params,
       :deploy_group_permitted_params,
       :build_permitted_params,

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -41,35 +41,29 @@ describe DeploysHelper do
   end
 
   describe '#redeploy_button' do
+    let(:redeploy_warning) { "Why? This deploy succeeded." }
+
     before do
       @deploy = deploy
       @project = projects(:test)
     end
 
-    describe 'when the deploy already succeeded' do
-      it 'generates a link' do
-        link = '<a class="btn btn-default" data-toggle="tooltip" data-placement="auto bottom" title="Why? This deploy'\
-               ' succeeded." rel="nofollow" data-method="post" href="/projects/foo/stages/staging/deploys?deploy%5Bre'\
-               'ference%5D=staging">Redeploy</a>'
-        redeploy_button.must_equal link
-      end
+    it "generates a link" do
+      link = redeploy_button
+      link.must_include redeploy_warning # warns about redeploying
+      link.must_include "?deploy%5Bkubernetes_rollback%5D=true&amp;deploy%5Breference%5D=staging\"" # copies params
+      link.must_include "Redeploy"
     end
 
-    describe 'when the deploy is still running' do
-      before { deploy.stubs(active?: true) }
-
-      it 'does not generate a link' do
-        redeploy_button.must_be_nil
-      end
+    it 'does not generate a link when deploy is active' do
+      deploy.stubs(active?: true)
+      redeploy_button.must_be_nil
     end
 
-    describe 'when the deploy failed' do
-      before { deploy.stubs(succeeded?: false) }
-
-      it 'generates a red link' do
-        redeploy_button.must_equal '<a class="btn btn-danger" rel="nofollow" data-method="post" href="/projects/foo/'\
-                                   'stages/staging/deploys?deploy%5Breference%5D=staging">Redeploy</a>'
-      end
+    it "generates a red link when deply failed" do
+      deploy.stubs(succeeded?: false)
+      redeploy_button.must_include "btn-danger"
+      redeploy_button.wont_include redeploy_warning
     end
   end
 end


### PR DESCRIPTION
https://github.com/zendesk/samson/pull/1543 introduced skipping kubernetes rollbacks, but that was not passed on when doing re-deploys

@jonmoter @irwaters 