### PR TITLE
show why there might be an error without completely ignoring that CI …

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -11,7 +11,16 @@ class CommitStatus
   end
 
   def status_list
-    combined_status.fetch(:statuses).map(&:to_h)
+    list = combined_status.fetch(:statuses).map(&:to_h)
+    if list.empty?
+      list << {
+        state: 'pending',
+        description:
+          "No status was reported for this commit on GitHub. " \
+          "See https://github.com/blog/1227-commit-status-api for details."
+      }
+    end
+    list
   end
 
   private

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -34,7 +34,7 @@ describe CommitStatus do
       status.status.must_equal 'success'
     end
 
-    it "returns failure when not found" do
+    it "is failure when not found" do
       failure!
       status.status.must_equal 'failure'
     end
@@ -97,6 +97,13 @@ describe CommitStatus do
     it "returns list" do
       success!
       status.status_list.must_equal [{foo: "bar"}]
+    end
+
+    it "shows that github is waiting for statuses to come when non has arrived yet ... or none are set up" do
+      stub_github_api(url, statuses: [], state: "pending")
+      list = status.status_list
+      list.map { |s| s[:state] }.must_equal ["pending"]
+      list.first[:description].must_include "No status was reported"
     end
 
     it "returns failure on Reference when not found list for consistent status display" do


### PR DESCRIPTION
…might be taking its time

@mfischer-zd @jonmoter 

before:

![screen shot 2017-01-06 at 9 53 33 am](https://cloud.githubusercontent.com/assets/11367/21727905/6593e0b2-d3f8-11e6-861e-bff22485f004.png)

after:
![screen shot 2017-01-06 at 10 09 57 am](https://cloud.githubusercontent.com/assets/11367/21727907/695baf90-d3f8-11e6-8e6e-19a028508236.png)
