### PR TITLE
callback improvements

### DIFF
--- a/app/mailers/deploy_mailer.rb
+++ b/app/mailers/deploy_mailer.rb
@@ -3,10 +3,10 @@ class DeployMailer < ApplicationMailer
   add_template_helper(DeploysHelper)
   add_template_helper(ApplicationHelper)
 
-  def deploy_email(deploy)
+  def deploy_email(deploy, emails)
     prepare_mail(deploy)
 
-    mail(to: deploy.stage.notify_email_addresses, subject: deploy_subject(deploy))
+    mail(to: emails, subject: deploy_subject(deploy))
   end
 
   def bypass_email(deploy, user)

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -93,8 +93,8 @@ class DeployService
   add_method_tracer :send_after_notifications
 
   def send_deploy_email(deploy)
-    if deploy.stage.send_email_notifications?
-      DeployMailer.deploy_email(deploy).deliver_now
+    if emails = deploy.stage.notify_email_addresses.presence
+      DeployMailer.deploy_email(deploy, emails).deliver_now
     end
   end
 

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -73,7 +73,7 @@ class JobExecution
   end
 
   def on_complete(&block)
-    @subscribers << JobExecutionSubscriber.new(job, block)
+    @subscribers << JobExecutionSubscriber.new(job, &block)
   end
 
   def descriptor

--- a/app/models/job_execution_subscriber.rb
+++ b/app/models/job_execution_subscriber.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class JobExecutionSubscriber
-  def initialize(job, block)
+  def initialize(job, &block)
     @job = job
     @block = block
   end
@@ -8,6 +8,8 @@ class JobExecutionSubscriber
   def call
     @block.call
   rescue => exception
+    # ideally append errors to log here, but would not work for before hooks and
+    # would not be streamed to the user for after hooks
     Airbrake.notify(
       exception,
       error_message: "JobExecutionSubscriber failed: #{exception.message}",

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -100,10 +100,6 @@ class Stage < ActiveRecord::Base
     notify_email_address.split(";").map(&:strip)
   end
 
-  def send_email_notifications?
-    notify_email_address.present?
-  end
-
   def global_name
     "#{name} - #{project.name}"
   end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -29,6 +29,10 @@ class Stage < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: { scope: [:project, :deleted_at] }
 
+  # n emails separated by ;
+  email = '([^\s;]+@[^\s;]+)'
+  validates :notify_email_address, format: /\A#{email}((\s*;\s*)?#{email}?)*\z/, allow_blank: true
+
   before_create :ensure_ordering
   after_destroy :destroy_deploy_groups_stages
   after_destroy :destroy_stage_pipeline
@@ -97,7 +101,7 @@ class Stage < ActiveRecord::Base
   end
 
   def notify_email_addresses
-    notify_email_address.split(";").map(&:strip)
+    notify_email_address.split(/\s*;\s*/).map(&:strip)
   end
 
   def global_name

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -16,9 +16,8 @@ describe DeployMailer do
 
   describe "#deploy_email" do
     before do
-      stage.update_attributes!(notify_email_address: 'test@test.com')
       stub_empty_changeset
-      DeployMailer.deploy_email(deploy).deliver_now
+      DeployMailer.deploy_email(deploy, ['test@test.com']).deliver_now
     end
 
     it 'is from deploys@' do

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -197,9 +197,10 @@ describe DeployService do
     end
 
     it "sends email notifications if the stage has email addresses" do
-      stage.stubs(:send_email_notifications?).returns(true)
+      stage.notify_email_address = 'a@b.com;b@c.com'
 
-      DeployMailer.expects(:deploy_email).returns(stub("DeployMailer", deliver_now: true))
+      DeployMailer.expects(:deploy_email).with(anything, ['a@b.com', 'b@c.com']).
+        returns(stub("DeployMailer", deliver_now: true))
 
       service.deploy!(stage, reference: reference)
       job_execution.send(:run!)

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -196,14 +196,25 @@ describe DeployService do
       JobExecution.stubs(:new).returns(job_execution)
     end
 
-    it "sends email notifications if the stage has email addresses" do
-      stage.notify_email_address = 'a@b.com;b@c.com'
+    describe "with email notifications setup" do
+      before { stage.notify_email_address = 'a@b.com;b@c.com' }
 
-      DeployMailer.expects(:deploy_email).with(anything, ['a@b.com', 'b@c.com']).
-        returns(stub("DeployMailer", deliver_now: true))
+      it "sends email notifications if the stage has email addresses" do
+        DeployMailer.expects(:deploy_email).with(anything, ['a@b.com', 'b@c.com']).
+          returns(stub("DeployMailer", deliver_now: true))
 
-      service.deploy!(stage, reference: reference)
-      job_execution.send(:run!)
+        service.deploy!(stage, reference: reference)
+        job_execution.send(:run!)
+      end
+
+      it "does not fail all callbacks when 1 callback fails" do
+        service.stubs(:send_sse_deploy_update)
+        service.expects(:send_sse_deploy_update).with('finish', anything).raises # first callback
+        Airbrake.expects(:notify).times(3) # ideally once, but there is another bug somewhere
+        DeployMailer.expects(:deploy_email)
+        service.deploy!(stage, reference: reference)
+        job_execution.send(:run!)
+      end
     end
 
     it "sends after_deploy hook" do
@@ -213,24 +224,26 @@ describe DeployService do
       end.must_equal [[deploy, nil]]
     end
 
-    it "sends github notifications if the stage has it enabled and deploy succeeded" do
-      stage.stubs(:update_github_pull_requests?).returns(true)
-      deploy.stubs(:status).returns("succeeded")
+    describe "with github notifications enabled" do
+      before { stage.stubs(:update_github_pull_requests?).returns(true) }
 
-      GithubNotification.any_instance.expects(:deliver)
+      it "sends github notifications if the stage has it enabled and deploy succeeded" do
+        deploy.stubs(:status).returns("succeeded")
 
-      service.deploy!(stage, reference: reference)
-      job_execution.send(:run!)
-    end
+        GithubNotification.any_instance.expects(:deliver)
 
-    it "does not send github notifications if the stage has it enabled and deploy failed" do
-      stage.stubs(:update_github_pull_requests?).returns(true)
-      deploy.stubs(:status).returns("failed")
+        service.deploy!(stage, reference: reference)
+        job_execution.send(:run!)
+      end
 
-      GithubNotification.any_instance.expects(:deliver).never
+      it "does not send github notifications if the stage has it enabled and deploy failed" do
+        deploy.stubs(:status).returns("failed")
 
-      service.deploy!(stage, reference: reference)
-      job_execution.send(:run!)
+        GithubNotification.any_instance.expects(:deliver).never
+
+        service.deploy!(stage, reference: reference)
+        job_execution.send(:run!)
+      end
     end
 
     it "updates a github deployment status" do

--- a/test/models/job_execution_subscriber_test.rb
+++ b/test/models/job_execution_subscriber_test.rb
@@ -6,8 +6,7 @@ SingleCov.covered!
 describe JobExecutionSubscriber do
   it 'sends exceptions to airbrake so other subscribers can continue' do
     Airbrake.expects(:notify)
-    block = lambda { raise 'Test' }
-    execution = JobExecutionSubscriber.new(stub(url: 1), block)
+    execution = JobExecutionSubscriber.new(stub(url: 1)) { raise 'Test' }
     execution.call
   end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -218,22 +218,6 @@ describe Stage do
     end
   end
 
-  describe "#send_email_notifications?" do
-    it "is false when there is no address" do
-      refute stage.send_email_notifications?
-    end
-
-    it "is false when there is a blank address" do
-      stage.notify_email_address = ''
-      refute stage.send_email_notifications?
-    end
-
-    it "is true when there is an address" do
-      stage.notify_email_address = 'a'
-      assert stage.send_email_notifications?
-    end
-  end
-
   describe "#global_name" do
     it "shows projects name to so we see where this stage belongs" do
       stage.global_name.must_equal "Staging - Project"

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -7,6 +7,47 @@ describe Stage do
   subject { stages(:test_staging) }
   let(:stage) { subject }
 
+  describe "#validations" do
+    it "is valid" do
+      assert_valid stage
+    end
+
+    it "is valid with 1 email" do
+      stage.notify_email_address = 'foo@bar.com'
+      assert_valid stage
+    end
+
+    it "is invalid with email that contains spaces" do
+      stage.notify_email_address = 'fo o@bar.com'
+      refute_valid stage
+    end
+
+    it "is valid with trailing semicolon email" do
+      stage.notify_email_address = 'foo@bar.com; '
+      assert_valid stage
+    end
+
+    it "is invalid with weird emails" do
+      stage.notify_email_address = 'sdfsfdfsd'
+      refute_valid stage
+    end
+
+    it "is invalid with valid followed by invalid email" do
+      stage.notify_email_address = 'foo@bar;sfdsdf;'
+      refute_valid stage
+    end
+
+    it "is invalid with invalid followed by valid email" do
+      stage.notify_email_address = 'sfdsdf;foo@bar'
+      refute_valid stage
+    end
+
+    it "is valid with multiple valid emails" do
+      stage.notify_email_address = 'foo@bar;bar@foo'
+      assert_valid stage
+    end
+  end
+
   describe ".where_reference_being_deployed" do
     it "returns stages where the reference is currently being deployed" do
       project = projects(:test)
@@ -213,8 +254,8 @@ describe Stage do
 
   describe "#notify_email_addresses" do
     it "returns email addresses separated by a semicolon" do
-      stage = Stage.new(notify_email_address: "a@foo.com; b@foo.com")
-      stage.notify_email_addresses.must_equal ["a@foo.com", "b@foo.com"]
+      stage = Stage.new(notify_email_address: "a@foo.com;b@foo.com ; c@foo.com; ")
+      stage.notify_email_addresses.must_equal ["a@foo.com", "b@foo.com", "c@foo.com"]
     end
   end
 


### PR DESCRIPTION
saw these weird bugs in airbake about being unable to send emails ...
https://zendesk.airbrake.io/projects/95346/groups/1748045765307475064/notices/1856265870884964594?tab=notice-detail

turns out users put crazy stuff into the email field ...
also noticed that atm when 1 hook fails we stop all hooks which is bad

 - consolidate email sending logic
 - do not stop all after deploy hooks when one of them fails
 - validate that emails are not crazy