### PR TITLE
execute the contents of samson/before_docker_build

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -138,7 +138,9 @@ class DockerBuilderService
     if File.file?(before_docker_build_file)
       output.puts "Running #{BEFORE_DOCKER_BUILD} ..."
 
-      unless execution.executor.execute!(before_docker_build_file)
+      commands = File.readlines(before_docker_build_file)
+
+      unless execution.executor.execute!(*commands)
         raise Samson::Hooks::UserError, "Error running #{BEFORE_DOCKER_BUILD}"
       end
     end

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -162,7 +162,7 @@ describe DockerBuilderService do
 
       it 'executes it' do
         service.send(:before_docker_build, tmp_dir)
-        output.string.must_equal "» #{before_docker_build_path}\r\nfoobar\r\n"
+        output.string.must_equal "» echo foobar\r\nfoobar\r\n"
       end
     end
 


### PR DESCRIPTION
Execute the contents of `samson/before_docker_build` instead of the file itself.
Why? Because this gives us secret resolution in this script.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
