### PR TITLE
let users filter secrets by project/key

### DIFF
--- a/app/controllers/admin/secrets_controller.rb
+++ b/app/controllers/admin/secrets_controller.rb
@@ -16,6 +16,11 @@ class Admin::SecretsController < ApplicationController
     if query = params.dig(:search, :query).presence
       @secret_keys.select! { |s| s.include?(query) }
     end
+    [:key, :project_permalink].each do |part|
+      if value = params.dig(:search, part).presence
+        @secret_keys = @secret_keys.grep(SecretStorage.secret_key_regex(part, value))
+      end
+    end
   rescue Samson::Secrets::BackendError => e
     flash[:error] = e.message
     render html: "", layout: true

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -68,6 +68,13 @@ module SecretStorage
       SECRET_KEYS_PARTS.zip(key.split(SEPARATOR, SECRET_KEYS_PARTS.size)).to_h
     end
 
+    def secret_key_regex(part, content)
+      position = SECRET_KEYS_PARTS.index(part) || raise("Unknown part #{part.inspect}")
+      matcher = Array.new(4) { "(?:[^/]+)" }
+      matcher[position] = Regexp.escape(content)
+      %r{\A#{matcher.join("/")}\z}
+    end
+
     private
 
     def modify_keys_cache

--- a/app/views/admin/commands/index.html.erb
+++ b/app/views/admin/commands/index.html.erb
@@ -5,7 +5,7 @@
   <div class="col-sm-3">
     <%= label_tag "Project" %><br/>
     <% options = options_for_select([['Global', 'global']] + Project.order('name asc').pluck(:name, :id), params[:search].try(:[], :project_id)) %>
-    <%= select_tag 'search[project_id]', options, include_blank: "", class: "form-control", style: "background-color: white; width: 100%; height: 35px" %>
+    <%= select_tag 'search[project_id]', options, include_blank: "", class: "form-control" %>
   </div>
   <%= render 'shared/search_button' %>
 <% end %>

--- a/app/views/admin/secrets/index.html.erb
+++ b/app/views/admin/secrets/index.html.erb
@@ -4,6 +4,18 @@
 
 <%= form_tag '?', method: :get, class: 'clearfix' do %>
   <%= render 'shared/search_query' %>
+
+  <div class="col-sm-2">
+    <%= label_tag "Project" %><br/>
+    <% options = options_for_select([['Global', 'global']] + Project.order('name asc').pluck(:name, :permalink), params[:search].try(:[], :project_permalink)) %>
+    <%= select_tag 'search[project_permalink]', options, include_blank: "", class: "form-control" %>
+  </div>
+
+  <div class="col-sm-2">
+    <%= label_tag "Key" %><br/>
+    <%= text_field_tag 'search[key]', params[:search].try(:[], :key), class: "form-control" %>
+  </div>
+
   <%= render 'shared/search_button' %>
 
   <div class="pull-right">

--- a/test/controllers/admin/secrets_controller_test.rb
+++ b/test/controllers/admin/secrets_controller_test.rb
@@ -53,11 +53,25 @@ describe Admin::SecretsController do
         response.body.wont_include secret.value
       end
 
-      it 'can filter' do
+      it 'can filter by query' do
         create_secret 'production/global/pod2/bar'
         get :index, params: {search: {query: 'bar'}}
         assert_template :index
         assigns[:secret_keys].must_equal ['production/global/pod2/bar']
+      end
+
+      it 'can filter by project' do
+        create_secret 'production/foo-bar/pod2/bar'
+        get :index, params: {search: {project_permalink: 'foo-bar'}}
+        assert_template :index
+        assigns[:secret_keys].must_equal ['production/foo-bar/pod2/bar']
+      end
+
+      it 'can filter by key' do
+        create_secret 'production/foo-bar/pod2/bar'
+        get :index, params: {search: {key: 'bar'}}
+        assert_template :index
+        assigns[:secret_keys].must_equal ['production/foo-bar/pod2/bar']
       end
 
       it 'raises when vault server is broken' do

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -101,6 +101,13 @@ describe SecretStorage do
     end
   end
 
+  describe ".secret_key_regex" do
+    it "can build a regex" do
+      SecretStorage.secret_key_regex(:project_permalink, 'foo.bar').
+        must_equal %r{\A(?:[^/]+)/foo\.bar/(?:[^/]+)/(?:[^/]+)\z}
+    end
+  end
+
   describe ".read" do
     it "reads" do
       data = SecretStorage.read(secret.id, include_value: true)


### PR DESCRIPTION
allowing env/deploy group made the UI too cluttered ... and I'd hope they are not needed too often ...
my usecases so far were:
 - show me everything for project x
 - show me all places foobar key is used

/cc @jonmoter 

... would show a screenshot if s3 worked :D
