### PR TITLE
make logs take more space on big screens

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,7 +29,7 @@
 .pre-scrollable.log {
   background-color: black;
   color: white;
-  max-height: 550px;
+  max-height: 65vh;
 }
 
 .navbar .navbar-btn.pull-right {


### PR DESCRIPTION
before: big screen ... lots of wasted space ...
![screen shot 2017-02-02 at 9 39 15 am](https://cloud.githubusercontent.com/assets/11367/22561158/e84b7810-e92b-11e6-8b08-29542ccfcf65.png)

after: big screen ... filled out
![screen shot 2017-02-02 at 9 39 00 am](https://cloud.githubusercontent.com/assets/11367/22561134/dee8e4c4-e92b-11e6-87fa-7da011c49568.png)

small screen ... filled out
![screen shot 2017-02-02 at 9 39 15 am](https://cloud.githubusercontent.com/assets/11367/22561180/fde410c4-e92b-11e6-8ed3-c3ff4bab8566.png)

/cc @henders 
