### PR TITLE
allow defining env variables per deploy

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -38,7 +38,6 @@ class DeploysController < ApplicationController
   #   * project_name (name of the project)
   #   * production (boolean, is this in proudction or not)
   #   * status (what is the status of this job failed|running| etc)
-
   def search
     status = params[:status].presence
 
@@ -159,7 +158,7 @@ class DeploysController < ApplicationController
   protected
 
   def deploy_permitted_params
-    [:reference, :stage_id] + Samson::Hooks.fire(:deploy_permitted_params)
+    [:reference, :stage_id, :environment_variables] + Samson::Hooks.fire(:deploy_permitted_params)
   end
 
   def reference

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -88,8 +88,12 @@ class Stage < ActiveRecord::Base
 
   def create_deploy(user, attributes = {})
     before_command = attributes.delete(:before_command)
+    environment_variables = attributes.delete(:environment_variables)
     deploys.create(attributes.merge(release: !no_code_deployed, project: project)) do |deploy|
       commands = before_command.to_s.dup << script
+      environment_variables.reverse_each do |k, v|
+        commands.prepend "export #{k.shellescape}=#{v.shellescape}\n"
+      end
       deploy.build_job(project: project, user: user, command: commands, commit: deploy.reference)
     end
   end

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -34,8 +34,6 @@
         </div>
       </div>
 
-      <%= Samson::Hooks.render_views(:deploy_form, self, project: @project, form: form) %>
-
       <% if recent_releases = @project.releases.last(5).presence %>
         <div class="form-group" id="recent-releases">
           <label class="col-lg-2 control-label">Recent releases</label>
@@ -46,6 +44,22 @@
           </div>
         </div>
       <% end %>
+
+      <div class="form-group">
+        <%= label_tag :environment_variables, nil, class: "col-lg-2 control-label" %>
+
+        <div class="col-lg-3">
+          <%= text_field_tag "deploy[environment_variables][0][name]", "", class: "form-control", placeholder: "Name" %>
+        </div>
+
+        <div class="col-lg-5">
+          <%# using a text area so users can resize them with browser controls %>
+          <%= text_area_tag "deploy[environment_variables][0][value]", "", class: "form-control", placeholder: "Value", rows: 1 %>
+        </div>
+      </div>
+      <%= link_to "Add row", "#", class: "duplicate_previous_row" %>
+
+      <%= Samson::Hooks.render_views(:deploy_form, self, project: @project, form: form) %>
 
       <div class="form-group" id="new-deploy-buttons">
         <div class="col-lg-offset-2 col-lg-10">


### PR DESCRIPTION
WIP for https://github.com/zendesk/samson/pull/1761

<img width="1057" alt="screen shot 2017-03-08 at 9 40 56 am" src="https://cloud.githubusercontent.com/assets/11367/23716097/d19f7d50-03e3-11e7-8f00-25d04dd1dc94.png">

TODO:
 - prefill names ?
 - make copy-row not copy the label
 - persist so re-deploy works ... possibly using env plugin
 - highlight prefixed section with a comment + newline after
