### PR TITLE
prevent encoding errors by making everything utf-8

### DIFF
--- a/app/models/output_buffer.rb
+++ b/app/models/output_buffer.rb
@@ -35,10 +35,12 @@ class OutputBuffer
   end
 
   def write(data, event = :message)
+    data = data.dup.force_encoding(Encoding::UTF_8) if data.is_a?(String) && data.encoding != Encoding::UTF_8
     @previous << [event, data] unless event == :close
     @listeners.dup.each { |listener| listener.push([event, data]) }
   end
 
+  # chunks can be split in half multi-bytes, so we have to sanitize them
   def write_docker_chunk(chunk)
     chunk = chunk.encode(Encoding::UTF_8, chunk.encoding, invalid: :replace, undef: :replace).strip
     chunk.split("\n").map { |line| write_docker_chunk_line(line) }

--- a/test/models/output_buffer_test.rb
+++ b/test/models/output_buffer_test.rb
@@ -43,6 +43,12 @@ describe OutputBuffer do
     build_listener.value.must_equal ["hello"]
   end
 
+  describe "#write" do
+    it "encodes everything as utf-8 to avoid CompatibilityError" do
+      listen { |o| o.write("Ó".dup.force_encoding(Encoding::BINARY)) }.map(&:encoding).must_equal [Encoding::UTF_8]
+    end
+  end
+
   describe "#puts" do
     it "writes a newline without argument" do
       listen(&:puts).must_equal ["\n"]


### PR DESCRIPTION
failed while joining output ... trying to fix the root cause
https://zendesk.airbrake.io/projects/95346/groups/1897390365372525702?tab=notice-detail
