### PR TITLE
do not fail on non-ascii encoding

### DIFF
--- a/app/models/webhook_recorder.rb
+++ b/app/models/webhook_recorder.rb
@@ -9,7 +9,7 @@ class WebhookRecorder
 
       data = {
         request: request_info,
-        request_body: request.body.read,
+        request_body: request.body.read.force_encoding(Encoding::UTF_8),
         status_code: response.status,
         body: response.body,
         log: log,

--- a/test/models/webhook_recorder_test.rb
+++ b/test/models/webhook_recorder_test.rb
@@ -30,6 +30,15 @@ describe WebhookRecorder do
       read.fetch(:log).must_equal "LOG"
       read.fetch(:request_body).must_equal "BODY"
     end
+
+    it "does not blow up when receiving utf8 as ascii-8-bit which is the default" do
+      bad = "EVIL->😈<-EVIL".dup.force_encoding(Encoding::BINARY)
+      bad.bytesize.must_equal 16
+      request.env["RAW_POST_DATA"] = bad
+      WebhookRecorder.record(project, request: request, log: "LOG", response: response)
+      read = WebhookRecorder.read(project)
+      read.fetch(:request_body).force_encoding(Encoding::BINARY).must_equal bad
+    end
   end
 
   describe ".read" do


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/1887890753108519385?tab=notice-detail

can test locally with:
```
curl -X POST --form "body=😈&file=@file.jpg" http://localhost:3000/ping
```