### PR TITLE
avoid breaking tests by ignoring missing pgid

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -95,17 +95,10 @@ class TerminalExecutor
   end
 
   # We need the group pid to cleanly shut down all children
-  # if we somehow fail to get that, kill everything now before more bad stuff happens
+  # if we fail to get that, the process is already dead (finished quickly or crashed)
   def pgid_from_pid(pid)
     Process.getpgid(pid)
   rescue Errno::ESRCH
-    @output.write "Failed to get pgid, stopping #{pid}."
-    begin
-      Process.kill(:KILL, pid)
-      @output.write "Stopped."
-    rescue Errno::ESRCH
-      @output.write "Already stopped."
-    end
     nil
   end
 

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -70,15 +70,9 @@ describe TerminalExecutor do
       output.string.must_equal("#{"ß" * 400}\r\n")
     end
 
-    it "terminates the program on getpgid failures so we fail fast" do
+    it "ignores getpgid failures since they mean the program finished early" do
       Process.expects(:getpgid).raises(Errno::ESRCH)
-      subject.execute!('sleep 0.1').must_be_nil # status? of a killed process is 9
-    end
-
-    it "handles the case when getpgid + kill both fail" do
-      Process.expects(:getpgid).raises(Errno::ESRCH)
-      Process.expects(:kill).raises(Errno::ESRCH)
-      subject.execute!('sleep 0.1 && false').must_equal(false) # status? of a killed process is 9
+      subject.execute!('sleep 0.1').must_equal true
     end
 
     it "ignores closed output errors that happen on linux" do


### PR DESCRIPTION
something like this:
```
Failure:
TerminalExecutor::#execute!::in verbose mode#test_0002_does not print subcommands [/Users/mgrosser/Code/zendesk/samson/test/models/terminal_executor_test.rb:114]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
-"» sh -c \"echo 111\"\r
+"Failed to get pgid, stopping 42504.Stopped.» sh -c \"echo 111\"\r
 111\r
 "
 ```

all docs I found say that this means the process is dead ... for example http://stackoverflow.com/questions/325082/how-can-i-check-from-ruby-whether-a-process-with-a-certain-pid-is-running

@henders @irwaters @zendesk/samson 