### PR TITLE
fix migration

### DIFF
--- a/db/migrate/20170208221802_enforce_ordering.rb
+++ b/db/migrate/20170208221802_enforce_ordering.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 class EnforceOrdering < ActiveRecord::Migration[5.0]
+  class Stage < ActiveRecord::Base
+  end
+
   def up
-    change_column_default :stages, :order, 0
+    Stage.where(order: nil).update_all(order: 0)
     change_column_null :stages, :order, false
-    change_column_default :stages, :order, nil
   end
 
   def down
     change_column_null :stages, :order, true
-    change_column_default :stages, :order, nil
   end
 end


### PR DESCRIPTION
Mysql2::Error: Data truncated for column 'order' at row 8: ALTER TABLE `stages` CHANGE `order` `order` int(11) DEFAULT 0 NOT NULL

followup for https://github.com/zendesk/samson/pull/1743