### PR TITLE
Correct exact tags

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -47,14 +47,15 @@ class GitRepository
 
   # @return [nil, tag-sha or tag]
   def fuzzy_tag_from_ref(git_reference)
-    return unless ensure_local_cache!
+    return unless update_local_cache!
     capture_stdout 'git', 'describe', '--tags', git_reference
   end
 
   # @return [nil, tag]
   def exact_tag_from_ref(git_reference)
-    return unless ensure_local_cache!
-    capture_stdout 'git', 'tag', '--points-at', git_reference
+    fuzzy_tag = fuzzy_tag_from_ref(git_reference)
+
+    fuzzy_tag && fuzzy_tag[Release::VERSION_REGEX, 0]
   end
 
   def repo_cache_dir

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -52,10 +52,13 @@ class GitRepository
   end
 
   # @return [nil, tag]
+  # fuzzy_tag_from_ref returns v1.0 or v1.0-abcd if no tag is defined.
+  # We only want the tag in the first case.
+  # git tag --points-at is preferred, but is only available in git 2.7+
   def exact_tag_from_ref(git_reference)
     fuzzy_tag = fuzzy_tag_from_ref(git_reference)
 
-    fuzzy_tag && fuzzy_tag[Release::VERSION_REGEX, 0]
+    fuzzy_tag && fuzzy_tag[Release::VERSION_REGEX]
   end
 
   def repo_cache_dir

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -79,7 +79,7 @@ class Release < ActiveRecord::Base
 
     return next_samson_version unless commit
 
-    latest_github_version = Gem::Version.new(project.repository.exact_tag_from_ref(commit)[1..-1])
+    latest_github_version = Gem::Version.new(project.repository.exact_tag_from_ref(commit)&.slice(1..-1))
 
     if latest_github_version > latest_samson_version
       latest_github_version.to_s

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -79,7 +79,7 @@ class Release < ActiveRecord::Base
 
     return next_samson_version unless commit
 
-    latest_github_version = Gem::Version.new(project.repository.exact_tag_from_ref(commit))
+    latest_github_version = Gem::Version.new(project.repository.exact_tag_from_ref(commit)[1..-1])
 
     if latest_github_version > latest_samson_version
       latest_github_version.to_s

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -181,7 +181,7 @@ describe GitRepository do
     it 'returns nil when repo has no tags' do
       create_repo_without_tags
       repository.update_local_cache!
-      repository.exact_tag_from_ref('master').must_equal ''
+      repository.exact_tag_from_ref('master').must_equal nil
     end
 
     it 'returns no tag if one is not defined' do
@@ -191,7 +191,7 @@ describe GitRepository do
         git commit -a -m 'untagged commit'
       SHELL
       repository.update_local_cache!
-      repository.exact_tag_from_ref('master').must_equal ''
+      repository.exact_tag_from_ref('master').must_equal nil
       repository.exact_tag_from_ref('master~').must_equal 'v1'
     end
 

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -83,7 +83,7 @@ describe Release do
     end
 
     it "uses the github version if it is present on the commit" do
-      GitRepository.any_instance.expects(:exact_tag_from_ref).with(commit).returns("125")
+      GitRepository.any_instance.expects(:exact_tag_from_ref).with(commit).returns("v125")
       release = project.releases.create!(author: author, commit: commit)
       release.commit.must_equal commit
       release.number.must_equal "125"


### PR DESCRIPTION
https://github.com/zendesk/samson/pull/1639 introduced the `exact_tag_from_ref` method, which was relying on `git tag --points-at`, which wasn't introduced into git until v2.7.  Doesn't look like we're running that in production, so a pivot is probably easiest.

This regexes the version number through our version regex to filter out made up version numbers like `v1.0-1-gbcf85da`.

/cc @zendesk/samson @zendesk/sustaining 

### Tasks
 - [ ] :+1: from team

### Risks
- Low:  `exact_tag_from_ref` is already broken.
