### PR TITLE
PAAS-733 allow deploying not ready services to enable us to deploy servers in off state

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -114,6 +114,7 @@ module Kubernetes
           when /\ALiveliness/ then :livelinessProbe
           else raise("Unknown probe #{event.message}")
           end
+        return false if ignore_probe?(probe)
         event.count >= failure_threshold(probe)
       end
 
@@ -123,11 +124,17 @@ module Kubernetes
         @pod.dig(:spec, :containers, 0, probe, :failureThreshold) || 3
       end
 
+      def ignore_probe?(probe)
+        @pod.dig(:spec, :containers, 0, probe, :samsonIgnore)
+      end
+
       def labels
         @pod.metadata.try(:labels)
       end
 
       def ready?
+        return true if ignore_probe?(:readinessProbe)
+
         if @pod.status.conditions.present?
           ready = @pod.status.conditions.find { |c| c['type'] == 'Ready' }
           ready && ready['status'] == 'True'


### PR DESCRIPTION
 - deploy service in off state (verify manually)
 - turn it on via arturo and traffic flows over

@zendesk/paas 