### PR TITLE
macros to stages

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -118,6 +118,7 @@ class StagesController < ApplicationController
       :is_template,
       :run_in_parallel,
       :cancel_queued_deploys,
+      :no_reference_selection,
       {
         deploy_group_ids: [],
         command_ids: []

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,9 @@ module ApplicationHelper
         class: "btn btn-primary"
     elsif Lock.locked_for?(stage, current_user)
       content_tag :a, "Locked", class: "btn btn-primary disabled", disabled: true
+    elsif stage.direct?
+      path = project_stage_deploys_path(project, stage, deploy: {reference: "master", stage_id: stage.id})
+      link_to "Deploy!", path, role: "button", class: "btn btn-warning", data: {method: :post}
     else
       path = new_project_stage_deploy_path(project, stage)
       link_to "Deploy", path, role: "button", class: "btn btn-primary"

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -183,6 +183,10 @@ class Stage < ActiveRecord::Base
     Stage.reorder(nil).where(id: stage_ids, project_id: project_id).pluck(:id)
   end
 
+  def direct?
+    !confirm? && no_reference_selection? && !deploy_requires_approval?
+  end
+
   private
 
   def permalink_base

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -17,14 +17,20 @@
 
       <div class="form-group">
         <%= form.label :reference, "Reference", class: "col-lg-2 control-label" %>
-        <div id="scrollable-dropdown-menu" class="col-lg-4">
-          <%= form.text_field :reference,
-              class: "form-control",
-              autofocus: true,
-              placeholder: "e.g. v2.1.43, master, fa0b4671",
-              data: { prefetch_url: project_references_path(@project, format: "json") }
-          %>
-        </div>
+        <% if @stage.no_reference_selection %>
+          <%= form.object.reference = 'master' %>
+          <%= form.hidden_field :reference, id: 'disable_js_hooks' %>
+          <%= additional_info "Reference selection is disabled for this stage." %>
+        <% else %>
+          <div id="scrollable-dropdown-menu" class="col-lg-4">
+            <%= form.text_field :reference,
+                class: "form-control",
+                autofocus: true,
+                placeholder: "e.g. v2.1.43, master, fa0b4671",
+                data: { prefetch_url: project_references_path(@project, format: "json") }
+            %>
+          </div>
+        <% end %>
       </div>
 
       <div class="form-group">

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -15,14 +15,22 @@
     %>
   <% end %>
 
+  <%
+    confirm_label = "Confirm before deployment"
+    no_code_label = "Does not deploy code"
+    no_ref_label = "When selected with '#{no_code_label}' and disabled '#{confirm_label}' the stage can be directly executed."
+  %>
+
   <% help = "Bypass " + [("buddy check" if BuddyCheck.enabled?), "release tracking"].compact.to_sentence %>
-  <%= form.input :no_code_deployed, as: :check_box, label: "Does not deploy code", help: help %>
+  <%= form.input :no_code_deployed, as: :check_box, label: no_code_label, help: help %>
 
   <%= form.input :run_in_parallel, as: :check_box, label: "Can run in parallel", help: "Deploys are not queued. Executed immediately" %>
 
   <%= form.input :cancel_queued_deploys, as: :check_box, label: "Max 1 queued deploy per user", help: "When a new deploy is created for a user. Any queued deploys for that user are cancelled. This most useful when trying to not deploy every push for frequently updated projects." %>
 
-  <%= form.input :confirm, as: :check_box, label: "Confirm before deployment", help: "Show a review page before starting a deploy" %>
+  <%= form.input :confirm, as: :check_box, label: confirm_label, help: "Show a review page before starting a deploy" %>
+
+  <%= form.input :no_reference_selection, as: :check_box, label: "Disable reference selection", help: no_ref_label %>
 
   <% if @project.releases.any? %>
     <%= form.input :deploy_on_release, as: :check_box, label: "Automatically deploy new releases" %>

--- a/db/migrate/20170402035231_add_macro_to_stages.rb
+++ b/db/migrate/20170402035231_add_macro_to_stages.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddMacroToStages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stages, :no_reference_selection, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -458,6 +458,7 @@ ActiveRecord::Schema.define(version: 20170407001330) do
     t.boolean  "run_in_parallel",                                            default: false, null: false
     t.boolean  "jenkins_build_params",                                       default: false, null: false
     t.boolean  "cancel_queued_deploys",                                      default: false, null: false
+    t.boolean  "no_reference_selection",                                     default: false, null: false
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }, using: :btree
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id", using: :btree
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -84,6 +84,12 @@ describe ApplicationHelper do
       assert_includes link, %(href="/projects/#{project.to_param}/deploys/#{deploy.id}")
     end
 
+    it "shows direct link when stage is direct" do
+      stage.stubs(direct?: true)
+      link.must_include ">Deploy!<"
+      link.must_include "btn-warning"
+    end
+
     describe "when stage can run in parallel" do
       before { stage.stubs(:run_in_parallel).returns true }
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -628,4 +628,32 @@ describe Stage do
       end
     end
   end
+
+  describe "#direct" do
+    before do
+      stage.confirm = false
+      stage.no_reference_selection = true
+    end
+
+    it "is direct" do
+      assert stage.direct?
+    end
+
+    it "is not direct when confirmation is required" do
+      stage.confirm = true
+      refute stage.direct?
+    end
+
+    it "is not direct when reference selection is required" do
+      stage.no_reference_selection = false
+      refute stage.direct?
+    end
+
+    # this could be loosened, but then we have to make sure it goes to pending and not
+    # into a running deploy
+    it "is not direct when approval is required" do
+      stage.stubs(deploy_requires_approval?: true)
+      refute stage.direct?
+    end
+  end
 end


### PR DESCRIPTION
/cc @zendesk/samson @craig-day @jcheatham 

### Problems
 - big code duplication around macros/stages
 - duplicate queries to look for macros and stages commands
 - macros lack many features stages have
 - no tracking of who executed a macro / what it did / what deploy groups it interacted with
 - macros and jobs take up 2 tabs in the project view

### Solution
Add a new `no_reference_selection` boolean that then allows a user to instantly `Deploy!` a stage when used with `no confirm` and `does not deploy code`.

Users are free to move them wherever they please ... so either at the top of the project page or the bottom ... or right after the stage they deal with.

Phase 1 (this PR):
 - [X] UI hints on how to combine flags
 - [X] show `Deploy!` button for `direct` stages
 - [x] bypasses reference selection when used without other flags
 - [ ] Update a few projects to use this and gather feedback

Phase 2:
 - [ ] migrate macros to stages with 'no code deployed' + 'no confirm' + 'no reference selection'
 - [ ] remove jobs view
 - [ ] remove macros

Phase 3:
 - [ ] inline modules we extracted to deal with stage/macro duplication

<img width="341" alt="screen shot 2017-04-01 at 9 21 27 pm" src="https://cloud.githubusercontent.com/assets/11367/24584432/cfdda4ae-1722-11e7-9065-cbb37f9ad57d.png">
<img width="512" alt="screen shot 2017-04-01 at 9 23 19 pm" src="https://cloud.githubusercontent.com/assets/11367/24584431/cdab2f6c-1722-11e7-8e02-77604f0c6e66.png">