### PR TITLE
clean up UI when adding project roles for a user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,9 +23,10 @@ class Admin::UsersController < ApplicationController
     if role_id = params[:role_id].presence
       @projects = @projects.where("user_project_roles.role_id >= ?", role_id)
     end
-    @projects = @projects.select('projects.*, user_project_roles.role_id AS user_project_role_id').sort_by(&:natural_order)
+    @projects = @projects.select('projects.*, user_project_roles.role_id AS user_project_role_id').
+      order(:name)
 
-    @projects_without_role = (Project.all - @projects).sort_by(&:natural_order)
+    @projects_without_role = (Project.all - @projects).sort_by(&:name)
   end
 
   def update

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,9 @@ class Admin::UsersController < ApplicationController
     if role_id = params[:role_id].presence
       @projects = @projects.where("user_project_roles.role_id >= ?", role_id)
     end
-    @projects = @projects.select('projects.*, user_project_roles.role_id AS user_project_role_id')
+    @projects = @projects.select('projects.*, user_project_roles.role_id AS user_project_role_id').sort_by(&:natural_order)
+
+    @projects_without_role = (Project.all - @projects).sort_by(&:natural_order)
   end
 
   def update

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -46,7 +46,7 @@
   <h3>Create new project role</h3>
   <%= form_tag project_roles_path(user_id: @user.id), class: 'form-horizontal' do %>
     <div class="col-md-2">
-      <%= select_tag :project_id, options_from_collection_for_select(Project.all, :id, :name), required: true, class: 'form-control col-md-2' %>
+      <%= select_tag :project_id, options_from_collection_for_select(@projects_without_role, :id, :name), required: true, class: 'form-control col-md-2' %>
     </div>
     &nbsp;
     <% UserProjectRole::ROLES.each do |role| %>


### PR DESCRIPTION
Currently, the UI when adding a role to a user is a pain, since the projects aren't sorted, and it includes projects you already have a role for.

![fullscreen_1_31_17__4_14_pm](https://cloud.githubusercontent.com/assets/1056506/22490209/b494960c-e7d0-11e6-9895-d4a62b7e26ee.jpg)

This sorts and filters the projects in the dropdown.

/cc @zendesk/samson, @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low/Med/High
