### PR TITLE
do not send our ENV to airbrake on rake errors, it includes tokens/secrets

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -10,6 +10,9 @@ if defined?(Airbrake)
     # this will be blacklist_params in v5 ... does not support the full rails syntax
     config.params_filters = Rails.application.config.filter_parameters
 
+    # do not send our environment (secrets etc) to airbrake
+    config.rake_environment_filters.concat ENV.keys
+
     # report in development:
     # - uncomment
     # - add development in application.rb


### PR DESCRIPTION
/cc @zendesk/samson
@cericksen 

fix is for airbrake v4 https://github.com/airbrake/airbrake/blob/v4.3.8/lib/airbrake/rake_handler.rb#L30-L34

this seems to still exist in latest airbrake:
https://github.com/airbrake/airbrake/blob/05e66f4941d4cedcb690124703b63ec0b498c293/spec/unit/rake/tasks_spec.rb#L21-L28

so most likely we want to do this for all our apps :(