### PR TITLE
add finished_at to deploys so we do not lose duration when deploy is …

### DIFF
--- a/app/helpers/date_time_helper.rb
+++ b/app/helpers/date_time_helper.rb
@@ -9,6 +9,7 @@ module DateTimeHelper
   end
 
   def render_time(time, format)
+    return '' unless time
     # grab the time format that the user has in their profile
     format ||= current_user.time_format
     if format == 'local'

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -25,32 +25,32 @@ module StatusHelper
     if deploy.active?
       content << content_tag(:br)
       content << "Started "
-      content << relative_time(deploy.start_time)
-      job = deploy.respond_to?(:job) ? deploy.job : deploy
+      content << relative_time(deploy.started_at)
+      job = (deploy.respond_to?(:job) ? deploy.job : deploy)
       content << " [Process ID: #{job.pid}]"
     end
 
     if deploy.finished?
       content << " "
-      content << render_time(deploy.start_time, current_user.time_format)
-      content << ", it took #{duration_text(deploy)}."
+      if deploy.started_at
+        content << render_time(deploy.started_at, current_user.time_format)
+        if deploy.finished_at
+          content << ", it took #{duration_text(deploy.started_at - deploy.finished_at)}."
+        end
+      end
     end
 
-    content_tag :div, content.html_safe, class: "alert #{status_alert(deploy.status)}"
+    content_tag :div, content, class: "alert #{status_alert(deploy.status)}"
   end
 
-  def duration_text(deploy)
-    seconds  = (deploy.updated_at - deploy.start_time).to_i
+  def duration_text(duration)
+    duration = duration.to_i
+    minutes = duration / 60
+    seconds = duration % 60
 
-    duration = "".dup
-
-    if seconds > 60
-      minutes = seconds / 60
-      seconds -= minutes * 60
-
-      duration << "#{minutes} minute".pluralize(minutes)
-    end
-
-    duration << (seconds.positive? || duration.empty? ? " #{seconds} second".pluralize(seconds) : "")
+    text = "".dup
+    text << "#{minutes} minute".pluralize(minutes) if minutes.nonzero?
+    text << " #{seconds} second".pluralize(seconds) if seconds.nonzero? || text.empty?
+    text
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -5,9 +5,6 @@ class Job < ActiveRecord::Base
 
   has_one :deploy
 
-  # Used by status_panel
-  alias_attribute :start_time, :created_at
-
   after_update { deploy&.touch }
 
   validate :validate_globally_unlocked
@@ -79,6 +76,7 @@ class Job < ActiveRecord::Base
 
   def run!
     status!("running")
+    update_attribute(:started_at, Time.now)
   end
 
   def success!
@@ -103,6 +101,10 @@ class Job < ActiveRecord::Base
 
   def finished?
     !ACTIVE_STATUSES.include?(status)
+  end
+
+  def finished_at
+    updated_at if finished?
   end
 
   def queued?

--- a/app/serializers/deploy_serializer.rb
+++ b/app/serializers/deploy_serializer.rb
@@ -3,7 +3,7 @@ class DeploySerializer < ActiveModel::Serializer
   include ApplicationHelper
   include ActionView::Helpers::DateHelper
 
-  attributes :id, :updated_at, :summary, :url, :production, :status
+  attributes :id, :summary, :url, :production, :status, :started_at, :finished_at, :created_at, :updated_at
 
   has_one :project
   has_one :stage

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -23,12 +23,7 @@
 
     <% if finished_at = @build.finished_at %>
       <dt>Duration</dt>
-      <dd>
-        <%=
-          duration = (finished_at - @build.started_at).to_i
-          "#{duration / 60}m#{duration % 60}s"
-        %>
-      </dd>
+      <dd><%= duration_text finished_at - @build.started_at %></dd>
     <% end %>
 
     <dt>Created By</dt>

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -7,7 +7,12 @@
 
       <% if @deploy.succeeded? && next_stage = @deploy.stage.next_stage %>
         <% unless Lock.locked_for?(next_stage, current_user) %>
-          <%= link_to "Deploy #{@deploy.short_reference} to #{next_stage.name}", new_project_stage_deploy_path(@project, next_stage, reference: @deploy.short_reference), class: "btn btn-primary" %>
+          <%= link_to(
+                "Deploy #{@deploy.short_reference} to #{next_stage.name}",
+                new_project_stage_deploy_path(@project, next_stage, reference: @deploy.short_reference),
+                class: "btn btn-primary"
+              )
+          %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/projects/_deploy.html.erb
+++ b/app/views/projects/_deploy.html.erb
@@ -3,7 +3,7 @@
     <% unless @project %>
       <td><%= link_to deploy.project.name, deploy.project %></td>
     <% end %>
-    <td><%= render_time(deploy.start_time, params[:time_format]) %></td>
+    <td><%= render_time(deploy.started_at, params[:time_format]) %></td>
     <td>
       <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.changeset.hotfix? %>
       <%= link_to "#{deploy.summary}", [@project || deploy.project, deploy] %>

--- a/db/migrate/20170119044208_move_started_at_to_jobs.rb
+++ b/db/migrate/20170119044208_move_started_at_to_jobs.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class MoveStartedAtToJobs < ActiveRecord::Migration[5.0]
+  class Job < ActiveRecord::Base
+    self.table_name = 'jobs'
+    has_one :deploy, class_name: 'MoveStartedAtToJobs::Deploy'
+  end
+
+  class Deploy < ActiveRecord::Base
+    self.table_name = 'deploys'
+    belongs_to :job, class_name: 'MoveStartedAtToJobs::Job'
+  end
+
+  def up
+    add_column :jobs, :started_at, :datetime
+    Job.joins(:deploy).update_all('jobs.started_at = deploys.started_at')
+    Job.where(started_at: nil).update_all('started_at = created_at') # assume all old jobs started
+    remove_column :deploys, :started_at, :datetime
+  end
+
+  def down
+    add_column :deploys, :started_at, :datetime
+    Deploy.joins(:job).update_all('deploys.started_at = jobs.started_at')
+    remove_column :jobs, :started_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118172040) do
+ActiveRecord::Schema.define(version: 20170119044208) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -84,7 +84,6 @@ ActiveRecord::Schema.define(version: 20170118172040) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "buddy_id"
-    t.datetime "started_at"
     t.datetime "deleted_at"
     t.integer  "build_id"
     t.boolean  "release",                default: false, null: false
@@ -157,6 +156,7 @@ ActiveRecord::Schema.define(version: 20170118172040) do
     t.datetime "updated_at"
     t.string   "commit"
     t.string   "tag"
+    t.datetime "started_at"
     t.index ["project_id"], name: "index_jobs_on_project_id", using: :btree
     t.index ["status"], name: "index_jobs_on_status", length: { status: 191 }, using: :btree
     t.index ["user_id"], name: "index_jobs_on_user_id", using: :btree

--- a/plugins/samson_ledger/lib/samson_ledger/client.rb
+++ b/plugins/samson_ledger/lib/samson_ledger/client.rb
@@ -38,7 +38,7 @@ module SamsonLedger
           name:          deploy.project.name,
           actor:         deploy.user.name,
           status:        deploy.status,
-          started_at:    deploy.updated_at.iso8601,
+          started_at:    deploy.started_at.iso8601,
           summary:       deploy.summary,
           environment:   deploy.stage.deploy_groups.map(&:environment).uniq.map(&:permalink).map(&:downcase).join(","),
           url:           deploy.url,

--- a/plugins/samson_ledger/test/lib/samson_ledger/client_test.rb
+++ b/plugins/samson_ledger/test/lib/samson_ledger/client_test.rb
@@ -70,10 +70,10 @@ describe 'SamsonLedger::Client' do
     end
 
     describe "started_at" do
-      it "posts the updated_at of the deploy as started_at in iso8601" do
+      it "posts the started_at of the deploy in iso8601" do
         SamsonLedger::Client.post_deployment(deploy)
 
-        results.first['started_at'].must_equal(deploy.updated_at.iso8601)
+        results.first['started_at'].must_equal(deploy.started_at.iso8601)
       end
     end
 

--- a/test/fixtures/deploys.yml
+++ b/test/fixtures/deploys.yml
@@ -4,7 +4,6 @@ succeeded_test:
   stage: test_staging
   job: succeeded_test
   reference: staging
-  started_at: 2014-01-01 20:00:00
   updated_at: 2014-01-01 20:10:00
   created_at: 2014-01-01 19:50:00
 
@@ -14,7 +13,6 @@ succeeded_production_test:
   stage: test_production
   job: succeeded_production_test
   reference: v1.0
-  started_at: 2014-01-02 20:00:00
   updated_at: 2014-01-02 20:10:00
   created_at: 2014-01-02 19:50:00
 
@@ -24,6 +22,5 @@ failed_staging_test:
   stage: test_staging
   job: failed_test
   reference: staging
-  started_at: 2014-01-03 20:00:00
   updated_at: 2014-01-03 20:10:00
   created_at: 2014-01-03 19:50:00

--- a/test/helpers/date_time_helper_test.rb
+++ b/test/helpers/date_time_helper_test.rb
@@ -53,5 +53,9 @@ describe DateTimeHelper do
         "<span data-time=\"1461001570000\" class=\"mouseover\">Mon, 18 Apr 2016 17:46:10 +0000</span>"
       )
     end
+
+    it "ignores unknown time" do
+      render_time(nil, 'foo').must_equal ''
+    end
   end
 end

--- a/test/helpers/status_helper_test.rb
+++ b/test/helpers/status_helper_test.rb
@@ -10,18 +10,48 @@ describe StatusHelper do
   let(:current_user) { users(:viewer) }
 
   describe "#status_panel" do
+    let(:deploy) { deploys(:succeeded_production_test) }
+
     it "accepts a deploy" do
-      refute_nil status_panel(deploys(:succeeded_production_test))
+      assert status_panel(deploy)
+    end
+
+    it "renders a weird deploy without started_at" do
+      deploy.job.created_at = nil
+      assert status_panel(deploy)
+    end
+
+    it "renders a weird deploy without finished_at" do
+      deploy.job.status = 'running'
+      assert status_panel(deploy)
     end
 
     it "accepts a job" do
-      refute_nil status_panel(jobs(:running_test))
+      assert status_panel(jobs(:running_test))
     end
   end
 
   describe "#status_label" do
     it "renders" do
       status_label("succeeded").must_equal "label-success"
+    end
+  end
+
+  describe "#duration_text" do
+    it "shows seconds when there is nothing" do
+      duration_text(0).must_equal " 0 seconds"
+    end
+
+    it "shows seconds" do
+      duration_text(12).must_equal " 12 seconds"
+    end
+
+    it "shows minutes and seconds" do
+      duration_text(61).must_equal "1 minute 1 second"
+    end
+
+    it "shows only minutes when seconds are 0" do
+      duration_text(60).must_equal "1 minute"
     end
   end
 end

--- a/test/lib/buddy_check_test.rb
+++ b/test/lib/buddy_check_test.rb
@@ -3,6 +3,7 @@ require_relative '../test_helper'
 
 SingleCov.covered! uncovered: 5
 
+# TODO: full converage and move deploy related tests into deploy
 describe BuddyCheck do
   let(:project) { job.project }
   let(:user) { job.user }
@@ -15,17 +16,10 @@ describe BuddyCheck do
 
   let(:other_user) { users(:deployer_buddy) }
 
-  it "start_time is set for buddy_checked deploy" do
+  it "buddy is set for buddy_checked deploy" do
     deploy_rtn = stage.create_deploy(user, reference: reference)
     deploy_rtn.confirm_buddy!(other_user)
-
-    assert_equal true, deploy_rtn.start_time.to_i.positive?
-  end
-
-  it "start_time is set for non-buddy_checked deploy" do
-    deploy_rtn = stage.create_deploy(user, reference: reference)
-
-    assert_equal true, deploy_rtn.start_time.to_i.positive?
+    deploy_rtn.buddy.must_equal other_user
   end
 
   it "does not deploy production if buddy check is enabled" do

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -36,7 +36,7 @@ describe DeployService do
       def create_previous_deploy(ref, stage, successful: true, bypassed: false)
         job = project.jobs.create!(user: user, command: "foo", status: successful ? "succeeded" : 'failed')
         buddy = bypassed ? user : other_user
-        Deploy.create!(job: job, reference: ref, stage: stage, buddy: buddy, started_at: Time.now, project: project)
+        Deploy.create!(job: job, reference: ref, stage: stage, buddy: buddy, project: project)
       end
 
       it "does not start the deploy" do
@@ -68,7 +68,7 @@ describe DeployService do
           end
 
           it "starts the deploy when stage was modified after an older similar deploy" do
-            Deploy.first.update_column(:started_at, 4.seconds.from_now)
+            Deploy.first.job.update_column(:created_at, 4.seconds.from_now)
             create_previous_deploy(ref1, stage_production_1)
             service.expects(:confirm_deploy!)
             service.deploy!(stage_production_2, reference: ref1)

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -250,7 +250,7 @@ describe Deploy do
       Deploy.start_deploys_waiting_for_restart!
       deploy.reload
       deploy.updated_at.must_be :>, 2.seconds.ago # did expire caches
-      deploy.started_at.must_be :<, 1.year.ago # did not update started_at
+      deploy.started_at.must_be :>, 2.seconds.ago # did update started_at
     end
 
     it "does not start deploys waiting for buddy" do
@@ -480,8 +480,8 @@ describe Deploy do
                   prod_deploy.summary,
                   prod_deploy.commit,
                   job.status,
-                  prod_deploy.updated_at,
-                  prod_deploy.start_time,
+                  prod_deploy.started_at,
+                  prod_deploy.finished_at,
                   deployer.name,
                   deployer.email,
                   other_user.name,
@@ -510,8 +510,8 @@ describe Deploy do
               prod_deploy.summary,
               prod_deploy.commit,
               job.status,
-              prod_deploy.updated_at,
-              prod_deploy.start_time,
+              prod_deploy.started_at,
+              prod_deploy.finished_at,
               deployer.name,
               deployer.email,
               other_user.name,

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -124,6 +124,17 @@ describe Job do
     end
   end
 
+  describe "#finished_at" do
+    it "has no time when not finished" do
+      job.finished_at.must_equal nil
+    end
+
+    it "shows last change when finished" do
+      job.status = 'succeeded'
+      job.finished_at.must_equal job.updated_at
+    end
+  end
+
   describe "#active?" do
     it "is active when its status is not finished" do
       job.status = "pending"


### PR DESCRIPTION
…updated

fix a few bugs around showing a unstarted deploy as started and deploys without buddy check never getting started_at

TODO:
 - backfill started_at where not started_at and finished