### PR TITLE
Use Github tags if present

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -56,9 +56,15 @@ class Release < ActiveRecord::Base
     # release-number-from-ci plugin.
     return if number != DEFAULT_RELEASE_NUMBER && number.present?
 
-    latest_release_number = project.releases.last.try(:number) || "0"
+    raise "Unable to auto bump version" unless self.number = next_release_number
+  end
 
-    raise "Unable to auto bump version" unless self.number = latest_release_number.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
+  def next_release_number
+    # If Github has a version tagged for this commit, use that version instead of ours
+    latest_samson_version = Gem::Version.new(project.releases.last.try(:number) || "0").to_s
+    latest_github_version = Gem::Version.new(project.repository.tag_from_ref(commit)).to_s
+
+    latest_github_version.present? ? latest_github_version : latest_samson_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
   end
 
   def contains_commit?(other_commit)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -59,18 +59,6 @@ class Release < ActiveRecord::Base
     errors.add :number, "Unable to auto bump version" unless self.number = next_release_number
   end
 
-  def next_release_number
-    # If Github has a version tagged for this commit, use that version instead of ours
-    latest_samson_version = Gem::Version.new(project.releases.last&.number || "0")
-    latest_github_version = Gem::Version.new(project.repository.tag_from_ref(commit))
-
-    if latest_github_version > latest_samson_version
-      latest_github_version.to_s
-    else
-      latest_samson_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
-    end
-  end
-
   def contains_commit?(other_commit)
     return true if other_commit == commit
     # status values documented here: http://stackoverflow.com/questions/23943855/github-api-to-compare-commits-response-status-is-diverged
@@ -83,6 +71,18 @@ class Release < ActiveRecord::Base
   end
 
   private
+
+  def next_release_number
+    # If Github has a version tagged for this commit, use that version instead of ours
+    latest_samson_version = Gem::Version.new(project.releases.last&.number || "0")
+    latest_github_version = Gem::Version.new(project.repository.tag_from_ref(commit))
+
+    if latest_github_version > latest_samson_version
+      latest_github_version.to_s
+    else
+      latest_samson_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
+    end
+  end
 
   def covert_ref_to_sha
     return if commit.blank? || commit =~ Build::SHA1_REGEX

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -56,15 +56,19 @@ class Release < ActiveRecord::Base
     # release-number-from-ci plugin.
     return if number != DEFAULT_RELEASE_NUMBER && number.present?
 
-    raise "Unable to auto bump version" unless self.number = next_release_number
+    errors.add :number, "Unable to auto bump version" unless self.number = next_release_number
   end
 
   def next_release_number
     # If Github has a version tagged for this commit, use that version instead of ours
-    latest_samson_version = Gem::Version.new(project.releases.last.try(:number) || "0").to_s
-    latest_github_version = Gem::Version.new(project.repository.tag_from_ref(commit)).to_s
+    latest_samson_version = Gem::Version.new(project.releases.last&.number || "0")
+    latest_github_version = Gem::Version.new(project.repository.tag_from_ref(commit))
 
-    latest_github_version.present? ? latest_github_version : latest_samson_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
+    if latest_github_version > latest_samson_version
+      latest_github_version.to_s
+    else
+      latest_samson_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
+    end
   end
 
   def contains_commit?(other_commit)

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -23,6 +23,7 @@ describe Integrations::BaseController do
     Integrations::BaseController.any_instance.stubs(:branch).returns('master')
     Project.any_instance.stubs(:create_release?).returns(true)
     Build.any_instance.stubs(:validate_git_reference).returns(true)
+    GitRepository.any_instance.stubs(:tag_from_ref).returns("")
     stub_request(:post, "https://api.github.com/repos/bar/foo/releases")
   end
 

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -42,12 +42,14 @@ describe ReleasesController do
     describe "#create" do
       let(:release_params) { { commit: "abcd" } }
       before do
-        GitRepository.any_instance.expects(:clone!)
+        GitRepository.any_instance.expects(:update_local_cache!)
         GitRepository.any_instance.expects(:commit_from_ref).with('abcd').returns('a' * 40)
         GITHUB.stubs(:create_release)
       end
 
       it "creates a new release" do
+        GitRepository.any_instance.expects(:tag_from_ref).with('abcd').returns("2")
+
         assert_difference "Release.count", +1 do
           post :create, params: {project_id: project.to_param, release: release_params}
           assert_redirected_to "/projects/foo/releases/v124"
@@ -63,6 +65,8 @@ describe ReleasesController do
 
     describe "#new" do
       it "renders" do
+        GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+
         get :new, params: {project_id: project.to_param}
         assert_response :success
       end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -15,7 +15,10 @@ describe Project do
     project.send(:clone_repository).join
   end
 
-  before { Project.any_instance.stubs(:valid_repository_url).returns(true) }
+  before do
+    Project.any_instance.stubs(:valid_repository_url).returns(true)
+    GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+  end
 
   describe "#generate_token" do
     it "generates a secure token when created" do

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -14,7 +14,10 @@ describe ReleaseService do
     let(:commit) { "abcd" * 10 }
     let(:release_params_used) { [] }
 
-    before { GITHUB.stubs(:create_release).capture(release_params_used) }
+    before do
+      GITHUB.stubs(:create_release).capture(release_params_used)
+      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+    end
 
     it "creates a new release" do
       count = Release.count

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -10,6 +10,10 @@ describe Release do
   let(:commit) { "abcde" * 8 }
 
   describe "create" do
+    before do
+      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+    end
+
     it "creates a new release" do
       release = project.releases.create!(commit: commit, author: author)
       assert_equal "124", release.number
@@ -54,14 +58,14 @@ describe Release do
     end
 
     it "converts refs to commits so we later know what exactly was deployed" do
-      GitRepository.any_instance.expects(:update_local_cache!).twice
+      GitRepository.any_instance.expects(:update_local_cache!)
       GitRepository.any_instance.expects(:commit_from_ref).with('master').returns(commit)
       release = project.releases.create!(author: author, commit: 'master')
       release.commit.must_equal commit
     end
 
     it "fails with unresolvable ref" do
-      GitRepository.any_instance.expects(:update_local_cache!).twice
+      GitRepository.any_instance.expects(:update_local_cache!)
       GitRepository.any_instance.expects(:commit_from_ref).with('master').returns(nil)
       e = assert_raises ActiveRecord::RecordInvalid do
         project.releases.create!(author: author, commit: 'master')
@@ -70,7 +74,6 @@ describe Release do
     end
 
     it "does not covert blank" do
-      GitRepository.any_instance.expects(:update_local_cache!)
       GitRepository.any_instance.expects(:clone!).never
       GitRepository.any_instance.expects(:commit_from_ref).never
       e = assert_raises ActiveRecord::RecordInvalid do
@@ -165,6 +168,10 @@ describe Release do
   end
 
   describe "#changeset" do
+    before do
+      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+    end
+
     it "returns changeset" do
       release = project.releases.create!(commit: commit, author: author)
       assert_equal "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd...#{commit}", release.changeset.commit_range

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -141,6 +141,7 @@ describe Stage do
     let(:releases) { Array.new(3).map { project.releases.create!(author: author, commit: "a" * 40) } }
 
     before do
+      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
       stage.deploys.create!(reference: "v124", job: job, project: project)
       stage.deploys.create!(reference: "v125", job: job, project: project)
     end


### PR DESCRIPTION
If a release is about to be created, and it has a tag already defined on Github, use that one for a release instead of creating a new one in Samson.

/cc @zendesk/samson @zendesk/sustaining 

### Risks
- Medium:  Could cause release numbers to go all sorts of wrong.
