### PR TITLE
Add 'Cancel scheduled builds' option

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -119,6 +119,7 @@ class StagesController < ApplicationController
       :no_code_deployed,
       :is_template,
       :run_in_parallel,
+      :cancel_queued_deploys,
       {
         deploy_group_ids: [],
         command_ids: []

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -151,6 +151,10 @@ class Deploy < ActiveRecord::Base
     stale.select(&:waiting_for_buddy?)
   end
 
+  def self.for_user(user)
+    joins(:job).where(jobs: { user: user })
+  end
+
   def buddy_name
     user.id == buddy_id ? "bypassed" : buddy.try(:name)
   end

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -15,8 +15,9 @@ class DeployService
 
       if stage.cancel_queued_deploys?
         stage.deploys.pending.prior_to(deploy).for_user(user).each do |queued_deploy|
-          JobExecution.dequeue(queued_deploy.job.id)
-          queued_deploy.job.cancelled!
+          if JobExecution.dequeue(queued_deploy.job.id)
+            queued_deploy.job.cancelled!
+          end
         end
       end
 

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -13,6 +13,13 @@ class DeployService
     if deploy.persisted?
       send_sse_deploy_update('new', deploy)
 
+      if stage.cancel_queued_deploys?
+        stage.deploys.pending.prior_to(deploy).for_user(user).each do |queued_deploy|
+          JobExecution.dequeue(queued_deploy.job.id)
+          queued_deploy.job.cancelled!
+        end
+      end
+
       if !deploy.waiting_for_buddy? || copy_approval_from_last_deploy(deploy)
         confirm_deploy!(deploy)
       end

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -20,7 +20,7 @@
 
   <%= form.input :run_in_parallel, as: :check_box, label: "Can run in parallel", help: "Deploys are not queued. Executed immediately" %>
 
-  <%= form.input :cancel_queued_deploys, as: :check_box, label: "Cancel queued deploys", help: "When a new deploy is created for a user. Any queued deploys for that user are cancelled." %>
+  <%= form.input :cancel_queued_deploys, as: :check_box, label: "Allow 1 queued deploy per user", help: "When a new deploy is created for a user. Any queued deploys for that user are cancelled. This most useful when trying to not deploy every push for frequently updated projects." %>
 
   <%= form.input :confirm, as: :check_box, label: "Confirm before deployment", help: "Show a review page before starting a deploy" %>
 

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -20,7 +20,7 @@
 
   <%= form.input :run_in_parallel, as: :check_box, label: "Can run in parallel", help: "Deploys are not queued. Executed immediately" %>
 
-  <%= form.input :cancel_queued_deploys, as: :check_box, label: "Allow 1 queued deploy per user", help: "When a new deploy is created for a user. Any queued deploys for that user are cancelled. This most useful when trying to not deploy every push for frequently updated projects." %>
+  <%= form.input :cancel_queued_deploys, as: :check_box, label: "Max 1 queued deploy per user", help: "When a new deploy is created for a user. Any queued deploys for that user are cancelled. This most useful when trying to not deploy every push for frequently updated projects." %>
 
   <%= form.input :confirm, as: :check_box, label: "Confirm before deployment", help: "Show a review page before starting a deploy" %>
 

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -20,6 +20,8 @@
 
   <%= form.input :run_in_parallel, as: :check_box, label: "Can run in parallel", help: "Deploys are not queued. Executed immediately" %>
 
+  <%= form.input :cancel_queued_deploys, as: :check_box, label: "Cancel queued deploys", help: "When a new deploy is created for a user. Any queued deploys for that user are cancelled." %>
+
   <%= form.input :confirm, as: :check_box, label: "Confirm before deployment", help: "Show a review page before starting a deploy" %>
 
   <% if @project.releases.any? %>

--- a/db/migrate/20170130235020_add_cancel_queued_deploys_to_stages.rb
+++ b/db/migrate/20170130235020_add_cancel_queued_deploys_to_stages.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddCancelQueuedDeploysToStages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stages, :cancel_queued_deploys, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118172040) do
+ActiveRecord::Schema.define(version: 20170130235020) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -448,6 +448,7 @@ ActiveRecord::Schema.define(version: 20170118172040) do
     t.boolean  "jenkins_email_committers",                                   default: false, null: false
     t.boolean  "run_in_parallel",                                            default: false, null: false
     t.boolean  "jenkins_build_params",                                       default: false, null: false
+    t.boolean  "cancel_queued_deploys",                                      default: false, null: false
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }, using: :btree
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id", using: :btree
   end

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -118,7 +118,7 @@ describe DeployService do
         deploy_one = create_deployment(user, 'v1', stage, 'running')
         deploy_two = create_deployment(user, 'v2', stage, 'pending')
 
-        JobExecution.expects(:dequeue).with(deploy_two.job.id)
+        JobExecution.expects(:dequeue).with(deploy_two.job.id).returns(true)
 
         service.deploy!(stage, reference: reference)
 

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -353,6 +353,16 @@ describe Deploy do
     end
   end
 
+  describe ".for_user" do
+    let!(:deploy_one) { create_deploy!(job_attributes: { user: user}) }
+    let!(:deploy_two) { create_deploy!(job_attributes: { user: user2}) }
+    let!(:deploy_three) { create_deploy!(job_attributes: { user: user}) }
+
+    it "finds  all the deploys for the given user" do
+      Deploy.for_user(user).to_a.sort.must_equal([deploy_one, deploy_three])
+    end
+  end
+
   describe "#url" do
     it 'builds an address for a deploy' do
       deploy.url.must_equal "http://www.test-url.com/projects/foo/deploys/#{deploy.id}"


### PR DESCRIPTION
Add option for stages to be able to cancel pending deploys for a user
when a new pending deploy is queued, this allows projects with frequent
deploys to skip deploys and save this, this is useful for non critial
applications, a staging environment is a good example.


#### Options with tooltip:

___

<img width="643" alt="screen shot 2017-01-31 at 12 08 51 pm" src="https://cloud.githubusercontent.com/assets/112153/22448517/155668b2-e7ae-11e6-8d29-03eba3237df2.png">

___


#### Deployed cancelled as more are queued:

___
<img width="1102" alt="queued_jobs" src="https://cloud.githubusercontent.com/assets/112153/22448541/368206fe-e7ae-11e6-8af8-5982d1dd52b9.png">

___

/cc @zendesk/samson

### Tasks
 - [x] Write some tests
 - [ ] :+1: from team

### Risks
- Level: Low
