### PR TITLE
speeling fix

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -33,7 +33,7 @@ module Kubernetes
     end
 
     # here to make restart_signal_handler happy
-    def gpid
+    def pgid
       pid
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -26,9 +26,9 @@ describe Kubernetes::DeployExecutor do
     end
   end
 
-  describe "#gpid" do
+  describe "#pgid" do
     it "returns a fake pid" do
-      executor.gpid.must_include "Kubernetes"
+      executor.pgid.must_include "Kubernetes"
     end
   end
 


### PR DESCRIPTION
`NoMethodError: undefined method `pgid' for #<Kubernetes::DeployExecutor:0x007fb866fba1c8>`


https://zendesk.airbrake.io/projects/95346/groups/1872609598234896359/notices/1876465365349726127?tab=notice-detail