### PR TITLE
do not show the request body twice

### DIFF
--- a/app/models/webhook_recorder.rb
+++ b/app/models/webhook_recorder.rb
@@ -5,7 +5,7 @@ class WebhookRecorder
 
   class << self
     def record(project, request:, response:, log:)
-      request_info = request.env.select { |k, _v| k =~ NATIVE_HEADER }
+      request_info = request.env.select { |k, _v| k =~ NATIVE_HEADER && k != 'RAW_POST_DATA' }
 
       data = {
         request: request_info,

--- a/test/models/webhook_recorder_test.rb
+++ b/test/models/webhook_recorder_test.rb
@@ -18,8 +18,7 @@ describe WebhookRecorder do
     it "does not record internal rails/rack headers" do
       WebhookRecorder.record(project, request: request, log: "", response: response)
       WebhookRecorder.read(project).fetch(:request).must_equal(
-        "FOO" => "bar",
-        "RAW_POST_DATA" => "BODY"
+        "FOO" => "bar"
       )
     end
 


### PR DESCRIPTION
atm we show the request body twice because it is also in RAW_POST_DATA which then generates a giant line in the headers text-area

![screen shot 2017-01-03 at 11 54 14 am](https://cloud.githubusercontent.com/assets/11367/21620901/7440cc6e-d1ab-11e6-8bbf-0e0d6cb1a0f0.png)
