### PR TITLE
make tests not hide errors inside of airbrake notices

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -101,7 +101,7 @@ class Stage < ActiveRecord::Base
   end
 
   def notify_email_addresses
-    notify_email_address.split(/\s*;\s*/).map(&:strip)
+    notify_email_address.to_s.split(/\s*;\s*/).map(&:strip)
   end
 
   def global_name

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -20,8 +20,12 @@ if defined?(Airbrake)
 else
   module Airbrake
     def self.notify(ex, *_args)
-      Rails.logger.error "AIRBRAKE: #{ex.class} - #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
-      nil
+      if Rails.env.test?
+        raise ex # tests have to use Airbrake.expects(:notify) to not hide unintented errors
+      else
+        Rails.logger.error "AIRBRAKE: #{ex.class} - #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
+        nil
+      end
     end
 
     def self.notify_or_ignore(ex, *_args)

--- a/test/jobs/csv_export_job_test.rb
+++ b/test/jobs/csv_export_job_test.rb
@@ -31,6 +31,7 @@ describe CsvExportJob do
     after { File.chmod(0o755, File.dirname(deploy_export_job.path_file)) }
 
     it "sets :failed" do
+      Airbrake.expects(:notify)
       CsvExportJob.perform_now(deploy_export_job)
       assert deploy_export_job.status?('failed'), "Not Finished"
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,7 +87,7 @@ class ActiveSupport::TestCase
     old = ar_queries
     yield
     new = ar_queries
-    extra = new[old.size..-1].reject { |q| q.include?('information_schema') || q.include?('sqlite_temp_master') }
+    extra = new[old.size..-1].reject { |q| q =~ /information_schema|sqlite_temp_master|pg_constraint|pg_attribute/ }
     message = extra.join("\n")
     if count.is_a?(Range)
       assert_includes count, extra.count, message


### PR DESCRIPTION
saw a few exceptions not getting raised because they triggered an airbrake ... best to know what is going on and expect an exception instead