### PR TITLE
Make release sources configurable

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -12,7 +12,7 @@ class Integrations::BaseController < ApplicationController
       return head(:ok)
     end
 
-    create_release = project.create_releases_for_branch?(branch, service_type, service_name)
+    create_release = project.create_release?(branch, service_type, service_name)
     record_log :info, "Branch #{branch} is release branch: #{create_release}"
     release = find_or_create_release if create_release
 

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -12,7 +12,7 @@ class Integrations::BaseController < ApplicationController
       return head(:ok)
     end
 
-    create_release = project.create_releases_for_branch?(branch)
+    create_release = project.create_releases_for_branch?(branch, service_type, service_name)
     record_log :info, "Branch #{branch} is release branch: #{create_release}"
     release = find_or_create_release if create_release
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -81,6 +81,7 @@ class ProjectsController < ApplicationController
         :owner,
         :permalink,
         :release_branch,
+        :release_source,
         :docker_release_branch,
         :include_new_deploy_groups,
       ] + Samson::Hooks.fire(:project_permitted_params)

--- a/app/helpers/webhooks_helper.rb
+++ b/app/helpers/webhooks_helper.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 module WebhooksHelper
-  def webhook_sources(sources)
-    [
-      ['Any CI', 'any_ci'],
-      ['Any code push', 'any_code'],
-      ['Any Pull Request', 'any_pull_request'],
-      ['Any', 'any']
-    ] + sources.map { |source| [source.titleize, source] }.to_a
+  GENERIC_SOURCES = [
+    ['Any CI', 'any_ci'],
+    ['Any code push', 'any_code'],
+    ['Any Pull Request', 'any_pull_request'],
+    ['Any', 'any']
+  ].freeze
+
+  NO_SOURCE = [['None', 'none']].freeze
+
+  def webhook_sources_select(sources, none: false)
+    default_sources = none ? GENERIC_SOURCES + NO_SOURCE : GENERIC_SOURCES
+    default_sources + sources_for_select(sources)
+  end
+
+  def sources_for_select(sources)
+    sources.map { |source| [source.titleize, source] }.to_a
   end
 end

--- a/app/helpers/webhooks_helper.rb
+++ b/app/helpers/webhooks_helper.rb
@@ -9,7 +9,7 @@ module WebhooksHelper
 
   NO_SOURCE = [['None', 'none']].freeze
 
-  def webhook_sources_select(sources, none: false)
+  def webhook_sources_for_select(sources, none: false)
     default_sources = none ? GENERIC_SOURCES + NO_SOURCE : GENERIC_SOURCES
     default_sources + sources_for_select(sources)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,8 +58,12 @@ class Project < ActiveRecord::Base
   # branch - The String name of the branch in question.
   #
   # Returns true if new releases should be created, false otherwise.
-  def create_releases_for_branch?(branch)
-    release_branch == branch
+  def create_releases_for_branch?(branch, service_type, service_name)
+    release_branch == branch && release_source_included?(service_type, service_name)
+  end
+
+  def release_source_included?(service_type, service_name)
+    release_source == 'any' || release_source == "any_#{service_type}" || release_source == service_name
   end
 
   # Whether to create a new docker image when the branch is updated.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,12 +58,8 @@ class Project < ActiveRecord::Base
   # branch - The String name of the branch in question.
   #
   # Returns true if new releases should be created, false otherwise.
-  def create_releases_for_branch?(branch, service_type, service_name)
-    release_branch == branch && release_source_included?(service_type, service_name)
-  end
-
-  def release_source_included?(service_type, service_name)
-    release_source == 'any' || release_source == "any_#{service_type}" || release_source == service_name
+  def create_release?(branch, service_type, service_name)
+    release_branch == branch && Webhook.source_matches?(release_source, service_type, service_name)
   end
 
   # Whether to create a new docker image when the branch is updated.

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -17,4 +17,8 @@ class Webhook < ActiveRecord::Base
   def self.for_source(service_type, service_name)
     where(source: ['any', "any_#{service_type}", service_name])
   end
+
+  def self.source_matches?(release_source, service_type, service_name)
+    release_source == 'any' || release_source == "any_#{service_type}" || release_source == service_name
+  end
 end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -8,12 +8,9 @@
     <%= form.input :repository_url, required: true %>
     <%= form.input :permalink, required: true if project.persisted? %>
     <%= form.input :release_branch, help: 'New commits on this branch will cause a release when a webhook arrives.' %>
-    <div class="form-group">
-      <%= form.label "Release source", class: "col-lg-2 control-label" %>
-      <div class="col-lg-4">
-        <%= form.collection_select :release_source, webhook_sources_for_select(Samson::Integration::SOURCES), :second, :first, {}, class: "form-control", help: 'Selects which type of webhook will create a release' %>
-      </div>
-    </div>
+    <%= form.input :release_source, help: 'Selects which type of webhook will create a release' do %>
+      <%= form.collection_select :release_source, webhook_sources_for_select(Samson::Integration::SOURCES, none: true), :second, :first, {}, class: "form-control" %>
+    <% end %>
     <% if ENV['DOCKER_FEATURE'] %>
       <%= form.input :docker_release_branch, help: 'New commits on this branch will cause a docker image to be built when a webhook arrives.' %>
     <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -8,6 +8,12 @@
     <%= form.input :repository_url, required: true %>
     <%= form.input :permalink, required: true if project.persisted? %>
     <%= form.input :release_branch, help: 'New commits on this branch will cause a release when a webhook arrives.' %>
+    <div class="form-group">
+      <%= form.label "Release source", class: "col-lg-2 control-label" %>
+      <div class="col-lg-4">
+        <%= form.collection_select :release_source, webhook_sources(Samson::Integration::SOURCES), :second, :first, {}, class: "form-control" %>
+      </div>
+    </div>
     <% if ENV['DOCKER_FEATURE'] %>
       <%= form.input :docker_release_branch, help: 'New commits on this branch will cause a docker image to be built when a webhook arrives.' %>
     <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -11,7 +11,7 @@
     <div class="form-group">
       <%= form.label "Release source", class: "col-lg-2 control-label" %>
       <div class="col-lg-4">
-        <%= form.collection_select :release_source, webhook_sources(Samson::Integration::SOURCES), :second, :first, {}, class: "form-control" %>
+        <%= form.collection_select :release_source, webhook_sources_select(Samson::Integration::SOURCES), :second, :first, {}, class: "form-control", help: 'Selects which type of webhook will create a release' %>
       </div>
     </div>
     <% if ENV['DOCKER_FEATURE'] %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -11,7 +11,7 @@
     <div class="form-group">
       <%= form.label "Release source", class: "col-lg-2 control-label" %>
       <div class="col-lg-4">
-        <%= form.collection_select :release_source, webhook_sources_select(Samson::Integration::SOURCES), :second, :first, {}, class: "form-control", help: 'Selects which type of webhook will create a release' %>
+        <%= form.collection_select :release_source, webhook_sources_for_select(Samson::Integration::SOURCES), :second, :first, {}, class: "form-control", help: 'Selects which type of webhook will create a release' %>
       </div>
     </div>
     <% if ENV['DOCKER_FEATURE'] %>

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -46,7 +46,7 @@
 
 
     <div class="form-group">
-      <%= form.select :source, webhook_sources_select(Samson::Integration::SOURCES), {}, class: "form-control" %>
+      <%= form.select :source, webhook_sources_for_select(Samson::Integration::SOURCES), {}, class: "form-control" %>
     </div>
 
     <p></p>

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -46,7 +46,7 @@
 
 
     <div class="form-group">
-      <%= form.select :source, webhook_sources(Samson::Integration::SOURCES), {}, class: "form-control" %>
+      <%= form.select :source, webhook_sources_select(Samson::Integration::SOURCES), {}, class: "form-control" %>
     </div>
 
     <p></p>

--- a/db/migrate/20161216202909_add_release_sources.rb
+++ b/db/migrate/20161216202909_add_release_sources.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReleaseSources < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :release_source, :string, null: false, default: "any"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,10 +27,11 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "kubernetes_job",                   default: false, null: false
-    t.index ["created_by"], name: "index_builds_on_created_by"
-    t.index ["git_sha"], name: "index_builds_on_git_sha", unique: true
-    t.index ["project_id"], name: "index_builds_on_project_id"
   end
+
+  add_index "builds", ["created_by"], name: "index_builds_on_created_by", using: :btree
+  add_index "builds", ["git_sha"], name: "index_builds_on_git_sha", unique: true, using: :btree
+  add_index "builds", ["project_id"], name: "index_builds_on_project_id", using: :btree
 
   create_table "commands", force: :cascade do |t|
     t.text     "command",    limit: 10485760
@@ -48,32 +49,35 @@ ActiveRecord::Schema.define(version: 20161216202909) do
   end
 
   create_table "deploy_groups", force: :cascade do |t|
-    t.string   "name",            limit: 255, null: false
-    t.integer  "environment_id",  limit: 4,   null: false
+    t.string   "name",           limit: 255, null: false
+    t.integer  "environment_id", limit: 4,   null: false
     t.datetime "deleted_at"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.string   "env_value",       limit: 255, null: false
-    t.string   "permalink",       limit: 255, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "env_value",      limit: 255, null: false
+    t.string   "permalink",      limit: 255, null: false
     t.integer  "vault_server_id"
-    t.index ["environment_id"], name: "index_deploy_groups_on_environment_id"
-    t.index ["permalink"], name: "index_deploy_groups_on_permalink", unique: true
   end
+
+  add_index "deploy_groups", ["environment_id"], name: "index_deploy_groups_on_environment_id", using: :btree
+  add_index "deploy_groups", ["permalink"], name: "index_deploy_groups_on_permalink", unique: true, length: {"permalink"=>191}, using: :btree
 
   create_table "deploy_groups_stages", id: false, force: :cascade do |t|
     t.integer "deploy_group_id", limit: 4
     t.integer "stage_id",        limit: 4
-    t.index ["deploy_group_id"], name: "index_deploy_groups_stages_on_deploy_group_id"
-    t.index ["stage_id"], name: "index_deploy_groups_stages_on_stage_id"
   end
+
+  add_index "deploy_groups_stages", ["deploy_group_id"], name: "index_deploy_groups_stages_on_deploy_group_id", using: :btree
+  add_index "deploy_groups_stages", ["stage_id"], name: "index_deploy_groups_stages_on_stage_id", using: :btree
 
   create_table "deploy_response_urls", force: :cascade do |t|
     t.integer  "deploy_id",    limit: 4,   null: false
     t.string   "response_url", limit: 255, null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
-    t.index ["deploy_id"], name: "index_deploy_response_urls_on_deploy_id", unique: true
   end
+
+  add_index "deploy_response_urls", ["deploy_id"], name: "index_deploy_response_urls_on_deploy_id", unique: true, using: :btree
 
   create_table "deploys", force: :cascade do |t|
     t.integer  "stage_id",                            null: false
@@ -89,18 +93,19 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.boolean  "kubernetes",          default: false, null: false
     t.integer  "project_id",                          null: false
     t.boolean  "kubernetes_rollback", default: true,  null: false
-    t.index ["build_id"], name: "index_deploys_on_build_id"
-    t.index ["deleted_at"], name: "index_deploys_on_deleted_at"
-    t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
-    t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at"
-    t.index ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at"
+    t.index ["build_id"], name: "index_deploys_on_build_id", using: :btree
+    t.index ["deleted_at"], name: "index_deploys_on_deleted_at", using: :btree
+    t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at", using: :btree
+    t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at", using: :btree
+    t.index ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at", using: :btree
   end
 
   create_table "environment_variable_groups", force: :cascade do |t|
-    t.string "name",    limit: 255,   null: false
+    t.string "name", limit: 255, null: false
     t.text   "comment", limit: 65535
-    t.index ["name"], name: "index_environment_variable_groups_on_name", unique: true
   end
+
+  add_index "environment_variable_groups", ["name"], name: "index_environment_variable_groups_on_name", unique: true, length: {"name"=>191}, using: :btree
 
   create_table "environment_variables", force: :cascade do |t|
     t.string  "name",        limit: 255, null: false
@@ -109,8 +114,9 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.string  "parent_type", limit: 255, null: false
     t.integer "scope_id",    limit: 4
     t.string  "scope_type",  limit: 255
-    t.index ["parent_id", "parent_type", "name", "scope_type", "scope_id"], name: "environment_variables_unique_scope", unique: true
   end
+
+  add_index "environment_variables", ["parent_id", "parent_type", "name", "scope_type", "scope_id"], name: "environment_variables_unique_scope", unique: true, length: {"parent_id"=>nil, "parent_type"=>191, "name"=>191, "scope_type"=>191, "scope_id"=>nil}, using: :btree
 
   create_table "environments", force: :cascade do |t|
     t.string   "name",       limit: 255,                 null: false
@@ -119,8 +125,9 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.string   "permalink",  limit: 255,                 null: false
-    t.index ["permalink"], name: "index_environments_on_permalink", unique: true
   end
+
+  add_index "environments", ["permalink"], name: "index_environments_on_permalink", unique: true, length: {"permalink"=>191}, using: :btree
 
   create_table "flowdock_flows", force: :cascade do |t|
     t.string   "name",       limit: 255,                null: false
@@ -128,7 +135,7 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.integer  "stage_id",   limit: 4,                  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "enabled",                default: true, null: false
+    t.boolean  "enabled",    default: true, null: false
   end
 
   create_table "jenkins_jobs", force: :cascade do |t|
@@ -140,9 +147,10 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
     t.string   "url",            limit: 255
-    t.index ["deploy_id"], name: "index_jenkins_jobs_on_deploy_id"
-    t.index ["jenkins_job_id"], name: "index_jenkins_jobs_on_jenkins_job_id"
   end
+
+  add_index "jenkins_jobs", ["deploy_id"], name: "index_jenkins_jobs_on_deploy_id", using: :btree
+  add_index "jenkins_jobs", ["jenkins_job_id"], name: "index_jenkins_jobs_on_jenkins_job_id", using: :btree
 
   create_table "jobs", force: :cascade do |t|
     t.text     "command",    limit: 65535,                          null: false
@@ -154,10 +162,11 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "updated_at"
     t.string   "commit",     limit: 255
     t.string   "tag",        limit: 255
-    t.index ["project_id"], name: "index_jobs_on_project_id"
-    t.index ["status"], name: "index_jobs_on_status"
-    t.index ["user_id"], name: "index_jobs_on_user_id"
   end
+
+  add_index "jobs", ["project_id"], name: "index_jobs_on_project_id", using: :btree
+  add_index "jobs", ["status"], name: "index_jobs_on_status", length: {"status"=>191}, using: :btree
+  add_index "jobs", ["user_id"], name: "index_jobs_on_user_id", using: :btree
 
   create_table "kubernetes_cluster_deploy_groups", force: :cascade do |t|
     t.integer  "kubernetes_cluster_id", limit: 4,   null: false
@@ -165,9 +174,10 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.string   "namespace",             limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["deploy_group_id"], name: "index_kubernetes_cluster_deploy_groups_on_deploy_group_id"
-    t.index ["kubernetes_cluster_id"], name: "index_kuber_cluster_deploy_groups_on_kuber_cluster_id"
   end
+
+  add_index "kubernetes_cluster_deploy_groups", ["deploy_group_id"], name: "index_kubernetes_cluster_deploy_groups_on_deploy_group_id", using: :btree
+  add_index "kubernetes_cluster_deploy_groups", ["kubernetes_cluster_id"], name: "index_kuber_cluster_deploy_groups_on_kuber_cluster_id", using: :btree
 
   create_table "kubernetes_clusters", force: :cascade do |t|
     t.string   "name",            limit: 255
@@ -186,35 +196,38 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.integer "ram",                limit: 4,                         null: false
     t.decimal "cpu",                          precision: 4, scale: 2, null: false
     t.integer "kubernetes_role_id", limit: 4,                         null: false
-    t.index ["deploy_group_id"], name: "index_kubernetes_deploy_group_roles_on_deploy_group_id"
-    t.index ["project_id", "deploy_group_id", "kubernetes_role_id"], name: "index_kubernetes_deploy_group_roles_on_project_id"
   end
 
+  add_index "kubernetes_deploy_group_roles", ["deploy_group_id"], name: "index_kubernetes_deploy_group_roles_on_deploy_group_id", using: :btree
+  add_index "kubernetes_deploy_group_roles", ["project_id", "deploy_group_id", "kubernetes_role_id"], name: "index_kubernetes_deploy_group_roles_on_project_id", using: :btree
+
   create_table "kubernetes_release_docs", force: :cascade do |t|
-    t.integer  "kubernetes_role_id",    limit: 4,                             null: false
-    t.integer  "kubernetes_release_id", limit: 4,                             null: false
-    t.integer  "replica_target",        limit: 4,                             null: false
+    t.integer  "kubernetes_role_id",          limit: 4,                         null: false
+    t.integer  "kubernetes_release_id",       limit: 4,                         null: false
+    t.integer  "replica_target",              limit: 4,                         null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "deploy_group_id"
-    t.decimal  "cpu",                                 precision: 4, scale: 2, null: false
-    t.integer  "ram",                   limit: 4,                             null: false
-    t.text     "resource_template",     limit: 65535
-    t.index ["kubernetes_release_id"], name: "index_kubernetes_release_docs_on_kubernetes_release_id"
-    t.index ["kubernetes_role_id"], name: "index_kubernetes_release_docs_on_kubernetes_role_id"
+    t.decimal  "cpu",                                       precision: 4, scale: 2,                     null: false
+    t.integer  "ram",                         limit: 4,                                                 null: false
+    t.text     "resource_template",           limit: 65535
   end
+
+  add_index "kubernetes_release_docs", ["kubernetes_release_id"], name: "index_kubernetes_release_docs_on_kubernetes_release_id", using: :btree
+  add_index "kubernetes_release_docs", ["kubernetes_role_id"], name: "index_kubernetes_release_docs_on_kubernetes_role_id", using: :btree
 
   create_table "kubernetes_releases", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "build_id"
     t.integer  "user_id"
-    t.integer  "project_id", limit: 4,   null: false
-    t.integer  "deploy_id",  limit: 4
-    t.string   "git_sha",    limit: 40,  null: false
-    t.string   "git_ref",    limit: 255, null: false
-    t.index ["build_id"], name: "index_kubernetes_releases_on_build_id"
+    t.integer  "project_id",         limit: 4,                       null: false
+    t.integer  "deploy_id",          limit: 4
+    t.string   "git_sha",            limit: 40,                      null: false
+    t.string   "git_ref",            limit: 255,                     null: false
   end
+
+  add_index "kubernetes_releases", ["build_id"], name: "index_kubernetes_releases_on_build_id"
 
   create_table "kubernetes_roles", force: :cascade do |t|
     t.integer  "project_id",    limit: 4,   null: false
@@ -225,22 +238,23 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "updated_at",                null: false
     t.datetime "deleted_at"
     t.string   "resource_name", limit: 255, null: false
-    t.index ["project_id"], name: "index_kubernetes_roles_on_project_id"
-    t.index ["resource_name", "deleted_at"], name: "index_kubernetes_roles_on_resource_name_and_deleted_at", unique: true
-    t.index ["service_name", "deleted_at"], name: "index_kubernetes_roles_on_service_name_and_deleted_at", unique: true
   end
+
+  add_index "kubernetes_roles", ["project_id"], name: "index_kubernetes_roles_on_project_id", using: :btree
+  add_index "kubernetes_roles", ["resource_name", "deleted_at"], name: "index_kubernetes_roles_on_resource_name_and_deleted_at", unique: true, length: {"resource_name"=>191, "deleted_at"=>nil}, using: :btree
+  add_index "kubernetes_roles", ["service_name", "deleted_at"], name: "index_kubernetes_roles_on_service_name_and_deleted_at", unique: true, length: {"service_name"=>191, "deleted_at"=>nil}, using: :btree
 
   create_table "locks", force: :cascade do |t|
     t.integer  "resource_id"
-    t.integer  "user_id",                                    null: false
+    t.integer  "user_id",                       null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string   "description",   limit: 1024
-    t.boolean  "warning",                    default: false, null: false
+    t.boolean  "warning",       default: false, null: false
     t.datetime "delete_at"
     t.string   "resource_type"
-    t.index ["resource_id", "resource_type", "deleted_at"], name: "index_locks_on_resource_id_and_resource_type_and_deleted_at", unique: true
+    t.index ["resource_id", "resource_type", "deleted_at"], name: "index_locks_on_resource_id_and_resource_type_and_deleted_at", unique: true, length: {"resource_id"=>nil, "resource_type"=>40, "deleted_at"=>nil}, using: :btree
   end
 
   create_table "macro_commands", force: :cascade do |t|
@@ -258,14 +272,16 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at"
   end
+
+  add_index "macros", ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at", using: :btree
 
   create_table "new_relic_applications", force: :cascade do |t|
     t.string  "name",     limit: 255
     t.integer "stage_id", limit: 4
-    t.index ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true
   end
+
+  add_index "new_relic_applications", ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true, length: {"stage_id"=>nil, "name"=>191}, using: :btree
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", limit: 4,     null: false
@@ -276,9 +292,10 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "created_at",                      null: false
     t.datetime "revoked_at"
     t.string   "scopes",            limit: 255
-    t.index ["application_id"], name: "fk_rails_b4b53e07b8"
-    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
+
+  add_index "oauth_access_grants", ["application_id"], name: "fk_rails_b4b53e07b8", using: :btree
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, length: {"token"=>191}, using: :btree
 
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id",      limit: 4
@@ -292,11 +309,12 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.string   "previous_refresh_token", limit: 255, default: "", null: false
     t.string   "description"
     t.datetime "last_used_at"
-    t.index ["application_id"], name: "fk_rails_732cb83ab7"
-    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
-    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
-    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
+
+  add_index "oauth_access_tokens", ["application_id"], name: "fk_rails_732cb83ab7", using: :btree
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, length: {"refresh_token"=>191}, using: :btree
+  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, length: {"token"=>191}, using: :btree
 
   create_table "oauth_applications", force: :cascade do |t|
     t.string   "name",         limit: 255,                null: false
@@ -306,59 +324,49 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.string   "scopes",       limit: 255,   default: "", null: false
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false
-    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "outbound_webhooks", force: :cascade do |t|
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-    t.datetime "deleted_at"
-    t.integer  "project_id", limit: 4,   default: 0, null: false
-    t.integer  "stage_id",   limit: 4,   default: 0, null: false
-    t.string   "url",        limit: 255,             null: false
-    t.string   "username",   limit: 255
-    t.string   "password",   limit: 255
-    t.index ["deleted_at"], name: "index_outbound_webhooks_on_deleted_at"
-    t.index ["project_id"], name: "index_outbound_webhooks_on_project_id"
-  end
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, length: {"uid"=>191}, using: :btree
 
   create_table "project_environment_variable_groups", force: :cascade do |t|
     t.integer "project_id",                    limit: 4, null: false
     t.integer "environment_variable_group_id", limit: 4, null: false
-    t.index ["environment_variable_group_id"], name: "project_environment_variable_groups_group_id"
-    t.index ["project_id", "environment_variable_group_id"], name: "project_environment_variable_groups_unique_group_id", unique: true
   end
 
+  add_index "project_environment_variable_groups", ["environment_variable_group_id"], name: "project_environment_variable_groups_group_id", using: :btree
+  add_index "project_environment_variable_groups", ["project_id", "environment_variable_group_id"], name: "project_environment_variable_groups_unique_group_id", unique: true, using: :btree
+
   create_table "projects", force: :cascade do |t|
-    t.string   "name",                      limit: 255,                   null: false
-    t.string   "repository_url",            limit: 255,                   null: false
+    t.string   "name",               limit: 255,                   null: false
+    t.string   "repository_url",     limit: 255,                   null: false
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "token"
     t.string   "release_branch"
+    t.string   "release_source",                          default: "any", null: false
     t.string   "permalink",                                               null: false
     t.text     "description",               limit: 65535
     t.string   "owner"
     t.boolean  "include_new_deploy_groups",               default: false, null: false
     t.string   "docker_release_branch"
-    t.string   "release_source",                          default: "All", null: false
-    t.index ["permalink"], name: "index_projects_on_permalink", unique: true
-    t.index ["token"], name: "index_projects_on_token", unique: true
+    t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: {"permalink"=>191}, using: :btree
+    t.index ["token"], name: "index_projects_on_token", unique: true, length: {"token"=>191}, using: :btree
   end
 
   create_table "releases", force: :cascade do |t|
-    t.integer  "project_id",  limit: 4,                 null: false
-    t.string   "commit",      limit: 255,               null: false
-    t.string   "number",      limit: 20,  default: "1", null: false
-    t.integer  "author_id",   limit: 4,                 null: false
-    t.string   "author_type", limit: 255,               null: false
+    t.integer  "project_id",  limit: 4,                null: false
+    t.string   "commit",      limit: 255,              null: false
+    t.string   "number",      limit: 20, default: "1", null: false
+    t.integer  "author_id",   limit: 4,                null: false
+    t.string   "author_type", limit: 255,              null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "build_id",    limit: 4
-    t.index ["build_id"], name: "index_releases_on_build_id"
-    t.index ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
   end
+
+  add_index "releases", ["build_id"], name: "index_releases_on_build_id", using: :btree
+  add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true, using: :btree
 
   create_table "secrets", id: false, force: :cascade do |t|
     t.string   "id",                 limit: 255
@@ -371,8 +379,9 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "updated_at",                                     null: false
     t.boolean  "visible",                        default: false, null: false
     t.string   "comment",            limit: 255
-    t.index ["id"], name: "index_secrets_on_id", unique: true
   end
+
+  add_index "secrets", ["id"], name: "index_secrets_on_id", unique: true, length: {"id"=>191}, using: :btree
 
   create_table "slack_channels", force: :cascade do |t|
     t.string   "name",       limit: 255, null: false
@@ -380,30 +389,33 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.integer  "stage_id",   limit: 4,   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["stage_id"], name: "index_slack_channels_on_stage_id"
   end
+
+  add_index "slack_channels", ["stage_id"], name: "index_slack_channels_on_stage_id", using: :btree
 
   create_table "slack_identifiers", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
     t.text     "identifier", limit: 65535, null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
-    t.index ["identifier"], name: "index_slack_identifiers_on_identifier"
-    t.index ["user_id"], name: "index_slack_identifiers_on_user_id", unique: true
   end
 
+  add_index "slack_identifiers", ["identifier"], name: "index_slack_identifiers_on_identifier", length: {"identifier"=>12}, using: :btree
+  add_index "slack_identifiers", ["user_id"], name: "index_slack_identifiers_on_user_id", unique: true, using: :btree
+
   create_table "slack_webhooks", force: :cascade do |t|
-    t.text     "webhook_url",     limit: 65535,                 null: false
-    t.string   "channel",         limit: 255
-    t.integer  "stage_id",        limit: 4,                     null: false
+    t.text     "webhook_url", limit: 65535, null: false
+    t.string   "channel",     limit: 255
+    t.integer  "stage_id",    limit: 4,     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "before_deploy",                 default: false, null: false
     t.boolean  "after_deploy",                  default: true,  null: false
     t.boolean  "for_buddy",                     default: false, null: false
     t.boolean  "only_on_failure",               default: false, null: false
-    t.index ["stage_id"], name: "index_slack_webhooks_on_stage_id"
   end
+
+  add_index "slack_webhooks", ["stage_id"], name: "index_slack_webhooks_on_stage_id", using: :btree
 
   create_table "stage_commands", force: :cascade do |t|
     t.integer  "stage_id",   limit: 4
@@ -445,8 +457,8 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.boolean  "jenkins_email_committers",                                   default: false, null: false
     t.boolean  "run_in_parallel",                                            default: false, null: false
     t.boolean  "jenkins_build_params",                                       default: false, null: false
-    t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true
-    t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
+    t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: {"project_id"=>nil, "permalink"=>191}, using: :btree
+    t.index ["template_stage_id"], name: "index_stages_on_template_stage_id", using: :btree
   end
 
   create_table "stars", force: :cascade do |t|
@@ -454,8 +466,9 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.integer  "project_id", limit: 4, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true
   end
+
+  add_index "stars", ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true, using: :btree
 
   create_table "user_project_roles", force: :cascade do |t|
     t.integer  "project_id", null: false
@@ -463,9 +476,10 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.integer  "role_id",    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["project_id"], name: "index_user_project_roles_on_project_id"
-    t.index ["user_id", "project_id"], name: "index_user_project_roles_on_user_id_and_project_id", unique: true
   end
+
+  add_index "user_project_roles", ["project_id"], name: "index_user_project_roles_on_project_id"
+  add_index "user_project_roles", ["user_id", "project_id"], name: "index_user_project_roles_on_user_id_and_project_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                                        null: false
@@ -482,7 +496,7 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.string   "time_format",            default: "relative", null: false
     t.datetime "last_login_at"
     t.datetime "last_seen_at"
-    t.index ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at"
+    t.index ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at", length: {"external_id"=>191, "deleted_at"=>nil}, using: :btree
   end
 
   create_table "vault_servers", force: :cascade do |t|
@@ -495,7 +509,7 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.text     "ca_cert",            limit: 65535
     t.datetime "created_at",                                       null: false
     t.datetime "updated_at",                                       null: false
-    t.index ["name"], name: "index_vault_servers_on_name", unique: true
+    t.index ["name"], name: "index_vault_servers_on_name", unique: true, length: {"name"=>191}, using: :btree
   end
 
   create_table "versions", force: :cascade do |t|
@@ -505,8 +519,9 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.string   "whodunnit",  limit: 255
     t.text     "object",     limit: 1073741823
     t.datetime "created_at"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
+
+  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", length: {"item_type"=>191, "item_id"=>nil}, using: :btree
 
   create_table "webhooks", force: :cascade do |t|
     t.integer  "project_id", limit: 4,   null: false
@@ -516,8 +531,26 @@ ActiveRecord::Schema.define(version: 20161216202909) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string   "source",     limit: 255, null: false
-    t.index ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch"
-    t.index ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch"
   end
 
+  add_index "webhooks", ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch", length: {"project_id"=>nil, "branch"=>191}, using: :btree
+  add_index "webhooks", ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch", length: {"stage_id"=>nil, "branch"=>191}, using: :btree
+
+  create_table :outbound_webhooks do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+
+    t.integer "project_id",   limit: 4, default: false, null: false
+    t.integer "stage_id",     limit: 4, default: false, null: false
+
+    t.string "url",           limit: 255, null: false
+    t.string "username",      limit: 255
+    t.string "password",      limit: 255
+  end
+
+  add_index "outbound_webhooks", "deleted_at"
+  add_index "outbound_webhooks", "project_id"
+
+  add_foreign_key "deploy_groups", "environments"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161216183341) do
+ActiveRecord::Schema.define(version: 20161216202909) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -27,11 +27,10 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "kubernetes_job",                   default: false, null: false
+    t.index ["created_by"], name: "index_builds_on_created_by"
+    t.index ["git_sha"], name: "index_builds_on_git_sha", unique: true
+    t.index ["project_id"], name: "index_builds_on_project_id"
   end
-
-  add_index "builds", ["created_by"], name: "index_builds_on_created_by", using: :btree
-  add_index "builds", ["git_sha"], name: "index_builds_on_git_sha", unique: true, using: :btree
-  add_index "builds", ["project_id"], name: "index_builds_on_project_id", using: :btree
 
   create_table "commands", force: :cascade do |t|
     t.text     "command",    limit: 10485760
@@ -49,35 +48,32 @@ ActiveRecord::Schema.define(version: 20161216183341) do
   end
 
   create_table "deploy_groups", force: :cascade do |t|
-    t.string   "name",           limit: 255, null: false
-    t.integer  "environment_id", limit: 4,   null: false
+    t.string   "name",            limit: 255, null: false
+    t.integer  "environment_id",  limit: 4,   null: false
     t.datetime "deleted_at"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.string   "env_value",      limit: 255, null: false
-    t.string   "permalink",      limit: 255, null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.string   "env_value",       limit: 255, null: false
+    t.string   "permalink",       limit: 255, null: false
     t.integer  "vault_server_id"
+    t.index ["environment_id"], name: "index_deploy_groups_on_environment_id"
+    t.index ["permalink"], name: "index_deploy_groups_on_permalink", unique: true
   end
-
-  add_index "deploy_groups", ["environment_id"], name: "index_deploy_groups_on_environment_id", using: :btree
-  add_index "deploy_groups", ["permalink"], name: "index_deploy_groups_on_permalink", unique: true, length: {"permalink"=>191}, using: :btree
 
   create_table "deploy_groups_stages", id: false, force: :cascade do |t|
     t.integer "deploy_group_id", limit: 4
     t.integer "stage_id",        limit: 4
+    t.index ["deploy_group_id"], name: "index_deploy_groups_stages_on_deploy_group_id"
+    t.index ["stage_id"], name: "index_deploy_groups_stages_on_stage_id"
   end
-
-  add_index "deploy_groups_stages", ["deploy_group_id"], name: "index_deploy_groups_stages_on_deploy_group_id", using: :btree
-  add_index "deploy_groups_stages", ["stage_id"], name: "index_deploy_groups_stages_on_stage_id", using: :btree
 
   create_table "deploy_response_urls", force: :cascade do |t|
     t.integer  "deploy_id",    limit: 4,   null: false
     t.string   "response_url", limit: 255, null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.index ["deploy_id"], name: "index_deploy_response_urls_on_deploy_id", unique: true
   end
-
-  add_index "deploy_response_urls", ["deploy_id"], name: "index_deploy_response_urls_on_deploy_id", unique: true, using: :btree
 
   create_table "deploys", force: :cascade do |t|
     t.integer  "stage_id",                            null: false
@@ -93,19 +89,18 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.boolean  "kubernetes",          default: false, null: false
     t.integer  "project_id",                          null: false
     t.boolean  "kubernetes_rollback", default: true,  null: false
-    t.index ["build_id"], name: "index_deploys_on_build_id", using: :btree
-    t.index ["deleted_at"], name: "index_deploys_on_deleted_at", using: :btree
-    t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at", using: :btree
-    t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at", using: :btree
-    t.index ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at", using: :btree
+    t.index ["build_id"], name: "index_deploys_on_build_id"
+    t.index ["deleted_at"], name: "index_deploys_on_deleted_at"
+    t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
+    t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at"
+    t.index ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at"
   end
 
   create_table "environment_variable_groups", force: :cascade do |t|
-    t.string "name", limit: 255, null: false
+    t.string "name",    limit: 255,   null: false
     t.text   "comment", limit: 65535
+    t.index ["name"], name: "index_environment_variable_groups_on_name", unique: true
   end
-
-  add_index "environment_variable_groups", ["name"], name: "index_environment_variable_groups_on_name", unique: true, length: {"name"=>191}, using: :btree
 
   create_table "environment_variables", force: :cascade do |t|
     t.string  "name",        limit: 255, null: false
@@ -114,9 +109,8 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.string  "parent_type", limit: 255, null: false
     t.integer "scope_id",    limit: 4
     t.string  "scope_type",  limit: 255
+    t.index ["parent_id", "parent_type", "name", "scope_type", "scope_id"], name: "environment_variables_unique_scope", unique: true
   end
-
-  add_index "environment_variables", ["parent_id", "parent_type", "name", "scope_type", "scope_id"], name: "environment_variables_unique_scope", unique: true, length: {"parent_id"=>nil, "parent_type"=>191, "name"=>191, "scope_type"=>191, "scope_id"=>nil}, using: :btree
 
   create_table "environments", force: :cascade do |t|
     t.string   "name",       limit: 255,                 null: false
@@ -125,9 +119,8 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.string   "permalink",  limit: 255,                 null: false
+    t.index ["permalink"], name: "index_environments_on_permalink", unique: true
   end
-
-  add_index "environments", ["permalink"], name: "index_environments_on_permalink", unique: true, length: {"permalink"=>191}, using: :btree
 
   create_table "flowdock_flows", force: :cascade do |t|
     t.string   "name",       limit: 255,                null: false
@@ -135,7 +128,7 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.integer  "stage_id",   limit: 4,                  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "enabled",    default: true, null: false
+    t.boolean  "enabled",                default: true, null: false
   end
 
   create_table "jenkins_jobs", force: :cascade do |t|
@@ -147,10 +140,9 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
     t.string   "url",            limit: 255
+    t.index ["deploy_id"], name: "index_jenkins_jobs_on_deploy_id"
+    t.index ["jenkins_job_id"], name: "index_jenkins_jobs_on_jenkins_job_id"
   end
-
-  add_index "jenkins_jobs", ["deploy_id"], name: "index_jenkins_jobs_on_deploy_id", using: :btree
-  add_index "jenkins_jobs", ["jenkins_job_id"], name: "index_jenkins_jobs_on_jenkins_job_id", using: :btree
 
   create_table "jobs", force: :cascade do |t|
     t.text     "command",    limit: 65535,                          null: false
@@ -162,11 +154,10 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "updated_at"
     t.string   "commit",     limit: 255
     t.string   "tag",        limit: 255
+    t.index ["project_id"], name: "index_jobs_on_project_id"
+    t.index ["status"], name: "index_jobs_on_status"
+    t.index ["user_id"], name: "index_jobs_on_user_id"
   end
-
-  add_index "jobs", ["project_id"], name: "index_jobs_on_project_id", using: :btree
-  add_index "jobs", ["status"], name: "index_jobs_on_status", length: {"status"=>191}, using: :btree
-  add_index "jobs", ["user_id"], name: "index_jobs_on_user_id", using: :btree
 
   create_table "kubernetes_cluster_deploy_groups", force: :cascade do |t|
     t.integer  "kubernetes_cluster_id", limit: 4,   null: false
@@ -174,10 +165,9 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.string   "namespace",             limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["deploy_group_id"], name: "index_kubernetes_cluster_deploy_groups_on_deploy_group_id"
+    t.index ["kubernetes_cluster_id"], name: "index_kuber_cluster_deploy_groups_on_kuber_cluster_id"
   end
-
-  add_index "kubernetes_cluster_deploy_groups", ["deploy_group_id"], name: "index_kubernetes_cluster_deploy_groups_on_deploy_group_id", using: :btree
-  add_index "kubernetes_cluster_deploy_groups", ["kubernetes_cluster_id"], name: "index_kuber_cluster_deploy_groups_on_kuber_cluster_id", using: :btree
 
   create_table "kubernetes_clusters", force: :cascade do |t|
     t.string   "name",            limit: 255
@@ -196,38 +186,35 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.integer "ram",                limit: 4,                         null: false
     t.decimal "cpu",                          precision: 4, scale: 2, null: false
     t.integer "kubernetes_role_id", limit: 4,                         null: false
+    t.index ["deploy_group_id"], name: "index_kubernetes_deploy_group_roles_on_deploy_group_id"
+    t.index ["project_id", "deploy_group_id", "kubernetes_role_id"], name: "index_kubernetes_deploy_group_roles_on_project_id"
   end
 
-  add_index "kubernetes_deploy_group_roles", ["deploy_group_id"], name: "index_kubernetes_deploy_group_roles_on_deploy_group_id", using: :btree
-  add_index "kubernetes_deploy_group_roles", ["project_id", "deploy_group_id", "kubernetes_role_id"], name: "index_kubernetes_deploy_group_roles_on_project_id", using: :btree
-
   create_table "kubernetes_release_docs", force: :cascade do |t|
-    t.integer  "kubernetes_role_id",          limit: 4,                         null: false
-    t.integer  "kubernetes_release_id",       limit: 4,                         null: false
-    t.integer  "replica_target",              limit: 4,                         null: false
+    t.integer  "kubernetes_role_id",    limit: 4,                             null: false
+    t.integer  "kubernetes_release_id", limit: 4,                             null: false
+    t.integer  "replica_target",        limit: 4,                             null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "deploy_group_id"
-    t.decimal  "cpu",                                       precision: 4, scale: 2,                     null: false
-    t.integer  "ram",                         limit: 4,                                                 null: false
-    t.text     "resource_template",           limit: 65535
+    t.decimal  "cpu",                                 precision: 4, scale: 2, null: false
+    t.integer  "ram",                   limit: 4,                             null: false
+    t.text     "resource_template",     limit: 65535
+    t.index ["kubernetes_release_id"], name: "index_kubernetes_release_docs_on_kubernetes_release_id"
+    t.index ["kubernetes_role_id"], name: "index_kubernetes_release_docs_on_kubernetes_role_id"
   end
-
-  add_index "kubernetes_release_docs", ["kubernetes_release_id"], name: "index_kubernetes_release_docs_on_kubernetes_release_id", using: :btree
-  add_index "kubernetes_release_docs", ["kubernetes_role_id"], name: "index_kubernetes_release_docs_on_kubernetes_role_id", using: :btree
 
   create_table "kubernetes_releases", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "build_id"
     t.integer  "user_id"
-    t.integer  "project_id",         limit: 4,                       null: false
-    t.integer  "deploy_id",          limit: 4
-    t.string   "git_sha",            limit: 40,                      null: false
-    t.string   "git_ref",            limit: 255,                     null: false
+    t.integer  "project_id", limit: 4,   null: false
+    t.integer  "deploy_id",  limit: 4
+    t.string   "git_sha",    limit: 40,  null: false
+    t.string   "git_ref",    limit: 255, null: false
+    t.index ["build_id"], name: "index_kubernetes_releases_on_build_id"
   end
-
-  add_index "kubernetes_releases", ["build_id"], name: "index_kubernetes_releases_on_build_id"
 
   create_table "kubernetes_roles", force: :cascade do |t|
     t.integer  "project_id",    limit: 4,   null: false
@@ -238,23 +225,22 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "updated_at",                null: false
     t.datetime "deleted_at"
     t.string   "resource_name", limit: 255, null: false
+    t.index ["project_id"], name: "index_kubernetes_roles_on_project_id"
+    t.index ["resource_name", "deleted_at"], name: "index_kubernetes_roles_on_resource_name_and_deleted_at", unique: true
+    t.index ["service_name", "deleted_at"], name: "index_kubernetes_roles_on_service_name_and_deleted_at", unique: true
   end
-
-  add_index "kubernetes_roles", ["project_id"], name: "index_kubernetes_roles_on_project_id", using: :btree
-  add_index "kubernetes_roles", ["resource_name", "deleted_at"], name: "index_kubernetes_roles_on_resource_name_and_deleted_at", unique: true, length: {"resource_name"=>191, "deleted_at"=>nil}, using: :btree
-  add_index "kubernetes_roles", ["service_name", "deleted_at"], name: "index_kubernetes_roles_on_service_name_and_deleted_at", unique: true, length: {"service_name"=>191, "deleted_at"=>nil}, using: :btree
 
   create_table "locks", force: :cascade do |t|
     t.integer  "resource_id"
-    t.integer  "user_id",                       null: false
+    t.integer  "user_id",                                    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string   "description",   limit: 1024
-    t.boolean  "warning",       default: false, null: false
+    t.boolean  "warning",                    default: false, null: false
     t.datetime "delete_at"
     t.string   "resource_type"
-    t.index ["resource_id", "resource_type", "deleted_at"], name: "index_locks_on_resource_id_and_resource_type_and_deleted_at", unique: true, length: {"resource_id"=>nil, "resource_type"=>40, "deleted_at"=>nil}, using: :btree
+    t.index ["resource_id", "resource_type", "deleted_at"], name: "index_locks_on_resource_id_and_resource_type_and_deleted_at", unique: true
   end
 
   create_table "macro_commands", force: :cascade do |t|
@@ -272,16 +258,14 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at"
   end
-
-  add_index "macros", ["project_id", "deleted_at"], name: "index_macros_on_project_id_and_deleted_at", using: :btree
 
   create_table "new_relic_applications", force: :cascade do |t|
     t.string  "name",     limit: 255
     t.integer "stage_id", limit: 4
+    t.index ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true
   end
-
-  add_index "new_relic_applications", ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true, length: {"stage_id"=>nil, "name"=>191}, using: :btree
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", limit: 4,     null: false
@@ -292,10 +276,9 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "created_at",                      null: false
     t.datetime "revoked_at"
     t.string   "scopes",            limit: 255
+    t.index ["application_id"], name: "fk_rails_b4b53e07b8"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
-
-  add_index "oauth_access_grants", ["application_id"], name: "fk_rails_b4b53e07b8", using: :btree
-  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, length: {"token"=>191}, using: :btree
 
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id",      limit: 4
@@ -309,12 +292,11 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.string   "previous_refresh_token", limit: 255, default: "", null: false
     t.string   "description"
     t.datetime "last_used_at"
+    t.index ["application_id"], name: "fk_rails_732cb83ab7"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
-
-  add_index "oauth_access_tokens", ["application_id"], name: "fk_rails_732cb83ab7", using: :btree
-  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, length: {"refresh_token"=>191}, using: :btree
-  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
-  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, length: {"token"=>191}, using: :btree
 
   create_table "oauth_applications", force: :cascade do |t|
     t.string   "name",         limit: 255,                null: false
@@ -324,21 +306,32 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.string   "scopes",       limit: 255,   default: "", null: false
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, length: {"uid"=>191}, using: :btree
+  create_table "outbound_webhooks", force: :cascade do |t|
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.datetime "deleted_at"
+    t.integer  "project_id", limit: 4,   default: 0, null: false
+    t.integer  "stage_id",   limit: 4,   default: 0, null: false
+    t.string   "url",        limit: 255,             null: false
+    t.string   "username",   limit: 255
+    t.string   "password",   limit: 255
+    t.index ["deleted_at"], name: "index_outbound_webhooks_on_deleted_at"
+    t.index ["project_id"], name: "index_outbound_webhooks_on_project_id"
+  end
 
   create_table "project_environment_variable_groups", force: :cascade do |t|
     t.integer "project_id",                    limit: 4, null: false
     t.integer "environment_variable_group_id", limit: 4, null: false
+    t.index ["environment_variable_group_id"], name: "project_environment_variable_groups_group_id"
+    t.index ["project_id", "environment_variable_group_id"], name: "project_environment_variable_groups_unique_group_id", unique: true
   end
 
-  add_index "project_environment_variable_groups", ["environment_variable_group_id"], name: "project_environment_variable_groups_group_id", using: :btree
-  add_index "project_environment_variable_groups", ["project_id", "environment_variable_group_id"], name: "project_environment_variable_groups_unique_group_id", unique: true, using: :btree
-
   create_table "projects", force: :cascade do |t|
-    t.string   "name",               limit: 255,                   null: false
-    t.string   "repository_url",     limit: 255,                   null: false
+    t.string   "name",                      limit: 255,                   null: false
+    t.string   "repository_url",            limit: 255,                   null: false
     t.datetime "deleted_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -349,23 +342,23 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.string   "owner"
     t.boolean  "include_new_deploy_groups",               default: false, null: false
     t.string   "docker_release_branch"
-    t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: {"permalink"=>191}, using: :btree
-    t.index ["token"], name: "index_projects_on_token", unique: true, length: {"token"=>191}, using: :btree
+    t.string   "release_source",                          default: "All", null: false
+    t.index ["permalink"], name: "index_projects_on_permalink", unique: true
+    t.index ["token"], name: "index_projects_on_token", unique: true
   end
 
   create_table "releases", force: :cascade do |t|
-    t.integer  "project_id",  limit: 4,                null: false
-    t.string   "commit",      limit: 255,              null: false
-    t.string   "number",      limit: 20, default: "1", null: false
-    t.integer  "author_id",   limit: 4,                null: false
-    t.string   "author_type", limit: 255,              null: false
+    t.integer  "project_id",  limit: 4,                 null: false
+    t.string   "commit",      limit: 255,               null: false
+    t.string   "number",      limit: 20,  default: "1", null: false
+    t.integer  "author_id",   limit: 4,                 null: false
+    t.string   "author_type", limit: 255,               null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "build_id",    limit: 4
+    t.index ["build_id"], name: "index_releases_on_build_id"
+    t.index ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
   end
-
-  add_index "releases", ["build_id"], name: "index_releases_on_build_id", using: :btree
-  add_index "releases", ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true, using: :btree
 
   create_table "secrets", id: false, force: :cascade do |t|
     t.string   "id",                 limit: 255
@@ -378,9 +371,8 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "updated_at",                                     null: false
     t.boolean  "visible",                        default: false, null: false
     t.string   "comment",            limit: 255
+    t.index ["id"], name: "index_secrets_on_id", unique: true
   end
-
-  add_index "secrets", ["id"], name: "index_secrets_on_id", unique: true, length: {"id"=>191}, using: :btree
 
   create_table "slack_channels", force: :cascade do |t|
     t.string   "name",       limit: 255, null: false
@@ -388,33 +380,30 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.integer  "stage_id",   limit: 4,   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["stage_id"], name: "index_slack_channels_on_stage_id"
   end
-
-  add_index "slack_channels", ["stage_id"], name: "index_slack_channels_on_stage_id", using: :btree
 
   create_table "slack_identifiers", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
     t.text     "identifier", limit: 65535, null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.index ["identifier"], name: "index_slack_identifiers_on_identifier"
+    t.index ["user_id"], name: "index_slack_identifiers_on_user_id", unique: true
   end
 
-  add_index "slack_identifiers", ["identifier"], name: "index_slack_identifiers_on_identifier", length: {"identifier"=>12}, using: :btree
-  add_index "slack_identifiers", ["user_id"], name: "index_slack_identifiers_on_user_id", unique: true, using: :btree
-
   create_table "slack_webhooks", force: :cascade do |t|
-    t.text     "webhook_url", limit: 65535, null: false
-    t.string   "channel",     limit: 255
-    t.integer  "stage_id",    limit: 4,     null: false
+    t.text     "webhook_url",     limit: 65535,                 null: false
+    t.string   "channel",         limit: 255
+    t.integer  "stage_id",        limit: 4,                     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "before_deploy",                 default: false, null: false
     t.boolean  "after_deploy",                  default: true,  null: false
     t.boolean  "for_buddy",                     default: false, null: false
     t.boolean  "only_on_failure",               default: false, null: false
+    t.index ["stage_id"], name: "index_slack_webhooks_on_stage_id"
   end
-
-  add_index "slack_webhooks", ["stage_id"], name: "index_slack_webhooks_on_stage_id", using: :btree
 
   create_table "stage_commands", force: :cascade do |t|
     t.integer  "stage_id",   limit: 4
@@ -456,8 +445,8 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.boolean  "jenkins_email_committers",                                   default: false, null: false
     t.boolean  "run_in_parallel",                                            default: false, null: false
     t.boolean  "jenkins_build_params",                                       default: false, null: false
-    t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: {"project_id"=>nil, "permalink"=>191}, using: :btree
-    t.index ["template_stage_id"], name: "index_stages_on_template_stage_id", using: :btree
+    t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true
+    t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end
 
   create_table "stars", force: :cascade do |t|
@@ -465,9 +454,8 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.integer  "project_id", limit: 4, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true
   end
-
-  add_index "stars", ["user_id", "project_id"], name: "index_stars_on_user_id_and_project_id", unique: true, using: :btree
 
   create_table "user_project_roles", force: :cascade do |t|
     t.integer  "project_id", null: false
@@ -475,10 +463,9 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.integer  "role_id",    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["project_id"], name: "index_user_project_roles_on_project_id"
+    t.index ["user_id", "project_id"], name: "index_user_project_roles_on_user_id_and_project_id", unique: true
   end
-
-  add_index "user_project_roles", ["project_id"], name: "index_user_project_roles_on_project_id"
-  add_index "user_project_roles", ["user_id", "project_id"], name: "index_user_project_roles_on_user_id_and_project_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                                        null: false
@@ -495,7 +482,7 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.string   "time_format",            default: "relative", null: false
     t.datetime "last_login_at"
     t.datetime "last_seen_at"
-    t.index ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at", length: {"external_id"=>191, "deleted_at"=>nil}, using: :btree
+    t.index ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at"
   end
 
   create_table "vault_servers", force: :cascade do |t|
@@ -508,7 +495,7 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.text     "ca_cert",            limit: 65535
     t.datetime "created_at",                                       null: false
     t.datetime "updated_at",                                       null: false
-    t.index ["name"], name: "index_vault_servers_on_name", unique: true, length: {"name"=>191}, using: :btree
+    t.index ["name"], name: "index_vault_servers_on_name", unique: true
   end
 
   create_table "versions", force: :cascade do |t|
@@ -518,9 +505,8 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.string   "whodunnit",  limit: 255
     t.text     "object",     limit: 1073741823
     t.datetime "created_at"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
-
-  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", length: {"item_type"=>191, "item_id"=>nil}, using: :btree
 
   create_table "webhooks", force: :cascade do |t|
     t.integer  "project_id", limit: 4,   null: false
@@ -530,26 +516,8 @@ ActiveRecord::Schema.define(version: 20161216183341) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string   "source",     limit: 255, null: false
+    t.index ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch"
+    t.index ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch"
   end
 
-  add_index "webhooks", ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch", length: {"project_id"=>nil, "branch"=>191}, using: :btree
-  add_index "webhooks", ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch", length: {"stage_id"=>nil, "branch"=>191}, using: :btree
-
-  create_table :outbound_webhooks do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
-
-    t.integer "project_id",   limit: 4, default: false, null: false
-    t.integer "stage_id",     limit: 4, default: false, null: false
-
-    t.string "url",           limit: 255, null: false
-    t.string "username",      limit: 255
-    t.string "password",      limit: 255
-  end
-
-  add_index "outbound_webhooks", "deleted_at"
-  add_index "outbound_webhooks", "project_id"
-
-  add_foreign_key "deploy_groups", "environments"
 end

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -21,7 +21,7 @@ describe Integrations::BaseController do
     Integrations::BaseController.any_instance.stubs(:deploy?).returns(true)
     Integrations::BaseController.any_instance.stubs(:commit).returns(sha)
     Integrations::BaseController.any_instance.stubs(:branch).returns('master')
-    Project.any_instance.stubs(:create_releases_for_branch?).returns(true)
+    Project.any_instance.stubs(:create_release?).returns(true)
     Build.any_instance.stubs(:validate_git_reference).returns(true)
     stub_request(:post, "https://api.github.com/repos/bar/foo/releases")
   end
@@ -42,9 +42,9 @@ describe Integrations::BaseController do
       project.releases.count.must_equal 1
     end
 
-    describe 'when the release branch source is defined' do
+    describe 'when the release branch source is specified' do
       before do
-        Project.any_instance.unstub(:create_releases_for_branch?)
+        Project.any_instance.unstub(:create_release?)
         project.update_column(:release_branch, 'master')
       end
 
@@ -112,7 +112,7 @@ describe Integrations::BaseController do
     end
 
     it 'does not blow up when creating docker image if a release was not created' do
-      Project.any_instance.expects(create_releases_for_branch?: false)
+      Project.any_instance.expects(create_release?: false)
       Project.any_instance.expects(build_docker_image_for_branch?: true)
 
       post :create, params: {test_route: true, token: token}
@@ -142,7 +142,7 @@ describe Integrations::BaseController do
       end
 
       it 'uses the commit to make the deploy when no release was created' do
-        Project.any_instance.stubs(:create_releases_for_branch?).returns(false)
+        Project.any_instance.stubs(:create_release?).returns(false)
         post :create, params: {test_route: true, token: token}
         assert_response :success
         Deploy.first.reference.must_equal sha

--- a/test/controllers/integrations/buildkite_controller_test.rb
+++ b/test/controllers/integrations/buildkite_controller_test.rb
@@ -63,7 +63,7 @@ describe Integrations::BuildkiteController do
       project.releases.destroy_all
       project.builds.destroy_all
       Integrations::BuildkiteController.any_instance.stubs(:project).returns(project)
-      project.stubs(:create_releases_for_branch?).returns(true)
+      project.stubs(:create_release?).returns(true)
       Build.any_instance.stubs(:validate_git_reference).returns(true)
       stub_request(:post, "https://api.github.com/repos/bar/foo/releases").
         to_return(status: 200, body: "", headers: {})

--- a/test/helpers/webhooks_helper_test.rb
+++ b/test/helpers/webhooks_helper_test.rb
@@ -4,13 +4,24 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe WebhooksHelper do
-  describe '#webhook_sources' do
+  describe '#webhook_sources_select' do
     it "renders" do
-      webhook_sources(["foo"]).must_equal [
+      webhook_sources_select(["foo"]).must_equal [
         ["Any CI", "any_ci"],
         ["Any code push", "any_code"],
         ["Any Pull Request", "any_pull_request"],
         ["Any", "any"],
+        ["Foo", "foo"]
+      ]
+    end
+
+    it "renders with none action" do
+      webhook_sources_select(["foo"], none: true).must_equal [
+        ["Any CI", "any_ci"],
+        ["Any code push", "any_code"],
+        ["Any Pull Request", "any_pull_request"],
+        ["Any", "any"],
+        ["None", 'none'],
         ["Foo", "foo"]
       ]
     end

--- a/test/helpers/webhooks_helper_test.rb
+++ b/test/helpers/webhooks_helper_test.rb
@@ -4,9 +4,9 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe WebhooksHelper do
-  describe '#webhook_sources_select' do
+  describe '#webhook_sources_for_select' do
     it "renders" do
-      webhook_sources_select(["foo"]).must_equal [
+      webhook_sources_for_select(["foo"]).must_equal [
         ["Any CI", "any_ci"],
         ["Any code push", "any_code"],
         ["Any Pull Request", "any_pull_request"],
@@ -16,7 +16,7 @@ describe WebhooksHelper do
     end
 
     it "renders with none action" do
-      webhook_sources_select(["foo"], none: true).must_equal [
+      webhook_sources_for_select(["foo"], none: true).must_equal [
         ["Any CI", "any_ci"],
         ["Any code push", "any_code"],
         ["Any Pull Request", "any_pull_request"],

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -338,18 +338,18 @@ describe Project do
     end
   end
 
-  describe "#create_releases_for_branch?" do
+  describe "#create_release?" do
     before do
       project.update_column(:release_source, "any")
     end
 
     describe "with no release source configured" do
       it "is true when it is the release branch" do
-        assert project.create_releases_for_branch?(project.release_branch, "test_service_type", "test_service")
+        assert project.create_release?(project.release_branch, "test_service_type", "test_service")
       end
 
       it "is false when it is not the release branch" do
-        refute project.create_releases_for_branch?("x", "test_service_type", "test_service")
+        refute project.create_release?("x", "test_service_type", "test_service")
       end
     end
 
@@ -357,23 +357,23 @@ describe Project do
       Samson::Integration::SOURCES.each do |release_source|
         it "is true when the source does match" do
           project.update_column(:release_source, release_source)
-          assert project.create_releases_for_branch?(project.release_branch, "release_type", release_source)
+          assert project.create_release?(project.release_branch, "release_type", release_source)
         end
 
         it "is always true if the source is any" do
           project.update_column(:release_source, "any")
-          assert project.create_releases_for_branch?(project.release_branch, "release_type", "none")
+          assert project.create_release?(project.release_branch, "release_type", "none")
         end
 
         it "is false when the source doesn't match" do
           project.update_column(:release_source, "none")
-          refute project.create_releases_for_branch?(project.release_branch, "release_type", release_source)
+          refute project.create_release?(project.release_branch, "release_type", release_source)
         end
       end
 
       it "is true if the source type matches" do
         project.update_column(:release_source, "any_code")
-        assert project.create_releases_for_branch?(project.release_branch, "code", "github")
+        assert project.create_release?(project.release_branch, "code", "github")
       end
     end
   end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -339,12 +339,42 @@ describe Project do
   end
 
   describe "#create_releases_for_branch?" do
-    it "is true when it is the release branch" do
-      assert project.create_releases_for_branch?(project.release_branch)
+    before do
+      project.update_column(:release_source, "any")
     end
 
-    it "is false when it is not the release branch" do
-      refute project.create_releases_for_branch?("x")
+    describe "with no release source configured" do
+      it "is true when it is the release branch" do
+        assert project.create_releases_for_branch?(project.release_branch, "test_service_type", "test_service")
+      end
+
+      it "is false when it is not the release branch" do
+        refute project.create_releases_for_branch?("x", "test_service_type", "test_service")
+      end
+    end
+
+    describe "with a release source configured" do
+      Samson::Integration::SOURCES.each do |release_source|
+        it "is true when the source does match" do
+          project.update_column(:release_source, release_source)
+          assert project.create_releases_for_branch?(project.release_branch, "release_type", release_source)
+        end
+
+        it "is always true if the source is any" do
+          project.update_column(:release_source, "any")
+          assert project.create_releases_for_branch?(project.release_branch, "release_type", "none")
+        end
+
+        it "is false when the source doesn't match" do
+          project.update_column(:release_source, "none")
+          refute project.create_releases_for_branch?(project.release_branch, "release_type", release_source)
+        end
+      end
+
+      it "is true if the source type matches" do
+        project.update_column(:release_source, "any_code")
+        assert project.create_releases_for_branch?(project.release_branch, "code", "github")
+      end
     end
   end
 

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -90,4 +90,24 @@ describe Webhook do
       assert_equal Webhook.for_branch('master').pluck(:branch), ['', 'master']
     end
   end
+
+  describe '.for_source' do
+    Samson::Integration::SOURCES.each do |release_source|
+      it 'is true when the source does match' do
+        assert Webhook.source_matches?(release_source, 'release_type', release_source)
+      end
+
+      it 'is always true if the source is any' do
+        assert Webhook.source_matches?('any', 'release_type', release_source)
+      end
+
+      it "is false when the source doesn't match" do
+        refute Webhook.source_matches?('poop', 'release_type', release_source)
+      end
+    end
+
+    it "is true if the source type matches" do
+      assert Webhook.source_matches?('any_code', 'code', 'github')
+    end
+  end
 end

--- a/test/models/webhook_test.rb
+++ b/test/models/webhook_test.rb
@@ -93,16 +93,16 @@ describe Webhook do
 
   describe '.for_source' do
     Samson::Integration::SOURCES.each do |release_source|
-      it 'is true when the source does match' do
+      it 'is true when the source matches' do
         assert Webhook.source_matches?(release_source, 'release_type', release_source)
-      end
-
-      it 'is always true if the source is any' do
-        assert Webhook.source_matches?('any', 'release_type', release_source)
       end
 
       it "is false when the source doesn't match" do
         refute Webhook.source_matches?('poop', 'release_type', release_source)
+      end
+
+      it 'is always true if the source is any' do
+        assert Webhook.source_matches?('any', 'release_type', release_source)
       end
     end
 


### PR DESCRIPTION
The Samson releases feature by default uses any webhook for a project to create a release.  This keeps the default behavior, but adds an option to restrict the release to a single webhook source (Travis for example).  This means that you could wait for a green build from CI before tagging a new release.

![](http://content.screencast.com/users/pididiot1/folders/Jing/media/fe9987b2-4664-4401-9ce7-d1b0cd92d028/00000087.png)

/cc @zendesk/samson @zendesk/sustaining 



### Risks
- Medium:  Could cause release feature to break.
