### PR TITLE
add ability to stop builds

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -27,6 +27,7 @@ class BuildsController < ApplicationController
   end
 
   def show
+    @project = @build.project
   end
 
   def edit

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -4,7 +4,8 @@ class JobsController < ApplicationController
 
   skip_before_action :require_project, only: [:enabled]
 
-  before_action :authorize_project_admin!, only: [:new, :create, :destroy]
+  before_action :authorize_project_admin!, only: [:new, :create]
+  before_action :authorize_project_deployer!, only: [:new, :create, :destroy]
   before_action :find_job, only: [:show, :destroy]
 
   def index
@@ -51,15 +52,14 @@ class JobsController < ApplicationController
   end
 
   def destroy
-    # if @job.can_be_stopped_by?(current_user)
-    @job.stop!
-    # else
-      # FIXME this can never happen since can_be_stopped_by?
-      # is always true for project admins, which is a before filter
-      # flash[:error] = "You do not have privileges to stop this job."
-    # end
+    if @job.can_be_stopped_by?(current_user)
+      @job.stop!
+      flash[:notice] = "Cancelled!"
+    else
+      flash[:error] = "You are not allowed to stop this job."
+    end
 
-    redirect_to [@project, @job]
+    redirect_back_or [@project, @job]
   end
 
   private

--- a/app/helpers/builds_helper.rb
+++ b/app/helpers/builds_helper.rb
@@ -23,9 +23,4 @@ module BuildsHelper
   def creator_for(build, method: :name_and_email)
     build.creator.try(method) || 'Trigger'
   end
-
-  def docker_build_running?(build)
-    job = build.docker_build_job
-    job&.active? && (JobExecution.find_by_id(job.id) || JobExecution.enabled)
-  end
 end

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -91,7 +91,7 @@ module DeploysHelper
   end
 
   def redeploy_button
-    return if @deploy.active?
+    return if @deploy.job.executing?
 
     html_options = {method: :post}
     if @deploy.succeeded?
@@ -117,11 +117,12 @@ module DeploysHelper
       html_options
   end
 
-  def stop_button(deploy: @deploy, **options)
-    return unless @project && deploy
+  # using project as argument to avoid an additional fetch
+  def stop_button(project:, deploy:, **options)
+    raise if !project || !deploy
     link_to(
       'Stop',
-      [@project, deploy],
+      [project, deploy, {redirect_to: request.fullpath}],
       options.merge(method: :delete, class: options.fetch(:class, 'btn btn-danger btn-xl'))
     )
   end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -98,8 +98,12 @@ class Job < ActiveRecord::Base
     ACTIVE_STATUSES.include?(status)
   end
 
+  def executing?
+    active? || JobExecution.active?(id)
+  end
+
   def waiting_for_restart?
-    !JobExecution.enabled && !finished? && !active? && !JobExecution.active?(id)
+    !JobExecution.enabled && !finished? && !executing?
   end
 
   def output

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -45,24 +45,24 @@
 
   <hr/>
 
-  <% job = @build.docker_build_job %>
-  <% if job %>
+  <% if job = @build.docker_build_job %>
     <h2>Docker Build Output</h2>
 
     <div id="output" data-stream-url="<%= stream_path(job) %>" data-desktop-notify="<%= current_user.desktop_notify? %>">
       <%= render partial: 'shared/output', locals: { job: job, deployable: job, hide: false } %>
-      <% if docker_build_running? @build %>
+      <% if job.executing? %>
         <%= javascript_tag do %>
           toggleOutputToolbar();
           startStream();
         <% end %>
       <% end %>
     </div>
-  <% end %>
 
-  <% unless docker_build_running? @build %>
-    <%= form_for :build, url: build_docker_image_project_build_path(@build.project, @build), html: { class: "form-inline" } do |form| %>
-      <%= form.submit (job ? 'Rebuild Docker Image' : 'Build Docker Image'), class: "btn btn-primary" %>
+    <% unless job.executing? %>
+      <%= form_for :build, url: build_docker_image_project_build_path(@build.project, @build), html: { class: "form-inline" } do |form| %>
+        <%= form.submit (job ? 'Rebuild Docker Image' : 'Build Docker Image'), class: "btn btn-primary" %>
+      <% end %>
     <% end %>
+
   <% end %>
 </section>

--- a/app/views/deploys/_buddy_check.html.erb
+++ b/app/views/deploys/_buddy_check.html.erb
@@ -5,7 +5,7 @@
       <p><%= details.html_safe %></p>
     <% end %>
     <div class="deployer-stop">
-      <%= stop_button %>
+      <%= stop_button deploy: @deploy, project: @project %>
       or
       <% confirm = "Are you sure this is an emergency and you cannot find a buddy?\n#{strip_tags(details)}" %>
       <%= link_to "Bypass", buddy_check_project_deploy_path(@project, @deploy), method: :post, data: {confirm: confirm}, class: "btn btn-danger" %>
@@ -16,7 +16,7 @@
       <%= link_to "Approve", buddy_check_project_deploy_path(@project, @deploy), method: :post, class: "btn btn-primary btn-xl" %>
       <% if @deploy.can_be_stopped_by?(current_user) %>
         or
-        <%= stop_button %>
+        <%= stop_button deploy: @deploy, project: @project %>
       <% end %>
     </div>
   <% else %>

--- a/app/views/deploys/_queued.html.erb
+++ b/app/views/deploys/_queued.html.erb
@@ -1,5 +1,5 @@
 <div class="row deploy-check">
   <p>This deploy is queued, it will be started when previous deploys have finished.</p>
 
-  <%= stop_button %>
+  <%= stop_button deploy: @deploy, project: @project %>
 </div>

--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -37,7 +37,7 @@
   </div>
 </section>
 
-<% if @deploy.active? %>
+<% if @deploy.job.executing? %>
   <script>
     toggleOutputToolbar();
     startStream();

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -10,7 +10,7 @@
   </div>
 </h1>
 
-<div id="header">
+<div id="header" class="stream-header">
   <% if @job.waiting_for_restart? %>
     <%= render 'jobs/restarting' %>
   <% else %>
@@ -24,9 +24,9 @@
   </div>
 </section>
 
-<% if (@job.active? && JobExecution.enabled) || @job.running? %>
-  <%= javascript_tag do %>
+<% if @job.executing? %>
+  <script>
     toggleOutputToolbar();
     startStream();
-  <% end %>
+  </script>
 <% end %>

--- a/app/views/shared/_output.html.erb
+++ b/app/views/shared/_output.html.erb
@@ -11,7 +11,7 @@
       <%= link_to "Download log", project_deploy_path(@project, deployable, format: :text), class: "btn btn-primary only-finished" %>
 
       <% if deployable.can_be_stopped_by?(current_user) %>
-        <%= stop_button(class: "btn btn-danger only-active") %>
+        <%= stop_button deploy: deployable, project: @project, class: "btn btn-danger only-active" %>
       <% end %>
     </div>
   </div>

--- a/test/helpers/builds_helper_test.rb
+++ b/test/helpers/builds_helper_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 11
+SingleCov.covered! uncovered: 9
 
 describe BuildsHelper do
 end

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 31
+SingleCov.covered! uncovered: 28
 
 describe DeploysHelper do
   include StatusHelper
@@ -40,7 +40,7 @@ describe DeploysHelper do
     end
   end
 
-  describe '#redeploy_button' do
+  describe "#redeploy_button" do
     let(:redeploy_warning) { "Why? This deploy succeeded." }
 
     before do
@@ -56,7 +56,7 @@ describe DeploysHelper do
     end
 
     it 'does not generate a link when deploy is active' do
-      deploy.stubs(active?: true)
+      deploy.job.stubs(executing?: true)
       redeploy_button.must_be_nil
     end
 
@@ -64,6 +64,21 @@ describe DeploysHelper do
       deploy.stubs(succeeded?: false)
       redeploy_button.must_include "btn-danger"
       redeploy_button.wont_include redeploy_warning
+    end
+  end
+
+  describe "#stop_button" do
+    before { stubs(request: stub(fullpath: '/hello')) }
+
+    it "builds with a deploy" do
+      button = stop_button(deploy: deploy, project: deploy.project)
+      button.must_include ">Stop<"
+      button.must_include "?redirect_to=%2Fhello\""
+    end
+
+    it "builds with a job" do
+      button = stop_button(deploy: deploy.job, project: deploy.project)
+      button.must_include ">Stop<"
     end
   end
 end


### PR DESCRIPTION
<img width="1160" alt="screen shot 2016-12-21 at 4 38 35 pm" src="https://cloud.githubusercontent.com/assets/11367/21411931/1b3879b4-c7a1-11e6-88bd-6f770d54e119.png">
<img width="420" alt="screen shot 2016-12-21 at 4 46 54 pm" src="https://cloud.githubusercontent.com/assets/11367/21411935/1d874420-c7a1-11e6-9687-94730e7063e3.png">

 - make jobs stoppable by whoever started them
 - unify deploy/build/job 'executing' logic
 - add stop button that directs user back to the build page

@jonmoter @irwaters @sandlerr 