### PR TITLE
render 404 when user tries a bogus key

### DIFF
--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -77,6 +77,7 @@ module Samson
         # ... could be faster by not jumping through hash generation and parsing
         def vault_path(key, direction = :encode)
           parts = SecretStorage.parse_secret_key(key)
+          raise ActiveRecord::RecordNotFound, "Invalid key #{key.inspect}" unless parts[:key]
           parts[:key] = convert_path(parts[:key], direction)
           SecretStorage.generate_secret_key(parts)
         end

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -30,6 +30,12 @@ describe Samson::Secrets::HashicorpVaultBackend do
     it "returns nil when trying to read nil" do
       Samson::Secrets::HashicorpVaultBackend.read(nil).must_be_nil
     end
+
+    it "raises when trying to read an invalid path so it behaves like a database backend" do
+      assert_raises ActiveRecord::RecordNotFound do
+        Samson::Secrets::HashicorpVaultBackend.read("wut")
+      end
+    end
   end
 
   describe ".read_multi" do


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/1885101560477198683/notices/1885101555608565266?tab=notice-detail

atm it fails with nil.dup which is misleading and unexpected