### PR TITLE
PAAS-882 add low new pod-only deploys which should be used for migrations

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -138,6 +138,11 @@ Kubernetes::ReleaseGroup
         -> Kubernetes Pods (how ever many replicas specified)
 ```
 
+### Migrations
+
+Add a role with only a `Pod`, the annotation `samson/prerequisite: true`, and command to run a migrations.
+It will be executed before the rest is deployed.
+
 ### Clair security scans
 
 To security scan docker images using hyperclair, enable hyperclair plugin and add:

--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -16,7 +16,7 @@ module Kubernetes
       end
 
       def live?
-        phase == 'Running' && ready?
+        completed? || (phase == 'Running' && ready?)
       end
 
       def completed?

--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -8,7 +8,7 @@ module Kubernetes
 
     DEPLOY_KINDS = ['Deployment', 'DaemonSet'].freeze
     JOB_KINDS = ['Job'].freeze
-    PRIMARY = (DEPLOY_KINDS + JOB_KINDS).freeze
+    PRIMARY_KINDS = (DEPLOY_KINDS + JOB_KINDS + ['Pod']).freeze
     SERVICE_KINDS = ['Service'].freeze
 
     def initialize(content, path)

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -38,8 +38,8 @@ describe Kubernetes::Api::Pod do
     )
   end
 
-  describe '#live?' do
-    it "is live" do
+  describe "#live?" do
+    it "is done" do
       assert pod.live?
     end
 
@@ -62,6 +62,11 @@ describe Kubernetes::Api::Pod do
       pod_attributes[:status].delete :conditions
       refute pod.live?
     end
+
+    it "is live when succeeded" do
+      pod_attributes[:status][:phase] = "Succeeded"
+      assert pod.live?
+    end
   end
 
   describe "#completed?" do
@@ -71,6 +76,7 @@ describe Kubernetes::Api::Pod do
     end
 
     it "is not completed when not succeeded" do
+      pod_attributes[:status][:phase] = "Running"
       refute pod.completed?
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -361,7 +361,7 @@ describe Kubernetes::DeployExecutor do
         out.must_include "resque-worker: Live\n"
         out.must_include "SUCCESS"
         out.must_include "stability" # testing deploy for stability
-        out.must_include "deploying jobs" # announcing that we deploy jobs first
+        out.must_include "deploying prerequisite" # announcing that we deploy prerequisites first
         out.must_include "other roles" # announcing that we have more to deploy
       end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -6,6 +6,7 @@ SingleCov.covered!
 describe Kubernetes::ReleaseDoc do
   def deployment_stub(replica_count)
     stub(
+      "Deployment stub",
       to_hash: {
         spec: {
           'replicas=' => replica_count
@@ -19,6 +20,7 @@ describe Kubernetes::ReleaseDoc do
 
   def daemonset_stub(scheduled, misscheduled)
     stub(
+      "DaemonSet stub",
       to_hash: {
         kind: "DaemonSet",
         metadata: {
@@ -192,37 +194,20 @@ describe Kubernetes::ReleaseDoc do
   end
 
   describe "#desired_pod_count" do
-    it "uses local value for deployment" do
+    it "delegates to primary resource" do
       doc.desired_pod_count.must_equal 2
     end
+  end
 
-    it "uses local value for job" do
-      primary_template[:kind] = 'Job'
-      doc.desired_pod_count.must_equal 2
-    end
-
-    it "asks kubernetes for daemon set since we do not know how many nodes it will match" do
-      primary_template[:kind] = 'DaemonSet'
-      stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/pod1/daemonsets/some-project-rc").
-        to_return(body: {status: {desiredNumberScheduled: 3}}.to_json)
-      doc.desired_pod_count.must_equal 3
+  describe "#prerequisite?" do
+    it "delegates to primary resource" do
+      refute doc.prerequisite?
     end
   end
 
   describe "#build" do
     it "fetches the build" do
       doc.build.must_equal builds(:docker_build)
-    end
-  end
-
-  describe "#job?" do
-    it "is a job when it is a job" do
-      doc.send(:resource_template=, YAML.load_stream(read_kubernetes_sample_file('kubernetes_job.yml')))
-      assert doc.job?
-    end
-
-    it "is not a job when it is not a job" do
-      refute doc.job?
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_verifier_test.rb
@@ -11,6 +11,9 @@ describe Kubernetes::RoleVerifier do
     let(:job_role) do
       [YAML.load(read_kubernetes_sample_file('kubernetes_job.yml')).deep_symbolize_keys]
     end
+    let(:pod_role) do
+      [{kind: 'Pod', metadata: {name: 'my-map'}, spec: {containers: [{name: "foo"}]}}]
+    end
     let(:role_json) { role.to_json }
     let(:errors) do
       elements = Kubernetes::Util.parse_file(role_json, 'fake.json').map(&:deep_symbolize_keys)
@@ -78,7 +81,7 @@ describe Kubernetes::RoleVerifier do
 
     it "reports missing containers" do
       role.first[:spec][:template][:spec].delete(:containers)
-      errors.must_include "Deployment/DaemonSet/Job need at least 1 container"
+      errors.must_include "Deployment/DaemonSet/Job/Pod need at least 1 container"
     end
 
     it "ignores unknown types" do
@@ -133,6 +136,24 @@ describe Kubernetes::RoleVerifier do
         value: 1234 # can happen when using yml configs
       }
       errors.must_include "Env values 1234 must be strings."
+    end
+
+    describe 'pod' do
+      let(:role) { pod_role }
+
+      it "allows only Pod" do
+        errors.must_equal nil
+      end
+
+      it "fails without containers" do
+        role[0][:spec][:containers].clear
+        errors.must_equal ["Deployment/DaemonSet/Job/Pod need at least 1 container"]
+      end
+
+      it "fails without name" do
+        role[0][:spec][:containers][0].delete :name
+        errors.must_equal ["Containers need a name"]
+      end
     end
 
     describe 'verify_job_restart_policy' do


### PR DESCRIPTION
Pods will need:

```
labels:
  samson/prerequisite: 'true'
spec:
  restartPolicy: Never
```

then will get deployed and stay around as Succeeded

```
truth-service-migrate                                           0/1       Completed     0          12s
```

```
[22:56:20] First deploying prerequisite ...
[22:56:20] Creating for pod 105 role job
[22:56:20] Creating for pod 105 role migrate
[22:56:20] Waiting for pods to be created
[22:56:20] Deploy status after 0 seconds:
[22:56:20]   pod 105 console: Waiting (Pending, ContainersNotReady/ContainerCreating)
[22:56:24] SUCCESS
[22:56:24] Now deploying other roles ...
[22:56:24] Creating for pod 105 role app-server
[22:56:25] Creating for pod 105 role worker
[22:56:25] Waiting for pods to be created
[22:56:29] READY, starting stability test
```


TODO:
 - [x] annotation support ... replace `job?` logic ... maybe delete old job logic
 - [ ] make PRs to all projects to replace migrations