### PR TITLE
support githubs default www-form-encoded payload

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -13,6 +13,14 @@ class Integrations::GithubController < Integrations::BaseController
 
   protected
 
+  def payload
+    if payload = params[:payload]
+      JSON.parse(payload)
+    else
+      params
+    end
+  end
+
   def validate_request
     unless valid_signature?
       record_log :warn, "Github webhook: failed to validate signature '#{signature}'"
@@ -21,7 +29,7 @@ class Integrations::GithubController < Integrations::BaseController
   end
 
   def deploy?
-    webhook_handler&.valid_webhook?(params)
+    webhook_handler&.valid_webhook?(payload)
   end
 
   # https://developer.github.com/webhooks/securing/
@@ -51,7 +59,7 @@ class Integrations::GithubController < Integrations::BaseController
   end
 
   def webhook_event
-    @webhook_event ||= webhook_handler.changeset_from_webhook(project, params)
+    @webhook_event ||= webhook_handler.changeset_from_webhook(project, payload)
   end
 
   def webhook_handler

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -102,4 +102,14 @@ describe Integrations::GithubController do
 
     it_deploys
   end
+
+  describe 'with payload as json because it is using x-ww-form-encoded' do
+    def payload
+      {
+        payload: super.to_json
+      }
+    end
+
+    it_deploys
+  end
 end


### PR DESCRIPTION
by default a webhook is now 

![screen shot 2017-01-17 at 1 22 48 pm](https://cloud.githubusercontent.com/assets/11367/22040551/0e761458-dcb8-11e6-9742-c05def1fb2e4.png)

content-type: application/x-www-form-urlencoded

which ends up with a payload looking like

![screen shot 2017-01-17 at 1 24 24 pm](https://cloud.githubusercontent.com/assets/11367/22040618/47f27c6c-dcb8-11e6-981a-d57f0e8ff12a.png)


and blows up like `NoMethodError: undefined method `[]' for nil:NilClass`
https://zendesk.airbrake.io/projects/95346/groups/1865431083722943737/notices/1865431075729152468?tab=notice-detail