### PR TITLE
use proper logic to check when to update desc of a jenkins job

### DIFF
--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -139,7 +139,7 @@ module Samson
       head = desc.index(JENKINS_DESC_HEADER)
       foot = desc.index(JENKINS_DESC_FOOTER)
       job = desc.index(jenkins_desc_job_name)
-      head && foot && job && head > job && job > foot
+      head && foot && job && head < job && job < foot
     end
 
     def find_or_add_parameter_definition(conf)

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -679,5 +679,13 @@ XML
       stub_get_build_id_from_queue(123)
       jenkins.build.must_equal 123
     end
+
+    it "does not update job when desc or params are not changed" do
+      stub_get_config(jenkins_xml_configured_with_other_params)
+      stub_build_with_parameters_when_autoconfig_is_enabled({})
+      to_post, new_conf = jenkins.check_and_build_job_config
+      assert to_post == false
+      assert_equal jenkins_xml_configured_with_other_params, new_conf.to_xml.to_s
+    end
   end
 end


### PR DESCRIPTION
As reported by @ievgenChernikov in SAMSON-329, configuration gets updated even when nothing was changed in job description or parameters. On debugging, code checking the order of indexes was doing in reverse manner. So, it expected `head` to be later than `job` and `job` to be later than `footer`. However, in description `header` would be before `job` and so forth. 
This change reverses this.

/cc @zendesk/samson @zendesk/vulcan @grosser @ievgenChernikov @rdhanoa 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-329

### Risks
- Level: Low/Med/High
