### PR TITLE
wait a bit before showing logs since we often miss the last lines

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -115,6 +115,8 @@ module Kubernetes
     end
 
     def show_failure_cause(release, release_docs, statuses)
+      sleep TICK # logs take a few seconds to arrive, might have to increase if this does not help
+
       release_docs.each { |doc| print_resource_events(doc) }
 
       statuses.reject(&:live).select(&:pod).each do |status|


### PR DESCRIPTION
for example https://samson.zende.sk/projects/kube_service_watcher/deploys/240180#L42 shows half the logs and the actual exception / failure cause is cut off ...