### PR TITLE
display previous stages in the pipeline as well as the next ones

### DIFF
--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -21,7 +21,7 @@ Stage.class_eval do
 
   def previous_stages
     @previous_stages ||= project.stages.to_a.select do |stage|
-      stage.next_stage_ids.include? id
+      stage.next_stage_ids.map(&:to_i).include? id
     end
   end
 

--- a/plugins/pipelines/app/decorators/stage_decorator.rb
+++ b/plugins/pipelines/app/decorators/stage_decorator.rb
@@ -19,6 +19,12 @@ Stage.class_eval do
     Stage.where(id: next_stage_ids).to_a
   end
 
+  def previous_stages
+    @previous_stages ||= project.stages.to_a.select do |stage|
+      stage.next_stage_ids.include? id
+    end
+  end
+
   protected
 
   # Ensure we don't have a circular pipeline:

--- a/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
@@ -1,9 +1,29 @@
-<% if next_stages = @stage.next_stages.presence %>
+<%
+  next_stages = @stage.next_stages.sort_by(&:name)
+  previous_stages = @stage.previous_stages.sort_by(&:name)
+%>
+<% if next_stages.presence || previous_stages.presence %>
   <h2>Pipelining</h2>
-  After this stage finishes deploying it will deploy to:
-  <ul>
-    <% next_stages.each do |stage| %>
-      <li><%= link_to stage.name, [@project, stage] %></li>
-    <% end %>
-  </ul>
+
+  <% if previous_stages.presence %>
+    <div>
+      The following stages will trigger this stage on completion:
+      <ul>
+        <% previous_stages.each do |stage| %>
+          <li><%= link_to stage.name, [@project, stage] %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% if next_stages.presence %>
+    <div>
+      After this stage finishes deploying it will deploy to:
+      <ul>
+        <% next_stages.each do |stage| %>
+          <li><%= link_to stage.name, [@project, stage] %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 <% end %>

--- a/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
@@ -2,6 +2,7 @@
   next_stages = @stage.next_stages.sort_by(&:name)
   previous_stages = @stage.previous_stages.sort_by(&:name)
 %>
+
 <% if next_stages.presence || previous_stages.presence %>
   <h2>Pipelining</h2>
 

--- a/plugins/pipelines/test/decorators/stage_decorator_test.rb
+++ b/plugins/pipelines/test/decorators/stage_decorator_test.rb
@@ -116,8 +116,8 @@ describe Stage do
 
     it 'returns stages correctly' do
       # Set both stage1 and stage2 to trigger stage3
-      stage1.update!(next_stage_ids: [stage3.id])
-      stage2.update!(next_stage_ids: [stage3.id])
+      stage1.update!(next_stage_ids: [stage3.id.to_s])
+      stage2.update!(next_stage_ids: [stage3.id.to_s])
 
       stage3.previous_stages.sort.must_equal [stage1, stage2]
       stage1.previous_stages.must_equal []

--- a/plugins/pipelines/test/decorators/stage_decorator_test.rb
+++ b/plugins/pipelines/test/decorators/stage_decorator_test.rb
@@ -108,4 +108,19 @@ describe Stage do
       stage1.valid?.must_equal true
     end
   end
+
+  describe '#previous_stages' do
+    it 'works with an empty pipeline' do
+      stage1.previous_stages.must_equal []
+    end
+
+    it 'returns stages correctly' do
+      # Set both stage1 and stage2 to trigger stage3
+      stage1.update!(next_stage_ids: [stage3.id])
+      stage2.update!(next_stage_ids: [stage3.id])
+
+      stage3.previous_stages.sort.must_equal [stage1, stage2]
+      stage1.previous_stages.must_equal []
+    end
+  end
 end


### PR DESCRIPTION
Added a `Stage#previous_stages` method, and updated the view so it shows the previous stages as well as the next stages.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
