### PR TITLE
Change status message for successful deploy

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -28,7 +28,7 @@ class Deploy < ActiveRecord::Base
     "running"    => "is deploying",
     "cancelling" => "is cancelling a deploy",
     "cancelled"  => "cancelled a deploy",
-    "succeeded"  => "deployed",
+    "succeeded"  => "started deploying",
     "failed"     => "failed to deploy",
     "errored"    => "encountered an error deploying"
   }.freeze

--- a/test/mailers/deploy_mailer_test.rb
+++ b/test/mailers/deploy_mailer_test.rb
@@ -77,7 +77,7 @@ describe DeployMailer do
     it "sends" do
       stub_empty_changeset
       DeployMailer.deploy_failed_email(deploy, ["foo@bar.com"]).deliver_now
-      subject.subject.must_equal "[AUTO-DEPLOY][DEPLOY][##{deploy.id}] Super Admin deployed Project to Staging (staging)" # rubocop:disable Metrics/LineLength
+      subject.subject.must_equal "[AUTO-DEPLOY][DEPLOY][##{deploy.id}] Super Admin started deploying Project to Staging (staging)" # rubocop:disable Metrics/LineLength
     end
   end
 end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -14,25 +14,25 @@ describe Deploy do
     let!(:deploy) { create_deploy! }
 
     it "shows no buddy" do
-      deploy.summary.must_equal "Deployer  deployed baz to Staging"
+      deploy.summary.must_equal "Deployer  started deploying baz to Staging"
     end
 
     it "shows soft delete user" do
       deploy.user.soft_delete!
       deploy.reload
-      deploy.summary.must_equal "Deployer  deployed baz to Staging"
+      deploy.summary.must_equal "Deployer  started deploying baz to Staging"
     end
 
     it "shows hard delete user" do
       deploy.user.delete
       deploy.reload
-      deploy.summary.must_equal "Deleted User  deployed baz to Staging"
+      deploy.summary.must_equal "Deleted User  started deploying baz to Staging"
     end
 
     it "shows soft delete stage when INCLUDE_DELETED" do
       deploy.stage.soft_delete!
       deploy.reload
-      Stage.with_deleted { deploy.summary.must_equal "Deployer  deployed baz to Staging" }
+      Stage.with_deleted { deploy.summary.must_equal "Deployer  started deploying baz to Staging" }
     end
 
     describe "when buddy was required" do
@@ -42,19 +42,19 @@ describe Deploy do
         before { deploy.update_column(:buddy_id, user2.id) }
 
         it "shows the buddy" do
-          deploy.summary.must_equal "Deployer (with Admin) deployed baz to Staging"
+          deploy.summary.must_equal "Deployer (with Admin) started deploying baz to Staging"
         end
 
         it "shows soft delete buddy" do
           deploy.buddy.soft_delete!
           deploy.reload
-          deploy.summary.must_equal "Deployer (with Admin) deployed baz to Staging"
+          deploy.summary.must_equal "Deployer (with Admin) started deploying baz to Staging"
         end
 
         it "shows hard delete buddy" do
           deploy.buddy.delete
           deploy.reload
-          deploy.summary.must_equal "Deployer (with Deleted User) deployed baz to Staging"
+          deploy.summary.must_equal "Deployer (with Deleted User) started deploying baz to Staging"
         end
       end
 
@@ -64,12 +64,12 @@ describe Deploy do
       end
 
       it "shows that there was no buddy" do
-        deploy.summary.must_equal "Deployer (without a buddy) deployed baz to Staging"
+        deploy.summary.must_equal "Deployer (without a buddy) started deploying baz to Staging"
       end
 
       it "shows that there was no buddy when skipping" do
         deploy.buddy = user
-        deploy.summary.must_equal "Deployer (without a buddy) deployed baz to Staging"
+        deploy.summary.must_equal "Deployer (without a buddy) started deploying baz to Staging"
       end
     end
   end
@@ -82,7 +82,7 @@ describe Deploy do
 
   describe "#summary_for_email" do
     it "renders" do
-      deploy.summary_for_email.must_equal "Super Admin deployed Project to Staging (staging)"
+      deploy.summary_for_email.must_equal "Super Admin started deploying Project to Staging (staging)"
     end
   end
 

--- a/test/serializers/deploy_serializer_test.rb
+++ b/test/serializers/deploy_serializer_test.rb
@@ -12,7 +12,7 @@ describe BuildSerializer do
   end
 
   it 'serializes summary' do
-    parsed['summary'].must_equal "staging was deployed to Staging"
+    parsed['summary'].must_equal "staging was started deploying to Staging"
   end
 
   it 'serializes created_at to milliseconds' do


### PR DESCRIPTION
The current wording:

Alice (with Bob) deployed v11105 to Production deploy 8 minutes ago, it took 5
minutes 36 seconds.

makes it hard to tell if the deploy was started or finished 8 minutes ago. This
commit changes the wording to be:

Alice (with Bob) started deploying v11105 to Production deploy 8 minutes ago,
it took 5 minutes 36 seconds.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Low, purely a string change.
