### PR TITLE
allow exporting of projects to a CSV file

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -24,7 +24,7 @@ class ProjectsController < ApplicationController
       end
 
       format.csv do
-        datetime = Time.now.strftime "%Y%m%d_%H%M"
+        datetime = Time.now.strftime "%Y-%m-%d_%H-%M"
         send_data as_csv, type: :csv, filename: "Projects_#{datetime}.csv"
       end
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'csv'
+
 class ProjectsController < ApplicationController
   include CurrentProject
 
@@ -19,6 +21,11 @@ class ProjectsController < ApplicationController
 
       format.json do
         render json: Project.ordered_for_user(current_user).all
+      end
+
+      format.csv do
+        datetime = Time.now.strftime "%Y%m%d_%H%M"
+        send_data as_csv, type: :csv, filename: "Projects_#{datetime}.csv"
       end
     end
   end
@@ -99,5 +106,17 @@ class ProjectsController < ApplicationController
   # Overriding require_project from CurrentProject
   def require_project
     @project = (Project.find_by_param!(params[:id]) if params[:id])
+  end
+
+  def as_csv
+    projects = Project.order(:id).all
+
+    CSV.generate do |csv|
+      csv << ProjectSerializer.csv_header
+
+      projects.each do |project|
+        csv << ProjectSerializer.new(project).csv_line
+      end
+    end
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ProjectSerializer < ActiveModel::Serializer
-  PROPERTIES = [:id, :name, :url, :permalink, :repository_url, :owner, :created_at]
+  PROPERTIES = [:id, :name, :url, :permalink, :repository_url, :owner, :created_at].freeze
   attributes *PROPERTIES
 
   def self.csv_header

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 class ProjectSerializer < ActiveModel::Serializer
-  attributes :id, :name, :url, :permalink, :repository_url
+  attributes :id, :name, :url, :permalink, :repository_url, :owner, :created_at
+
+  def self.csv_header
+    ['ID', 'Name', 'URL', 'Permalink', 'Repository URL', 'Owner', 'Created At']
+  end
 
   def url
     Rails.application.routes.url_helpers.project_url(object)
+  end
+
+  def csv_line
+    to_h.values
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 class ProjectSerializer < ActiveModel::Serializer
-  attributes :id, :name, :url, :permalink, :repository_url, :owner, :created_at
+  PROPERTIES = [:id, :name, :url, :permalink, :repository_url, :owner, :created_at]
+  attributes *PROPERTIES
 
   def self.csv_header
-    ['ID', 'Name', 'URL', 'Permalink', 'Repository URL', 'Owner', 'Created At']
+    PROPERTIES.map { |p| p.to_s.humanize }
   end
 
   def url
@@ -11,6 +12,6 @@ class ProjectSerializer < ActiveModel::Serializer
   end
 
   def csv_line
-    to_h.values
+    PROPERTIES.map { |p| object.public_send p }
   end
 end

--- a/test/controllers/api/projects_controller_test.rb
+++ b/test/controllers/api/projects_controller_test.rb
@@ -21,7 +21,8 @@ describe Api::ProjectsController do
 
     it 'lists projects' do
       subject.keys.must_equal ['projects']
-      subject['projects'].first.keys.sort.must_equal ["id", "name", "permalink", "repository_url", "url"]
+      keys = subject['projects'].first.keys.sort
+      keys.must_equal ["created_at", "id", "name", "owner", "permalink", "repository_url", "url"]
     end
   end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -59,7 +59,7 @@ describe ProjectsController do
         all_projects = Project.order(:id).to_a
 
         csv.each_with_index do |row, idx|
-          %w(ID Name URL).each do |attr|
+          %w[ID Name URL].each do |attr|
             row.headers.must_include attr
           end
           row['ID'].must_equal all_projects[idx].id.to_s

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -59,10 +59,10 @@ describe ProjectsController do
         all_projects = Project.order(:id).to_a
 
         csv.each_with_index do |row, idx|
-          %w[ID Name URL].each do |attr|
+          %w[Id Name Url].each do |attr|
             row.headers.must_include attr
           end
-          row['ID'].must_equal all_projects[idx].id.to_s
+          row['Id'].must_equal all_projects[idx].id.to_s
         end
       end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -53,6 +53,19 @@ describe ProjectsController do
         result['projects'].map(&:symbolize_keys!).map { |obj| obj[:name] }.must_equal ['Project']
       end
 
+      it "responds to CSV requests" do
+        get :index, params: { format: 'csv' }
+        csv = CSV.new(response.body, headers: true)
+        all_projects = Project.order(:id).to_a
+
+        csv.each_with_index do |row, idx|
+          %w(ID Name URL).each do |attr|
+            row.headers.must_include attr
+          end
+          row['ID'].must_equal all_projects[idx].id.to_s
+        end
+      end
+
       it 'renders starred projects first for json' do
         starred_project1 = Project.create!(name: 'Z', repository_url: 'Z')
         starred_project2 = Project.create!(name: 'A', repository_url: 'A')

--- a/test/serializers/project_serializer_test.rb
+++ b/test/serializers/project_serializer_test.rb
@@ -5,9 +5,26 @@ SingleCov.covered!
 
 describe ProjectSerializer do
   let(:project) { projects(:test) }
-  let(:parsed) { JSON.parse(ProjectSerializer.new(project).to_json) }
+  let(:serializer) { ProjectSerializer.new(project) }
+  let(:parsed) { JSON.parse(serializer.to_json) }
 
   it 'serializes url' do
     parsed['url'].must_equal "http://www.test-url.com/projects/foo"
+  end
+
+  describe '.csv_header' do
+    it 'returns an array of strings' do
+      header = ProjectSerializer.csv_header
+      header.must_be_kind_of Array
+      header.first.must_equal 'ID'
+    end
+  end
+
+  describe '#csv_line' do
+    it 'returns a CSV line' do
+      line = serializer.csv_line
+      line.must_be_kind_of Array
+      line.first.must_equal project.id
+    end
   end
 end

--- a/test/serializers/project_serializer_test.rb
+++ b/test/serializers/project_serializer_test.rb
@@ -16,7 +16,7 @@ describe ProjectSerializer do
     it 'returns an array of strings' do
       header = ProjectSerializer.csv_header
       header.must_be_kind_of Array
-      header.first.must_equal 'ID'
+      header.first.must_equal 'Id'
     end
   end
 


### PR DESCRIPTION
I wanted to download a CSV file of all the projects in Samson, along with their owners, so we could see which projects belonged to which teams, and so we can easily export the set of projects into a spreadsheet.

/cc @zendesk/samson, @pswadi-zendesk, @JLandersZen, @kazraza 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
