### PR TITLE
stop spamming about binary builder

### DIFF
--- a/plugins/docker_binary_builder/lib/samson_docker_binary_builder/samson_plugin.rb
+++ b/plugins/docker_binary_builder/lib/samson_docker_binary_builder/samson_plugin.rb
@@ -13,8 +13,6 @@ end
 Samson::Hooks.callback :after_deploy_setup do |dir, job, output, reference|
   if job.deploy&.stage&.docker_binary_plugin_enabled
     BinaryBuilder.new(dir, job.project, reference, output).build
-  else
-    output.puts 'Skipping binary build phase!'
   end
 end
 

--- a/plugins/docker_binary_builder/test/samson_docker_binary_builder/samson_plugin_test.rb
+++ b/plugins/docker_binary_builder/test/samson_docker_binary_builder/samson_plugin_test.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 2
+SingleCov.covered!
 
 describe SamsonDockerBinaryBuilder do
-  describe '#after_deploy_setup' do
+  describe :after_deploy_setup do
     let(:admin) { users(:admin) }
     let(:stage) { stages(:test_production) }
     let(:deploy) { stage.create_deploy(admin, reference: 'reference', project: stage.project) }
@@ -19,7 +19,7 @@ describe SamsonDockerBinaryBuilder do
       deploy.stage.update_column(:docker_binary_plugin_enabled, false)
       BinaryBuilder.any_instance.expects(:build).never
       Samson::Hooks.fire(:after_deploy_setup, dir, deploy.job, output, deploy.reference)
-      output.string.must_equal "Skipping binary build phase!\n"
+      output.string.must_equal ''
     end
 
     it 'kicks off the docker build after_deploy_setup is fired' do
@@ -27,6 +27,19 @@ describe SamsonDockerBinaryBuilder do
       BinaryBuilder.any_instance.expects(:build).once
       Samson::Hooks.fire(:after_deploy_setup, dir, deploy.job, output, deploy.reference)
       output.string.must_equal ''
+    end
+  end
+
+  describe :stage_permitted_params do
+    it "lists extra keys" do
+      Samson::Hooks.fire(:stage_permitted_params).must_include :docker_binary_plugin_enabled
+    end
+  end
+
+  describe :before_docker_build do
+    it "starts a build" do
+      BinaryBuilder.any_instance.expects(:build)
+      Samson::Hooks.fire(:before_docker_build, 'foobar', builds(:docker_build), StringIO.new)
     end
   end
 end


### PR DESCRIPTION
if every disabled plugin would do that, we'd have 10+ lines of log for every build :D

@henders 