### PR TITLE
fix project specific secrets being always created as visible since we…

### DIFF
--- a/app/controllers/admin/secrets_controller.rb
+++ b/app/controllers/admin/secrets_controller.rb
@@ -7,9 +7,9 @@ class Admin::SecretsController < ApplicationController
   before_action :find_project_permalinks
   before_action :find_secret, only: [:update, :show, :destroy]
 
+  before_action :convert_visible_to_boolean, only: [:update, :create, :new]
   before_action :authorize_any_deployer!
   before_action :authorize_project_admin!, except: [:index, :new]
-  before_action :convert_visible_to_boolean, only: [:update, :create, :new]
 
   def index
     @secret_keys = SecretStorage.keys.map { |key| [key, SecretStorage.parse_secret_key(key)] }

--- a/test/controllers/admin/secrets_controller_test.rb
+++ b/test/controllers/admin/secrets_controller_test.rb
@@ -100,6 +100,12 @@ describe Admin::SecretsController do
         assert_response :success
         response.body.wont_include checked
       end
+
+      it "renders pre-filled visible false values from params of last form with project set" do
+        get :new, params: {secret: {visible: 'false', project_permalink: 'foo'}}
+        assert_response :success
+        response.body.wont_include "checked=\"checked\""
+      end
     end
 
     describe '#show' do


### PR DESCRIPTION
… modified params after caching secret_params

@smo921 

TODO:
 - [x] go though all visible secrets and make them invisible if necessary