### PR TITLE
fix bugs introduced in PR #1696

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -37,10 +37,6 @@ module Kubernetes
         reasons.reject(&:blank?).uniq.join("/").presence || "Unknown"
       end
 
-      def deploy_group_id
-        labels.deploy_group_id.to_i
-      end
-
       def role_id
         labels.role_id.to_i
       end

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -46,8 +46,7 @@ module Kubernetes
 
     def pod_selector(deploy_group)
       {
-        release_id: id,
-        deploy_group_id: deploy_group.id,
+        release_id: id
       }
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -38,13 +38,13 @@ module Kubernetes
       scopes.map do |group, namespace|
         query = {
           namespace: namespace,
-          label_selector: pod_selector(group).map { |k, v| "#{k}=#{v}" }.join(",")
+          label_selector: pod_selector.map { |k, v| "#{k}=#{v}" }.join(",")
         }
         [group.kubernetes_cluster.client, query, group]
       end
     end
 
-    def pod_selector(deploy_group)
+    def pod_selector
       {
         release_id: id
       }

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -146,7 +146,6 @@ module Kubernetes
           },
           annotations: {
             deploy_id: release.deploy_id,
-            deploy_group_id: pod_selector[:deploy_group_id],
             project_id: release.project_id,
             role_id: role.id,
           }

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -140,6 +140,7 @@ module Kubernetes
         {
           labels: {
             deploy_group: deploy_group.env_value.parameterize.tr('_', '-'),
+            release_id: pod_selector[:release_id],
             revision: release.git_sha,
             tag: release.git_ref.parameterize.tr('_', '-'),
           },
@@ -147,7 +148,6 @@ module Kubernetes
             deploy_id: release.deploy_id,
             deploy_group_id: pod_selector[:deploy_group_id],
             project_id: release.project_id,
-            release_id: pod_selector[:release_id],
             role_id: role.id,
           }
         }
@@ -210,7 +210,7 @@ module Kubernetes
       end
 
       # name of the cluster
-      kube_cluster_name = DeployGroup.find(metadata[:deploy_group_id]).kubernetes_cluster.name.to_s
+      kube_cluster_name = @doc.deploy_group.kubernetes_cluster.name.to_s
       env[:KUBERNETES_CLUSTER_NAME] = kube_cluster_name
 
       # env from plugins

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -135,7 +135,7 @@ module Kubernetes
         release = @doc.kubernetes_release
         role = @doc.kubernetes_role
         deploy_group = @doc.deploy_group
-        pod_selector = release.pod_selector(deploy_group)
+        pod_selector = release.pod_selector
 
         {
           labels: {

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -11,7 +11,6 @@ describe Kubernetes::Api::Pod do
         name: pod_name,
         namespace: 'the-namespace',
         labels: {
-          deploy_group_id: '123',
           role_id: '234',
         }
       },
@@ -102,12 +101,6 @@ describe Kubernetes::Api::Pod do
   describe "#namespace" do
     it "reads" do
       pod.namespace.must_equal 'the-namespace'
-    end
-  end
-
-  describe "#deploy_group_id" do
-    it 'is the label' do
-      pod.deploy_group_id.must_equal 123
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -127,9 +127,8 @@ describe Kubernetes::Release do
 
   describe "#pod_selector" do
     it "generates a query that selects all pods for this deploy group" do
-      release.pod_selector(deploy_group).must_equal(
-        release_id: release.id,
-        deploy_group_id: deploy_group.id
+      release.pod_selector.must_equal(
+        release_id: release.id
       )
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -32,6 +32,7 @@ describe Kubernetes::TemplateFiller do
         revision: "abababababa",
         tag: "master",
         project: "some-project",
+        release_id: doc.kubernetes_release_id.to_s,
         role: "some-role",
         deploy_group: 'pod1'
       )
@@ -40,7 +41,6 @@ describe Kubernetes::TemplateFiller do
         deploy_group_id: doc.deploy_group_id.to_s,
         deploy_id: "123",
         project_id: doc.kubernetes_release.project_id.to_s,
-        release_id: doc.kubernetes_release_id.to_s,
         role_id: doc.kubernetes_role_id.to_s
       )
 
@@ -66,6 +66,15 @@ describe Kubernetes::TemplateFiller do
 
     it "overrides the name" do
       template.to_hash[:metadata][:name].must_equal 'test-app-server'
+    end
+
+    it "creates labels that match up with the release pod_selector" do
+      pod_selector = doc.kubernetes_release.pod_selector(doc.deploy_group)
+
+      pod_labels = template.to_hash[:spec][:template][:metadata][:labels]
+      pod_selector.keys.each do |key|
+        pod_labels.keys.must_include(key)
+      end
     end
 
     it "sets imagePullSecrets" do

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -69,7 +69,7 @@ describe Kubernetes::TemplateFiller do
     end
 
     it "creates labels that match up with the release pod_selector" do
-      pod_selector = doc.kubernetes_release.pod_selector(doc.deploy_group)
+      pod_selector = doc.kubernetes_release.pod_selector
 
       pod_labels = template.to_hash[:spec][:template][:metadata][:labels]
       pod_selector.keys.each do |key|

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -38,7 +38,6 @@ describe Kubernetes::TemplateFiller do
       )
 
       spec.fetch(:template).fetch(:metadata).fetch(:annotations).symbolize_keys.must_equal(
-        deploy_group_id: doc.deploy_group_id.to_s,
         deploy_id: "123",
         project_id: doc.kubernetes_release.project_id.to_s,
         role_id: doc.kubernetes_role_id.to_s


### PR DESCRIPTION
In #1696, I accidentally introduced a bug that broke Kubernetes deployments, 'cause `DeployExecutor` was looking for labels that no longer existed in the pods. Whoops.

This fixes the problem, and adds a test to ensure it doesn't happen again.

/cc @grosser, @craig-day 

### Risks
- Level: Low
