### PR TITLE
added samson/before_docker_build

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -133,7 +133,7 @@ class DockerBuilderService
     build.save!
   end
 
-  def before_docker_build(tmp_dir)
+  def execute_before_docker_build_script(tmp_dir)
     before_docker_build_file = File.join(tmp_dir, BEFORE_DOCKER_BUILD)
     if File.file?(before_docker_build_file)
       output.puts "Running #{BEFORE_DOCKER_BUILD} ..."
@@ -142,7 +142,10 @@ class DockerBuilderService
         raise Samson::Hooks::UserError, "Error running #{BEFORE_DOCKER_BUILD}"
       end
     end
+  end
 
+  def before_docker_build(tmp_dir)
+    execute_before_docker_build_script(tmp_dir)
     Samson::Hooks.fire(:before_docker_build, tmp_dir, build, output)
   end
   add_method_tracer :before_docker_build

--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -4,6 +4,7 @@ require 'docker'
 class DockerBuilderService
   DIGEST_SHA_REGEX = /Digest:.*(sha256:[0-9a-f]+)/i
   DOCKER_REPO_REGEX = /^BUILD DIGEST: (.*@sha256:[0-9a-f]+)/i
+  BEFORE_DOCKER_BUILD = 'samson/before_docker_build'
   include ::NewRelic::Agent::MethodTracer
 
   attr_reader :build, :execution
@@ -132,8 +133,22 @@ class DockerBuilderService
     build.save!
   end
 
-  def build_image(tmp_dir)
+  def before_docker_build(tmp_dir)
+    before_docker_build_file = File.join(tmp_dir, BEFORE_DOCKER_BUILD)
+    if File.file?(before_docker_build_file)
+      output.puts "Running #{BEFORE_DOCKER_BUILD} ..."
+
+      unless execution.executor.execute!(before_docker_build_file)
+        raise Samson::Hooks::UserError, "Error running #{BEFORE_DOCKER_BUILD}"
+      end
+    end
+
     Samson::Hooks.fire(:before_docker_build, tmp_dir, build, output)
+  end
+  add_method_tracer :before_docker_build
+
+  def build_image(tmp_dir)
+    before_docker_build(tmp_dir)
 
     File.write("#{tmp_dir}/REVISION", build.git_sha)
 


### PR DESCRIPTION
This adds a hook for running a script before building docker containers. All you have to do is have a `samson/before_docker_build` executable in your repository, and it will get run just before starting the docker builds.

@jonmoter and I agreed that this was a good addition.

/cc @jonmoter @zendesk/samson

### Tasks
 - [x] :+1: from team

### Risks
- Level: Low
