### PR TITLE
use real repo to run proper setup and not crash

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -263,7 +263,8 @@ class JobExecution
     Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
       result = yield dir
     end
-  rescue Errno::ENOTEMPTY
+  rescue Errno::ENOTEMPTY, Errno::ENOENT
+    Airbrake.notify("Notify: make_tempdir error #{$!}")
     result # tempdir ensure sometimes fails ... not sure why ... return normally
   end
 

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -7,7 +7,6 @@ describe DockerBuilderService do
   include GitRepoTestHelper
 
   let(:tmp_dir) { Dir.mktmpdir }
-  let(:project_repo_url) { repo_temp_dir }
   let(:git_tag) { 'v123' }
   let(:project) { projects(:test) }
   let(:build) { project.builds.create!(git_ref: git_tag, git_sha: 'a' * 40) }
@@ -17,11 +16,9 @@ describe DockerBuilderService do
   let(:mock_docker_image) { stub(json: docker_image_json) }
 
   with_registries ["docker-registry.example.com"]
+  with_project_on_remote_repo
 
-  before do
-    project.update_column(:repository_url, project_repo_url)
-    create_repo_with_tags(git_tag)
-  end
+  before { execute_on_remote_repo "git tag #{git_tag}" }
 
   describe "#run!" do
     def run!(options = {})

--- a/test/support/job_queue_support.rb
+++ b/test/support/job_queue_support.rb
@@ -27,4 +27,11 @@ ActiveSupport::TestCase.class_eval do
       end
     end
   end
+
+  def self.with_full_job_execution
+    with_job_execution
+    with_job_stop_timeout 0.1
+    with_project_on_remote_repo
+    around { |t| ArMultiThreadedTransactionalTests.activate &t }
+  end
 end

--- a/test/support/multi_thread_db_detector.rb
+++ b/test/support/multi_thread_db_detector.rb
@@ -19,9 +19,10 @@ end)
 
 ActiveRecord::ConnectionAdapters::ConnectionPool.prepend(Module.new do
   def with_connection
+    old = MultiThreadDbDetector.in_with_connection
     MultiThreadDbDetector.in_with_connection = true
     super
   ensure
-    MultiThreadDbDetector.in_with_connection = false
+    MultiThreadDbDetector.in_with_connection = old
   end
 end)


### PR DESCRIPTION
now that we have proper mutithreaded testing we can use less stubs and more real callbacks

previously all jobs crashed in `setup` and the tests just ignored that ... also found a bug in the thread monitoring code :)