### PR TITLE
Revert "do not blow up when directory was removed during deploy"

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -98,7 +98,7 @@ class JobExecution
 
     @job.run!
 
-    success = make_temp_directory do |dir|
+    success = Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
       return @job.error! unless setup!(dir)
 
       if @execution_block
@@ -250,17 +250,6 @@ class JobExecution
 
   def puts_if_present(message)
     @output.puts message if message
-  end
-
-  def make_temp_directory
-    Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
-      begin
-        yield dir
-      ensure
-        # make the mktmpdir ensure not blow up if the directory was removed
-        Dir.mkdir(dir) unless Dir.exist?(dir)
-      end
-    end
   end
 
   class << self

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -268,11 +268,6 @@ describe JobExecution do
     x.must_equal :called
   end
 
-  it 'can finish when temp directory is cleaned up during the run' do
-    execution = JobExecution.new('master', job) { |_, dir| Dir.delete(dir) }
-    assert execution.send(:run!)
-  end
-
   describe "kubernetes" do
     before { stage.update_column :kubernetes, true }
 


### PR DESCRIPTION
Real reason is that the permisson on the directory changes ... so don't need this code

This reverts commit 38f96205da6f6e90770eb67345e8098dbff7ad35.

reverts https://github.com/grosser/soft_deletion/pull/22/files

https://zendesk.airbrake.io/projects/95346/groups/1744273568143190802/notices/1856763762433926512?tab=comments