### PR TITLE
make admin/users filterable by role

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,10 +5,7 @@ class UsersController < ApplicationController
   before_action :authorize_project_admin!
 
   def index
-    @users = User.search_by_criteria(params)
-    if role_id = params[:role_id]
-      @users = @users.with_role(role_id, current_project.id)
-    end
+    @users = User.search_by_criteria(params.merge(project_id: current_project.id))
 
     respond_to do |format|
       format.html

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,7 +1,8 @@
 <%= page_title "Users" %>
 
 <section class="clearfix">
-  <%= render partial: "shared/search_bar", locals: { url: admin_users_path, query: params[:search] } %>
+  <%= render 'users/search_bar', system_level: true %>
+
   <div class="users-csv">
     <%= link_to "Download as CSV", new_csv_export_path(format: :csv, type: :users) %>
   </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -18,6 +18,7 @@
   <h2 class="section-subtitle">Project Level Roles</h2>
 
   <%= render partial: "shared/search_bar", locals: {url: admin_user_path, query: params[:search]} %>
+
   <div class="users-csv">
     <%= link_to "Download as CSV", new_csv_export_path(format: :csv, type: :users, user_id: @user.id) %>
   </div>

--- a/app/views/users/_search_bar.html.erb
+++ b/app/views/users/_search_bar.html.erb
@@ -1,0 +1,18 @@
+<%= form_tag '?', method: :get do %>
+  <div class="col-md-6 clearfix">&nbsp;</div>
+
+  <div class="col-md-3 clearfix">
+    <%= text_field_tag :search, params[:search], class: 'form-control', placeholder: 'Search' %>
+  </div>
+
+  <div class="col-md-2 clearfix">
+    <% roles = [['', '']] + (system_level ? Role.all[1..-1] : UserProjectRole::ROLES).map { |r| [r.name.capitalize, r.id] } %>
+    <%= select_tag :role_id, options_for_select(roles, params[:role_id]), class: 'form-control' %>
+  </div>
+
+  <%= hidden_field_tag :project_id, @project.id unless system_level %>
+
+  <div class="col-md-1 clearfix">
+    <%= submit_tag "Search", class: "btn btn-default form-control" %>
+  </div>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,22 +5,7 @@
 <section id="user-project-roles" class="tabs">
   <h2 class="section-subtitle">Project Level Roles</h2>
 
-  <%= form_tag '?', method: :get do %>
-    <div class="col-md-6 clearfix">&nbsp;</div>
-
-    <div class="col-md-3 clearfix">
-      <%= text_field_tag :search, params[:search], class: 'form-control', placeholder: 'Search' %>
-    </div>
-
-    <div class="col-md-2 clearfix">
-      <% roles = [['', '']] + UserProjectRole::ROLES.map { |r| [r.name.capitalize, r.id] } %>
-      <%= select_tag :role_id, options_for_select(roles, params[:role_id]), class: 'form-control' %>
-    </div>
-
-    <div class="col-md-1 clearfix">
-      <%= submit_tag "Search", class: "btn btn-default form-control" %>
-    </div>
-  <% end %>
+  <%= render 'users/search_bar', system_level: false %>
 
   <div class="users-csv">
     <%= link_to "Download as CSV", new_csv_export_path(format: :csv, type: :users, project_id: @project.id) %>
@@ -37,7 +22,7 @@
     </tr>
     </thead>
     <tbody>
-    <% if @users.empty? %>
+    <% if @users.length == 0 %>
       <tr>
         <td>No users found.</td>
       </tr>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -279,6 +279,20 @@ describe User do
     end
   end
 
+  describe ".search_by_criteria" do
+    it "can filter by system level role" do
+      User.search_by_criteria(search: "", role_id: Role::ADMIN.id).sort.must_equal(
+        [users(:admin), users(:super_admin)].sort
+      )
+    end
+
+    it "can filter by system level role and project role" do
+      User.search_by_criteria(search: "", role_id: Role::ADMIN.id, project_id: projects(:test).id).sort.must_equal(
+        [users(:admin), users(:super_admin), users(:project_admin)].sort
+      )
+    end
+  end
+
   describe ".with_role" do
     let(:project) { projects(:test) }
     let(:deployer_list) do


### PR DESCRIPTION
@jonmoter 

![screen shot 2017-01-03 at 2 33 37 pm](https://cloud.githubusercontent.com/assets/11367/21625699/b882a9fe-d1c1-11e6-93ec-9869b9a11ac0.png)

filtering projects role is more tricky and ugly ... this is a nice UI win and simple ... so let's do that for now ...

project roles on /admin/users/1 need a rewrite so that they only show the existing roles + a from to create a new role ... but that is another PR