### PR TITLE
PAAS-707 endpoint to create builds from external builds

### DIFF
--- a/app/controllers/api/builds_controller.rb
+++ b/app/controllers/api/builds_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+class Api::BuildsController < Api::BaseController
+  include CurrentProject
+
+  before_action :authorize_resource!
+
+  def create
+    build_params = params.require(:build)
+    digest = extract_param(build_params, :docker_repo_digest)
+    sha = extract_param(build_params, :git_sha)
+
+    Samson::Hooks.fire(:before_docker_repository_usage, current_project)
+
+    build = current_project.builds.create!(
+      build_params.permit(*Build::ASSIGNABLE_KEYS).merge(
+        creator: current_user,
+        docker_repo_digest: digest,
+        git_sha: sha
+      )
+    )
+
+    Samson::Hooks.fire(:after_docker_build, build)
+
+    head :created
+  end
+
+  private
+
+  # show a nice error when not present but remove it so .permit does not crash
+  def extract_param(build_params, param)
+    build_params.require(param) && build_params.delete(param)
+  end
+end

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -2,8 +2,7 @@
 class BuildsController < ApplicationController
   include CurrentProject
 
-  before_action :authorize_project_deployer!
-
+  before_action :authorize_resource!
   before_action :find_build, only: [:show, :build_docker_image, :edit, :update]
 
   def index
@@ -58,9 +57,7 @@ class BuildsController < ApplicationController
   end
 
   def new_build_params
-    params.require(:build).permit(
-      *[:git_ref, :label, :description] + Samson::Hooks.fire(:build_permitted_params)
-    )
+    params.require(:build).permit(*Build::ASSIGNABLE_KEYS)
   end
 
   def edit_build_params

--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -63,6 +63,8 @@ module CurrentUser
 
   def authorize_resource!
     case controller_name
+    when 'builds'
+      authorize_project_deployer!
     when 'locks'
       if @project
         authorize_project_deployer!

--- a/app/helpers/builds_helper.rb
+++ b/app/helpers/builds_helper.rb
@@ -2,7 +2,7 @@
 module BuildsHelper
   # shorten Docker SHAs "sha256:0123abc..." -> "0123abc"
   def short_sha(value, length: 7)
-    value.split(':').last.slice(0, length) if value
+    value.split(':', 2).last.slice(0, length) if value
   end
 
   def git_ref_and_sha_for(build, make_link: false)

--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -45,7 +45,7 @@ class DockerBuilderService
   end
 
   def run!(push: false, tag_as_latest: false)
-    build.docker_build_job.try(:destroy) # if there's an old build job, delete it
+    build.docker_build_job&.destroy # if there's an old build job, delete it
     build.docker_tag = build.label.try(:parameterize).presence || 'latest'
     build.started_at = Time.now
 
@@ -140,6 +140,7 @@ class DockerBuilderService
   end
 
   def before_docker_build(tmp_dir)
+    Samson::Hooks.fire(:before_docker_repository_usage, build.project)
     Samson::Hooks.fire(:before_docker_build, tmp_dir, build, output)
     execute_build_command(tmp_dir, build.project.build_command)
   end

--- a/app/views/builds/_build.html.erb
+++ b/app/views/builds/_build.html.erb
@@ -6,5 +6,5 @@
   <td><%= relative_time(build.created_at) %></td>
   <td><%= build.creator&.name || "Trigger" %></td>
   <td><%= git_ref_and_sha_for(build) %></td>
-  <td><%= (job = build.docker_build_job) ? job_status_badge(job) : 'not built' %></td>
+  <td><%= (job = build.docker_build_job) ? job_status_badge(job) : build.docker_status %></td>
 </tr>

--- a/app/views/builds/edit.html.erb
+++ b/app/views/builds/edit.html.erb
@@ -17,7 +17,7 @@
     <%= form.input :git_ref, label: 'Git Reference' do %>
       <p class="form-control-static"><%= git_ref_and_sha_for(@build) %></p>
     <% end %>
-    <%= form.input :docker_image, label: 'Docker Repo Digest' do %>
+    <%= form.input :docker_repo_digest, label: 'Docker Digest' do %>
       <p class="form-control-static"><%= @build.docker_repo_digest %></p>
     <% end %>
 

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -29,6 +29,11 @@
     <dt>Created By</dt>
     <dd><%= @build.creator&.name_and_email || "Trigger" %></dd>
 
+    <% if url = @build.source_url %>
+      <dt>Created Via</dt>
+      <dd><%= url %></dd>
+    <% end %>
+
     <dt>Label</dt>
     <dd><%= @build.label  %></dd>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,4 +26,4 @@ en:
       help:
         # Ideally make dynamic https://github.com/doorkeeper-gem/doorkeeper/issues/896
         # and enforce inclusion ... for now keep in sync with api controllers
-        scopes: "Separate scopes with spaces. Possible: automated_deploys, deploy_groups, deploys, locks, projects, stages, default (everything)"
+        scopes: "Separate scopes with spaces. Possible: automated_deploys, builds, deploy_groups, deploys, locks, projects, stages, default (everything)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,15 +12,14 @@ Samson::Application.routes.draw do
     resources :deploy_groups, only: [:index]
 
     resources :projects, only: [:index] do
+      resources :automated_deploys, only: [:create]
+      resources :builds, only: [:create]
+      resources :deploys, only: [:index]
       resources :stages, only: [:index] do
         member do
           get :deploy_groups, to: 'deploy_groups#index'
         end
       end
-
-      resources :deploys, only: [:index]
-
-      resources :automated_deploys, only: [:create]
     end
 
     resources :stages, only: [] do

--- a/db/migrate/20170208195102_add_source_url_to_builds.rb
+++ b/db/migrate/20170208195102_add_source_url_to_builds.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddSourceUrlToBuilds < ActiveRecord::Migration[5.0]
+  def change
+    add_column :builds, :source_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20170208221802) do
     t.boolean  "kubernetes_job",                   default: false, null: false
     t.datetime "started_at"
     t.datetime "finished_at"
+    t.string   "source_url"
     t.index ["created_by"], name: "index_builds_on_created_by", using: :btree
     t.index ["git_sha"], name: "index_builds_on_git_sha", unique: true, using: :btree
     t.index ["project_id"], name: "index_builds_on_project_id", using: :btree

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -32,6 +32,7 @@ module Samson
       :before_deploy,
       :after_deploy_setup,
       :after_deploy,
+      :before_docker_repository_usage,
       :before_docker_build,
       :after_docker_build,
       :after_job_execution,

--- a/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
+++ b/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
@@ -63,7 +63,7 @@ end
 
 # need credentials to pull (via Dockerfile FROM) and push images
 # ATM this only authenticates the default docker registry and not any extra registries
-Samson::Hooks.callback :before_docker_build do |_, build, _|
-  SamsonAwsEcr::Engine.ensure_repositories(build.project)
+Samson::Hooks.callback :before_docker_repository_usage do |project|
+  SamsonAwsEcr::Engine.ensure_repositories(project)
   SamsonAwsEcr::Engine.refresh_credentials
 end

--- a/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
+++ b/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
@@ -33,9 +33,9 @@ describe SamsonAwsEcr::Engine do
     end
   end
 
-  describe :before_docker_build do
+  describe :before_docker_repository_usage do
     def fire
-      Samson::Hooks.fire(:before_docker_build, 'foobar', builds(:docker_build), StringIO.new)
+      Samson::Hooks.fire(:before_docker_repository_usage, builds(:docker_build).project)
     end
 
     run_inside_of_temp_directory

--- a/plugins/hyperclair/test/samson_hyperclair/samson_plugin_test.rb
+++ b/plugins/hyperclair/test/samson_hyperclair/samson_plugin_test.rb
@@ -4,36 +4,39 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe SamsonHyperclair do
+  let(:build) do
+    build = builds(:docker_build)
+    build.docker_build_job = jobs(:succeeded_test)
+    build.docker_tag = 'latest'
+    build
+  end
+
   describe :after_docker_build do
-    let(:build) { builds(:docker_build) }
-
-    before { build.docker_build_job = jobs(:succeeded_test) }
-
     it "runs clair" do
-      SamsonHyperclair.expects(:append_job_with_scan)
+      SamsonHyperclair.expects(:append_build_job_with_scan)
       Samson::Hooks.fire(:after_docker_build, build)
     end
 
     it "does not run clair when build failed" do
-      build.docker_build_job.status = 'errored'
-      SamsonHyperclair.expects(:append_job_with_scan).never
+      build.docker_repo_digest = nil
+      SamsonHyperclair.expects(:append_build_job_with_scan).never
       Samson::Hooks.fire(:after_docker_build, build)
     end
   end
 
-  describe '.append_job_with_scan' do
+  describe '.append_build_job_with_scan' do
+    let(:job) { build.docker_build_job }
+
     share_database_connection_in_all_threads
     with_registries ["docker-registry.example.com"]
 
     def execute!
-      SamsonHyperclair.append_job_with_scan(job, 'latest')
+      SamsonHyperclair.append_build_job_with_scan(build)
     end
-
-    let(:job) { jobs(:succeeded_test) }
 
     around do |t|
       Tempfile.open('clair') do |f|
-        f.write("#!/bin/bash\necho HELLO\nexit 0")
+        f.write("#!/bin/bash\necho HELLO\necho OUT $@\nexit 0")
         f.close
         File.chmod 0o755, f.path
         with_env(HYPERCLAIR_PATH: f.path, DOCKER_REGISTRY: 'my.registry', &t)
@@ -49,7 +52,13 @@ describe SamsonHyperclair do
       wait_for_threads
 
       job.output.must_include "Clair scan: success"
-      job.output.must_include "HELLO"
+      job.output.must_include "\nHELLO\nOUT docker-registry.example.com/test@sha256:5f1d7"
+    end
+
+    it "runs clair with external build" do
+      build.docker_build_job = nil
+      execute!
+      wait_for_threads
     end
 
     it "runs clair and reports missing script to the database" do

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -269,7 +269,7 @@ module Kubernetes
     end
 
     def wait_for_build(build)
-      if !build.docker_repo_digest && build.docker_build_job.try(:active?)
+      if !build.docker_repo_digest && build.docker_build_job&.active?
         @output.puts("Waiting for Build #{build.url} to finish.")
         loop do
           break if @stopped

--- a/test/controllers/api/builds_controller_test.rb
+++ b/test/controllers/api/builds_controller_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Api::BuildsController do
+  let(:project) { projects(:test) }
+
+  as_a_viewer do
+    before { @request_format = :json }
+    unauthorized :post, :create, project_id: :foo
+  end
+
+  as_a_project_deployer do
+    describe "#create" do
+      let(:digest) { "foo.com/bar@sha256:#{"a" * 64}" }
+      let(:build_params) do
+        {
+          docker_repo_digest: digest,
+          git_sha: 'aaaa' * 10,
+          git_ref: 'reff',
+          source_url: 'https://source.url'
+        }
+      end
+
+      before do
+        GitRepository.any_instance.stubs(:update_local_cache!)
+        GitRepository.any_instance.stubs(:commit_from_ref).with('reff').returns('some-commit')
+      end
+
+      it "creates" do
+        assert_difference "Build.count", +1 do
+          post :create, params: {build: build_params, project_id: project}, format: :json
+          assert_response :created
+        end
+        build = Build.last
+        build.creator.must_equal user
+        build.project.must_equal project
+        build.git_sha.must_equal 'aaaa' * 10
+        build.git_ref.must_equal 'reff'
+        build.source_url.must_equal 'https://source.url'
+        build.docker_repo_digest.must_equal digest
+      end
+
+      it "fails nicely without docker_repo_digest" do
+        post :create, params: {build: build_params.except(:docker_repo_digest), project_id: project}, format: :json
+        assert_response :bad_request
+      end
+
+      it "fails nicely without git_sha" do
+        post :create, params: {build: build_params.except(:git_sha), project_id: project}, format: :json
+        assert_response :bad_request
+      end
+    end
+  end
+end

--- a/test/controllers/concerns/current_user_test.rb
+++ b/test/controllers/concerns/current_user_test.rb
@@ -200,7 +200,7 @@ class CurrentUserConcernTest < ActionController::TestCase
     end
   end
 
-  describe "#resource_action" do
+  describe "#authorize_resource!" do
     def perform_get(add = {})
       get :resource_action, params: add.merge(test_route: true)
     end
@@ -211,6 +211,12 @@ class CurrentUserConcernTest < ActionController::TestCase
     end
 
     it "renders when authorized" do
+      perform_get
+      assert_response :success
+    end
+
+    it "renders when authorized for builds" do
+      @controller.stubs(:controller_name).returns('builds')
       perform_get
       assert_response :success
     end

--- a/test/lib/samson/hooks_test.rb
+++ b/test/lib/samson/hooks_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../../test_helper'
 
-SingleCov.covered! uncovered: 14
+SingleCov.covered! uncovered: 12
 
 describe Samson::Hooks do
   let(:number_of_plugins) { Dir['plugins/*'].size }

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -59,8 +59,19 @@ describe Build do
     it 'validates docker digest' do
       assert_valid(valid_build(docker_repo_digest: repo_digest))
       assert_valid(valid_build(docker_repo_digest: "my-registry.zende.sk/samson/another_project@sha256:#{example_sha}"))
+      assert_valid(valid_build(docker_repo_digest: "ruby@sha256:#{"a" * 64}"))
       refute_valid(valid_build(docker_repo_digest: example_sha))
       refute_valid(valid_build(docker_repo_digest: 'some random string'))
+    end
+
+    it 'is invalid with protocol weird url' do
+      refute_valid(valid_build(source_url: 'foo.com'))
+      refute_valid(valid_build(source_url: 'ftp://foo.com'))
+    end
+
+    it 'is valid with real url' do
+      assert_valid(valid_build(source_url: 'http://foo.com'))
+      assert_valid(valid_build(source_url: 'https://foo.com'))
     end
   end
 
@@ -134,6 +145,11 @@ describe Build do
 
     it "is not built when there is no build" do
       build.docker_status.must_equal "not built"
+    end
+
+    it "is built externally when digest exists without job" do
+      build.docker_repo_digest = 'foo'
+      build.docker_status.must_equal "built externally"
     end
   end
 

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -146,6 +146,7 @@ describe DockerBuilderService do
     before { service.instance_variable_set(:@execution, execution) }
 
     it 'fires the before_docker_build hook' do
+      Samson::Hooks.expects(:fire).with(:before_docker_repository_usage, build.project)
       Samson::Hooks.expects(:fire).with(:before_docker_build, tmp_dir, build, anything)
       service.send(:before_docker_build, tmp_dir)
     end


### PR DESCRIPTION
 - scanned with clair ... needs a docker_tag atm ... waiting for PAAS-579
 - refreshes ecr credentials before pulling
 - stores source_url so we know where it came from

```
curl -X POST -H "Content-Type: application/json" -H 'Authorization: Bearer 02d27ce039eb7cb734e1c5a9eb674e110abcdc2a0af7f61ce59545181119c6ca' 'http://localhost:3000/api/projects/consul2dogstats/builds.json?build%5Bdocker_repo_digest%5D=ruby@sha256:4a8993318e41d8814ea6a30ca2eccf36078b59ed2ab2f9cf2b4be81331d8caa3&build%5Bgit_sha%5D=816d74a57b2cad9fa75495c0fd3e29e785bc7d3d&build%5Bgit_ref%5D=master'
```

<img width="641" alt="screen shot 2017-02-08 at 4 12 25 pm" src="https://cloud.githubusercontent.com/assets/11367/22768976/9e1312a8-ee3a-11e6-9944-88991dc0cf8e.png">


and was able to kick off a kubernetes with this https://samsontest.zende.sk/projects/kube_service_watcher/deploys/4253

TODO: test new logic