### PR TITLE
render buddy check even if we are waiting for restart ... render rest…

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -12,25 +12,19 @@ module DeploysHelper
   }.freeze
 
   def deploy_output
-    output_hidden = false
     output = ActiveSupport::SafeBuffer.new
 
     if JobExecution.enabled
       output << Samson::Hooks.render_views(:deploy_view, self, deploy: @deploy, project: @project)
-
-      if @deploy.job.queued?
-        output_hidden = true
-        output << render('queued')
-      elsif @deploy.waiting_for_buddy?
-        output_hidden = true
-        output << render('buddy_check', deploy: @deploy)
-      end
-    elsif @deploy.pending?
-      output_hidden = true
-      output << render('queued')
     end
 
-    output << render('shared/output', deployable: @deploy, job: @deploy.job, project: @project, hide: output_hidden)
+    if @deploy.waiting_for_buddy?
+      output << render('deploys/buddy_check', deploy: @deploy)
+    elsif @deploy.pending?
+      output << render('deploys/queued')
+    end
+
+    output << render('shared/output', deployable: @deploy, job: @deploy.job, project: @project, hide: @deploy.pending?)
   end
 
   def deploy_page_title

--- a/app/views/deploys/_queued.html.erb
+++ b/app/views/deploys/_queued.html.erb
@@ -1,5 +1,12 @@
 <div class="row deploy-check">
-  <p>This deploy is queued, it will be started when previous deploys have finished.</p>
+  <p>
+    This deploy is queued, it will be started when
+    <% if JobExecution.enabled %>
+      previous deploys have finished.
+    <% else %>
+      Samson has restarted.
+    <% end %>
+  </p>
 
   <%= stop_button deploy: @deploy, project: @project %>
 </div>


### PR DESCRIPTION
…art warning when waiting forrestart

this will go nicely with https://github.com/zendesk/samson/pull/1660 which changes expired to only include deploys that are waiting for buddy ... so during restart you can still do the buddy check and then the deploy will go into the 'safe' waiting-for-restart state

@jonmoter @irwaters 

<img width="506" alt="screen shot 2017-01-11 at 9 22 09 pm" src="https://cloud.githubusercontent.com/assets/11367/21878015/0ed08078-d844-11e6-9d6b-8f31c801fee4.png">

... also adding some html safety tests for github-ursers since they looked suspicious

confirmed locally by disabling job execution and then making a deploy