### PR TITLE
Include request info in exceptions to make it easy to see what reques…

### DIFF
--- a/plugins/kubernetes/config/initializers/kubeclient_extensions.rb
+++ b/plugins/kubernetes/config/initializers/kubeclient_extensions.rb
@@ -33,3 +33,15 @@ module Kubeclient
     end
   end
 end
+
+# Make our exceptions tell us what url/server/method they were triggered from
+# https://github.com/abonas/kubeclient/pull/221
+class KubeException < StandardError
+  def to_s
+    string = "HTTP status code #{@error_code} #{@message}"
+    if @response.is_a?(RestClient::Response) && @response.request
+      string += " for #{@response.request.method.upcase} #{@response.request.url}"
+    end
+    string
+  end
+end

--- a/plugins/kubernetes/test/initializers/kubeclient_extensions_test.rb
+++ b/plugins/kubernetes/test/initializers/kubeclient_extensions_test.rb
@@ -31,3 +31,12 @@ describe Kubeclient::Client do
     end
   end
 end
+
+describe KubeException do
+  it "has request information" do
+    client = Kubeclient::Client.new('http://foobar.server/apis')
+    stub_request(:get, "http://foobar.server/apis/v1").to_return(status: 404)
+    e = assert_raises(KubeException) { client.get_secret 'nope' }
+    e.to_s.must_equal "HTTP status code 404 404 Not Found for GET http://foobar.server/apis/v1"
+  end
+end


### PR DESCRIPTION
…t and what server failed

same as https://github.com/abonas/kubeclient/pull/221

to solve unhelpful errors like https://zendesk.airbrake.io/projects/95346/groups/1819685868710340276/notices/1859658156702649501?tab=notice-detail

"KubeException: client: etcd cluster is unavailable or misconfigured"

/cc @jonmoter 