### PR TITLE
reset output height to previous hight instead of hardcoded value

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -13,7 +13,8 @@ $(function () {
       $placeholderPanes = $container.find(".changeset-placeholder"),
       $form = $("#new_deploy"),
       $submit = $form.find('input[type=submit]'),
-      $messages = $("#messages");
+      $messages = $("#messages"),
+      old_height = $messages.css('max-height');
 
   $("#deploy-tabs a[data-type=github]").click(function (e) {
       e.preventDefault();
@@ -116,7 +117,7 @@ $(function () {
   });
 
   function shrinkOutput() {
-    $messages.css("max-height", 550);
+    $messages.css("max-height", old_height);
   }
 
   $("#output-follow").click(function() {

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -14,7 +14,8 @@ $(function () {
       $form = $("#new_deploy"),
       $submit = $form.find('input[type=submit]'),
       $messages = $("#messages"),
-      old_height = $messages.css('max-height');
+      old_height = $messages.css('max-height'),
+      expanded = false;
 
   $("#deploy-tabs a[data-type=github]").click(function (e) {
       e.preventDefault();
@@ -117,37 +118,41 @@ $(function () {
   });
 
   function shrinkOutput() {
+    expanded = false;
     $messages.css("max-height", old_height);
   }
 
+  // also toggles the button that will be on the finished page so deploys that stop transition cleanly
+  function activateModalButton($current) {
+    $("#output-options > button, #output-expand-toggle").removeClass("active");
+    $current.addClass("active");
+  }
+
   $("#output-follow").click(function() {
+    activateModalButton($(this));
+
     following = true;
 
     shrinkOutput();
 
+    // scroll to bottom
     $messages.scrollTop($messages.prop("scrollHeight"));
-
-    $("#output-options > button, #output-expand-toggle").removeClass("active");
-    $(this).addClass("active");
   });
 
   $("#output-no-follow").click(function() {
+    activateModalButton($(this));
+
     following = false;
 
     shrinkOutput();
-
-    $("#output-options > button").removeClass("active");
-    $(this).addClass("active");
   });
 
   $("#output-expand").click(function() {
+    activateModalButton($("#output-expand-toggle, #output-expand"));
+
     following = false;
 
     growOutput();
-
-    $("#output-options > button").removeClass("active");
-    $(this).addClass("active");
-    $("#output-expand-toggle").addClass("active");
   });
 
   // on finished pages we only have the 'Expand' button, so it toggles
@@ -164,6 +169,7 @@ $(function () {
   });
 
   function growOutput() {
+    expanded = true;
     $messages.css("max-height", "none");
   }
 
@@ -179,7 +185,9 @@ $(function () {
   // when user scrolls all the way down, start following
   // when user scrolls up, stop following since it would cause jumping
   // (adds 30 px wiggle room since the math does not quiet add up)
+  // ... do nothing when in expanded view
   $messages.scroll(function() {
+    if(expanded) { return; }
     var position = $messages.prop("scrollHeight") - $messages.scrollTop() - $messages.height() - 30;
     if(position > 0 && following) {
       $("#output-no-follow").click();

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -127,15 +127,29 @@ $(function () {
 
     $messages.scrollTop($messages.prop("scrollHeight"));
 
-    $("#output-options > button, #output-grow-toggle").removeClass("active");
+    $("#output-options > button, #output-expand-toggle").removeClass("active");
     $(this).addClass("active");
   });
 
-  function growOutput() {
-    $messages.css("max-height", "none");
-  }
+  $("#output-no-follow").click(function() {
+    following = false;
 
-  $("#output-grow-toggle").click(function() {
+    shrinkOutput();
+
+    $("#output-options > button").removeClass("active");
+    $(this).addClass("active");
+  });
+
+  $("#output-expand").click(function() {
+    growOutput();
+
+    $("#output-options > button").removeClass("active");
+    $(this).addClass("active");
+    $("#output-expand-toggle").addClass("active");
+  });
+
+  // on finished pages we only have the 'Expand' button, so it toggles
+  $("#output-expand-toggle").click(function() {
     var $self = $(this);
 
     if($self.hasClass("active")) {
@@ -147,22 +161,9 @@ $(function () {
     }
   });
 
-  $("#output-grow").click(function() {
-    growOutput();
-
-    $("#output-options > button").removeClass("active");
-    $(this).addClass("active");
-    $("#output-grow-toggle").addClass("active");
-  });
-
-  $("#output-steady").click(function() {
-    following = false;
-
-    shrinkOutput();
-
-    $("#output-options > button").removeClass("active");
-    $(this).addClass("active");
-  });
+  function growOutput() {
+    $messages.css("max-height", "none");
+  }
 
   // If there are messages being streamed, then show the output and hide buddy check
   $messages.bind('contentchanged', function() {
@@ -179,7 +180,7 @@ $(function () {
   $messages.scroll(function() {
     var position = $messages.prop("scrollHeight") - $messages.scrollTop() - $messages.height() - 30;
     if(position > 0 && following) {
-      $("#output-steady").click();
+      $("#output-no-follow").click();
     } else if (position < 0 && !following) {
       $("#output-follow").click();
     }

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -141,6 +141,8 @@ $(function () {
   });
 
   $("#output-expand").click(function() {
+    following = false;
+
     growOutput();
 
     $("#output-options > button").removeClass("active");

--- a/app/views/shared/_output.html.erb
+++ b/app/views/shared/_output.html.erb
@@ -3,11 +3,11 @@
     <div class="btn-toolbar pull-right" id="output-toolbar">
       <div id="output-options" class="btn-group only-active">
         <button class="btn btn-default active" id="output-follow">Follow</button>
-        <button class="btn btn-default" id="output-steady">Don't Follow</button>
-        <button class="btn btn-default" id="output-grow">Expand</button>
+        <button class="btn btn-default" id="output-no-follow">Don't Follow</button>
+        <button class="btn btn-default" id="output-expand">Expand</button>
       </div>
 
-      <button class="btn btn-default only-finished" id="output-grow-toggle">Expand</button>
+      <button class="btn btn-default only-finished" id="output-expand-toggle">Expand</button>
       <%= link_to "Download log", [@project, deployable, {format: :text}], class: "btn btn-primary only-finished" %>
 
       <% if deployable.can_be_stopped_by?(current_user) %>


### PR DESCRIPTION
 - when scrolling around output got resized to 550px
 - move following logic into a sane order and name the ids after the button labels
 - do not scroll the user when in expanded mode
 - do not follow/unfollow when in expanded mode