### PR TITLE
escape references so we do not build invalid urls

### DIFF
--- a/app/controllers/integrations/tddium_controller.rb
+++ b/app/controllers/integrations/tddium_controller.rb
@@ -13,7 +13,7 @@ class Integrations::TddiumController < Integrations::BaseController
   def skip?
     # Tddium doesn't send commit message, so we have to get creative
     repo_name = "#{params[:repository][:org_name]}/#{params[:repository][:name]}"
-    data = GITHUB.commit(repo_name, params[:commit_id])
+    data = GITHUB.commit(repo_name, CGI.escape(params[:commit_id]))
 
     contains_skip_token?(data.commit.message)
   rescue Octokit::Error => e

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -76,7 +76,7 @@ class Changeset
       # for branches that frequently change we make sure to always get the correct cache,
       # others might get an outdated changeset if they are reviewed with different shas
       if BRANCH_TAGS.include?(commit)
-        @commit = GITHUB.branch(repo, commit).commit[:sha]
+        @commit = GITHUB.branch(repo, CGI.escape(commit)).commit[:sha]
       end
 
       Rails.cache.fetch(cache_key) do

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -29,7 +29,7 @@ class CommitStatus
   end
 
   def github_status
-    GITHUB.combined_status(@stage.project.user_repo_part, @reference).to_h
+    GITHUB.combined_status(@stage.project.user_repo_part, CGI.escape(@reference)).to_h
   rescue Octokit::NotFound
     {
       state: "failure",

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -81,6 +81,16 @@ describe CommitStatus do
         status.status.must_equal 'success'
       end
     end
+
+    describe "with bad ref" do
+      let(:reference) { '[/r' }
+      let(:url) { "repos/#{stage.project.user_repo_part}/commits/%255B%252Fr/status" }
+
+      it "escapes the url" do
+        failure!
+        status.status.must_equal 'failure'
+      end
+    end
   end
 
   describe "#status_list" do


### PR DESCRIPTION
/fyi @zendesk/samson there might be a way to abuse samson to perform privileged requests by using bad refs in a few other places ...

https://zendesk.airbrake.io/projects/95346/groups/1755381237528602731/notices/1860481649482315689

fixed 2 more places that looked suspicious ... others only use clean data we pulled from github