### PR TITLE
fix Save and add another switching from hidden to visible by making c…

### DIFF
--- a/app/controllers/admin/secrets_controller.rb
+++ b/app/controllers/admin/secrets_controller.rb
@@ -11,6 +11,7 @@ class Admin::SecretsController < ApplicationController
   before_action :ensure_project_access, except: DEPLOYER_ACCESS
   before_action :authorize_project_admin!, except: DEPLOYER_ACCESS
   before_action :authorize_any_deployer!, only: DEPLOYER_ACCESS
+  before_action :convert_visible_to_boolean, only: [:update, :create, :new]
 
   def index
     @secret_keys = SecretStorage.keys
@@ -102,5 +103,11 @@ class Admin::SecretsController < ApplicationController
     if !current_user.deployer? && !current_user.user_project_roles.where('role_id >= ?', Role::DEPLOYER).exists?
       unauthorized!
     end
+  end
+
+  # vault backend needs booleans and so does our view logic
+  def convert_visible_to_boolean
+    return unless secret = params[:secret]
+    secret[:visible] = ActiveRecord::Type::Boolean.new.cast(secret[:visible])
   end
 end

--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -43,7 +43,7 @@ module Samson
             :write,
             vault_path(key),
             vault: data.fetch(:value),
-            visible: ActiveRecord::Type::Boolean.new.cast(data.fetch(:visible)),
+            visible: data.fetch(:visible),
             comment: data.fetch(:comment),
             creator_id: creator_id,
             updater_id: user_id

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -70,7 +70,7 @@ describe Samson::Secrets::HashicorpVaultBackend do
       assert_vault_request :get, "production/foo/pod2/bar", status: 404 do
         assert_vault_request :put, "production/foo/pod2/bar", with: {body: data.to_json} do
           assert Samson::Secrets::HashicorpVaultBackend.write(
-            'production/foo/pod2/bar', value: 'whatever', visible: 'false', user_id: 1, comment: 'secret!'
+            'production/foo/pod2/bar', value: 'whatever', visible: false, user_id: 1, comment: 'secret!'
           )
         end
       end
@@ -81,7 +81,7 @@ describe Samson::Secrets::HashicorpVaultBackend do
       assert_vault_request :get, "production/foo/pod2/bar", body: {data: {creator_id: 2, vault: "old"}}.to_json do
         assert_vault_request :put, "production/foo/pod2/bar", with: {body: data.to_json} do
           assert Samson::Secrets::HashicorpVaultBackend.write(
-            'production/foo/pod2/bar', value: 'whatever', visible: 'true', user_id: 1, comment: 'secret!'
+            'production/foo/pod2/bar', value: 'whatever', visible: true, user_id: 1, comment: 'secret!'
           )
         end
       end


### PR DESCRIPTION
…ontroller cleanup check box values

![screen shot 2017-01-17 at 2 38 15 pm](https://cloud.githubusercontent.com/assets/11367/22043016/9808eaa6-dcc2-11e6-8ffd-617b3386755d.png)

would make the next form always have visible pre-filled ... which can lead to exposing secrets by accident