### PR TITLE
remove now invalid roles when project is soft deleted

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Project < ActiveRecord::Base
-  has_soft_deletion default_scope: true
+  has_soft_deletion default_scope: true unless self < SoftDeletion::Core
 
   include Permalinkable
   include Searchable

--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 Project.class_eval do
+  has_soft_deletion default_scope: true
+
   has_many :kubernetes_releases, class_name: 'Kubernetes::Release'
   has_many :kubernetes_roles, class_name: 'Kubernetes::Role', dependent: :destroy
   has_many :kubernetes_deploy_group_roles, class_name: 'Kubernetes::DeployGroupRole'
 
   scope :with_kubernetes_roles, -> { where(id: Kubernetes::Role.not_deleted.pluck('distinct project_id')) }
+
+  after_soft_delete :delete_kubernetes_deploy_group_roles
+
+  private
+
+  def delete_kubernetes_deploy_group_roles
+    kubernetes_deploy_group_roles.each(&:destroy)
+  end
 end

--- a/plugins/kubernetes/test/decorators/project_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/project_decorator_test.rb
@@ -6,10 +6,18 @@ SingleCov.covered!
 describe Project do
   let(:project) { projects(:test) }
 
+  before { project.stubs(:valid_repository_url) }
+
   describe "#kubernetes_deploy_group_roles" do
     it "cleans them up when getting destroyed" do
       assert_difference 'Kubernetes::DeployGroupRole.count', -4 do
         project.destroy
+      end
+    end
+
+    it "cleans them up when getting soft deleted" do
+      assert_difference 'Kubernetes::DeployGroupRole.count', -4 do
+        project.soft_delete!
       end
     end
   end
@@ -18,6 +26,12 @@ describe Project do
     it "cleans them up when getting destroyed" do
       assert_difference 'Kubernetes::Role.count', -2 do
         project.destroy
+      end
+    end
+
+    it "cleans them up when getting soft deleted" do
+      assert_difference 'Kubernetes::Role.not_deleted.count', -2 do
+        project.soft_delete!
       end
     end
   end


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/1745416631217498244?tab=overview
NoMethodError: undefined method `name' for nil:NilClass
plugins/kubernetes/app/views/admin/kubernetes/deploy_group_roles/index.html.erb:36

@jonmoter @prudhvi 