### PR TITLE
use existing fuzzy tag if it is higher then current

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -51,16 +51,6 @@ class GitRepository
     capture_stdout 'git', 'describe', '--tags', git_reference
   end
 
-  # @return [nil, tag]
-  # fuzzy_tag_from_ref returns v1.0 or v1.0-abcd if no tag is defined.
-  # We only want the tag in the first case.
-  # git tag --points-at is preferred, but is only available in git 2.7+
-  def exact_tag_from_ref(git_reference)
-    fuzzy_tag = fuzzy_tag_from_ref(git_reference)
-
-    fuzzy_tag && fuzzy_tag[Release::VERSION_REGEX]
-  end
-
   def repo_cache_dir
     File.join(cached_repos_dir, @repository_directory)
   end

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -23,7 +23,7 @@ describe Integrations::BaseController do
     Integrations::BaseController.any_instance.stubs(:branch).returns('master')
     Project.any_instance.stubs(:create_release?).returns(true)
     Build.any_instance.stubs(:validate_git_reference).returns(true)
-    GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
+    GitRepository.any_instance.stubs(:fuzzy_tag_from_ref).returns(nil)
     stub_request(:post, "https://api.github.com/repos/bar/foo/releases")
   end
 

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -48,7 +48,7 @@ describe ReleasesController do
       end
 
       it "creates a new release" do
-        GitRepository.any_instance.expects(:exact_tag_from_ref).with('abcd').returns("2")
+        GitRepository.any_instance.expects(:fuzzy_tag_from_ref).with('abcd').returns("v2")
 
         assert_difference "Release.count", +1 do
           post :create, params: {project_id: project.to_param, release: release_params}
@@ -65,8 +65,6 @@ describe ReleasesController do
 
     describe "#new" do
       it "renders" do
-        GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
-
         get :new, params: {project_id: project.to_param}
         assert_response :success
       end

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -177,34 +177,6 @@ describe GitRepository do
     end
   end
 
-  describe "#exact_tag_from_ref" do
-    it 'returns nil when repo has no tags' do
-      create_repo_without_tags
-      repository.update_local_cache!
-      repository.exact_tag_from_ref('master').must_equal nil
-    end
-
-    it 'returns no tag if one is not defined' do
-      create_repo_with_tags
-      execute_on_remote_repo <<-SHELL
-        echo update > foo
-        git commit -a -m 'untagged commit'
-      SHELL
-      repository.update_local_cache!
-      repository.exact_tag_from_ref('master').must_equal nil
-      repository.exact_tag_from_ref('master~').must_equal 'v1'
-    end
-
-    it 'returns tag when it is ambiguous' do
-      create_repo_with_tags
-      execute_on_remote_repo <<-SHELL
-        git checkout -b v1
-      SHELL
-      repository.update_local_cache!
-      repository.exact_tag_from_ref('v1').must_equal 'v1'
-    end
-  end
-
   describe "#tags" do
     it 'returns the tags repository' do
       create_repo_with_tags

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -17,7 +17,7 @@ describe Project do
 
   before do
     Project.any_instance.stubs(:valid_repository_url).returns(true)
-    GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
+    GitRepository.any_instance.stubs(:fuzzy_tag_from_ref).returns(nil)
   end
 
   describe "#generate_token" do

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -16,7 +16,7 @@ describe ReleaseService do
 
     before do
       GITHUB.stubs(:create_release).capture(release_params_used)
-      GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
+      GitRepository.any_instance.expects(:fuzzy_tag_from_ref).returns(nil)
     end
 
     it "creates a new release" do

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -9,11 +9,9 @@ describe Release do
   let(:release) { releases(:test) }
   let(:commit) { "abcde" * 8 }
 
-  describe "create" do
-    before do
-      GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
-    end
+  before { GitRepository.any_instance.stubs(:fuzzy_tag_from_ref).returns(nil) }
 
+  describe "create" do
     it "creates a new release" do
       release = project.releases.create!(commit: commit, author: author)
       assert_equal "124", release.number
@@ -58,14 +56,14 @@ describe Release do
     end
 
     it "converts refs to commits so we later know what exactly was deployed" do
-      GitRepository.any_instance.expects(:update_local_cache!)
+      GitRepository.any_instance.expects(:update_local_cache!).at_least_once
       GitRepository.any_instance.expects(:commit_from_ref).with('master').returns(commit)
       release = project.releases.create!(author: author, commit: 'master')
       release.commit.must_equal commit
     end
 
     it "fails with unresolvable ref" do
-      GitRepository.any_instance.expects(:update_local_cache!)
+      GitRepository.any_instance.expects(:update_local_cache!).at_least_once
       GitRepository.any_instance.expects(:commit_from_ref).with('master').returns(nil)
       e = assert_raises ActiveRecord::RecordInvalid do
         project.releases.create!(author: author, commit: 'master')
@@ -73,7 +71,7 @@ describe Release do
       e.message.must_equal "Validation failed: Commit can only be a full sha"
     end
 
-    it "does not covert blank" do
+    it "does not covert blank commits" do
       GitRepository.any_instance.expects(:clone!).never
       GitRepository.any_instance.expects(:commit_from_ref).never
       e = assert_raises ActiveRecord::RecordInvalid do
@@ -82,11 +80,25 @@ describe Release do
       e.message.must_equal "Validation failed: Commit can only be a full sha"
     end
 
-    it "uses the github version if it is present on the commit" do
-      GitRepository.any_instance.expects(:exact_tag_from_ref).with(commit).returns("v125")
+    it "uses the samson version if it is higher than the github version" do
+      GitRepository.any_instance.expects(:fuzzy_tag_from_ref).with(commit).returns("v122")
+      release = project.releases.create!(author: author, commit: commit)
+      release.commit.must_equal commit
+      release.number.must_equal "124"
+    end
+
+    it "uses the github version if it is exact on the commit" do
+      GitRepository.any_instance.expects(:fuzzy_tag_from_ref).with(commit).returns("v125")
       release = project.releases.create!(author: author, commit: commit)
       release.commit.must_equal commit
       release.number.must_equal "125"
+    end
+
+    it "uses github version +1 if it is fuzzy on the commit" do
+      GitRepository.any_instance.expects(:fuzzy_tag_from_ref).with(commit).returns("v125-123123")
+      release = project.releases.create!(author: author, commit: commit)
+      release.commit.must_equal commit
+      release.number.must_equal "126"
     end
   end
 
@@ -222,7 +234,7 @@ describe Release do
 
   describe "#assign_release_number" do
     it "skips the github version check if no commit is defined" do
-      GitRepository.any_instance.expects(:exact_tag_from_ref).never
+      GitRepository.any_instance.expects(:fuzzy_tag_from_ref).never
       release = project.releases.new
 
       release.assign_release_number

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -142,7 +142,7 @@ describe Stage do
     let(:releases) { Array.new(3).map { project.releases.create!(author: author, commit: "a" * 40) } }
 
     before do
-      GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")
+      GitRepository.any_instance.stubs(:fuzzy_tag_from_ref).returns(nil)
       stage.deploys.create!(reference: "v124", job: job, project: project)
       stage.deploys.create!(reference: "v125", job: job, project: project)
     end


### PR DESCRIPTION
if the repo is already at v20 then do not try to release v1/v2 ...

also
 - removing exact_tag_from_ref which we no longer need and was borked since it did not return a tag
 - fixing stubs that returned the unrealistic value '' ... which would never happen ... most likely added
   to make broken code pass tests ...
 - fixing release_number logic to always return a number and not version/number
 - improving release number logic to do 1 thing at a time and not mix multiple concerns