### PR TITLE
safely link obvious urls in job output

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -160,6 +160,7 @@ $(function () {
     }
 
     $('#messages').on('click', 'span', function(event) {
+      if ($(event.target).is('a')) { return; } // let users click on links
       event.preventDefault();
       var clickedNumber = indexOfLine($(event.currentTarget));
       var shift = event.shiftKey;

--- a/app/assets/javascripts/streams.js
+++ b/app/assets/javascripts/streams.js
@@ -6,7 +6,7 @@ function startStream() {
     var origin = $('meta[name=deploy-origin]').first().attr('content');
     var source = new EventSource(origin + streamUrl, { withCredentials: true });
 
-    var addLine = function(data, replace) {
+    function addLine(data, replace) {
       var msg = JSON.parse(data).msg;
       if (replace) {
         $messages.children().last().remove();
@@ -14,9 +14,9 @@ function startStream() {
         msg = "\n" + msg;
       }
       $messages.append(msg);
-    };
+    }
 
-    var updateStatusAndTitle = function(e) {
+    function updateStatusAndTitle(e) {
       var data = JSON.parse(e.data);
 
       $('#header').html(data.html);
@@ -26,7 +26,7 @@ function startStream() {
         var notification = new Notification(data.notification, {icon: '/favicon.ico'});
         notification.onclick = function() { window.focus(); };
       }
-    };
+    }
 
     source.addEventListener('append', function(e) {
       $messages.trigger('contentchanged');

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,12 @@ module ApplicationHelper
 
   def render_log(str)
     escaped = ERB::Util.html_escape(str)
-    ansi_escaped(escaped).html_safe
+    autolink(ansi_escaped(escaped)).html_safe
+  end
+
+  # turn exact urls into links so we can follow build urls ... only super simple to stay safe
+  def autolink(text)
+    text.gsub(%r{https?://[\w:./\d-]+}, %(<a href="\\0">\\0</a>))
   end
 
   # https://github.com/showdownjs/showdown/wiki/Markdown's-XSS-Vulnerability-(and-how-to-mitigate-it)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -8,7 +8,7 @@ describe ApplicationHelper do
   include LocksHelper
 
   describe "#render_log" do
-    it "removes ascii escapes" do
+    it "removes translates ascii escapes to html colors" do
       # false positive ansi codes
       render_log("a[Aa").must_equal "<span class=\"ansible_none\">a[Aa</span>"
       render_log("a[AAa").must_equal "<span class=\"ansible_none\">a[AAa</span>"
@@ -26,6 +26,13 @@ describe ApplicationHelper do
       result = render_log("<script>1</script>")
       result.must_equal "<span class=\"ansible_none\">&lt;script&gt;1&lt;/script&gt;</span>"
       assert result.html_safe?
+    end
+
+    it "converts urls to links" do
+      result = render_log("foo http://bar.com bar https://sdf.dd/sdfs/2131/fdfdsf.json baz")
+      result.must_equal "<span class=\"ansible_none\">foo " \
+        "<a href=\"http://bar.com\">http://bar.com</a> bar " \
+        "<a href=\"https://sdf.dd/sdfs/2131/fdfdsf.json\">https://sdf.dd/sdfs/2131/fdfdsf.json</a> baz</span>"
     end
   end
 


### PR DESCRIPTION
keeping the regex stupid to not allow any fancy injection ... not adding a auto-linker gem to keep overhead low and speed fast ... this is only meant for obvious urls in the output ... no fancy `google.com` detection and highlighting

<img width="773" alt="screen shot 2017-03-03 at 8 44 57 pm" src="https://cloud.githubusercontent.com/assets/11367/23576192/5179e3ec-0053-11e7-8db7-92155e3f3d7b.png">

/cc @jonmoter 
