### PR TITLE
Update slack webhook plugin content with PR info

### DIFF
--- a/plugins/slack_webhooks/app/models/slack_webhook_notification_renderer.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification_renderer.rb
@@ -3,6 +3,7 @@ class SlackWebhookNotificationRenderer
   def self.render(deploy, subject)
     controller = ActionController::Base.new
     view = ActionView::Base.new(File.expand_path("../../views/samson_slack_webhooks", __FILE__), {}, controller)
+    show_prs = deploy.pending? || deploy.running?
     status_emoji = if deploy.pending?
       ':stopwatch:'
     elsif deploy.running?
@@ -20,7 +21,8 @@ class SlackWebhookNotificationRenderer
       deploy: deploy,
       status_emoji: status_emoji,
       changeset: deploy.changeset,
-      subject: subject
+      subject: subject,
+      show_prs: show_prs
     }
     view.render(template: 'notification', locals: locals).chomp
   end

--- a/plugins/slack_webhooks/app/views/samson_slack_webhooks/notification.text.erb
+++ b/plugins/slack_webhooks/app/views/samson_slack_webhooks/notification.text.erb
@@ -3,4 +3,16 @@
 There are no new commits since last time.
 <% else %>
 _<<%= changeset.github_url %>|<%= pluralize changeset.commits.count, "commit" %>> and <%= pluralize changeset.pull_requests.count, "pull request" %> by <%= changeset.author_names.to_sentence %>._
+
+<% if show_prs %>
+<% if changeset.pull_requests.empty? %>
+  <!channel> :bangbang: Warning. There are commits going live that did not go through a pull request. Please ensure this is what you really want. :bangbang:
+<% else %>
+*Pull Requests*
+
+<% changeset.pull_requests.each do |pr| %>
+> PR#<%= pr.number %> <<%= pr.url + '|' + pr.title %>> (<%= pr.users.map(&:login).join(", ") %>)
+<% end %>
+<% end %>
+<% end %>
 <% end %>

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_renderer_test.rb
@@ -5,11 +5,17 @@ SingleCov.covered!
 
 describe SlackWebhookNotificationRenderer do
   let(:subject) { 'Deploy starting' }
+  let(:pull_requests) do
+    [
+      stub("PR one", number: 42, title: 'Fix bug', url: 'http://pr1.url/', users: [stub(login: 'author1')]),
+      stub("PR two", number: 43, title: 'Properly fix bug', url: 'http://pr2.url/', users: [stub(login: 'author2')])
+    ]
+  end
   let(:changeset) do
     stub "changeset",
       commits: stub("commits", count: 3),
       github_url: "https://github.com/url",
-      pull_requests: stub("pull_requests", count: 2),
+      pull_requests: pull_requests,
       author_names: ['author1', 'author2']
   end
 
@@ -25,6 +31,11 @@ describe SlackWebhookNotificationRenderer do
     result.must_equal <<-RESULT.strip_heredoc.chomp
       :stopwatch: *Deploy starting* (<http://sams.on/url|view the deploy>)
       _<https://github.com/url|3 commits> and 2 pull requests by author1 and author2._
+
+      *Pull Requests*
+
+      > PR#42 <http://pr1.url/|Fix bug> (author1)
+      > PR#43 <http://pr2.url/|Properly fix bug> (author2)
     RESULT
   end
 
@@ -95,5 +106,37 @@ describe SlackWebhookNotificationRenderer do
 
     result = SlackWebhookNotificationRenderer.render(deploy, subject)
     result.wont_match /:.*:/
+  end
+
+  context 'when there are no pull requests in the deploy' do
+    let(:pull_requests) { [] }
+
+    it 'renders a warning' do
+      deploy = stub("deploy",
+        short_reference: "xyz",
+        changeset: changeset,
+        pending?: true,
+        url: "http://sams.on/url")
+
+      result = SlackWebhookNotificationRenderer.render(deploy, subject)
+      result.must_include 'There are commits going live that did not go through a pull request'
+    end
+  end
+
+  context 'when the deploy is not pending or running' do
+    it 'does not display pull request information' do
+      deploy = stub("deploy",
+        short_reference: "xyz",
+        changeset: changeset,
+        pending?: false,
+        running?: false,
+        errored?: false,
+        failed?: false,
+        succeeded?: true,
+        url: "http://sams.on/url")
+
+      result = SlackWebhookNotificationRenderer.render(deploy, subject)
+      result.wont_match /Pull Requests/
+    end
   end
 end


### PR DESCRIPTION
Add pull request information to the slack notifications for pending and
running deploys. Notifications for other states like
error/failed/succeeded won't output this information as there's no need
to print it twice.

It looks like this:

![example notification](http://i.imgur.com/vPoZ7E2.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low