### PR TITLE
feat: add manage projects link under projects menu

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,6 +24,10 @@
                 <% end %>
               </li>
             <% end %>
+            <% if current_user.try(:admin?) %>
+              <li class="divider"></li>
+              <li><%= link_to "Manage Projects", admin_projects_path %></li>
+            <% end %>
           </ul>
         </li>
         <% if DeployGroup.enabled? %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,7 +24,7 @@
                 <% end %>
               </li>
             <% end %>
-            <% if current_user.try(:admin?) %>
+            <% if current_user&.admin? %>
               <li class="divider"></li>
               <li><%= link_to "Manage Projects", admin_projects_path %></li>
             <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,9 +24,9 @@
                 <% end %>
               </li>
             <% end %>
-            <% if current_user&.admin? %>
+            <% if current_user.admin? %>
               <li class="divider"></li>
-              <li><%= link_to "Manage Projects", admin_projects_path %></li>
+              <li><%= link_to "Manage", admin_projects_path %></li>
             <% end %>
           </ul>
         </li>


### PR DESCRIPTION
As a new user to Samson, when I want to add a new project, I first look under the "Projects" menu. However, to add a new project, you actually need to go to the "Manage" menu, and then choose "Projects".

This PR adds a menu item on the "Projects" menu for "Manage Projects", so this common action can be accomplished in a more straightforward and logical manner.

#### Before:

![screen shot 2017-03-10 at 14 21 42](https://cloud.githubusercontent.com/assets/125108/23780838/51b6883e-059d-11e7-955f-86f7732729f5.png)

#### After:

![screen shot 2017-03-10 at 14 21 23](https://cloud.githubusercontent.com/assets/125108/23780842/5c960482-059d-11e7-8700-0945108eb9ea.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Medium, adds new item to projects menu
