### PR TITLE
[SAMSON-337] fix bug where edit stage page crashes on pipeline plugin

### DIFF
--- a/plugins/pipelines/app/views/samson_pipelines/_stage_form.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_stage_form.html.erb
@@ -4,7 +4,7 @@
   <div class="col-lg-4 col-lg-offset-2">
     <%= hidden_field_tag "#{form.object_name}[next_stage_ids][]" %>
     <table>
-      <% (@project.stages - [@stage]).sort_by(&:order).each do |next_stage| %>
+      <% (@project.stages - [@stage]).sort_by { |s| s.order || 0 }.each do |next_stage| %>
         <tr>
           <td>
             <%= label_tag do %>


### PR DESCRIPTION
Was crashing when editing a stage.  Apparently we have a bunch of stages with an order of nil.  This patches the crash, but we should probably fix the records missing.

/cc @zendesk/samson, @staugaard 

### Tasks
 - [ ] :+1: from team

### References
 - JIRA: https://zendesk.atlassian.net/browse/SAMSON-337
 - Airbrake: https://zendesk.airbrake.io/projects/95346/groups/1881455414135434331

### Risks
- Level: Low
