### PR TITLE
Restyle project search box

### DIFF
--- a/app/assets/javascripts/directives/handle_dropdown_selection_directive.js
+++ b/app/assets/javascripts/directives/handle_dropdown_selection_directive.js
@@ -16,7 +16,10 @@ samson.directive('handleDropdownSelection', function($timeout) {
           listItems.eq((index + (e.keyCode - 39)) % listItems.length).addClass('selected');
         } else if (e.keyCode == 13) { // enter
           e.preventDefault();
-          selected.find('a').get(0).click();
+          var a = selected.find('a').get(0);
+          if (a) {
+            a.click();
+          }
         } else {
           $timeout(function() {
             if(!selected.is(':visible')) {

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -99,6 +99,26 @@ h3 {
     }
   }
 
+  .project-search {
+    border: none;
+    box-shadow: none;
+    padding: 16px 20px 15px;
+    border-radius: 0;
+    margin-top: -5px;
+    margin-bottom: -9px;
+    width: 100%;
+    &:focus {
+      outline: none;
+      background: #f5f5f5;
+    }
+  }
+
+  .project-search-icon {
+    position: absolute;
+    right: 18px;
+    top: 19px;
+    color: #c7c7c7;
+  }
   .profile {
 
     .dropdown-toggle {

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,9 +8,8 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" focus-on="{ click: '#project_search' }">Projects <b class="caret"></b></a>
           <ul class="dropdown-menu">
             <li>
-              <a class="padding-sm">
-                <input id="project_search" type="search" handle-dropdown-selection class="filter-list form-control input-block" placeholder="Search projects" data-target=".filtered-projects">
-              </a>
+              <input id="project_search" type="search" handle-dropdown-selection class="project-search filter-list" placeholder="Search projects" data-target=".filtered-projects">
+              <div class="project-search-icon glyphicon glyphicon-search"></div>
             </li>
             <li class="divider"></li>
             <% Project.ordered_for_user(current_user).each do |project| %>


### PR DESCRIPTION
Restyled the search box in the "Projects" drop-down menu to make it look a bit more modern.

Also, fixed an issue where an error alert box shows when the "enter" key is pressed while the project search box is focused.

#### Before:

![screen shot 2017-03-10 at 16 02 11](https://cloud.githubusercontent.com/assets/125108/23782941/032bd4e4-05ac-11e7-9592-0c3eeacb1f3b.png)

#### After:

![screen shot 2017-03-10 at 16 09 35](https://cloud.githubusercontent.com/assets/125108/23782950/0da24d90-05ac-11e7-8868-bb400017f682.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low - style change
