### PR TITLE
split out zendesk specific migrations so people without that plugin d…

### DIFF
--- a/plugins/zendesk/db/migrate/20160901175937_prevent_3_state_booleans2.rb
+++ b/plugins/zendesk/db/migrate/20160901175937_prevent_3_state_booleans2.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-# same as plugins/zendesk/db/migrate/20160901175937_prevent_3_state_booleans2.rb
-class Prevent3StateBooleans < ActiveRecord::Migration[4.2]
+# same as db/migrate/20160901175936_prevent_3_state_booleans.rb
+class Prevent3StateBooleans2 < ActiveRecord::Migration[4.2]
   class Stage < ActiveRecord::Base
   end
 
-  COLUMNS = [:update_github_pull_requests, :use_github_deployment_api].freeze
+  COLUMNS = [:comment_on_zendesk_tickets].freeze
 
   def up
     COLUMNS.each do |column|


### PR DESCRIPTION
…o not blow up

fixes https://github.com/zendesk/samson/issues/1820

the migration is idempotent so making it run twice for users that already ran it should not be a problem, worked fine for me locally

@ryan0x44