### PR TITLE
Add and use exact tags

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -45,10 +45,16 @@ class GitRepository
     capture_stdout(*command)
   end
 
-  # @return [nil, sha1]
-  def tag_from_ref(git_reference)
+  # @return [nil, tag-sha or tag]
+  def fuzzy_tag_from_ref(git_reference)
     return unless ensure_local_cache!
     capture_stdout 'git', 'describe', '--tags', git_reference
+  end
+
+  # @return [nil, tag]
+  def exact_tag_from_ref(git_reference)
+    return unless ensure_local_cache!
+    capture_stdout 'git', 'tag', '--points-at', git_reference
   end
 
   def repo_cache_dir

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -180,7 +180,7 @@ class JobExecution
   def resolve_ref_to_commit
     @repository.update_local_cache!
     commit = @repository.commit_from_ref(@reference)
-    tag = @repository.tag_from_ref(@reference)
+    tag = @repository.fuzzy_tag_from_ref(@reference)
     if commit
       @job.update_git_references!(commit: commit, tag: tag)
       @output.puts("Commit: #{commit}")

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -75,12 +75,16 @@ class Release < ActiveRecord::Base
   def next_release_number
     # If Github has a version tagged for this commit, use that version instead of ours
     latest_samson_version = Gem::Version.new(project.releases.last&.number || "0")
-    latest_github_version = Gem::Version.new(project.repository.tag_from_ref(commit))
+    next_samson_version = latest_samson_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
+
+    return next_samson_version unless commit
+
+    latest_github_version = Gem::Version.new(project.repository.exact_tag_from_ref(commit))
 
     if latest_github_version > latest_samson_version
       latest_github_version.to_s
     else
-      latest_samson_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
+      next_samson_version
     end
   end
 

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -23,7 +23,7 @@ describe Integrations::BaseController do
     Integrations::BaseController.any_instance.stubs(:branch).returns('master')
     Project.any_instance.stubs(:create_release?).returns(true)
     Build.any_instance.stubs(:validate_git_reference).returns(true)
-    GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+    GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
     stub_request(:post, "https://api.github.com/repos/bar/foo/releases")
   end
 

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -48,7 +48,7 @@ describe ReleasesController do
       end
 
       it "creates a new release" do
-        GitRepository.any_instance.expects(:tag_from_ref).with('abcd').returns("2")
+        GitRepository.any_instance.expects(:exact_tag_from_ref).with('abcd').returns("2")
 
         assert_difference "Release.count", +1 do
           post :create, params: {project_id: project.to_param, release: release_params}
@@ -65,7 +65,7 @@ describe ReleasesController do
 
     describe "#new" do
       it "renders" do
-        GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+        GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
 
         get :new, params: {project_id: project.to_param}
         assert_response :success

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -17,7 +17,7 @@ describe Project do
 
   before do
     Project.any_instance.stubs(:valid_repository_url).returns(true)
-    GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+    GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
   end
 
   describe "#generate_token" do

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -16,7 +16,7 @@ describe ReleaseService do
 
     before do
       GITHUB.stubs(:create_release).capture(release_params_used)
-      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+      GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
     end
 
     it "creates a new release" do

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -11,7 +11,7 @@ describe Release do
 
   describe "create" do
     before do
-      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+      GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
     end
 
     it "creates a new release" do
@@ -83,7 +83,7 @@ describe Release do
     end
 
     it "uses the github version if it is present on the commit" do
-      GitRepository.any_instance.expects(:tag_from_ref).with(commit).returns("125")
+      GitRepository.any_instance.expects(:exact_tag_from_ref).with(commit).returns("125")
       release = project.releases.create!(author: author, commit: commit)
       release.commit.must_equal commit
       release.number.must_equal "125"
@@ -169,7 +169,7 @@ describe Release do
 
   describe "#changeset" do
     before do
-      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+      GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
     end
 
     it "returns changeset" do

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -219,4 +219,13 @@ describe Release do
       refute release.contains_commit?("NEW")
     end
   end
+
+  describe "#assign_release_number" do
+    it "skips the github version check if no commit is defined" do
+      GitRepository.any_instance.expects(:exact_tag_from_ref).never
+      release = project.releases.new
+
+      release.assign_release_number
+    end
+  end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -182,7 +182,7 @@ describe Stage do
     let(:releases) { Array.new(3).map { project.releases.create!(author: author, commit: "a" * 40) } }
 
     before do
-      GitRepository.any_instance.stubs(:tag_from_ref).returns("")
+      GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
       stage.deploys.create!(reference: "v124", job: job, project: project)
       stage.deploys.create!(reference: "v125", job: job, project: project)
     end


### PR DESCRIPTION
The command I used to pull tags in https://github.com/zendesk/samson/pull/1625 allows for a "fuzzy" tag return.  If no explicit tag is set, it takes the latest tag and appends the shortened commit SHA.  This caused an error when converting it to a gem version for comparison.  This adds a new command which should check for explicitly defined tags.

It also adds an early return if no commit is defined (which broke the form initializer).

/cc @zendesk/samson @zendesk/sustaining 

### Risks
- Medium:  Could cause auto tagging to break more.
