### PR TITLE
make textarea as big as the text they try to show

### DIFF
--- a/app/views/shared/_commands.html.erb
+++ b/app/views/shared/_commands.html.erb
@@ -54,6 +54,11 @@
       alert("Editing for " + $(this).data('others-warning') + ". If you do not want this, make a copy.");
     });
 
+    $('#commands pre').dblclick(function(){
+      var $textarea = $($($(this).get(0)).siblings().get(0)).find('textarea');
+      $textarea.attr('rows', ($(this).text().match(/\n/g) || []).length + 1);
+    });
+
     $('#commands pre.global').dblclick(function(){
       var $warning = $('<div class="cannot-edit">Global commands cannot be edited inline, use the Admin UI.</div>')
       $(this).after($warning);


### PR DESCRIPTION
was very confused when I clicked on a big command and then everything shifted around ... also then had to scroll to edit which is annoying ... much simpler now:

![screen shot 2017-02-09 at 4 18 46 pm](https://cloud.githubusercontent.com/assets/11367/22808937/af0f2f7a-eee3-11e6-901b-e693863db7b8.png)
