### PR TITLE
get rid of distracting active checkboxes on empty stage page

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170208221802) do
+ActiveRecord::Schema.define(version: 20170310033621) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -127,13 +127,13 @@ ActiveRecord::Schema.define(version: 20170208221802) do
   end
 
   create_table "flowdock_flows", force: :cascade do |t|
-    t.string   "name",                      null: false
-    t.string   "token",                     null: false
-    t.integer  "stage_id",                  null: false
+    t.string   "name",       null: false
+    t.string   "token",      null: false
+    t.integer  "stage_id",   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "enabled",    default: true, null: false
   end
+
 
   create_table "jenkins_jobs", force: :cascade do |t|
     t.integer  "jenkins_job_id"
@@ -407,7 +407,7 @@ ActiveRecord::Schema.define(version: 20170208221802) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "before_deploy",                 default: false, null: false
-    t.boolean  "after_deploy",                  default: true,  null: false
+    t.boolean  "after_deploy",                  default: false, null: false
     t.boolean  "for_buddy",                     default: false, null: false
     t.boolean  "only_on_failure",               default: false, null: false
     t.index ["stage_id"], name: "index_slack_webhooks_on_stage_id", using: :btree

--- a/plugins/flowdock/app/decorators/stage_decorator.rb
+++ b/plugins/flowdock/app/decorators/stage_decorator.rb
@@ -5,7 +5,7 @@ Stage.class_eval do
   accepts_nested_attributes_for :flowdock_flows, allow_destroy: true, reject_if: :no_flowdock_token?
 
   def send_flowdock_notifications?
-    flowdock_flows.enabled.any?
+    flowdock_flows.any?
   end
 
   def flowdock_tokens
@@ -14,9 +14,5 @@ Stage.class_eval do
 
   def no_flowdock_token?(flowdock_attrs)
     flowdock_attrs['token'].blank?
-  end
-
-  def enabled_flows_names
-    flowdock_flows.enabled.map(&:name)
   end
 end

--- a/plugins/flowdock/app/models/flowdock_flow.rb
+++ b/plugins/flowdock/app/models/flowdock_flow.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 class FlowdockFlow < ActiveRecord::Base
   belongs_to :stage
-  scope :enabled, -> { where(enabled: true) }
 end

--- a/plugins/flowdock/app/views/samson_flowdock/_fields.html.erb
+++ b/plugins/flowdock/app/views/samson_flowdock/_fields.html.erb
@@ -15,13 +15,6 @@
         <%= flow_field.text_field :token, class: "form-control", placeholder: "Token" %>
       </div>
 
-      <div class="col-lg-2 checkbox">
-        <%= flow_field.label :enabled do %>
-          <%= flow_field.check_box :enabled %>
-          Enabled
-        <% end %>
-      </div>
-
       <%= delete_checkbox flow_field %>
     </div>
   <% end %>

--- a/plugins/flowdock/app/views/samson_flowdock/_notify_buddy_box.html.erb
+++ b/plugins/flowdock/app/views/samson_flowdock/_notify_buddy_box.html.erb
@@ -5,7 +5,7 @@
     form_path: Rails.application.routes.url_helpers.flowdock_notify_path(deploy_id: deploy.id),
     title: 'Request a buddy via Flowdock',
     message: FlowdockNotification.new(deploy).default_buddy_request_message,
-    channels: deploy.stage.enabled_flows_names.join(', '),
+    channels: deploy.stage.flowdock_flows.map(&:name).join(', '),
     users: SamsonFlowdock::FlowdockService.new(deploy).users,
     channel_type: 'flows'
   %>

--- a/plugins/flowdock/db/migrate/20170310033621_remove_enabled_flag.rb
+++ b/plugins/flowdock/db/migrate/20170310033621_remove_enabled_flag.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class RemoveEnabledFlag < ActiveRecord::Migration[5.0]
+  class FlowdockFlow < ActiveRecord::Base
+  end
+
+  def up
+    FlowdockFlow.where(enabled: false).each do |flow|
+      puts "Deleting flow from stage #{flow.stage_id}: #{flow.name} #{flow.token}"
+      flow.destroy
+    end
+    remove_column :flowdock_flows, :enabled
+  end
+
+  def down
+    add_column :flowdock_flows, :enabled, default: true, null: false
+  end
+end

--- a/plugins/flowdock/lib/samson_flowdock/samson_plugin.rb
+++ b/plugins/flowdock/lib/samson_flowdock/samson_plugin.rb
@@ -14,7 +14,7 @@ Samson::Hooks.callback :stage_clone do |old_stage, new_stage|
 end
 
 Samson::Hooks.callback :stage_permitted_params do
-  { flowdock_flows_attributes: [:id, :name, :token, :_destroy, :enabled] }
+  { flowdock_flows_attributes: [:id, :name, :token, :_destroy] }
 end
 
 notify = -> (deploy, _buddy) do

--- a/plugins/flowdock/test/decorators/stage_decorator_test.rb
+++ b/plugins/flowdock/test/decorators/stage_decorator_test.rb
@@ -1,24 +1,20 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 3
+SingleCov.covered! uncovered: 2
 
 describe Stage do
   subject { stages(:test_staging) }
 
-  before do
-    subject.notify_email_address = "test@test.ttt"
-    subject.flowdock_flows = [FlowdockFlow.new(name: "test", token: "abcxyz", stage_id: subject.id, enabled: false)]
-    subject.save
-  end
+  before { subject.notify_email_address = "test@test.ttt" }
 
   describe '#send_flowdock_notifications?' do
-    it 'returns that there are no flows with enabled notifications' do
+    it 'returns that there are no flows' do
       subject.send_flowdock_notifications?.must_equal(false)
     end
 
-    it 'returns that there are flows with enabled notifications' do
-      subject.flowdock_flows.first.update!(enabled: true)
+    it 'returns that there are flows' do
+      subject.flowdock_flows = [FlowdockFlow.new(name: "test", token: "abcxyz", stage_id: subject.id)]
       subject.send_flowdock_notifications?.must_equal(true)
     end
   end

--- a/plugins/flowdock/test/samson_flowdock/samson_plugin_test.rb
+++ b/plugins/flowdock/test/samson_flowdock/samson_plugin_test.rb
@@ -35,7 +35,7 @@ describe SamsonFlowdock do
 
   describe :stage_clone do
     it "copies all attributes except id" do
-      stage.flowdock_flows << FlowdockFlow.new(name: "test", token: "abcxyz", enabled: false)
+      stage.flowdock_flows << FlowdockFlow.new(name: "test", token: "abcxyz")
       new_stage = Stage.new
       Samson::Hooks.fire(:stage_clone, stage, new_stage)
       new_stage.flowdock_flows.map(&:attributes).must_equal [{
@@ -44,8 +44,7 @@ describe SamsonFlowdock do
         "token" => "abcxyz",
         "stage_id" => nil,
         "created_at" => nil,
-        "updated_at" => nil,
-        "enabled" => false
+        "updated_at" => nil
       }]
     end
   end

--- a/plugins/slack_webhooks/app/models/slack_webhook.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class SlackWebhook < ActiveRecord::Base
   validate :validate_url
+  validate :validate_used
 
   belongs_to :stage
 
@@ -11,19 +12,23 @@ class SlackWebhook < ActiveRecord::Base
     when :for_buddy then for_buddy?
     when :before_deploy then before_deploy?
     when :after_deploy then after_deploy? && (!only_on_failure? || !deploy.succeeded?)
-    else raise
+    else raise "Unknown phase #{deploy_phase.inspect}"
     end
   end
 
   private
 
   def validate_url
-    valid = webhook_url.start_with?('http') && begin
+    valid = webhook_url&.start_with?('http') && begin
       URI.parse(webhook_url)
     rescue URI::InvalidURIError
       false
     end
 
     errors.add(:webhook_url, "is invalid") unless valid
+  end
+
+  def validate_used
+    errors.add :base, "select at least one delivery time" if !for_buddy && !before_deploy && !after_deploy
   end
 end

--- a/plugins/slack_webhooks/db/migrate/20170310020151_make_checkboxes_off_by_default.rb
+++ b/plugins/slack_webhooks/db/migrate/20170310020151_make_checkboxes_off_by_default.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class MakeCheckboxesOffByDefault < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :slack_webhooks, :after_deploy, false
+  end
+end

--- a/plugins/slack_webhooks/test/decorators/stage_decorator_test.rb
+++ b/plugins/slack_webhooks/test/decorators/stage_decorator_test.rb
@@ -5,6 +5,7 @@ SingleCov.covered!
 
 describe Stage do
   let(:stage) { stages(:test_staging) }
+  let(:attributes) { {channel: "test", webhook_url: "http://slack.com/abcdef", stage_id: stage.id, after_deploy: true} }
 
   describe "#send_slack_webhook_notifications?" do
     it "does not send when there are no hooks" do
@@ -31,32 +32,24 @@ describe Stage do
 
   describe "#slack_buddy_channels" do
     it "returns channels when for_buddy is true" do
-      stage.slack_webhooks = [SlackWebhook.new(
-        channel: "test", webhook_url: "http://slack.com/abcdef", stage_id: stage.id, for_buddy: true
-      )]
+      stage.slack_webhooks = [SlackWebhook.new(attributes.merge(for_buddy: true))]
       stage.slack_buddy_channels.must_equal ["test"]
     end
 
     it "does not return channels when for_buddy is false" do
-      stage.slack_webhooks = [SlackWebhook.new(
-        channel: "test", webhook_url: "http://slack.com/abcdef", stage_id: stage.id, for_buddy: false
-      )]
+      stage.slack_webhooks = [SlackWebhook.new(attributes.merge(for_buddy: false))]
       stage.slack_buddy_channels.size.must_equal 0
     end
   end
 
   describe "#send_slack_buddy_request?" do
     it "sends when there are hooks with for_buddy is true" do
-      stage.slack_webhooks = [SlackWebhook.new(
-        channel: "test", webhook_url: "http://slack.com/abcdef", stage_id: stage.id, for_buddy: true
-      )]
+      stage.slack_webhooks = [SlackWebhook.new(attributes.merge(for_buddy: true))]
       stage.send_slack_buddy_request?.must_equal true
     end
 
     it "does not send when there are no hooks with for_buddy is true" do
-      stage.slack_webhooks = [SlackWebhook.new(
-        channel: "test", webhook_url: "http://slack.com/abcdef", stage_id: stage.id, for_buddy: false
-      )]
+      stage.slack_webhooks = [SlackWebhook.new(attributes.merge(for_buddy: false))]
       stage.send_slack_buddy_request?.must_equal false
     end
   end

--- a/plugins/slack_webhooks/test/samson_slack_webhooks/samson_plugin_test.rb
+++ b/plugins/slack_webhooks/test/samson_slack_webhooks/samson_plugin_test.rb
@@ -35,7 +35,7 @@ describe SamsonSlackWebhooks do
 
   describe :stage_clone do
     it "copies all attributes except id" do
-      stage.slack_webhooks << SlackWebhook.new(webhook_url: 'http://example.com')
+      stage.slack_webhooks << SlackWebhook.new(webhook_url: 'http://example.com', after_deploy: true)
       new_stage = Stage.new
       Samson::Hooks.fire(:stage_clone, stage, new_stage)
       new_stage.slack_webhooks.map(&:attributes).must_equal [{


### PR DESCRIPTION
I always do a double-check on these ... would be easier to read if they were off by default
also adding an error when leaving all options blank for the slack webhook


<img width="928" alt="screen shot 2017-03-09 at 7 34 20 pm" src="https://cloud.githubusercontent.com/assets/11367/23781036/71a1fbae-04ff-11e7-9f5c-3946b4e6b436.png">
<img width="915" alt="screen shot 2017-03-09 at 7 34 28 pm" src="https://cloud.githubusercontent.com/assets/11367/23781037/71bc12f0-04ff-11e7-910c-3b68877c7ef5.png">
<img width="504" alt="screen shot 2017-03-09 at 8 37 24 pm" src="https://cloud.githubusercontent.com/assets/11367/23782321/3c0a6ebe-0508-11e7-8500-41ba375b5723.png">
