### PR TITLE
use an option that works for all sources as default to avoid configur…

### DIFF
--- a/app/helpers/webhooks_helper.rb
+++ b/app/helpers/webhooks_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 module WebhooksHelper
   GENERIC_SOURCES = [
+    ['Any', 'any'],
     ['Any CI', 'any_ci'],
     ['Any code push', 'any_code'],
-    ['Any Pull Request', 'any_pull_request'],
-    ['Any', 'any']
+    ['Any Pull Request', 'any_pull_request']
   ].freeze
 
   NO_SOURCE = [['None', 'none']].freeze

--- a/test/helpers/webhooks_helper_test.rb
+++ b/test/helpers/webhooks_helper_test.rb
@@ -7,20 +7,20 @@ describe WebhooksHelper do
   describe '#webhook_sources_for_select' do
     it "renders" do
       webhook_sources_for_select(["foo"]).must_equal [
+        ["Any", "any"],
         ["Any CI", "any_ci"],
         ["Any code push", "any_code"],
         ["Any Pull Request", "any_pull_request"],
-        ["Any", "any"],
         ["Foo", "foo"]
       ]
     end
 
     it "renders with none action" do
       webhook_sources_for_select(["foo"], none: true).must_equal [
+        ["Any", "any"],
         ["Any CI", "any_ci"],
         ["Any code push", "any_code"],
         ["Any Pull Request", "any_pull_request"],
-        ["Any", "any"],
         ["None", 'none'],
         ["Foo", "foo"]
       ]


### PR DESCRIPTION
…ation errors

'any CI' does not work for github but is our most common hook and can be confusing for new users
most projects only use 1 hook anyway, so no need to be that specific

![screen shot 2017-03-09 at 8 57 46 am](https://cloud.githubusercontent.com/assets/11367/23761195/d26c0186-04a6-11e7-817b-14a4639abb32.png)
