### PR TITLE
Slack notification threads

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118172040) do
+ActiveRecord::Schema.define(version: 20170125010044) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -393,6 +393,14 @@ ActiveRecord::Schema.define(version: 20170118172040) do
     t.datetime "updated_at",               null: false
     t.index ["identifier"], name: "index_slack_identifiers_on_identifier", length: { identifier: 12 }, using: :btree
     t.index ["user_id"], name: "index_slack_identifiers_on_user_id", unique: true, using: :btree
+  end
+
+  create_table "slack_webhook_threads", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "deploy_id",  null: false
+    t.string   "slack_ts",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deploy_id"], name: "index_slack_webhook_threads_on_deploy_id", using: :btree
   end
 
   create_table "slack_webhooks", force: :cascade do |t|

--- a/plugins/slack_webhooks/app/models/slack_webhook_thread.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_thread.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class SlackWebhookThread < ActiveRecord::Base
+  belongs_to :deploy
+end

--- a/plugins/slack_webhooks/db/migrate/20170125010044_add_slack_timestamp_for_threading.rb
+++ b/plugins/slack_webhooks/db/migrate/20170125010044_add_slack_timestamp_for_threading.rb
@@ -1,0 +1,11 @@
+class AddSlackTimestampForThreading < ActiveRecord::Migration[5.0]
+  def change
+    create_table :slack_webhook_threads do |t|
+      t.integer :deploy_id, null: false
+      t.string :slack_ts, null: false
+      t.timestamps
+    end
+
+    add_index :slack_webhook_threads, :deploy_id
+  end
+end


### PR DESCRIPTION
This adds the ability for the Slack webhook notifications to collapse notifications into a thread so as not to clutter up the chat flow.

### Lo-fi mockup

A successful deploy would look like this in the main flow:
![image](https://cloud.githubusercontent.com/assets/39902/22275239/0c665e40-e260-11e6-8f4b-1ef756ab42ef.png)

Full thread contents:
![image](https://cloud.githubusercontent.com/assets/39902/22275330/e3adf37c-e260-11e6-9d40-002a97a07c45.png)

Failure and error messages would get dropped into the main channel as well:
![image](https://cloud.githubusercontent.com/assets/39902/22275343/f224b530-e260-11e6-96e6-44e893307c0e.png)

/cc @zendesk/samson

### Tasks
- [x] New DB table
- [ ] Alter logic to use [thread timestamps and reply_broadcast](https://api.slack.com/docs/message-threading#posting_replies)
- [ ] Tests
- [ ] :+1: from team

### Risks
- Level: Low
