### PR TITLE
dont update a release with build if the release doesnt exist

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -104,7 +104,7 @@ class Integrations::BaseController < ApplicationController
 
   def create_docker_image(release)
     build = find_or_create_build(branch)
-    release.update_attribute(:build, build)
+    release.update_attribute(:build, build) if release
     DockerBuilderService.new(build).run!(push: true, tag_as_latest: true)
   end
 

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -86,6 +86,18 @@ describe Integrations::BaseController do
       assert_response :unauthorized
     end
 
+    it 'does not blow up when creating docker image if a release was not created' do
+      Project.any_instance.expects(create_releases_for_branch?: false)
+      Project.any_instance.expects(build_docker_image_for_branch?: true)
+
+      post :create, params: {test_route: true, token: token}
+
+      assert_response :success
+      project.reload
+      project.releases.count.must_equal 0
+      project.builds.count.must_equal 1
+    end
+
     describe "when deploy hooks are setup" do
       before do
         project.webhooks.create!(branch: 'master', stage: stage, source: 'any')


### PR DESCRIPTION
Projects might not be using the releases feature, but have a docker build branch set. This causes an error to happen when a build is run without a release being created. This will allow the build to run without blowing up on the missing release. 

An alternative option would be to not run the build if the release isn't created, but I think this is simpler. 

Example error:
```
{"method":"POST","path":"/integrations/travis/[TOKEN]","format":"*/*","controller":"integrations/travis","action":"create","status":500,"error":"NoMethodError: undefined method `update_attribute' for nil:NilClass"}
```

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Low. Docker builds will proceed without a release.