### PR TITLE
SAMSON-335 run custom command before docker builds

### DIFF
--- a/app/controllers/build_commands_controller.rb
+++ b/app/controllers/build_commands_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+class BuildCommandsController < ApplicationController
+  include CurrentProject
+
+  before_action :authorize_project_admin!, except: [:show]
+  before_action :find_command
+
+  def show
+  end
+
+  def update
+    command = params[:command][:command]
+    if command.blank?
+      @command.destroy
+    else
+      @command.command = command
+      @command.project = @project
+      @command.save!
+      @project.update_column(:build_command_id, @command.id) unless @project.build_command_id
+    end
+    redirect_to project_builds_path(@project), notice: 'Build command updated!'
+  end
+
+  private
+
+  def find_command
+    @command = current_project.build_command || current_project.build_build_command(project: @project)
+  end
+end

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -32,7 +32,7 @@ class DeployService
   def confirm_deploy!(deploy)
     stage = deploy.stage
 
-    job_execution = JobExecution.new(deploy.reference, deploy.job, construct_env(stage))
+    job_execution = JobExecution.new(deploy.reference, deploy.job, env: construct_env(stage))
     job_execution.on_start do
       send_before_notifications(deploy)
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -27,6 +27,8 @@ class Project < ActiveRecord::Base
   has_many :user_project_roles, dependent: :destroy
   has_many :users, through: :user_project_roles
 
+  belongs_to :build_command, class_name: 'Command'
+
   # For permission checks on callbacks. Currently used in private plugins.
   attr_accessor :current_user
 

--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -67,8 +67,8 @@ class TerminalExecutor
   end
 
   def resolve_secrets(command)
-    deploy_groups = @deploy.try(:stage).try(:deploy_groups) || []
-    project = @deploy.try(:project)
+    deploy_groups = @deploy&.stage&.deploy_groups || []
+    project = @deploy&.project
     resolver = Samson::Secrets::KeyResolver.new(project, deploy_groups)
 
     result = command.gsub(/\b#{SECRET_PREFIX}(#{SecretStorage::SECRET_KEY_REGEX})\b/) do

--- a/app/views/admin/commands/show.html.erb
+++ b/app/views/admin/commands/show.html.erb
@@ -1,4 +1,5 @@
 <%= page_title(@command.new_record? ? "New Command" : "Edit Command") %>
+<% usages = @command.usages.presence %>
 
 <section>
   <%= form_for [:admin, @command], html: { class: "form-horizontal" } do |form| %>
@@ -19,15 +20,21 @@
         </div>
       </div>
 
-      <% if @command.usages.present? %>
+      <% if usages %>
         <div class="form-group">
           <%= form.label :usage, value: "Usage", class: "col-lg-2 control-label" %>
-          <% [['stage', @command.stages], ['macro', @command.macros]].select { |_,u| u.any? }.each do |type, usages| %>
+          <% usages.group_by(&:class).each do |klass, usages_by_class| %>
             <div class="col-lg-4">
-              Used in <%= pluralize(usages.count, type) %>:
+              Used in <%= pluralize(usages_by_class.count, klass.name) %>:
               <ul>
-                <% usages.each do |s| %>
-                  <li><%= link_to "#{s.project.name} - #{s.name}", [s.project, s, action: :edit] %></li>
+                <% usages_by_class.each do |s| %>
+                  <li>
+                    <% if s.is_a?(Project) %>
+                      <%= link_to s.name, project_build_command_path(s) %>
+                    <% else %>
+                      <%= link_to "#{s.project.name} - #{s.name}", [s.project, s, action: :edit] %>
+                    <% end %>
+                  </li>
                 <% end %>
               </ul>
             </div>
@@ -38,8 +45,8 @@
       <div class="form-group">
         <div class="col-lg-offset-2 col-lg-10">
           <button type="submit" class="btn btn-default">Save</button>
-          <% disabled = @command.usages.present? && "Can only delete unused commands." %>
-          <%= link_to_delete([:admin, @command], disabled: disabled) unless @command.new_record? %>
+          <% disabled = "Can only delete unused commands." if usages %>
+          <%= link_to_delete([:admin, @command], disabled: disabled) if @command.persisted? %>
         </div>
       </div>
     </fieldset>

--- a/app/views/build_commands/show.html.erb
+++ b/app/views/build_commands/show.html.erb
@@ -1,0 +1,18 @@
+<%= page_title "#{@project.name} Build Command" %>
+
+<%= breadcrumb @project, "Build Command" %>
+
+<section>
+  <%= form_for @command, url: project_build_command_path(@project), html: { class: "form-horizontal", method: :patch } do |form| %>
+    <%= render 'shared/errors', object: @command %>
+
+    <div class="col-lg-offset-2">
+      This command will be run before a new docker image is built.
+      <%= form.text_area :command, size: '120x10' %>
+    </div>
+
+    <%= form.actions do %>
+    | <%= link_to_history @command %>
+    <% end %>
+  <% end %>
+</section>

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -4,6 +4,7 @@
 
 <section class="tabs">
   <p class="pull-right">
+    <%= link_to "Edit Build Command", project_build_command_path(@project), class: "btn btn-default"  %>
     <%= link_to "Create Build", new_project_build_path(@project), class: "btn btn-default" %>
   </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Samson::Application.routes.draw do
       end
     end
 
+    resource :build_command, only: [:show, :update]
+
     resources :deploys, only: [:index, :show, :destroy] do
       collection do
         get :active

--- a/db/migrate/20170207193042_add_build_command_to_projects.rb
+++ b/db/migrate/20170207193042_add_build_command_to_projects.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class AddBuildCommandToProjects < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :build_command_id, :integer
+    add_index :projects, :build_command_id
+    add_index :macro_commands, :command_id
+    add_index :macro_commands, :macro_id
+    add_index :stage_commands, :command_id
+    add_index :stage_commands, :stage_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202231551) do
+ActiveRecord::Schema.define(version: 20170207193042) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -252,6 +252,8 @@ ActiveRecord::Schema.define(version: 20170202231551) do
     t.integer  "position",   default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["command_id"], name: "index_macro_commands_on_command_id", using: :btree
+    t.index ["macro_id"], name: "index_macro_commands_on_macro_id", using: :btree
   end
 
   create_table "macros", force: :cascade do |t|
@@ -346,6 +348,8 @@ ActiveRecord::Schema.define(version: 20170202231551) do
     t.boolean  "include_new_deploy_groups",               default: false, null: false
     t.string   "docker_release_branch"
     t.string   "release_source",                          default: "any", null: false
+    t.integer  "build_command_id"
+    t.index ["build_command_id"], name: "index_projects_on_build_command_id", using: :btree
     t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: { permalink: 191 }, using: :btree
     t.index ["token"], name: "index_projects_on_token", unique: true, length: { token: 191 }, using: :btree
   end
@@ -415,6 +419,8 @@ ActiveRecord::Schema.define(version: 20170202231551) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
+    t.index ["command_id"], name: "index_stage_commands_on_command_id", using: :btree
+    t.index ["stage_id"], name: "index_stage_commands_on_stage_id", using: :btree
   end
 
   create_table "stages", force: :cascade do |t|

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -58,6 +58,24 @@ describe SamsonEnv do
     end
   end
 
+  describe :before_docker_build do
+    def fire
+      Samson::Hooks.fire(:before_docker_build, Dir.pwd, Build.new(project: project), StringIO.new)
+    end
+
+    run_inside_of_temp_directory
+
+    before do
+      project.environment_variables.create!(name: "HELLO", value: "world")
+      project.environment_variables.create!(name: "WORLD", value: "hello")
+    end
+
+    it "writes to .env" do
+      fire
+      File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
+    end
+  end
+
   describe :deploy_group_env do
     it "adds env variables" do
       deploy_group = deploy_groups(:pod1)

--- a/test/controllers/build_commands_controller_test.rb
+++ b/test/controllers/build_commands_controller_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe BuildCommandsController do
+  let(:project) { projects(:test) }
+
+  as_a_viewer do
+    unauthorized :patch, :update, project_id: :foo
+
+    describe '#show' do
+      it "is renders" do
+        get :show, params: {project_id: :foo}
+        assert_response :success
+      end
+    end
+  end
+
+  as_a_project_admin do
+    describe '#update' do
+      it "creates when it does not exist" do
+        assert_difference 'Command.count', +1 do
+          patch :update, params: {project_id: project, command: {command: 'hello'}}
+          assert_redirected_to "/projects/#{project.to_param}/builds"
+        end
+        project.reload
+        project.build_command.command.must_equal 'hello'
+        project.build_command.project.must_equal project
+      end
+
+      describe "with existing build command" do
+        before { project.update_column(:build_command_id, Command.create(command: 'foo').id) }
+
+        it "updates when it does already exist" do
+          refute_difference 'Command.count' do
+            patch :update, params: {project_id: project, command: {command: "bar\r\nfoo"}}
+            assert_redirected_to "/projects/#{project.to_param}/builds"
+          end
+          project.reload.build_command.command.must_equal "bar\r\nfoo"
+        end
+
+        it "deletes when blank" do
+          assert_difference 'Command.count', -1 do
+            patch :update, params: {project_id: project, command: {command: '   '}}
+            assert_redirected_to "/projects/#{project.to_param}/builds"
+          end
+          project.reload.build_command.must_equal nil
+        end
+      end
+    end
+  end
+end

--- a/test/models/command_test.rb
+++ b/test/models/command_test.rb
@@ -63,8 +63,17 @@ describe Command do
   end
 
   describe "#usages" do
-    it "lists stages and macros" do
-      command.usages.map(&:class).uniq.must_equal [Stage, Macro]
+    it "lists stages, macros and projects" do
+      projects(:test).update_column(:build_command_id, command.id)
+      command.usages.map(&:class).uniq.sort_by(&:name).must_equal [Macro, Project, Stage]
+    end
+  end
+
+  describe ".usage_ids" do
+    it "returns all used commands" do
+      extra_id = Command.create!(command: 'foo').id
+      projects(:test).update_column(:build_command_id, extra_id)
+      Command.usage_ids.uniq.sort.must_equal [extra_id, command.id].sort
     end
   end
 end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -6,10 +6,7 @@ SingleCov.covered! uncovered: 7
 describe JobExecution do
   include GitRepoTestHelper
 
-  def execute_job(branch = 'master', **options)
-    on_complete = options.delete(:on_complete)
-    on_start = options.delete(:on_start)
-
+  def execute_job(branch = 'master', on_complete: nil, on_start: nil, **options)
     execution = JobExecution.new(branch, job, options)
     execution.on_complete(&on_complete) if on_complete.present?
     execution.on_start(&on_start) if on_start.present?
@@ -142,7 +139,7 @@ describe JobExecution do
 
   it "exports deploy information as environment variables" do
     job.update(command: 'env | sort')
-    execute_job('master', FOO: 'bar')
+    execute_job 'master', env: {FOO: 'bar'}
     lines = job.output.split "\n"
     lines.must_include "DEPLOY_URL=#{deploy.url}"
     lines.must_include "DEPLOYER=jdoe@test.com"


### PR DESCRIPTION
/cc @zendesk/samson

@jonmoter @henders

 - versioned ... can be modified by admins, viewed by all
 - 1 command per project ... reuse is not planned
 - executes inside of temp dir
 - shown in command usages
 - findable via command search
 - access to secrets
 - access to .env from env plugin
 - access to artifact_cache_dir
 - replaces binary builder ?
 - replaces BEFORE_DOCKER_BUILD