### PR TITLE
remove hotfix feature

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,11 +36,6 @@
   margin-right: 15px;
 }
 
-.label-hotfix {
-  background-color: #f0ad4e;
-  text-transform: uppercase;
-}
-
 a.no-hover:hover {
   text-decoration: none;
 }

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 module ReleasesHelper
   def release_label(project, release)
-    if release.changeset.hotfix?
-      content = link_to(release.version, [project, release], class: "release-label label label-warning")
-      warning = content_tag(:span, "", class: "glyphicon glyphicon-exclamation-sign", title: "Hotfix!")
-
-      content + " " + warning
-    else
-      link_to(release.version, [project, release], class: "release-label label label-success")
-    end
+    link_to(release.version, [project, release], class: "release-label label label-success")
   end
 
   def link_to_deploy_stage(stage, release)

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -13,12 +13,6 @@ class Changeset
     "#{Rails.application.config.samson.github.web_url}/#{repo}/compare/#{commit_range}"
   end
 
-  def hotfix?
-    Rails.cache.fetch("#{cache_key}-hotfix", expires_in: 1.year) do
-      commits.any?(&:hotfix?)
-    end
-  end
-
   def commit_range
     "#{previous_commit}...#{commit}"
   end

--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -32,10 +32,6 @@ class Changeset::Commit
     @data.sha.slice(0, 7)
   end
 
-  def hotfix?
-    @data.commit.message.start_with?("HOTFIX")
-  end
-
   def pull_request_number
     Integer(Regexp.last_match(1)) if summary =~ PULL_REQUEST_MERGE_MESSAGE
   end

--- a/app/views/projects/_deploy.html.erb
+++ b/app/views/projects/_deploy.html.erb
@@ -5,7 +5,6 @@
     <% end %>
     <td><%= render_time(deploy.start_time, params[:time_format]) %></td>
     <td>
-      <%= content_tag :span, "Hotfix!", class: "label label-hotfix" if deploy.changeset.hotfix? %>
       <%= link_to "#{deploy.summary}", [@project || deploy.project, deploy] %>
     </td>
     <% unless @stage %>

--- a/test/helpers/releases_helper_test.rb
+++ b/test/helpers/releases_helper_test.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# rubocop:disable Metrics/LineLength
 require_relative '../test_helper'
 
 SingleCov.covered!
@@ -11,11 +10,6 @@ describe ReleasesHelper do
 
     it "produces a label" do
       result.must_equal "<a class=\"release-label label label-success\" href=\"/projects/foo/releases/v123\">v123</a>"
-    end
-
-    it "adds warnings for hotfix" do
-      release.changeset.stubs(hotfix?: true)
-      result.must_equal "<a class=\"release-label label label-warning\" href=\"/projects/foo/releases/v123\">v123</a> <span class=\"glyphicon glyphicon-exclamation-sign\" title=\"Hotfix!\"></span>"
     end
   end
 

--- a/test/models/changeset/commit_test.rb
+++ b/test/models/changeset/commit_test.rb
@@ -69,18 +69,6 @@ describe Changeset::Commit do
     end
   end
 
-  describe "#hotfix?" do
-    it "returns true if the commit message starts with HOTFIX" do
-      commit_data.stubs(:message).returns("HOTFIX: DANCE!")
-      assert commit.hotfix?
-    end
-
-    it "returns false if the commit message does not start with HOTFIX" do
-      commit_data.stubs(:message).returns("JUST DANCE!")
-      assert !commit.hotfix?
-    end
-  end
-
   describe "#url" do
     it "builds an url" do
       commit.url.must_equal "https://github.com/foo/bar/commit/aa2a33444343"


### PR DESCRIPTION
Saw that we do a lot of github checks to find out if a release or deploy is "hotfix" (include any commit that starts with "HOTFIX")

I never saw this being used, so I'd opt to delete that feature to avoid all these github lookups
on deploy and when displaying release labels

@zendesk/samson
/cc @henders @jonmoter @irwaters 