### PR TITLE
document GITHUB_HOOK_SECRET, make it optional, properly test it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,8 @@ GITHUB_TOKEN=
 
 # DEPLOY_GROUP_FEATURE=1 # optional, enable Environments and DeployGroups
 
+# GITHUB_HOOK_SECRET=abcdef # optional, verify github hooks are signed with webhook secret
+
 # AIRBRAKE_API_KEY= # optional, report errors to airbrake
 
 # FORCE_SSL=1 # optional, to require SSL

--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 class Integrations::GithubController < Integrations::BaseController
-  cattr_accessor(:github_hook_secret) { ENV['GITHUB_HOOK_SECRET'] }
-
   HMAC_DIGEST = OpenSSL::Digest.new('sha1')
   WEBHOOK_HANDLERS = {
     'push' => Changeset::CodePush,
@@ -23,9 +21,10 @@ class Integrations::GithubController < Integrations::BaseController
   end
 
   def valid_signature?
+    return true unless secret = ENV['GITHUB_HOOK_SECRET']
     hmac = OpenSSL::HMAC.hexdigest(
       HMAC_DIGEST,
-      github_hook_secret,
+      secret,
       request.body.tap(&:rewind).read
     )
 

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -16,8 +16,7 @@ class Changeset::IssueComment
 
   def self.valid_webhook?(params)
     return false unless VALID_ACTIONS.include? params.dig('github', 'action')
-    comment = params['comment'] || {}
-    !(comment['body'] =~ Changeset::PullRequest::WEBHOOK_FILTER).nil?
+    params.dig('comment', 'body') =~ Changeset::PullRequest::WEBHOOK_FILTER
   end
 
   def sha

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -87,6 +87,7 @@ class Changeset::PullRequest
     @data['head']['sha']
   end
 
+  # does not include refs/head
   def branch
     @data['head']['ref']
   end

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -8,62 +8,56 @@ describe Integrations::GithubController do
 
   let(:commit) { "dc395381e650f3bac18457909880829fc20e34ba" }
   let(:project) { projects(:test) }
-
   let(:payload) do
     {
       ref: 'refs/heads/dev',
       after: commit
     }.with_indifferent_access
   end
+  let(:user_name) { 'Github' }
 
   before do
     Deploy.delete_all
-    Integrations::GithubController.github_hook_secret = 'test'
+    request.headers['X-Github-Event'] = 'push'
+    project.webhooks.create!(stage: stages(:test_staging), branch: "dev", source: 'any')
   end
+
+  test_regular_commit "Github", no_mapping: { ref: 'refs/heads/foobar' }, failed: false
 
   it_does_not_deploy 'when the event is invalid' do
     request.headers['X-Github-Event'] = 'event'
   end
 
-  it 'does not deploy if signature is invalid' do
-    request.headers['X-Github-Event'] = 'push'
-    request.headers['X-Hub-Signature'] = "nope"
+  describe "when signature is enforced" do
+    with_env GITHUB_HOOK_SECRET: 'test'
 
-    post :create, params: payload.merge(token: project.token)
-
-    project.deploys.must_equal []
-    response.status.must_equal 401
-  end
-
-  describe 'with a code push event' do
     before do
-      request.headers['X-Github-Event'] = 'code_push'
-      project.webhooks.create!(stage: stages(:test_staging), branch: "dev", source: 'github')
+      hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['GITHUB_HOOK_SECRET'], payload.to_param)
+      request.headers['X-Hub-Signature'] = "sha1=#{hmac}"
     end
 
-    let(:user_name) { 'Github' }
+    it_deploys "when signature is valid"
 
-    test_regular_commit "Github", no_mapping: { ref: 'refs/heads/foobar' }, failed: false do
-      request.headers['X-Github-Event'] = 'push'
-      hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), 'test', payload.to_param)
-      request.headers['X-Hub-Signature'] = "sha1=#{hmac}"
+    it_does_not_deploy "when signature is invalid", status: 401 do
+      request.headers['X-Hub-Signature'] = "nope"
+    end
+
+    it_does_not_deploy "when signature is invalid", status: 401 do
+      request.headers['X-Hub-Signature'] = nil
     end
   end
 
   describe 'with a pull request event' do
-    before do
-      request.headers['X-Github-Event'] = 'pull_request'
-      project.webhooks.create!(stage: stages(:test_staging), branch: "dev", source: 'any_pull_request')
-    end
+    before { request.headers['X-Github-Event'] = 'pull_request' }
 
-    let(:user_name) { 'Github' }
     let(:payload) do
       {
         after: commit,
         number: '42',
         pull_request: {
           head: {
-            ref: 'refs/heads/dev'
+            ref: 'dev', # name of branch the user created
+            sha: 'abcdef'
           },
           state: 'open',
           body: 'imafixwolves [samson review]'
@@ -78,14 +72,8 @@ describe Integrations::GithubController do
         }
       }.with_indifferent_access
     end
-    let(:api_response) do
-      stub(
-        user: stub(login: 'foo'),
-        merged_by: stub(login: 'bar'),
-        body: '',
-        head: stub(sha: commit, ref: 'refs/heads/dev')
-      )
-    end
+
+    it_deploys
 
     it_does_not_deploy 'with a non-open pull request state' do
       payload.deep_merge!(pull_request: {state: 'closed'})
@@ -94,5 +82,24 @@ describe Integrations::GithubController do
     it_does_not_deploy 'without "[samson review]" in the body' do
       payload.deep_merge!(pull_request: {body: 'imafixwolves'})
     end
+  end
+
+  describe 'with a pull issue comment' do
+    let(:payload) do
+      {
+        github: {
+          action: 'created'
+        },
+        comment: {body: '[samson review]'},
+        issue: {number: 123}
+      }.with_indifferent_access
+    end
+
+    before do
+      request.headers['X-Github-Event'] = 'issue_comment'
+      Changeset::IssueComment.any_instance.expects(:pull_request).at_least_once.returns(stub(sha: 'abc', branch: 'dev'))
+    end
+
+    it_deploys
   end
 end

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -1,10 +1,30 @@
 # frozen_string_literal: true
 require_relative '../../test_helper'
 
-SingleCov.covered! uncovered: 8
+SingleCov.covered!
 
 describe Changeset::IssueComment do
-  describe ".valid_webhook" do
+  let(:project) { projects(:test) }
+  let(:issue_data) do
+    {
+      issue: {
+        number: 1
+      },
+      comment: {
+        id: 123
+      }
+    }.with_indifferent_access
+  end
+  let(:pr_data) do
+    {
+      head: {
+        sha: 'abcd123',
+        ref: 'a/test'
+      }
+    }.with_indifferent_access
+  end
+
+  describe ".valid_webhook?" do
     let(:webhook_data) do
       {
         github: {},
@@ -16,56 +36,45 @@ describe Changeset::IssueComment do
 
     it 'is valid for new comments' do
       webhook_data[:github][:action] = 'created'
-      Changeset::IssueComment.valid_webhook?(webhook_data).must_equal true
+      assert Changeset::IssueComment.valid_webhook?(webhook_data)
     end
 
     it 'is not valid for deleted comments' do
       webhook_data[:github][:action] = 'deleted'
-      Changeset::IssueComment.valid_webhook?(webhook_data).must_equal false
+      refute Changeset::IssueComment.valid_webhook?(webhook_data)
     end
 
     it 'is not valid for edited comments' do
       webhook_data[:github][:action] = 'edited'
-      Changeset::IssueComment.valid_webhook?(webhook_data).must_equal false
+      refute Changeset::IssueComment.valid_webhook?(webhook_data)
+    end
+  end
+
+  describe ".changeset_from_webhook" do
+    it "builds a new instance" do
+      Changeset::IssueComment.changeset_from_webhook(project, {}).class.must_equal Changeset::IssueComment
     end
   end
 
   describe '#sha' do
-    let(:issue_data) do
-      {
-        issue: {
-          number: 1
-        },
-        comment: {
-          id: 123
-        }
-      }.with_indifferent_access
-    end
-
-    let(:pr_data) do
-      {
-        head: {
-          sha: 'abcd123',
-          ref: 'a/test'
-        }
-      }.with_indifferent_access
-    end
-
-    let(:cached_pr_data) do
-      {
-        head: {
-          sha: 'cach123',
-          ref: 'a/test'
-        }
-      }.with_indifferent_access
-    end
-
-    it 'shows the latest sha when a new comment is made' do
-      Rails.cache.write(['Changeset::PullRequest', 'foo/bar', 1].join("-"), cached_pr_data)
-      Rails.cache.write(['IssueComment', 'foo/bar', 1].join("-"), cached_pr_data)
+    it 'shows the latest PR sha' do
       GITHUB.stubs(:pull_request).with("foo/bar", 1).returns(pr_data)
       issue = Changeset::IssueComment.new('foo/bar', issue_data)
       issue.sha.must_equal 'abcd123'
+    end
+  end
+
+  describe '#branch' do
+    it 'shows the PR branch' do
+      GITHUB.stubs(:pull_request).with("foo/bar", 1).returns(pr_data)
+      issue = Changeset::IssueComment.new('foo/bar', issue_data)
+      issue.branch.must_equal 'a/test'
+    end
+  end
+
+  describe "#service_type" do
+    it "is pull_request" do
+      Changeset::IssueComment.new('foo/bar', {}).service_type.must_equal 'pull_request'
     end
   end
 end


### PR DESCRIPTION
 - would previously fail with nil error when not set
 - previous tests did not verify that no_mapping works because they failed signature
 - dry up signing into a single place
 - make tests start from a valid setup
 - more debug info `Deploy to Staging failed: ["Reference can't be blank"]`

@jonmoter @irwaters 