### PR TITLE
when reloading rails in development periodical state is destroyed and…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,6 @@ GEM
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    brakeman (3.6.0)
     brakeman (3.6.1)
     builder (3.2.2)
     byebug (8.2.2)

--- a/config/initializers/periodical.rb
+++ b/config/initializers/periodical.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'samson/periodical' # avoid auto-load since we setup global state
+
 Samson::Periodical.register :stop_expired_deploys, "Stop deploys when buddy approval request timed out" do
   Deploy.expired.each(&:stop!)
 end

--- a/lib/samson/periodical.rb
+++ b/lib/samson/periodical.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # Inline Cron: use PERIODICAL environment variable
 # Cron: Execute from commandline as cron via `rails runner 'Samson::Periodical.run_once :stop_expired_deploys'`
+#
+# Has global state so should never be autoloaded
 require 'concurrent'
 
 module Samson


### PR DESCRIPTION
… we fail when calling overdue?

@dbuchi 

```
rails c
reload!
Samson::Periodical -> global state should still be there
```