### PR TITLE
prevent accidental secret override during creation

### DIFF
--- a/app/controllers/admin/secrets_controller.rb
+++ b/app/controllers/admin/secrets_controller.rb
@@ -28,7 +28,11 @@ class Admin::SecretsController < ApplicationController
   end
 
   def create
-    update
+    if SecretStorage.exist?(key)
+      failure_response "The secret #{key} already exists."
+    else
+      update
+    end
   end
 
   def show
@@ -56,7 +60,7 @@ class Admin::SecretsController < ApplicationController
   end
 
   def key
-    params[:id] || SecretStorage.generate_secret_key(secret_params.slice(*SecretStorage::SECRET_KEYS_PARTS))
+    @key ||= (params[:id] || SecretStorage.generate_secret_key(secret_params.slice(*SecretStorage::SECRET_KEYS_PARTS)))
   end
 
   def project_permalink

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -34,6 +34,10 @@ module SecretStorage
       data
     end
 
+    def exist?(key)
+      !!(backend.read_multi([key]).values.map(&:nil?) == [false])
+    end
+
     # reads multiple keys from the backend into a hash, not raising on missing
     # [a, b, c] -> {a: 1, c: 2}
     def read_multi(keys, include_value: false)

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -119,6 +119,26 @@ describe SecretStorage do
     end
   end
 
+  describe ".exist?" do
+    it "is true when when it exists" do
+      SecretStorage.exist?(secret.id).must_equal true
+    end
+
+    it "is false on unknown" do
+      SecretStorage.exist?('sdfsfsf').must_equal false
+    end
+
+    it "is false when backend returns no values" do
+      SecretStorage.backend.expects(:read_multi).returns({})
+      SecretStorage.exist?('sdfsfsf').must_equal false
+    end
+
+    it "is false when backend returns nil values" do
+      SecretStorage.backend.expects(:read_multi).returns(foo: nil)
+      SecretStorage.exist?('sdfsfsf').must_equal false
+    end
+  end
+
   describe ".read_multi" do
     it "reads" do
       data = SecretStorage.read_multi([secret.id], include_value: true)


### PR DESCRIPTION
currently when you accidentally pick an existing key/env/group combination it silently overrides the existing secret ... can easily happen during 'create new and make another' workflow

![screen shot 2017-02-24 at 3 24 18 pm](https://cloud.githubusercontent.com/assets/11367/23324833/54eb41f0-faa5-11e6-9867-c1e3feda6617.png)
