### PR TITLE
make required env less vorbose and less error prone

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -180,12 +180,12 @@ describe Kubernetes::DeployExecutor do
       it "fails before building when env is not configured" do
         # overriding the stubbed value
         template = Kubernetes::ReleaseDoc.new.send(:raw_template)[0]
-        template[:spec][:template][:spec][:containers][0][:env] = [{name: "FOO", value: 'filled-by-samson'}]
+        template[:spec][:template][:metadata][:annotations] = {required_env: "FOO BAR"}
 
         e = assert_raises Samson::Hooks::UserError do
           refute execute!
         end
-        e.message.must_include "Missing env variables FOO"
+        e.message.must_include "Missing env variables FOO, BAR"
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -264,22 +264,24 @@ describe Kubernetes::TemplateFiller do
   end
 
   describe "#verify_env" do
-    it "passes when everything is filled out" do
+    it "passes when nothing is required" do
       template.expects(:set_env).never # does not call expensive stuff if nothing is required
       template.verify_env
     end
 
-    it "fails when value is missing" do
-      template.send(:env) << {name: 'FOO', value: 'filled-by-samson'}
-      assert_raises Samson::Hooks::UserError do
+    describe "when something is required" do
+      before { raw_template[:spec][:template][:metadata][:annotations] = {required_env: 'FOO'} }
+
+      it "fails when value is missing" do
+        assert_raises Samson::Hooks::UserError do
+          template.verify_env
+        end
+      end
+
+      it "passes when missing value is filled out" do
+        EnvironmentVariable.create!(parent: projects(:test), name: 'FOO', value: 'BAR')
         template.verify_env
       end
-    end
-
-    it "passes when missing value is filled out" do
-      EnvironmentVariable.create!(parent: projects(:test), name: 'FOO', value: 'BAR')
-      template.send(:env) << {name: 'FOO', value: 'filled-by-samson'}
-      template.verify_env
     end
   end
 end


### PR DESCRIPTION
atm if a user has a typo or does not use samson weird default values will be set,
also the syntax is very verbose.

so switch to a simpler configuration style that uses an annotation key

supported formats:
```
required_env: FOO,BAR
required_env: >
  FOO
  BAR
required_env: |
  FOO
  BAR
```
