### PR TITLE
fold empty stage sections

### DIFF
--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -70,3 +70,30 @@
 </fieldset>
 
 <%= Samson::Hooks.render_views(:stage_form, self, form: form) %>
+
+<script>
+  // fold empty fieldsets and let users unfold them to reduce clutter
+  $(function(){
+    $("fieldset").each(function(_, fieldset){
+      var fieldset = $(fieldset);
+      var form_elements = fieldset.find('> *').not('legend');
+
+      var filled = fieldset.find(':input').filter(function(_, el){
+        if(el.type == "checkbox" || el.type == "radio") {
+          return $(el).is(':checked');
+        } else if(el.type == "hidden") {
+          return false;
+        } else {
+          return $(el).val() != "";
+        }
+      });
+
+      if(filled.size() == 0) {
+        fieldset.find('legend').
+          click(function(){ form_elements.toggle() }).click().
+          css('cursor', 'pointer').
+          append(' &#x2304;');
+      }
+    });
+  });
+</script>

--- a/plugins/new_relic/app/views/samson_new_relic/_fields.html.erb
+++ b/plugins/new_relic/app/views/samson_new_relic/_fields.html.erb
@@ -18,9 +18,9 @@
         </div>
       <% end %>
     <% else %>
-      Error fetching newrelic apps.
+      <div>Error fetching newrelic apps.</div>
     <% end %>
   <% else %>
-    Set NEWRELIC_API_KEY to use NewRelic stats (disable the new_relic plugin to hide this warning).
+    <div>Set NEWRELIC_API_KEY to use NewRelic stats (disable the new_relic plugin to hide this warning).</div>
   <% end %>
 </fieldset>


### PR DESCRIPTION
we have so many plugins we don't need / don't regularly use ... maybe it's time to fold the sections that are not filled out ...

<img width="725" alt="screen shot 2017-03-09 at 8 59 42 pm" src="https://cloud.githubusercontent.com/assets/11367/23782732/6d7a2568-050b-11e7-80c2-18e8b1988323.png">

@zendesk/samson 