### PR TITLE
Update before_deploy hook location

### DIFF
--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -22,11 +22,12 @@ class DeployService
   end
 
   def confirm_deploy!(deploy)
-    send_before_notifications(deploy)
-
     stage = deploy.stage
 
     job_execution = JobExecution.new(deploy.reference, deploy.job, construct_env(stage))
+    job_execution.on_start do
+      send_before_notifications(deploy)
+    end
     job_execution.on_complete do
       send_after_notifications(deploy)
     end

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -99,7 +99,13 @@ class JobExecution
   end
 
   def run!
-    @start_callbacks.each(&:call)
+    begin
+      @start_callbacks.each(&:call)
+    rescue => e
+      @output.write(e.message)
+      finish
+      return
+    end
 
     @output.write('', :started)
 

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -23,8 +23,8 @@ class JobExecution
     @executor = TerminalExecutor.new(@output, verbose: true, deploy: job.deploy)
     @viewers = JobViewers.new(@output)
 
-    @start_subscribers = []
-    @complete_subscribers = []
+    @start_callbacks = []
+    @complete_callbacks = []
     @env = env
     @job = job
     @reference = reference
@@ -74,11 +74,11 @@ class JobExecution
   end
 
   def on_start(&block)
-    @start_subscribers << JobExecutionSubscriber.new(job, &block)
+    @start_callbacks << block
   end
 
   def on_complete(&block)
-    @complete_subscribers << JobExecutionSubscriber.new(job, &block)
+    @complete_callbacks << JobExecutionSubscriber.new(job, &block)
   end
 
   def descriptor
@@ -99,7 +99,7 @@ class JobExecution
   end
 
   def run!
-    @start_subscribers.each(&:call)
+    @start_callbacks.each(&:call)
 
     @output.write('', :started)
 
@@ -134,7 +134,7 @@ class JobExecution
   def finish
     return if @finished
     @finished = true
-    @complete_subscribers.each(&:call)
+    @complete_callbacks.each(&:call)
   end
 
   def execute!(dir)

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -99,16 +99,8 @@ class JobExecution
   end
 
   def run!
-    begin
-      @start_callbacks.each(&:call)
-    rescue => e
-      @output.write(e.message)
-      finish
-      return
-    end
-
     @output.write('', :started)
-
+    @start_callbacks.each(&:call)
     @job.run!
 
     success = Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|

--- a/test/lib/buddy_check_test.rb
+++ b/test/lib/buddy_check_test.rb
@@ -69,7 +69,9 @@ describe BuddyCheck do
       stage.update_attribute(:production, true)
       job_execution.stubs(:execute!)
       job_execution.stubs(:setup!).returns(true)
-      JobExecution.expects(:start_job).returns(job_execution)
+
+      JobExecution.stubs(:new).returns(job_execution)
+      JobQueue.any_instance.stubs(:delete_and_enqueue_next) # we do not properly add the job, so removal fails
 
       BuddyCheck.stubs(:enabled?).returns(true)
     end

--- a/test/lib/buddy_check_test.rb
+++ b/test/lib/buddy_check_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 4
+SingleCov.covered! uncovered: 5
 
 describe BuddyCheck do
   let(:project) { job.project }

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -202,9 +202,10 @@ describe JobExecution do
   end
 
   it 'fails when on start callback fails' do
-    execute_job('master', on_start: -> { raise('failure') })
+    execute_job('master', on_start: -> { raise Samson::Hooks::UserError.new('failure') })
 
     job.output.wont_include 'monkey'
+    assert_equal 'errored', job.status
   end
 
   it 'outputs start / stop events' do

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -11,8 +11,8 @@ describe JobExecution do
     on_start = options.delete(:on_start)
 
     execution = JobExecution.new(branch, job, options)
-    execution.on_complete { on_complete.call } if on_complete.present?
-    execution.on_start { on_start.call } if on_start.present?
+    execution.on_complete(&on_complete) if on_complete.present?
+    execution.on_start(&on_start) if on_start.present?
     execution.send(:run!)
   end
 
@@ -199,6 +199,12 @@ describe JobExecution do
     called_subscriber = false
     execute_job('master', on_start: -> { called_subscriber = true })
     assert_equal true, called_subscriber
+  end
+
+  it 'fails when on start callback fails' do
+    execute_job('master', on_start: -> { raise('failure') })
+
+    job.output.wont_include 'monkey'
   end
 
   it 'outputs start / stop events' do

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -204,7 +204,7 @@ describe JobExecution do
   it 'fails when on start callback fails' do
     execute_job('master', on_start: -> { raise(Samson::Hooks::UserError, 'failure') })
 
-    job.output.wont_include 'monkey'
+    assert job.output.include?('failed')
     assert_equal 'errored', job.status
   end
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -202,7 +202,7 @@ describe JobExecution do
   end
 
   it 'fails when on start callback fails' do
-    execute_job('master', on_start: -> { raise Samson::Hooks::UserError.new('failure') })
+    execute_job('master', on_start: -> { raise(Samson::Hooks::UserError, 'failure') })
 
     job.output.wont_include 'monkey'
     assert_equal 'errored', job.status


### PR DESCRIPTION
When the feature to enqueue jobs as 'pending' was added, it meant that
the before_deploy hooks now fire before deploy are enqueued, not before
they're deployed.

To fix this we can create a hook for job execution for `on_start`
similar to how `on_complete` works currently :)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low