### PR TITLE
check that every action has authentification tests

### DIFF
--- a/app/controllers/admin/deploy_groups_controller.rb
+++ b/app/controllers/admin/deploy_groups_controller.rb
@@ -99,12 +99,6 @@ class Admin::DeployGroupsController < ApplicationController
     render_failures try_each_cloned_stage { |stage| delete_stage(stage) }
   end
 
-  def render_failures(failures)
-    message = failures.map { |reason, stage| "#{stage.project.name} #{stage.name} #{reason}" }.join(", ")
-
-    redirect_to [:admin, deploy_group], alert: (failures.empty? ? nil : "Some stages were skipped: #{message}")
-  end
-
   def self.create_all_stages(deploy_group)
     _, missing_stages = stages_for_creation(deploy_group)
     missing_stages.map do |template_stage|
@@ -113,6 +107,12 @@ class Admin::DeployGroupsController < ApplicationController
   end
 
   private
+
+  def render_failures(failures)
+    message = failures.map { |reason, stage| "#{stage.project.name} #{stage.name} #{reason}" }.join(", ")
+
+    redirect_to [:admin, deploy_group], alert: (failures.empty? ? nil : "Some stages were skipped: #{message}")
+  end
 
   # executes the block for each cloned stage, returns an array of [result, stage] any non-nil responses.
   def try_each_cloned_stage

--- a/app/controllers/admin/environments_controller.rb
+++ b/app/controllers/admin/environments_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Admin::EnvironmentsController < ApplicationController
-  before_action :authorize_admin!, except: [:index]
-  before_action :authorize_super_admin!, only: [:create, :new, :show, :update, :destroy]
+  before_action :authorize_super_admin!, except: [:index]
   before_action :environment, only: [:show, :update, :destroy]
 
   def index

--- a/plugins/env/test/controllers/admin/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/admin/environment_variable_groups_controller_test.rb
@@ -17,7 +17,12 @@ describe Admin::EnvironmentVariableGroupsController do
     )
   end
 
-  as_a_deployer do
+  as_a_viewer do
+    unauthorized :get, :new
+    unauthorized :post, :create
+    unauthorized :patch, :update, id: 1
+    unauthorized :delete, :destroy, id: 1
+
     describe "#index" do
       it "renders" do
         get :index
@@ -49,23 +54,6 @@ describe Admin::EnvironmentVariableGroupsController do
         assert_response :success
       end
     end
-
-    it 'responds with unauthorized' do
-      post :create, params: {authenticity_token: set_form_authenticity_token}
-      assert_response :unauthorized
-    end
-
-    it 'responds with unauthorized' do
-      delete :destroy, params: {id: 1, authenticity_token: set_form_authenticity_token}
-      assert_response :unauthorized
-    end
-
-    it 'responds with unauthorized' do
-      post :update, params: {id: 1, authenticity_token: set_form_authenticity_token}
-      assert_response :unauthorized
-    end
-
-    unauthorized :get, :new
   end
 
   as_a_admin do
@@ -84,8 +72,7 @@ describe Admin::EnvironmentVariableGroupsController do
               environment_variable_group: {
                 environment_variables_attributes: {"0" => {name: "N1", value: "V1"}},
                 name: "G2"
-              },
-              authenticity_token:  set_form_authenticity_token
+              }
             }
           end
         end
@@ -106,8 +93,7 @@ describe Admin::EnvironmentVariableGroupsController do
               environment_variables_attributes: {
                 "0" => {name: "N1", value: "V1"}
               }
-            },
-            authenticity_token:  set_form_authenticity_token
+            }
           }
         end
 
@@ -126,8 +112,7 @@ describe Admin::EnvironmentVariableGroupsController do
               environment_variables_attributes: {
                 "0" => {name: "N1", value: "V2", scope_type_and_id: "DeployGroup-#{deploy_group.id}", id: variable.id}
               }
-            },
-            authenticity_token:  set_form_authenticity_token
+            }
           }
         end
 
@@ -144,8 +129,7 @@ describe Admin::EnvironmentVariableGroupsController do
               environment_variables_attributes: {
                 "0" => {name: "N1", value: "V2", id: variable.id, _destroy: true}
               }
-            },
-            authenticity_token:  set_form_authenticity_token
+            }
           }
         end
 
@@ -157,7 +141,7 @@ describe Admin::EnvironmentVariableGroupsController do
       it "destroy" do
         env_group
         assert_difference "EnvironmentVariableGroup.count", -1 do
-          delete :destroy, params: {id: env_group.id, authenticity_token:  set_form_authenticity_token}
+          delete :destroy, params: {id: env_group.id}
         end
         assert_redirected_to "/admin/environment_variable_groups"
       end

--- a/plugins/kubernetes/test/controllers/admin/kubernetes/clusters_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/admin/kubernetes/clusters_controller_test.rb
@@ -14,6 +14,7 @@ describe Admin::Kubernetes::ClustersController do
     unauthorized :get, :index
     unauthorized :get, :new
     unauthorized :post, :create
+    unauthorized :get, :show, id: 1
     unauthorized :get, :edit, id: 1
     unauthorized :patch, :update, id: 1
     unauthorized :post, :seed_ecr, id: 1
@@ -29,6 +30,15 @@ describe Admin::Kubernetes::ClustersController do
       it "renders" do
         get :index
         assert_template :index
+      end
+    end
+
+    describe "#show" do
+      use_example_config
+
+      it "renders" do
+        get :show, params: {id: cluster.id}
+        assert_template :show
       end
     end
 
@@ -84,15 +94,6 @@ describe Admin::Kubernetes::ClustersController do
         params.delete(:name)
         post :create, params: {kubernetes_cluster: params}
         assert_template :edit
-      end
-    end
-
-    describe "#show" do
-      use_example_config
-
-      it "renders" do
-        get :show, params: {id: cluster.id}
-        assert_template :show
       end
     end
 

--- a/plugins/slack_app/app/controllers/slack_app_controller.rb
+++ b/plugins/slack_app/app/controllers/slack_app_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 class SlackAppController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:command, :interact]
-  skip_around_action :login_user, except: :oauth
+  PUBLIC = [:command, :interact].freeze
+  skip_before_action :verify_authenticity_token, only: PUBLIC
+  skip_around_action :login_user, only: PUBLIC
 
   before_action :handle_slack_inputs
 

--- a/test/controllers/admin/deploy_groups_controller_test.rb
+++ b/test/controllers/admin/deploy_groups_controller_test.rb
@@ -19,6 +19,8 @@ describe Admin::DeployGroupsController do
     unauthorized :post, :deploy_all, id: 1
     unauthorized :post, :create_all_stages, id: 1
     unauthorized :post, :delete_all_stages, id: 1
+    unauthorized :post, :merge_all_stages, id: 1
+    unauthorized :get, :create_all_stages_preview, id: 1
   end
 
   as_a_admin do

--- a/test/controllers/admin/environments_controller_test.rb
+++ b/test/controllers/admin/environments_controller_test.rb
@@ -4,48 +4,39 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Admin::EnvironmentsController do
-  def self.it_renders_index
-    it 'get :index succeeds' do
-      get :index
-      assert_response :success
-      assert_select('tbody tr').count.must_equal Environment.count
+  as_a_viewer do
+    describe "#index" do
+      it 'renders' do
+        get :index
+        assert_response :success
+        assert_select('tbody tr').count.must_equal Environment.count
+      end
+
+      it 'renders json' do
+        get :index, format: 'json'
+        result = JSON.parse(response.body)
+        result.wont_be_nil
+        result['environments'].count.must_equal Environment.count
+      end
     end
-  end
-
-  def self.it_renders_index_with_json_format
-    it 'get :index with format json succeeds' do
-      get :index, params: {format: 'json'}
-      result = JSON.parse(response.body)
-      result.wont_be_nil
-      result['environments'].count.must_equal Environment.count
-    end
-  end
-
-  as_a_deployer do
-    it_renders_index
-    it_renders_index_with_json_format
-
-    unauthorized :get, :new
-    unauthorized :post, :create
-    unauthorized :delete, :destroy, id: 1
-    unauthorized :post, :update, id: 1
   end
 
   as_a_admin do
     unauthorized :post, :create
     unauthorized :get, :new
+    unauthorized :get, :show, id: 1
     unauthorized :delete, :destroy, id: 1
     unauthorized :post, :update, id: 1
     unauthorized :put, :update, id: 1
   end
 
   as_a_super_admin do
-    it_renders_index
-
-    it 'get :new succeeds' do
-      get :new
-      assert_response :success
-      assert assigns(:environment)
+    describe "#new" do
+      it 'renders' do
+        get :new
+        assert_response :success
+        assert assigns(:environment)
+      end
     end
 
     describe '#create' do
@@ -61,6 +52,13 @@ describe Admin::EnvironmentsController do
         post :create, params: {environment: {name: nil, production: true}}
         assert_template :show
         Environment.count.must_equal env_count
+      end
+    end
+
+    describe "#show" do
+      it "renders" do
+        get :show, params: {id: environments(:production).id}
+        assert_response :success
       end
     end
 

--- a/test/controllers/admin/secrets_controller_test.rb
+++ b/test/controllers/admin/secrets_controller_test.rb
@@ -26,8 +26,13 @@ describe Admin::SecretsController do
   end
 
   as_a_viewer do
+    before { create_secret 'production/foo/group/bar' }
+
     unauthorized :get, :index
     unauthorized :get, :new
+    unauthorized :get, :show, id: 'production/foo/group/bar'
+    unauthorized :patch, :update, id: 'production/foo/group/bar'
+    unauthorized :delete, :destroy, id: 'production/foo/group/bar'
   end
 
   as_a_project_deployer do

--- a/test/controllers/api/automated_deploys_controller_test.rb
+++ b/test/controllers/api/automated_deploys_controller_test.rb
@@ -4,10 +4,6 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Api::AutomatedDeploysController do
-  def post_create
-    post :create, params: {project_id: :foo, deploy_group: 'pod100', env: {'FOO' => "bar\nba$"}}, format: :json
-  end
-
   before do
     # trigger deploy validation error we saw in staging ... validate_stage_uses_deploy_groups_properly
     # we set $DEPLOY_GROUPS via before_command but do not select any deploy group
@@ -18,6 +14,10 @@ describe Api::AutomatedDeploysController do
   oauth_setup!
 
   describe "#create" do
+    def post_create
+      post :create, params: {project_id: :foo, deploy_group: 'pod100', env: {'FOO' => "bar\nba$"}}, format: :json
+    end
+
     let(:template) { stages(:test_staging) }
     let(:copied_deploy) { deploys(:failed_staging_test) }
 

--- a/test/controllers/api/locks_controller_test.rb
+++ b/test/controllers/api/locks_controller_test.rb
@@ -9,6 +9,7 @@ describe Api::LocksController do
     unauthorized :get, :index
     unauthorized :post, :create # TODO: should allow to create a stage lock as a project deployer
     unauthorized :delete, :destroy, id: 1
+    unauthorized :delete, :destroy_via_resource
   end
 
   as_a_admin do

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -265,6 +265,7 @@ describe DeploysController do
     unauthorized :post, :create, project_id: :foo, stage_id: 2
     unauthorized :post, :buddy_check, project_id: :foo, id: 1
     unauthorized :delete, :destroy, project_id: :foo, id: 1
+    unauthorized :post, :confirm, project_id: :foo, stage_id: 2
   end
 
   as_a_project_deployer do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -252,10 +252,6 @@ class ActionController::TestCase
     Warden.test_reset!
   end
 
-  def set_form_authenticity_token
-    session[:_csrf_token] = SecureRandom.base64(32)
-  end
-
   def warden
     request.env['warden']
   end


### PR DESCRIPTION
@zendesk/samson 

static analysis of controller tests to find the ones missing authentication tests
 - find all controller actions
 - substract methods tested as 'public' or as 'for viewer' or as unauthenticated
 - report the remainder as bad

bad: we do not check that deployers or viewers do not have access
```Ruby
as_a_admin do
  get :show
  assert_response :success
end
```

good:
```Ruby
as_a_deployer do
  unauthorized :get, :show
end
as_a_admin do
  get :show
  assert_response :success
end
```