### PR TITLE
SAMSON-325 make project role UI only existing roles to make it less n…

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,7 +18,11 @@ class Admin::UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @projects = Project.search_by_criteria(params)
+    @projects = Project.search_by_criteria(params).joins(:user_project_roles).
+      where(user_project_roles: {user_id: @user.id})
+    if role_id = params[:role_id].presence
+      @projects = @projects.where("user_project_roles.role_id >= ?", role_id)
+    end
   end
 
   def update

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,15 +25,15 @@ class ApplicationController < ActionController::Base
     payload["params"] = request.params
   end
 
-  def redirect_back_or(fallback)
+  def redirect_back_or(fallback, options = {})
     if param_location = params[:redirect_to].presence
       if param_location.is_a?(String) && param_location.start_with?('/')
-        redirect_to URI("http://nope.nope#{param_location}").request_uri # using URI to silence Brakeman
+        redirect_to URI("http://ignor.ed#{param_location}").request_uri, options # using URI to silence Brakeman
         return
       else
         Rails.logger.error("Invalid redirect_to parameter #{param_location}")
       end
     end
-    redirect_back fallback_location: fallback
+    redirect_back options.merge(fallback_location: fallback)
   end
 end

--- a/app/controllers/project_roles_controller.rb
+++ b/app/controllers/project_roles_controller.rb
@@ -18,9 +18,13 @@ class ProjectRolesController < ApplicationController
 
     role_name = (role.role.try(:display_name) || 'None')
     Rails.logger.info(
-      "#{current_user.name_and_email} set the role #{role_name} to #{user.name}} on project #{current_project.name}"
+      "#{current_user.name_and_email} set the role #{role_name} to #{user.name} on project #{current_project.name}"
     )
 
-    render plain: "Saved!"
+    if request.xhr?
+      render plain: "Saved!"
+    else
+      redirect_back_or "/", notice: "Saved!"
+    end
   end
 end

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -22,7 +22,7 @@
       <div class="form-group">
         <label class="col-lg-2 control-label">Projects</label>
         <div class="col-lg-4">
-          <%= select_tag :project_ids, options_from_collection_for_select(@projects, 'id', 'name'),
+          <%= select_tag :project_ids, options_from_collection_for_select(@projects, :id, :name),
                          class: 'form-control', multiple: true, required: 'required' %>
         </div>
       </div>
@@ -30,7 +30,7 @@
       <div class="form-group">
         <label class="col-lg-2 control-label">Role</label>
         <div class="col-lg-4">
-          <%= select_tag :role_id, options_from_collection_for_select(@roles, 'id', 'display_name'),
+          <%= select_tag :role_id, options_from_collection_for_select(@roles, :id, :display_name),
                          class: 'form-control', required: 'required' %>
         </div>
       </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -17,7 +17,7 @@
 <section id="user-project-roles" class="clearfix">
   <h2 class="section-subtitle">Project Level Roles</h2>
 
-  <%= render partial: "shared/search_bar", locals: {url: admin_user_path, query: params[:search]} %>
+  <%= render "users/search_bar", system_level: false %>
 
   <div class="users-csv">
     <%= link_to "Download as CSV", new_csv_export_path(format: :csv, type: :users, user_id: @user.id) %>
@@ -34,7 +34,7 @@
     <tbody>
     <% if @projects.empty? %>
       <tr>
-        <td>No project was found!</td>
+        <td>No project roles exist.</td>
       </tr>
     <% else %>
       <%= render partial: 'project', collection: @projects, as: :project, locals: {user: @user} %>
@@ -42,4 +42,20 @@
     </tbody>
   </table>
   <%= paginate @projects %>
+
+  <h3>Create new project role</h3>
+  <%= form_tag project_roles_path(user_id: @user.id), class: 'form-horizontal' do %>
+    <div class="col-md-2">
+      <%= select_tag :project_id, options_from_collection_for_select(Project.all, :id, :name), required: true, class: 'form-control col-md-2' %>
+    </div>
+    &nbsp;
+    <% UserProjectRole::ROLES.each do |role| %>
+      <%= label_tag do %>
+        <%= radio_button_tag :role_id, role.id %>
+        <%= role.name %>
+      <% end %>
+      &nbsp;
+    <% end %>
+    <%= submit_tag "Create", class: 'btn btn-default' %>
+  <% end %>
 </section>

--- a/app/views/shared/_project_role.html.erb
+++ b/app/views/shared/_project_role.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag project_project_roles_path(project, user_id: user.id), class: 'autosubmit' do %>
+<%= form_tag project_roles_path(project_id: project.id, user_id: user.id), class: 'autosubmit' do %>
   <% options = [['None', nil]] + UserProjectRole::ROLES.map { |r| [r.name, r.id] } %>
   <% options.each do |name, id| %>
     <%= user_project_role_radio user, project, name, id %>

--- a/app/views/users/_search_bar.html.erb
+++ b/app/views/users/_search_bar.html.erb
@@ -10,7 +10,13 @@
     <%= select_tag :role_id, options_for_select(roles, params[:role_id]), class: 'form-control' %>
   </div>
 
-  <%= hidden_field_tag :project_id, @project.id unless system_level %>
+  <% unless system_level %>
+    <% if @project %>
+      <%= hidden_field_tag :project_id, @project.id %>
+    <% else %>
+      <%= hidden_field_tag :user_id, @user.id %>
+    <% end %>
+  <% end %>
 
   <div class="col-md-1 clearfix">
     <%= submit_tag "Search", class: "btn btn-default form-control" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,13 +83,12 @@ Samson::Application.routes.draw do
 
     resources :users, only: [:index, :update]
 
-    resources :project_roles, only: [:create]
-
     member do
       get :deploy_group_versions
     end
   end
 
+  resources :project_roles, only: [:create]
   resources :streams, only: [:show]
   resources :locks, only: [:create, :destroy]
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -103,6 +103,28 @@ describe Admin::UsersController do
       it 'succeeds' do
         get :show, params: {id: modified_user.id}
         assert_template :show, partial: '_project', locals: { user: modified_user }
+        assigns[:projects].must_equal []
+      end
+
+      describe "with project level roles" do
+        let!(:role) do
+          UserProjectRole.create!(role_id: Role::DEPLOYER.id, project: projects(:test), user: modified_user)
+        end
+
+        it 'shows projects with roles' do
+          get :show, params: {id: modified_user.id}
+          assigns[:projects].must_equal [role.project]
+        end
+
+        it 'can filter by project name' do
+          get :show, params: {id: modified_user.id, search: 'nope'}
+          assigns[:projects].must_equal []
+        end
+
+        it 'can filter by role' do
+          get :show, params: {id: modified_user.id, role_id: Role::ADMIN.id}
+          assigns[:projects].must_equal []
+        end
       end
     end
   end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -10,7 +10,7 @@ describe ApplicationController do
     end
 
     def test_redirect_back_or
-      redirect_back_or '/fallback'
+      redirect_back_or '/fallback', notice: params[:notice]
     end
   end
 
@@ -63,6 +63,12 @@ describe ApplicationController do
         Rails.logger.expects(:error)
         get :test_redirect_back_or, params: {test_route: true, redirect_to: {host: 'hacks.com', path: 'bar'}}
         assert_redirected_to '/fallback'
+      end
+
+      it "can set a notice" do
+        get :test_redirect_back_or, params: {test_route: true, redirect_to: '/param', notice: "hello"}
+        assert_redirected_to '/param'
+        assert flash[:notice]
       end
     end
   end


### PR DESCRIPTION
…oisy + add role filtering

previously we would show all projects here, which would waste space and do plenty N+1s to get all the user project role settings ... now we simply show the existing project roles and add a form to create new ones

<img width="794" alt="screen shot 2017-01-08 at 9 42 04 pm" src="https://cloud.githubusercontent.com/assets/11367/21775763/3bb00d38-d64c-11e6-8a9f-431c20fc842e.png">
<img width="414" alt="screen shot 2017-01-08 at 10 06 00 pm" src="https://cloud.githubusercontent.com/assets/11367/21775766/40fac99a-d64c-11e6-937c-64c793569ea9.png">
