### PR TITLE
make search select consistent with form select

### DIFF
--- a/app/views/admin/secrets/index.html.erb
+++ b/app/views/admin/secrets/index.html.erb
@@ -7,7 +7,7 @@
 
   <div class="col-sm-2">
     <%= label_tag "Project" %><br/>
-    <% options = options_for_select([['Global', 'global']] + Project.order('name asc').pluck(:name, :permalink), params[:search].try(:[], :project_permalink)) %>
+    <% options = options_for_select([['global']] + Project.order('permalink asc').pluck(:permalink), params[:search].try(:[], :project_permalink)) %>
     <%= select_tag 'search[project_permalink]', options, include_blank: "", class: "form-control" %>
   </div>
 


### PR DESCRIPTION
<img width="230" alt="screen shot 2017-03-08 at 9 55 23 pm" src="https://cloud.githubusercontent.com/assets/11367/23737772/036a6aaa-044a-11e7-9933-ef18421325dc.png">

alternatively could have reworked both to show names, but that would be more translation/work in the controller/views and this way we are a bit closer to the metal which should be good ...