### PR TITLE
make visible settable in vault

### DIFF
--- a/db/migrate/20170106212807_privatize_all_vault_secrets.rb
+++ b/db/migrate/20170106212807_privatize_all_vault_secrets.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class PrivatizeAllVaultSecrets < ActiveRecord::Migration[5.0]
+  def change
+    if SecretStorage.backend == Samson::Secrets::HashicorpVaultBackend
+      SecretStorage.keys.each do |key|
+        begin
+          old = SecretStorage.read(key, include_value: true) # lots of random values
+          new = {
+            user_id: old[:updater_id],
+            visible: ActiveRecord::Type::Boolean.new.cast(old[:visible]),
+            comment: old[:comment],
+            value: old.fetch(:value)
+          }
+          SecretStorage.write(key, new)
+        rescue
+          puts "Error re-writing key #{key}, fix manually #{$!}"
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170102212707) do
+ActiveRecord::Schema.define(version: 20170106212807) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false

--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'vault'
 
 module Samson
   module Secrets
@@ -42,7 +43,7 @@ module Samson
             :write,
             vault_path(key),
             vault: data.fetch(:value),
-            visible: data.fetch(:visible),
+            visible: ActiveRecord::Type::Boolean.new.cast(data.fetch(:visible)),
             comment: data.fetch(:comment),
             creator_id: creator_id,
             updater_id: user_id

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -70,18 +70,18 @@ describe Samson::Secrets::HashicorpVaultBackend do
       assert_vault_request :get, "production/foo/pod2/bar", status: 404 do
         assert_vault_request :put, "production/foo/pod2/bar", with: {body: data.to_json} do
           assert Samson::Secrets::HashicorpVaultBackend.write(
-            'production/foo/pod2/bar', value: 'whatever', visible: false, user_id: 1, comment: 'secret!'
+            'production/foo/pod2/bar', value: 'whatever', visible: 'false', user_id: 1, comment: 'secret!'
           )
         end
       end
     end
 
     it "updates without changing the creator" do
-      data = {vault: "whatever", visible: false, comment: "secret!", creator_id: 2, updater_id: 1}
+      data = {vault: "whatever", visible: true, comment: "secret!", creator_id: 2, updater_id: 1}
       assert_vault_request :get, "production/foo/pod2/bar", body: {data: {creator_id: 2, vault: "old"}}.to_json do
         assert_vault_request :put, "production/foo/pod2/bar", with: {body: data.to_json} do
           assert Samson::Secrets::HashicorpVaultBackend.write(
-            'production/foo/pod2/bar', value: 'whatever', visible: false, user_id: 1, comment: 'secret!'
+            'production/foo/pod2/bar', value: 'whatever', visible: 'true', user_id: 1, comment: 'secret!'
           )
         end
       end


### PR DESCRIPTION
rails forms send 'true' or 'false' ... need to cast that
other fields are fine as string since they are ids

and migrating all old secrets to have the correct visibility setting

@jonmoter @smo921 