### PR TITLE
make logs visible when debugging from integration service

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -24,11 +24,11 @@ class Integrations::BaseController < ApplicationController
     failed = deploy_to_stages(release, stages)
 
     if failed
-      head :unprocessable_entity, message: "Failed to start deploy to #{failed.name}"
+      record_log :error, "Failed to start deploy to #{failed.name}"
     else
       record_log :info, "Deploying to #{stages.size} stages"
-      head :ok
     end
+    render plain: @recorded_log.to_s, status: (failed ? :unprocessable_entity : :ok)
   end
 
   protected

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -86,12 +86,13 @@ describe Integrations::BaseController do
       post :create, params: {test_route: true, token: token}
       assert_response :success
       result = WebhookRecorder.read(project)
-      result.fetch(:log).must_equal <<-LOG.strip_heredoc
+      log = <<-LOG.strip_heredoc
         INFO: Branch master is release branch: true
         INFO: Deploying to 0 stages
       LOG
+      result.fetch(:log).must_equal log
       result.fetch(:status_code).must_equal 200
-      result.fetch(:body).must_equal ""
+      result.fetch(:body).must_equal log
     end
 
     it 'creates a release and a connected build' do


### PR DESCRIPTION
atm the response in githubs debug view is not very helpful ... and users need to dig into samson to find details ... this should make things simpler

@henders @jonmoter @irwaters 

### Risks: 
 - medium: a few integrations might expect an empty response, we'll have to add exceptions for these, but I'd start by assuming they don't care ...