### PR TITLE
sort env vars by their position in the select

### DIFF
--- a/plugins/env/app/views/samson_env/_environment_variables.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables.html.erb
@@ -1,6 +1,6 @@
 <% scopes = EnvironmentVariable.env_deploygroup_array %>
-<% form.object.environment_variables.build %>
-<%= form.fields_for :environment_variables do |fields| %>
+<% sorted = form.object.environment_variables.sort_by { |x| [x.name, scopes.index { |_, s| s == x.scope_type_and_id } || 999] } %>
+<%= form.fields_for :environment_variables, sorted << EnvironmentVariable.new do |fields| %>
   <div class="form-group">
     <div class="col-lg-3">
       <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>


### PR DESCRIPTION
This keeps things in a nicely readable order of specificity ... All / Environment / DeployGroup

if the value is no longer in the select, then go to the end

<img width="888" alt="screen shot 2017-03-28 at 9 02 22 pm" src="https://cloud.githubusercontent.com/assets/11367/24438150/3a992a9c-13fa-11e7-85da-6358bf59b5f8.png">
