### PR TITLE
make backtraces clickable in airbrake

### DIFF
--- a/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
+++ b/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
@@ -26,6 +26,7 @@ module SamsonAirbrake
             deploy: {
               rails_env: rails_env,
               scm_revision: deploy.job.commit,
+              scm_repository: git_to_http(deploy.project.repository_url),
               local_username: deploy.user.name
             }
           )
@@ -33,6 +34,13 @@ module SamsonAirbrake
       end
 
       private
+
+      # git@foo:bar/baz.git -> https://foo/bar/baz
+      # https://foo/bar/baz.git -> https://foo/bar/baz
+      def git_to_http(url)
+        url = url.sub(/\.git\z/, '')
+        url.sub(/.*?@(.*?):/, "https://\\1/")
+      end
 
       def read_secret(project, deploy_groups, key)
         Samson::Secrets::KeyResolver.new(project, deploy_groups).read(key)

--- a/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
+++ b/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
@@ -23,7 +23,12 @@ describe SamsonAirbrake::Engine do
         with(
           body: {
             "api_key" => "MY-SECRET",
-            "deploy" => {"rails_env" => "staging", "scm_revision" => "abcabc1", "local_username" => "Super Admin"}
+            "deploy" => {
+              "rails_env" => "staging",
+              "scm_revision" => "abcabc1",
+              "local_username" => "Super Admin",
+              "scm_repository" => "https://example.com/bar/foo",
+            }
           }
         )
       notify
@@ -80,6 +85,20 @@ describe SamsonAirbrake::Engine do
   describe :stage_permitted_params do
     it "allows notify_airbrake" do
       Samson::Hooks.fire(:stage_permitted_params).must_include :notify_airbrake
+    end
+  end
+
+  describe ".git_to_http" do
+    it "converts git to http" do
+      SamsonAirbrake::Notification.send(:git_to_http, 'git@foo.com:a.git').must_equal 'https://foo.com/a'
+    end
+
+    it "converts ssh git to http" do
+      SamsonAirbrake::Notification.send(:git_to_http, 'ssh://git@foo.com:a.git').must_equal 'https://foo.com/a'
+    end
+
+    it "converts http git" do
+      SamsonAirbrake::Notification.send(:git_to_http, 'http://foo.com/a.git').must_equal 'http://foo.com/a'
     end
   end
 end


### PR DESCRIPTION
following docs in https://airbrake.io/docs/airbrake-faq/deploy-tracking-troubleshooting/

this should give us back backtrace links