### PR TITLE
refactor restart handler to be more descriptive/dry and add logging

### DIFF
--- a/app/models/restart_signal_handler.rb
+++ b/app/models/restart_signal_handler.rb
@@ -2,6 +2,9 @@
 # JobQueue locks a mutex, hence the need for a separate SignalHandler thread
 # Self-pipe is also best practice, since signal handlers can themselves be interrupted
 class RestartSignalHandler
+  LISTEN_SIGNAL = 'SIGUSR1'
+  PASSED_SIGNAL = 'SIGUSR2'
+
   class << self
     alias_method :listen, :new
   end
@@ -9,24 +12,42 @@ class RestartSignalHandler
   def initialize
     @read, @write = IO.pipe
     Thread.new { run }
-    Signal.trap('SIGUSR1') { signal }
+    Signal.trap(LISTEN_SIGNAL) { signal_restart }
   end
 
   private
 
-  def signal
+  def signal_restart
     @write.puts
   end
 
   def run
+    wait_for_restart_signal
+
+    output 'preparing restart'
+
+    JobExecution.enabled = false # Disable new job execution
+    wait_for_active_jobs_to_finish
+    JobExecution.clear_queue
+
+    output "Passing #{PASSED_SIGNAL} on."
+
+    Process.kill(PASSED_SIGNAL, Process.pid) # shut down underlying server
+  end
+
+  def wait_for_restart_signal
     IO.select([@read])
+  end
 
-    # Disable new job execution
-    JobExecution.enabled = false
+  def wait_for_active_jobs_to_finish
+    loop do
+      # dup-ing to avoid racing with other threads
+      active = JobExecution.active.dup
+      locks = MultiLock.locks.dup
+      break if active.empty? && locks.empty?
 
-    until JobExecution.active.empty? && MultiLock.locks.empty?
-      loginfo = {
-        jobs: JobExecution.active.map do |job_exec|
+      info = {
+        jobs: active.map do |job_exec|
           {
             job_id: job_exec.id,
             pid: job_exec.pid,
@@ -34,19 +55,12 @@ class RestartSignalHandler
             descriptor: job_exec.descriptor
           }
         end,
-        locks: MultiLock.locks
+        locks: locks
       }
 
-      output 'waiting for jobs to complete', loginfo
-      sleep(5)
+      output 'waiting for jobs to complete', info
+      sleep 5
     end
-
-    JobExecution.clear_queue
-
-    output 'Passing SIGUSR2 on.'
-
-    # Pass USR2 to the underlying server
-    Process.kill('SIGUSR2', Process.pid)
   end
 
   def output(message, data = {})


### PR DESCRIPTION
trying to find why it does not work ... first trying to understand it and refactoring a bit
also 
 - fixing a global test pollution issue we saw with the previous test runner (running without isolation)
 - fixing a race condition from fetching active/locks twice

tested in staging:

```
{"timestamp":"2017-01-11 23:02:43 +0000","message":"preparing restart"}
{"timestamp":"2017-01-11 23:02:43 +0000","message":"Passing SIGUSR2 on."}
```