### PR TITLE
show init container logs too

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -46,7 +46,7 @@ module Kubernetes
       end
 
       def containers
-        @pod.spec.containers
+        @pod.spec.containers.map(&:to_h)
       end
 
       def logs(container)
@@ -72,6 +72,11 @@ module Kubernetes
           namespace: namespace,
           field_selector: "involvedObject.name=#{name}"
         )
+      end
+
+      def init_containers
+        return [] unless containers = @pod.dig(:metadata, :annotations, :'pod.alpha.kubernetes.io/init-containers')
+        JSON.parse(containers, symbolize_names: true)
       end
 
       private

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -132,8 +132,9 @@ module Kubernetes
     def print_pod_logs(pod)
       @output.puts "LOGS:"
 
-      pod.containers.map(&:name).each do |container|
-        @output.puts "Container #{container}" if pod.containers.size > 1
+      containers = (pod.containers + pod.init_containers).map { |c| c.fetch(:name) }
+      containers.each do |container|
+        @output.puts "Container #{container}" if containers.size > 1
 
         # Display the first and last n_lines of the log
         max = 50

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -119,7 +119,7 @@ describe Kubernetes::Api::Pod do
 
   describe "#containers" do
     it 'reads' do
-      pod.containers.first.name.must_equal 'container1'
+      pod.containers.first[:name].must_equal 'container1'
     end
   end
 
@@ -243,6 +243,17 @@ describe Kubernetes::Api::Pod do
       readiness_failed[:message] = readiness_failed[:message].sub('Readiness', 'Liveliness')
       stub_request(:get, events_url).to_return(body: {items: [readiness_failed.merge(count: 20)]}.to_json)
       assert pod_with_client.events_indicate_failure?
+    end
+  end
+
+  describe "#init_containers" do
+    it "is empty for no containers" do
+      pod.init_containers.must_equal []
+    end
+
+    it "finds init containers" do
+      pod_attributes[:metadata][:annotations] = {"pod.alpha.kubernetes.io/init-containers": [{foo: :bar}].to_json}
+      pod.init_containers.must_equal [{foo: "bar"}]
     end
   end
 end


### PR DESCRIPTION
@jonmoter @irwaters @prudhvi 

these containers are atm not logged, which might hide important debugging information

```
LOGS:
Container truth-service
  No logs found
Container secret-puller
  2016-12-29 23:51:46 +0000: secrets found: TEST,"master/global/global/rails_env"
  2016-12-29 23:51:46 +0000: writing secrets: TEST
  2016-12-29 23:51:46 +0000: all secrets written
```