### PR TITLE
PAAS-743 do not allow deploy groups with different environments to sh…

### DIFF
--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -43,7 +43,11 @@
     <div class="form-group">
       <label class="col-lg-2 control-label">Vault Server</label>
       <div class="col-lg-4">
-        <p class="form-control-static"><%= @deploy_group.vault_server&.name %></p>
+        <p class="form-control-static">
+          <% if vault_server = @deploy_group.vault_server %>
+            <%= link_to vault_server.name, [:admin, vault_server] %>
+          <% end %>
+        </p>
       </div>
     </div>
   <% end %>

--- a/test/models/deploy_group_test.rb
+++ b/test/models/deploy_group_test.rb
@@ -146,4 +146,23 @@ describe DeployGroup do
       refute deploy_group.template_stages.empty?
     end
   end
+
+  describe "#validate_vault_server_has_same_environment" do
+    let(:server) { Samson::Secrets::VaultServer.create!(name: 'a', address: 'http://a.com', token: 't') }
+
+    before do
+      Samson::Secrets::VaultServer.any_instance.stubs(:validate_cert)
+      Samson::Secrets::VaultServer.any_instance.stubs(:validate_connection)
+    end
+
+    before { deploy_groups(:pod1).update_attributes!(vault_server: server) }
+
+    it "is valid when vault servers have enclusive environments" do
+      assert deploy_groups(:pod2).update_attributes(vault_server: server)
+    end
+
+    it "is invalid when vault servers share environments environments" do
+      refute deploy_groups(:pod100).update_attributes(vault_server: server)
+    end
+  end
 end


### PR DESCRIPTION
…are a vault server

This will avoid accidental misconfiguration that might leak production secrets to staging
since a changed secret will be written to all vault servers in that environment

![screen shot 2017-02-14 at 1 50 51 pm](https://cloud.githubusercontent.com/assets/11367/22951054/a47d7788-f2bc-11e6-8fbc-92768df43f06.png)
