### PR TITLE
make command deletion ajax to be less anooying and flow interrupting

### DIFF
--- a/app/assets/javascripts/remove_container.js.erb
+++ b/app/assets/javascripts/remove_container.js.erb
@@ -1,0 +1,23 @@
+// clicking the 'delete' link sends a DELETE and removes the container the 'delete' is in
+$(document).on('click', 'a.remove_container', function() {
+  var $link = $(this);
+  var $container = $link.closest($link.data('remove-container'));
+  var loading = '<center><%= image_tag "ajax-loader.gif" %></center>';
+  $container.html(loading);
+
+  $.ajax({
+    url: $link.attr('href'),
+    type: 'POST',
+    data: '_method=DELETE',
+    statusCode: {
+      200: function() {
+        $container.html('Done!');
+        $container.hide('slow');
+      }
+    },
+    error: function() {
+      $container.html("Error");
+    }
+  });
+  return false;
+});

--- a/app/assets/javascripts/responsive_load.js.erb
+++ b/app/assets/javascripts/responsive_load.js.erb
@@ -1,6 +1,6 @@
 // show loading animation and errors inside the container that is being replaced
 $.fn.responsiveLoad = function(url, callback){
-  var loading = '<center><img src="<%= asset_path "ajax-loader.gif" %>" alt="Loading"/></center>';
+  var loading = '<center><%= image_tag "ajax-loader.gif" %></center>';
   var $container = $(this);
   var height = $container.height();
   $container.html(loading).css("height", height + "px").load(url, function(response, status, xhr){

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,7 +115,14 @@ module ApplicationHelper
         else
           "Are you sure ?"
         end
-      link_to text, path, options.merge(method: :delete, data: { confirm: message })
+      options[:data] = {confirm: message}
+      if container = options[:remove_container]
+        options[:data][:remove_container] = container
+        options[:class] = "remove_container"
+      else
+        options[:method] = :delete
+      end
+      link_to text, path, options
     end
   end
 

--- a/app/views/admin/commands/index.html.erb
+++ b/app/views/admin/commands/index.html.erb
@@ -35,7 +35,7 @@
             <% if used > 0 %>
               <%= content_tag :span, "Used by #{used}", title: "Click Edit to see usage details" %>
             <% else %>
-              <%= link_to_delete([:admin, command]) %>
+              <%= link_to_delete([:admin, command], remove_container: 'tr') %>
             <% end %>
           </td>
         </tr>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -286,6 +286,13 @@ describe ApplicationHelper do
         "<span title=\"Foo\" class=\"mouseover\">Delete</span>"
       )
     end
+
+    it "adds data/class attribute for remove_container" do
+      html = link_to_delete("/foo", remove_container: "tr")
+      html.must_include "data-remove-container=\"tr\""
+      html.must_include "class=\"remove_container\""
+      html.wont_include "method" # would conflict between our js and rails ujs
+    end
   end
 
   describe "#link_to_delete_button" do


### PR DESCRIPTION
before: clicking navigates to commands index page, losing current scope
after:
<img width="1029" alt="screen shot 2017-02-27 at 5 58 14 pm" src="https://cloud.githubusercontent.com/assets/11367/23388491/5db2726c-fd17-11e6-80e4-9ba76fd8c16f.png">
<img width="418" alt="screen shot 2017-02-27 at 5 58 25 pm" src="https://cloud.githubusercontent.com/assets/11367/23388493/5f8ab09a-fd17-11e6-8822-9ed253042b79.png">
<img width="931" alt="screen shot 2017-02-27 at 6 03 25 pm" src="https://cloud.githubusercontent.com/assets/11367/23388494/61e27044-fd17-11e6-8186-6b3baad46ef3.png">
and then it disappears
