### PR TITLE
fix BuildJobExecutor wants a registry object and not a hash

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -107,7 +107,7 @@ class DockerBuilderService
     k8s_job = Kubernetes::BuildJobExecutor.new(
       output,
       job: local_job,
-      registry: self.class.registry_credentials(DockerRegistry.first)
+      registry: DockerRegistry.first
     )
     success, build_log = k8s_job.execute!(
       build, project,


### PR DESCRIPTION
sadly has no integration test, so saw this only when someone tried to run it ...

https://zendesk.airbrake.io/projects/95346/groups/1872823466483722440/notices/1872823450533137521?tab=comments
