### PR TITLE
do not send binary builder errors to airbrake

### DIFF
--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -74,6 +74,7 @@ class BinaryBuilder
     untar(File.join(@dir, ARTIFACTS_FILE))
   end
 
+  # FIXME: does not set permissons ... reuse some library instead of re-inventing
   def untar(file_path)
     @output.puts "About to untar: #{file_path}"
 
@@ -88,9 +89,7 @@ class BinaryBuilder
           else
             destination_directory = File.dirname(destination_file)
             FileUtils.mkdir_p destination_directory unless File.directory?(destination_directory)
-            File.open destination_file, "wb" do |f|
-              f.print tarfile.read
-            end
+            File.open(destination_file, "wb") { |f| f.print tarfile.read }
           end
         end
       end

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -45,7 +45,7 @@ class BinaryBuilder
 
     @output.puts "Running pre build script..."
     unless @executor.execute! pre_build_file
-      raise "Error running pre build script"
+      raise Samson::Hooks::UserError, "Error running pre build script"
     end
   end
 
@@ -59,8 +59,8 @@ class BinaryBuilder
     @output.puts 'Now starting Build container...'
     @container.tap(&:start).attach { |_stream, chunk| @output.write_docker_chunk(chunk) }
   rescue
-    @output.puts "Failed to run the build script '#{BUILD_SCRIPT}' inside container."
-    raise
+    Rails.logger.error("Binary builder error:\n#{$!}\n#{$!.backtrace.join("\n")}")
+    raise Samson::Hooks::UserError, "Failed to run the build script '#{BUILD_SCRIPT}' inside container.\n#{$!}"
   end
 
   def retrieve_binaries

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -150,11 +150,16 @@ class BinaryBuilder
     @docker_api_version ||= Docker.version['ApiVersion']
   end
 
+  # TODO: not sure what happens when value is shell safe "foo;\n;bar"
   def env_vars_for_project
-    if defined?(EnvironmentVariable) # make sure 'env' plugin is enabled
+    if env_plugin_enabled?
       EnvironmentVariable.env(@project, nil).map { |name, value| "#{name}=#{value}" }
     else
       []
     end
+  end
+
+  def env_plugin_enabled?
+    defined?(EnvironmentVariable)
   end
 end

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -175,4 +175,17 @@ describe BinaryBuilder do
       end
     end
   end
+
+  describe "#env_vars_for_project" do
+    it "returns env vars" do
+      EnvironmentVariable.expects(:env).returns('A' => "B")
+      builder.send(:env_vars_for_project).must_equal ["A=B"]
+    end
+
+    it "is empty when plugin is not loaded" do
+      EnvironmentVariable.expects(:env).never
+      builder.expects(:env_plugin_enabled?).returns(false)
+      builder.send(:env_vars_for_project).must_equal []
+    end
+  end
 end

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -46,6 +46,11 @@ describe BinaryBuilder do
       ].join
     end
 
+    it 'reports docker errors' do
+      fake_container.expects(:attach).raises("Opps")
+      assert_raises(Samson::Hooks::UserError) { builder.build }
+    end
+
     it 'does nothing if docker flag is set for project but no dockerfile.build exists' do
       builder.unstub(:build_file_exist?)
       builder.expects(:create_build_image).never
@@ -77,7 +82,7 @@ describe BinaryBuilder do
 
       it 'stop build when pre build script fails' do
         File.write(pre_build_script, 'oops')
-        assert_raises(RuntimeError) { builder.build }
+        assert_raises(Samson::Hooks::UserError) { builder.build }
       end
     end
   end


### PR DESCRIPTION
users fault ... so let them fix it ...

https://zendesk.airbrake.io/projects/95346/groups/1774910190152787640/notices/1854650037090094484

@henders @apanzerj @jonmoter 

also:
 - remove stubs and test real execution
 - test homegrown untar
 - use a temp dir that we clean up instead of polluting /tmp