### PR TITLE
stream logs from live/dead pods to fight incomplete logs without havi…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -115,8 +115,6 @@ module Kubernetes
     end
 
     def show_failure_cause(release, release_docs, statuses)
-      sleep TICK # logs take a few seconds to arrive, might have to increase if this does not help
-
       release_docs.each { |doc| print_resource_events(doc) }
 
       statuses.reject(&:live).select(&:pod).each do |status|


### PR DESCRIPTION
…ng to sleep

We had many deploys where asking for the logs even 2-10s after the pod died
did not result in the complete logs.

FYI using no container argument was often more reliable at getting logs.

With this approach we can increase the timeout without affecting good deploys
instead of always sleeping which would be ineffective.
We also get notified when the logs did not finish so we know to inspect manually.

