### PR TITLE
stop fixes

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -148,7 +148,7 @@ class DeploysController < ApplicationController
 
   def destroy
     if @deploy.can_be_stopped_by?(current_user)
-      DeployService.new(current_user).stop!(@deploy)
+      @deploy.stop!
     else
       flash[:error] = "You do not have privileges to stop this deploy."
     end

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -37,10 +37,6 @@ class DeployService
     send_sse_deploy_update('start', deploy)
   end
 
-  def stop!(deploy)
-    deploy.stop!
-  end
-
   private
 
   def construct_env(stage)

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -60,8 +60,6 @@ class JobExecution
   end
 
   def stop!
-    return unless @thread&.alive?
-
     @stopped = true
     @executor.stop! 'INT'
     unless @thread.join(stop_timeout)

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -366,7 +366,7 @@ describe DeploysController do
         before do
           DeployService.stubs(:new).with(user).returns(deploy_service)
           Job.any_instance.stubs(:started_by?).returns(true)
-          deploy_service.expects(:stop!).once
+          Deploy.any_instance.expects(:stop!).once
 
           delete :destroy, params: {project_id: project.to_param, id: deploy.to_param}
         end

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -399,7 +399,7 @@ describe DeploysController do
 
     describe "#destroy" do
       it "cancels the deploy" do
-        deploy_service.expects(:stop!).once
+        Deploy.any_instance.expects(:stop!).once
         delete :destroy, params: {project_id: project.to_param, id: deploy.to_param}
         flash[:error].must_be_nil
       end

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -165,14 +165,6 @@ describe DeployService do
     end
   end
 
-  describe "#stop!" do
-    it "stops the deploy" do
-      deploy.job = jobs(:running_test)
-      service.stop!(deploy)
-      deploy.job.status.must_equal 'cancelled'
-    end
-  end
-
   describe "before notifications" do
     before do
       stage.stubs(:create_deploy).returns(deploy)

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -412,16 +412,15 @@ describe JobExecution do
         true
       end
       execution.stop!
-      execution.stop!
       called.must_equal [1]
     end
 
-    it "does not mark the execution as cancelled when it was already stopped" do
+    it "marks the execution as cancelled when it was already stopped since we always need to enqueu the next" do
       execution.start!
       lock.unlock
       sleep 0.1
       execution.stop!
-      job.reload.status.must_equal 'succeeded'
+      job.reload.status.must_equal 'cancelled'
     end
   end
 


### PR DESCRIPTION
when an exception happens while stopping a job execution, the job would stay active forever ...
so now it allows hitting stop even when the thread is already dead, which could have happened during previous stop or when the thread naturally died ... we protect against running finish multiple times, so that should work out fine
