### PR TITLE
improve instructions and layout for pre docker build

### DIFF
--- a/app/views/build_commands/show.html.erb
+++ b/app/views/build_commands/show.html.erb
@@ -6,13 +6,16 @@
   <%= form_for @command, url: project_build_command_path(@project), html: { class: "form-horizontal", method: :patch } do |form| %>
     <%= render 'shared/errors', object: @command %>
 
-    <div class="col-lg-offset-2">
-      This command will be run before a new docker image is built.
-      <%= form.text_area :command, size: '120x10' %>
-    </div>
+    This command will run before a docker image is built.<br/>
+    Use it to build artifacts and store them in $CACHE_DIR.<br/>
+    Ideally execute a comitted <%= link_to "build.sh", "https://github.com/zendesk/samson/blob/master/docs/pre_build_command_example.md" %>
+    that can be reused and debugged locally.<br/>
 
-    <%= form.actions do %>
-    | <%= link_to_history @command %>
-    <% end %>
+    <br/>
+
+    <%= form.text_area :command, cols: 155, rows: [form.object.command.to_s.count("\n") + 1, 10].max %>
+
+    <%= form.submit "Save", class: "btn btn-primary" %> |
+    <%= link_to_history @command %>
   <% end %>
 </section>

--- a/docs/pre_build_command_example.md
+++ b/docs/pre_build_command_example.md
@@ -1,0 +1,16 @@
+Example `build.sh` that uses a secondary `Dockerfile.build` to generate artifacts the main `Dockerfile`
+cannot produce without adding secrets or installing dev-tools that increase the image size.
+
+```Bash
+# This script prepares the target folder with compiled classes that the main Dockerfile needs to build the main image
+# This can be used both locally and on samson.
+test -n "$ARTIFACTORY_USERNAME" && test -n "$ARTIFACTORY_KEY" && \ # make sure we have all env vars we need
+    set -x && \ # show what we run so it is easy to debug
+    rm -rf target build_container_id && \ # cleanup before we start
+    docker build -t app_binary_builder -f Dockerfile.build . && \
+    docker run --cidfile build_container_id -e ARTIFACTORY_USERNAME -e ARTIFACTORY_KEY app_binary_builder command_goes_here && \
+    docker cp $(cat build_container_id):/app/target . && \ # copy generated artifacts to disk
+    touch done
+
+docker rm $(cat build_container_id) && docker rmi app_binary_builder && rm done # cleanup and fail when something went wrong
+```


### PR DESCRIPTION
@prudhvi 

makes the textarea always show the full command and gives more details on what this should be used for.

<img width="863" alt="screen shot 2017-02-26 at 9 06 29 pm" src="https://cloud.githubusercontent.com/assets/11367/23349373/8d4f93de-fc67-11e6-8242-1c69cb020487.png">
