### PR TITLE
deprecate basic strategy by allowing OAuth to replace it

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,4 +26,4 @@ en:
       help:
         # Ideally make dynamic https://github.com/doorkeeper-gem/doorkeeper/issues/896
         # and enforce inclusion ... for now keep in sync with api controllers
-        scopes: "Separate scopes with spaces. Possible: automated_deploys, builds, deploy_groups, deploys, locks, projects, stages, default (everything)"
+        scopes: "Separate scopes with spaces. Possible: automated_deploys, builds, deploy_groups, deploys, locks, projects, stages, default (api/*), web-ui (non api/)"

--- a/lib/warden/strategies/basic_strategy.rb
+++ b/lib/warden/strategies/basic_strategy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Strategy that allows login via email / token header
+# DEPRECATED: use OAuth
 class Warden::Strategies::BasicStrategy < Warden::Strategies::Base
   KEY = :basic
 

--- a/lib/warden/strategies/doorkeeper_strategy.rb
+++ b/lib/warden/strategies/doorkeeper_strategy.rb
@@ -3,31 +3,28 @@
 # Strategy that allows login via OAuth baerer token
 class Warden::Strategies::Doorkeeper < ::Warden::Strategies::Base
   KEY = :doorkeeper
+  WEB_UI_SCOPE = 'web-ui'
 
   def valid?
     request.authorization.to_s.start_with?("Bearer ")
   end
 
   def authenticate!
-    if !request.path.start_with?('/api/')
-      custom! [400, {}, ["Only api can be used with OAuth tokens"]]
-    else
-      token = ::Doorkeeper::OAuth::Token.authenticate(request, :from_bearer_authorization)
-      requested_scope = request.env.fetch('requested_oauth_scope')
+    token = ::Doorkeeper::OAuth::Token.authenticate(request, :from_bearer_authorization)
+    requested_scope = request.env.fetch('requested_oauth_scope')
 
-      if !token
-        halt_json "Unable to find OAuth token"
-      elsif !token.accessible?
-        halt_json "OAuth token is expired"
-      elsif !token.acceptable?('default') && !token.acceptable?(requested_scope)
-        halt_json "OAuth token does not have scope #{requested_scope}"
-      elsif !(user = User.find_by_id(token.resource_owner_id))
-        halt_json "OAuth token belongs to deleted user #{token.resource_owner_id}"
-      else
-        token.update_column(:last_used_at, Time.now) unless token.last_used_at&.> 1.minutes.ago
-        request.session_options[:skip] = true # do not store user in session
-        success! user
-      end
+    if !token
+      halt_json "Unable to find OAuth token"
+    elsif !token.accessible?
+      halt_json "OAuth token is expired"
+    elsif (requested_scope == WEB_UI_SCOPE || !token.acceptable?('default')) && !token.acceptable?(requested_scope)
+      halt_json "OAuth token does not have scope #{requested_scope}"
+    elsif !(user = User.find_by_id(token.resource_owner_id))
+      halt_json "OAuth token belongs to deleted user #{token.resource_owner_id}"
+    else
+      token.update_column(:last_used_at, Time.now) unless token.last_used_at&.> 1.minutes.ago
+      request.session_options[:skip] = true # do not store user in session
+      success! user
     end
   end
 

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -72,4 +72,60 @@ describe ApplicationController do
       end
     end
   end
+
+  describe "#store_requested_oauth_scope" do
+    it "stores the web-ui scope" do
+      get :test_render, params: {test_route: true}
+      request.env['requested_oauth_scope'].must_equal 'web-ui'
+    end
+  end
+end
+
+describe "ApplicationController Integration" do
+  let(:user) { users(:super_admin) }
+  let(:token) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, scopes: 'default') }
+
+  describe "#using_per_request_auth?" do
+    let(:post_params) { {lock: {resource_id: nil, resource_type: nil}, format: :json} }
+
+    with_forgery_protection
+
+    it 'can POST without authenticity_token when logging in via per request doorkeeper auth' do
+      post '/api/locks', params: post_params, headers: {'Authorization' => "Bearer #{token.token}"}
+      assert_response :success
+    end
+
+    it 'can POST without authenticity_token when logging in via per request basic auth' do
+      auth = "Basic #{Base64.encode64(user.email + ':' + user.token).strip}"
+      post '/api/locks', params: post_params, headers: {'Authorization' => auth}
+      assert_response :success
+    end
+
+    it 'does not authenticate twice' do
+      ::Doorkeeper::OAuth::Token.expects(:authenticate).returns(token) # called inside of DoorkeeperStrategy
+      post '/api/locks', params: post_params, headers: {'Authorization' => "Bearer #{token.token}"}
+      assert_response :success
+    end
+
+    describe "when in the browser" do
+      before { stub_session_auth }
+
+      it 'can GET without authenticity_token' do
+        get '/api/locks', params: {format: :json}
+        assert_response :success
+      end
+
+      it 'cannot POST without authenticity_token' do
+        assert_raises ActionController::InvalidAuthenticityToken do
+          post '/api/locks', params: post_params
+        end
+      end
+    end
+
+    it 'cannot POST without authenticity_token when not logged in' do
+      assert_raises ActionController::InvalidAuthenticityToken do
+        post '/api/locks', params: post_params
+      end
+    end
+  end
 end

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -41,14 +41,6 @@ describe "cleanliness" do
     end
   end
 
-  it "does not use let(:user) inside of a as_xyz block" do
-    assert_content all_tests do |content|
-      if content.include?("  as_") && content.include?("let(:user)")
-        "uses as_xyz and let(:user) these do not mix!"
-      end
-    end
-  end
-
   it "does not have public actions on base controller" do
     found = ApplicationController.action_methods.to_a
     found.reject! { |a| a =~ /^(_conditional_callback_around_|_callback_before_)/ }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -218,6 +218,12 @@ class ActionController::TestCase
       define_method "as_a_#{user}" do |&block|
         describe "as a #{user}" do
           let(:user) { users(user) }
+
+          def self.let(*args)
+            raise "Cannot override :user in as_a_*" if args.first.to_sym == :user
+            super
+          end
+
           before { login_as(self.user) } # rubocop:disable Style/RedundantSelf
           instance_eval(&block)
         end


### PR DESCRIPTION
/cc @zendesk/samson
/fyi @apanzerj 

Get and Post requests work with this strategy (posting with basic never worked ...)
and the UI is much better anyway ... so we can get rid of the user token in time

new scope: web-ui allows access to everything that is not api ... and allows posting ... default scope does not include web-ui to not add new permissions that users did not want

```
curl -X PATCH -H "Authorization: Bearer TOKEN-GOES-HERE" 'http://localhost:3000/profile?user%5Bemail%5D=sdfsdf@sdfsfd.dd'
<html><body>You are being <a href="http://localhost:3000/profile">redirected</a>.</body></html>
```