### PR TITLE
namespace pods so it is always clear where they live no matter what t…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -122,7 +122,9 @@ module Kubernetes
     end
 
     def set_name
-      template[:metadata][:name] = @doc.kubernetes_role.resource_name
+      name = @doc.kubernetes_role.resource_name
+      template[:metadata][:name] = name
+      template[:spec][:template][:metadata][:name] = "#{name}-#{@doc.deploy_group.permalink}"
     end
 
     # Sets the labels for each new Pod.


### PR DESCRIPTION
…hey report to

should be useful for any kind of error / newrelic etc reporting where we often only see the hostname

@zendesk/paas 

... tried this and seems to not work ... need to dig deeper ... alternatively change name of deployment, but that would be sad ...

these don't work either:
```
        pod.beta.kubernetes.io/hostname: my-pod-name
        pod.beta.kubernetes.io/subdomain: foo
```