### PR TITLE
do not blow up on empty directory error

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -101,7 +101,7 @@ class JobExecution
     @start_callbacks.each(&:call)
     @job.run!
 
-    success = Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
+    success = make_tempdir do |dir|
       return @job.error! unless setup!(dir)
 
       if @execution_block
@@ -253,6 +253,15 @@ class JobExecution
 
   def puts_if_present(message)
     @output.puts message if message
+  end
+
+  def make_tempdir
+    result = nil
+    Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
+      result = yield dir
+    end
+  rescue Errno::ENOTEMPTY
+    result # tempdir ensure sometimes fails ... not sure why ... return normally
   end
 
   class << self

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -432,6 +432,13 @@ describe JobExecution do
     end
   end
 
+  describe "#make_tempdir" do
+    it "does not fail when directory cannot be removed" do
+      Dir.expects(:rmdir).at_least_once.raises(Errno::ENOTEMPTY)
+      execution.send(:make_tempdir) { 111 }.must_equal 111
+    end
+  end
+
   describe ".debug" do
     it "returns job queue interansl" do
       JobExecution.debug.must_equal([{}, {}])


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/1744273568143190802/notices/1875557707875952483?tab=notice-detail

tried to track that down before without success ... silencing it now so we don't get randomly failed deploys

previous try https://github.com/zendesk/samson/pull/1541