### PR TITLE
fix: gracefully handle error when github user is unauthorized

### DIFF
--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -15,7 +15,7 @@ class ReleaseService
 
   def can_release?
     GITHUB.repo(@project.user_repo_part).permissions[:push]
-  rescue Octokit::NotFound
+  rescue Octokit::NotFound, Octokit::Unauthorized
     false
   end
 

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -75,6 +75,11 @@ describe ReleaseService do
       refute service.can_release?
     end
 
+    it "cannot release when user is unauthorized" do
+      stub_github_api("repos/bar/foo", {}, 401)
+      refute service.can_release?
+    end
+
     it "cannot release when user does not have github access" do
       stub_github_api("repos/bar/foo", {}, 404)
       refute service.can_release?


### PR DESCRIPTION
When GitHub user is not correctly configured and Samson attempts to create a release, this causes a confusing exception to occur. In this fix, we instead catch the error and pass back `false` to the validation, causing it to display the usual nice error message explaining that write access is required.

#### Before:

![screen shot 2017-03-10 at 14 47 14](https://cloud.githubusercontent.com/assets/125108/23781315/8c46fb34-05a0-11e7-947e-fe99194feda7.png)

#### After:

![screen shot 2017-03-10 at 14 46 58](https://cloud.githubusercontent.com/assets/125108/23781324/992ea8ba-05a0-11e7-8ccb-f0987762b687.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low - just adds nicer error handling
