### PR TITLE
make release numbers not float right

### DIFF
--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -26,7 +26,8 @@
           %>
         </div>
       </div>
-      <div>
+
+      <div class="form-group">
         <div id="ref-problem-warning" class="col-lg-5 col-lg-offset-2 alert alert-warning hidden">
           <p>Problems detected, are you sure you wish to deploy?</p>
           <ul id="ref-problem-list"></ul>
@@ -35,8 +36,7 @@
 
       <%= Samson::Hooks.render_views(:deploy_form, self, project: @project, form: form) %>
 
-      <% recent_releases = @project.releases.last(5) %>
-      <% if recent_releases.any? %>
+      <% if recent_releases = @project.releases.last(5).presence %>
         <div class="form-group" id="recent-releases">
           <label class="col-lg-2 control-label">Recent releases</label>
           <div class="col-lg-4">


### PR DESCRIPTION
problems are a column ... so they need to be in a form group to not just float left onto the previous element

before:
![screen shot 2017-01-30 at 4 31 09 pm](https://cloud.githubusercontent.com/assets/11367/22560421/667d2826-e929-11e6-92c3-50e5541f6f91.png)


after:
![screen shot 2017-02-02 at 9 22 29 am](https://cloud.githubusercontent.com/assets/11367/22560427/69119478-e929-11e6-80df-72e9f74cef33.png)
