### PR TITLE
PAAS-698 limit the amount of replicasets we leave behind

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -15,6 +15,7 @@ module Kubernetes
     def to_hash
       @to_hash ||= begin
         set_rc_unique_label_key
+        set_history_limit
         set_name
         set_replica_target
         set_spec_template_metadata
@@ -38,6 +39,13 @@ module Kubernetes
     end
 
     private
+
+    # make sure we clean up old replicasets
+    # we only ever do rollback to latest release ... and the default is infitite
+    # see discussion in https://github.com/kubernetes/kubernetes/issues/23597
+    def set_history_limit
+      template[:spec][:revisionHistoryLimit] ||= 1
+    end
 
     # look up keys in all possible namespaces by specificity
     def expand_secret_annotations

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -79,6 +79,10 @@ describe Kubernetes::TemplateFiller do
       )
     end
 
+    it "sets revisionHistoryLimit" do
+      template.to_hash[:spec][:revisionHistoryLimit].must_equal 1
+    end
+
     describe "containers" do
       let(:result) { template.to_hash }
       let(:container) { result.fetch(:spec).fetch(:template).fetch(:spec).fetch(:containers).first }


### PR DESCRIPTION
before: 8+ replicasets and each deploy adds one
after: 2 (current and previous)

existing ones will be cleaned up on next deploy, so no need to write a big migration