### PR TITLE
PAAS-633 push to multiple images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,7 @@ GITHUB_TOKEN=
 # DOCKER_URL= # optional, use this url instead of connecting to unix socket
 # DOCKER_KEEP_BUILT_IMGS # optional. Set to 1 to keep built images for cache. Fills the disk so some cleanup machanism is needed
 # DOCKER_REPO_NAMESPACE=samson # optional. Configure a namespace that all images should be pushed to, useful for access management.
+# DOCKER_EXTRA_REGISTRIES=my.alternative.registry,and.some.other # optional, push images to these registries too, no credential support atm
 
 # FLOWDOCK_API_TOKEN= # optional. only required for the flowdock integration user mention autocomplete in the buddy approval request form (when BUDDY_CHECK_FEATURE=1). Buddy approval notification would still work without this
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,11 +43,14 @@ class Project < ActiveRecord::Base
 
   scope :search, ->(name) { where("name like ?", "%#{name}%") }
 
-  def docker_repo
-    @docker_repo ||= begin
-      registry = Rails.application.config.samson.docker.registry
-      File.join(registry, ENV['DOCKER_REPO_NAMESPACE'].to_s, permalink_base)
-    end
+  def docker_repo(registry:)
+    default_registry = Rails.application.config.samson.docker.registries.first
+    registry = default_registry  if registry == :default
+    parts = []
+    parts << registry
+    parts << ENV['DOCKER_REPO_NAMESPACE'].to_s if registry == default_registry
+    parts << permalink_base
+    File.join(*parts)
   end
 
   # Whether to create new releases when the branch is updated.

--- a/config/application.rb
+++ b/config/application.rb
@@ -135,7 +135,10 @@ module Samson
     config.samson.auth.gitlab = Samson::EnvCheck.set?("AUTH_GITLAB")
 
     config.samson.docker = ActiveSupport::OrderedOptions.new
-    config.samson.docker.registry = ENV['DOCKER_REGISTRY'].presence
+    config.samson.docker.registries = [
+      ENV['DOCKER_REGISTRY'].presence,
+      *ENV['DOCKER_EXTRA_REGISTRIES'].to_s.split(',')
+    ].compact
 
     config.samson.uri = URI(ENV["DEFAULT_URL"] || 'http://localhost:3000')
     config.sse_rails_engine.access_control_allow_origin = config.samson.uri.to_s

--- a/lib/samson/clair.rb
+++ b/lib/samson/clair.rb
@@ -6,7 +6,8 @@
 # discussion see https://github.com/wemanity-belgium/hyperclair/pull/90
 module Samson
   # TODO: should check based on docker_repo_digest not tag
-  # TODO: this should be a plugin instead and use hooks
+  # TODO: should be a plugin instead and use hooks
+  # TODO: should immediately leave a 'clair job started' output on the job
   module Clair
     class << self
       def append_job_with_scan(job, docker_tag)
@@ -30,7 +31,7 @@ module Samson
         with_time do
           Samson::CommandExecutor.execute(
             executable,
-            *project.docker_repo.split('/', 2),
+            *project.docker_repo(registry: :default).split('/', 2),
             docker_ref,
             whitelist_env: [
               'DOCKER_REGISTRY_USER',

--- a/plugins/kubernetes/app/controllers/admin/kubernetes/clusters_controller.rb
+++ b/plugins/kubernetes/app/controllers/admin/kubernetes/clusters_controller.rb
@@ -77,7 +77,7 @@ class Admin::Kubernetes::ClustersController < ApplicationController
   # kubectl create secret docker-registry kube-ecr-auth --docker-server=X --docker-username=X --docker-password=X
   def update_secret(namespace, user, pass)
     docker_config = {
-      Rails.application.config.samson.docker.registry => {
+      Rails.application.config.samson.docker.registries.first => {
         username: user,
         password: pass
       }

--- a/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
@@ -83,7 +83,7 @@ module Kubernetes
       container_params = {
         env: [{name: 'DOCKER_REGISTRY', value: @registry.fetch(:serveraddress) }],
         args: [
-          project.repository_url, build.git_sha, project.docker_repo, docker_ref,
+          project.repository_url, build.git_sha, project.docker_repo(registry: :default), docker_ref,
           push ? "yes" : "no",
           tag_as_latest ? "yes" : "no"
         ]

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -141,7 +141,8 @@ module Kubernetes
 
     def set_docker_image
       if @doc.build
-        docker_path = @doc.build.docker_repo_digest || "#{project.docker_repo}:#{@doc.build.docker_ref}"
+        docker_path = @doc.build.docker_repo_digest ||
+          "#{project.docker_repo(registry: :default)}:#{@doc.build.docker_ref}"
         # Assume first container is one we want to update docker image in
         container[:image] = docker_path
       end

--- a/test/lib/samson/clair_test.rb
+++ b/test/lib/samson/clair_test.rb
@@ -5,6 +5,7 @@ SingleCov.covered!
 
 describe Samson::Clair do
   share_database_connection_in_all_threads
+  with_registries ["docker-registry.example.com"]
 
   def execute!
     Samson::Clair.append_job_with_scan(job, 'latest')

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -275,17 +275,30 @@ describe Project do
   end
 
   describe '#docker_repo' do
+    with_registries ["docker-registry.example.com"]
+
     it "builds" do
-      project.docker_repo.must_equal "docker-registry.example.com/foo"
+      project.docker_repo(registry: :default).must_equal "docker-registry.example.com/foo"
     end
 
-    it "caches" do
-      project.docker_repo.object_id.must_equal project.docker_repo.object_id
+    it "supports custom registries" do
+      project.docker_repo(registry: 'xyz').must_equal "xyz/foo"
     end
 
-    it "supports namespaces" do
-      with_env DOCKER_REPO_NAMESPACE: 'bar' do
-        project.docker_repo.must_equal "docker-registry.example.com/bar/foo"
+    describe 'with namespace' do
+      with_env DOCKER_REPO_NAMESPACE: 'bar'
+
+      it "namespaces default registry" do
+        project.docker_repo(registry: :default).must_equal "docker-registry.example.com/bar/foo"
+      end
+
+      it "namespaces implicit default registries" do
+        project.docker_repo(registry: 'docker-registry.example.com').must_equal "docker-registry.example.com/bar/foo"
+      end
+
+      # Not great ... but what we need atm :(
+      it "does not namespace extra registries" do
+        project.docker_repo(registry: 'xyz').must_equal "xyz/foo"
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -185,6 +185,18 @@ class ActiveSupport::TestCase
   def self.share_database_connection_in_all_threads
     before { ActiveRecord::Base.stubs(connection: ActiveRecord::Base.connection) }
   end
+
+  def self.with_registries(registries)
+    around do |test|
+      begin
+        old = Rails.application.config.samson.docker.registries
+        Rails.application.config.samson.docker.registries = registries
+        test.call
+      ensure
+        Rails.application.config.samson.docker.registries = old
+      end
+    end
+  end
 end
 
 Mocha::Expectation.class_eval do


### PR DESCRIPTION
for now only supporting pushing without or with same credentials

 - pushing to extra registries is done without namespacing ... not sure if that is what we want (given that it won't work for multiple ECR registries), but it is what would make the transition easiest ...
 - ECR auth will only perform for the first registry ... this is tricky to implement for all since we atm store credentials in the ENV ... so will need to rework if we ever want multiple ECR registries

@jonmoter @irwaters 

confirmed working with https://samsontest.zende.sk/projects/truth_service/builds/470

FYI we do not push our automated-build-triggered-via-deploy-4131 tags

simplified testing and made it always list all pushes/tags
fixed bugs:
 - where tagging something as latest would not force-push that tag.
 - when pushing failed but digest was created it did not stop fail build