### PR TITLE
pass DOCKER_HOST env var to commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60
 ## Docker
 # DOCKER_FEATURE=1 # optional, docker support
 # DOCKER_REGISTRIES=https://user:pass@my.registry/some-namespace # required, where to push/pull your docker images
-# DOCKER_URL= # optional, use this url instead of connecting to unix socket
+# DOCKER_HOST= # optional, use this url instead of connecting to unix socket
 # DOCKER_KEEP_BUILT_IMGS # optional. Set to 1 to keep built images for cache. Fills the disk so some cleanup machanism is needed
 
 # FLOWDOCK_API_TOKEN= # optional. only required for the flowdock integration user mention autocomplete in the buddy approval request form (when BUDDY_CHECK_FEATURE=1). Buddy approval notification would still work without this

--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60
 ## Docker
 # DOCKER_FEATURE=1 # optional, docker support
 # DOCKER_REGISTRIES=https://user:pass@my.registry/some-namespace # required, where to push/pull your docker images
-# DOCKER_HOST= # optional, use this url instead of connecting to unix socket
+# DOCKER_HOST= # e.g. tcp://my-docker-registry.example.com:2375
 # DOCKER_KEEP_BUILT_IMGS # optional. Set to 1 to keep built images for cache. Fills the disk so some cleanup machanism is needed
 
 # FLOWDOCK_API_TOKEN= # optional. only required for the flowdock integration user mention autocomplete in the buddy approval request form (when BUDDY_CHECK_FEATURE=1). Buddy approval notification would still work without this

--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -106,10 +106,13 @@ class TerminalExecutor
     whitelist = [
       'PATH', 'HOME', 'TMPDIR', 'CACHE_DIR', 'TERM', 'SHELL', # general
       'RBENV_ROOT', 'RBENV_HOOK_PATH', 'RBENV_DIR', # ruby
-      'DOCKER_URL', 'DOCKER_REGISTRY' # docker
+      'DOCKER_HOST', 'DOCKER_URL', 'DOCKER_REGISTRY' # docker
     ] + ENV['ENV_WHITELIST'].to_s.split(/, ?/)
     env = ENV.to_h.slice(*whitelist)
     env['DOCKER_REGISTRY'] ||= DockerRegistry.first&.host # backwards compatibility
+
+    # DOCKER_HOST is the env var that the docker CLI uses to connect to a remote host
+    env['DOCKER_HOST'] ||= env['DOCKER_URL'] if env['DOCKER_URL']
     env
   end
 end

--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -110,9 +110,6 @@ class TerminalExecutor
     ] + ENV['ENV_WHITELIST'].to_s.split(/, ?/)
     env = ENV.to_h.slice(*whitelist)
     env['DOCKER_REGISTRY'] ||= DockerRegistry.first&.host # backwards compatibility
-
-    # DOCKER_HOST is the env var that the docker CLI uses to connect to a remote host
-    env['DOCKER_HOST'] ||= env['DOCKER_URL'] if env['DOCKER_URL']
     env
   end
 end

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -4,7 +4,8 @@ require 'docker'
 if !Rails.env.test? && !ENV['PRECOMPILE'] && ENV['DOCKER_FEATURE']
   DockerRegistry.check_config!
 
-  if (url = ENV['DOCKER_URL'].presence)
+  # Check DOCKER_URL for backwards-compatibility
+  if (url = ENV['DOCKER_HOST'].presence || ENV['DOCKER_URL'].presence)
     Docker.url = url
   end
 


### PR DESCRIPTION
`DOCKER_HOST` is the env var that the docker CLI uses

```
$ host_value=tcp://redacted.docker-server.example.com:2375

$ DOCKER_URL=$host_value docker ps | head -1
Cannot connect to the Docker daemon. Is the docker daemon running on this host?

$ DOCKER_HOST=$host_value docker ps | head -1
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
```

Pass this environment variable to the scripts, if they want to connect to the docker daemon.

/cc @zendesk/samson, @staugaard 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
