### PR TITLE
do not fail when opening a running deploy with a line that is not yet…

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -321,7 +321,7 @@ $(function () {
     }
 
     function scroll() {
-      if ($highlightedLines) {
+      if ($highlightedLines && $highlightedLines.get(0)) {
         $highlightedLines.get(0).scrollIntoView(true);
       }
     }


### PR DESCRIPTION
… streamed in

ideally it should wait for the content to be streamed in and then scroll to the correct line
but that's a bit harder to do and this bug atm breaks the output from getting streamed in at all

/cc @jonmoter 

