### PR TITLE
remove rake check, it can be loaded when using rails db:migrate ... s…

### DIFF
--- a/config/initializers/zz_boot_speed_test.rb
+++ b/config/initializers/zz_boot_speed_test.rb
@@ -5,7 +5,6 @@ if Rails.env.development? && !ENV['SERVER_MODE']
     [
       ActiveRecord::Base.send(:descendants).map(&:name),
       ActionController::Base.descendants,
-      (File.basename($0) != "rake" ? (defined?(Rake) && "rake") : nil),
       (defined?(Mocha) && "mocha")
     ].compact.flatten.each { |c| raise "#{c} should not be loaded" }
   end


### PR DESCRIPTION
…o no easy way to detect that and it does not bring much speed improvement anyway
fixes #1586

@attahkhan016 works for you ?
fyi @apanzerj since you always loved these patches