### PR TITLE
exclude our private plugin so tests run clean

### DIFF
--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -159,7 +159,7 @@ describe "cleanliness" do
   it "links every plugin in docs" do
     readme_path = 'docs/plugins.md'
     readme = File.read(readme_path)
-    plugins = Dir['plugins/*'].map { |f| File.basename(f) } - ['samson_ledger']
+    plugins = Dir['plugins/*'].map { |f| File.basename(f) } - ['samson_ledger', 'extra_migrations']
     plugins.each do |plugin_name|
       assert(
         readme.include?("https://github.com/zendesk/samson/tree/master/plugins/#{plugin_name}"),


### PR DESCRIPTION
atm fails with `docs/plugins.md must include link to extra_migrations`