### PR TITLE
SAMSON-328 stop button should cancel a queued deploy

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -61,7 +61,9 @@ class Job < ActiveRecord::Base
   end
 
   def stop!
-    if ex = execution
+    if JobExecution.dequeue(id)
+      cancelled!
+    elsif ex = execution # is active
       cancelling!
       ex.stop!
     else

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -265,6 +265,10 @@ class JobExecution
       job_queue.queued?(id)
     end
 
+    def dequeue(id)
+      job_queue.dequeue(id)
+    end
+
     def start_job(*args)
       job_queue.add(*args)
     end

--- a/app/models/job_queue.rb
+++ b/app/models/job_queue.rb
@@ -20,6 +20,10 @@ class JobQueue
     @queue.values.detect { |jes| jes.detect { |je| return je if je.id == id } }
   end
 
+  def dequeue(id)
+    !!@queue.values.detect { |jes| jes.reject! { |je| je.id == id } }
+  end
+
   def find_by_id(id)
     LOCK.synchronize { active?(id) || queued?(id) }
   end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -344,15 +344,7 @@ describe JobExecution do
   end
 
   describe "#stop!" do
-    around do |test|
-      begin
-        old = JobExecution.stop_timeout
-        JobExecution.stop_timeout = 0.1
-        test.call
-      ensure
-        JobExecution.stop_timeout = old
-      end
-    end
+    with_job_stop_timeout 0.1
 
     let(:lock) { Mutex.new }
     let(:execution) { JobExecution.new('master', job) { lock.lock } }
@@ -424,9 +416,16 @@ describe JobExecution do
     end
   end
 
-  describe "#debug" do
+  describe ".debug" do
     it "returns job queue interansl" do
       JobExecution.debug.must_equal([{}, {}])
+    end
+  end
+
+  describe ".dequeue" do
+    it "calls job queue" do
+      JobExecution.send(:job_queue).expects(:dequeue)
+      JobExecution.dequeue(12)
     end
   end
 end

--- a/test/support/job_queue_support.rb
+++ b/test/support/job_queue_support.rb
@@ -15,4 +15,16 @@ ActiveSupport::TestCase.class_eval do
   def self.with_job_execution
     around { |t| with_job_execution(&t) }
   end
+
+  def self.with_job_stop_timeout(value)
+    around do |test|
+      begin
+        old = JobExecution.stop_timeout
+        JobExecution.stop_timeout = value
+        test.call
+      ensure
+        JobExecution.stop_timeout = old
+      end
+    end
+  end
 end


### PR DESCRIPTION
/cc @jonmoter 

confirmed working with a local deploy that does:

```
sleep 20
echo $DEPLOY_URL >> /tmp/testing
```