### PR TITLE
move k8s labels that Samson adds to annotations

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -122,6 +122,7 @@ module Kubernetes
     def set_spec_template_metadata
       [:labels, :annotations].each do |type|
         release_doc_metadata[type].each do |key, value|
+          template[:spec][:template][:metadata][type] ||= {}
           template[:spec][:template][:metadata][type][key] ||= value.to_s
         end
       end

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -120,8 +120,10 @@ module Kubernetes
     # Sets the labels for each new Pod.
     # Adding the Release ID to allow us to track the progress of a new release from the UI.
     def set_spec_template_metadata
-      release_doc_metadata.each do |key, value|
-        template[:spec][:template][:metadata][:labels][key] ||= value.to_s
+      [:labels, :annotations].each do |type|
+        release_doc_metadata[type].each do |key, value|
+          template[:spec][:template][:metadata][type][key] ||= value.to_s
+        end
       end
     end
 
@@ -132,15 +134,22 @@ module Kubernetes
         release = @doc.kubernetes_release
         role = @doc.kubernetes_role
         deploy_group = @doc.deploy_group
+        pod_selector = release.pod_selector(deploy_group)
 
-        release.pod_selector(deploy_group).merge(
-          deploy_id: release.deploy_id,
-          project_id: release.project_id,
-          role_id: role.id,
-          deploy_group: deploy_group.env_value.parameterize.tr('_', '-'),
-          revision: release.git_sha,
-          tag: release.git_ref.parameterize.tr('_', '-')
-        )
+        {
+          labels: {
+            deploy_group: deploy_group.env_value.parameterize.tr('_', '-'),
+            tag: release.git_ref.parameterize.tr('_', '-'),
+          },
+          annotations: {
+            deploy_id: release.deploy_id,
+            deploy_group_id: pod_selector[:deploy_group_id],
+            project_id: release.project_id,
+            release_id: pod_selector[:release_id],
+            revision: release.git_sha,
+            role_id: role.id,
+          }
+        }
       end
     end
 
@@ -190,7 +199,7 @@ module Kubernetes
     def static_env
       env = {}
 
-      metadata = release_doc_metadata
+      metadata = release_doc_metadata.values.reduce(&:merge)
       [:REVISION, :TAG, :DEPLOY_ID, :DEPLOY_GROUP].each do |k|
         env[k] = metadata.fetch(k.downcase)
       end

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -139,6 +139,7 @@ module Kubernetes
         {
           labels: {
             deploy_group: deploy_group.env_value.parameterize.tr('_', '-'),
+            revision: release.git_sha,
             tag: release.git_ref.parameterize.tr('_', '-'),
           },
           annotations: {
@@ -146,7 +147,6 @@ module Kubernetes
             deploy_group_id: pod_selector[:deploy_group_id],
             project_id: release.project_id,
             release_id: pod_selector[:release_id],
-            revision: release.git_sha,
             role_id: role.id,
           }
         }

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -29,16 +29,19 @@ describe Kubernetes::TemplateFiller do
       spec.fetch(:uniqueLabelKey).must_equal "rc_unique_identifier"
       spec.fetch(:replicas).must_equal doc.replica_target
       spec.fetch(:template).fetch(:metadata).fetch(:labels).symbolize_keys.must_equal(
-        revision: "abababababa",
         tag: "master",
-        release_id: doc.kubernetes_release_id.to_s,
         project: "some-project",
-        project_id: doc.kubernetes_release.project_id.to_s,
-        role_id: doc.kubernetes_role_id.to_s,
         role: "some-role",
         deploy_group: 'pod1',
+      )
+
+      spec.fetch(:template).fetch(:metadata).fetch(:annotations).symbolize_keys.must_equal(
         deploy_group_id: doc.deploy_group_id.to_s,
-        deploy_id: "123"
+        deploy_id: "123",
+        project_id: doc.kubernetes_release.project_id.to_s,
+        release_id: doc.kubernetes_release_id.to_s,
+        revision: "abababababa",
+        role_id: doc.kubernetes_role_id.to_s,
       )
 
       metadata = result.fetch(:metadata)

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -29,11 +29,11 @@ describe Kubernetes::TemplateFiller do
       spec.fetch(:uniqueLabelKey).must_equal "rc_unique_identifier"
       spec.fetch(:replicas).must_equal doc.replica_target
       spec.fetch(:template).fetch(:metadata).fetch(:labels).symbolize_keys.must_equal(
+        revision: "abababababa",
         tag: "master",
         project: "some-project",
-        revision: "abababababa",
         role: "some-role",
-        deploy_group: 'pod1',
+        deploy_group: 'pod1'
       )
 
       spec.fetch(:template).fetch(:metadata).fetch(:annotations).symbolize_keys.must_equal(
@@ -41,7 +41,7 @@ describe Kubernetes::TemplateFiller do
         deploy_id: "123",
         project_id: doc.kubernetes_release.project_id.to_s,
         release_id: doc.kubernetes_release_id.to_s,
-        role_id: doc.kubernetes_role_id.to_s,
+        role_id: doc.kubernetes_role_id.to_s
       )
 
       metadata = result.fetch(:metadata)
@@ -188,10 +188,8 @@ describe Kubernetes::TemplateFiller do
         )
 
         # secrets got resolved?
-        template.to_hash[:spec][:template][:metadata][:annotations].
-          except(init_container_key).must_equal(
-            "secret/FOO" => "global/global/global/bar"
-          )
+        annotations = template.to_hash[:spec][:template][:metadata][:annotations]
+        annotations['secret/FOO'].must_equal 'global/global/global/bar'
       end
 
       it "keeps existing init containers" do

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -31,6 +31,7 @@ describe Kubernetes::TemplateFiller do
       spec.fetch(:template).fetch(:metadata).fetch(:labels).symbolize_keys.must_equal(
         tag: "master",
         project: "some-project",
+        revision: "abababababa",
         role: "some-role",
         deploy_group: 'pod1',
       )
@@ -40,7 +41,6 @@ describe Kubernetes::TemplateFiller do
         deploy_id: "123",
         project_id: doc.kubernetes_release.project_id.to_s,
         release_id: doc.kubernetes_release_id.to_s,
-        revision: "abababababa",
         role_id: doc.kubernetes_role_id.to_s,
       )
 


### PR DESCRIPTION
A lot of the `id` fields that Samson adds as labels aren't things we ever use to filter. Move them to annotations instead.

Things like `project`, `role`, and `deploy_group` are left as labels, 'cause I'm more likely to select or filter based on those.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
