### PR TITLE
remove giant blob from deploy logs

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/releases_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/releases_controller.rb
@@ -7,4 +7,8 @@ class Kubernetes::ReleasesController < ApplicationController
   def index
     @kubernetes_releases = current_project.kubernetes_releases.order('id desc')
   end
+
+  def show
+    @kubernetes_release = current_project.kubernetes_releases.find(params.require(:id))
+  end
 end

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -318,7 +318,7 @@ module Kubernetes
         raise Samson::Hooks::UserError, "Failed to create release: #{release.errors.full_messages.inspect}"
       end
 
-      @output.puts("Created release #{release.id}\nConfig: #{deploy_group_configs.to_json}")
+      @output.puts("Created kubernetes release #{release.url}")
       release
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -51,6 +51,10 @@ module Kubernetes
       }
     end
 
+    def url
+      Rails.application.routes.url_helpers.project_kubernetes_release_url(project, self)
+    end
+
     private
 
     # Creates a ReleaseDoc per each DeployGroup and Role combination.

--- a/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
@@ -9,6 +9,7 @@
     <thead>
       <tr>
         <th>Id</th>
+        <th>Deploy</th>
         <th>Build</th>
         <th>Deploy Groups</th>
         <th>Created</th>
@@ -23,7 +24,16 @@
       <% else %>
         <% @kubernetes_releases.each do |kubernetes_release| %>
           <tr>
-            <td><%= kubernetes_release.deploy ? link_to(kubernetes_release.id, project_deploy_path(@project, kubernetes_release.deploy, anchor: 'kubernetes_release')) : kubernetes_release.id %></td>
+            <td>
+              <%= link_to kubernetes_release.id, project_kubernetes_release_path(@project, kubernetes_release) %>
+            </td>
+            <td>
+              <% if kubernetes_release.deploy %>
+                <%= link_to job_status_badge(kubernetes_release.deploy.job), project_deploy_path(@project, kubernetes_release.deploy) %>
+              <% else %>
+                Not deployed.
+              <% end %>
+            </td>
             <td>
               <%= link_to kubernetes_release.build.label, [kubernetes_release.project, kubernetes_release.build] if kubernetes_release.build %>
             </td>

--- a/plugins/kubernetes/app/views/kubernetes/releases/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/releases/show.html.erb
@@ -1,0 +1,52 @@
+<% page_title "Kubernetes Release #{@kubernetes_release.id}" %>
+
+<%= render 'projects/header', project: @project, tab: 'kubernetes' %>
+
+<section class="tabs kubernetes-section">
+  <%= render 'samson_kubernetes/navigation' %>
+
+  <dl class="dl-horizontal">
+    <dt>Build</dt>
+    <dd>
+      <% if @kubernetes_release.build_id %>
+        <%= link_to @kubernetes_release.build_id, project_build_path(@project, @kubernetes_release.build_id) %>
+      <% else %>
+        None
+      <% end %>
+    </dd>
+    <dt>Deploy</dt>
+    <dd>
+      <% if @kubernetes_release.deploy %>
+        <%= link_to job_status_badge(@kubernetes_release.deploy.job), project_deploy_path(@project, @kubernetes_release.deploy) %>
+      <% else %>
+        None
+      <% end %>
+    </dd>
+    <dt>Git SHA</dt>
+    <dd><%= short_sha @kubernetes_release.git_sha %></dd>
+    <dt>Git REF</dt>
+    <dd><%= @kubernetes_release.git_ref %></dd>
+  </dl>
+
+  <h2>Docs</h2>
+  <table class="table">
+    <tr>
+      <th>Id</th>
+      <th>Deploy Group</th>
+      <th>Role</th>
+      <th>Replicas</th>
+      <th>CPU Cores</th>
+      <th>Ram in MB</th>
+    </tr>
+    <% @kubernetes_release.release_docs.each do |doc| %>
+      <tr>
+        <td><%= doc.id %></td>
+        <td><%= link_to doc.deploy_group.name, doc.deploy_group %></td>
+        <td><%= link_to doc.kubernetes_role.name, project_kubernetes_role_path(@project, doc.kubernetes_role) %></td>
+        <td><%= doc.replica_target %></td>
+        <td><%= doc.cpu %></td>
+        <td><%= doc.ram %></td>
+      </tr>
+    <% end %>
+  </table>
+</section>

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -8,7 +8,7 @@ Samson::Application.routes.draw do
           get :example
         end
       end
-      resources :releases, only: [:index]
+      resources :releases, only: [:index, :show]
     end
   end
 

--- a/plugins/kubernetes/test/controllers/kubernetes/releases_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/releases_controller_test.rb
@@ -6,12 +6,20 @@ SingleCov.covered!
 describe Kubernetes::ReleasesController do
   as_a_viewer do
     unauthorized :get, :index, project_id: :foo
+    unauthorized :get, :show, project_id: :foo, id: 123
   end
 
   as_a_project_deployer do
-    describe 'a GET to #index' do
+    describe '#index' do
       it 'renders' do
         get :index, params: {project_id: :foo}
+        assert_response :success
+      end
+    end
+
+    describe '#show' do
+      it 'renders' do
+        get :show, params: {project_id: :foo, id: kubernetes_releases(:test_release)}
         assert_response :success
       end
     end

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -148,6 +148,13 @@ describe Kubernetes::Release do
     end
   end
 
+  describe "#url" do
+    it "builds" do
+      release.id = 123
+      release.url.must_equal "http://www.test-url.com/projects/foo/kubernetes/releases/123"
+    end
+  end
+
   def expect_file_contents_from_repo
     GitRepository.any_instance.expects(:file_content).returns(role_config_file)
   end


### PR DESCRIPTION
before:
<img width="382" alt="screen shot 2017-03-28 at 7 55 04 pm" src="https://cloud.githubusercontent.com/assets/11367/24436473/8954fa30-13f0-11e7-837d-93e29021520d.png">

after:
<img width="1090" alt="screen shot 2017-03-28 at 8 14 55 pm" src="https://cloud.githubusercontent.com/assets/11367/24436968/47a393e6-13f3-11e7-887c-e37968116558.png">
