### PR TITLE
do not fail deploy when previous generation had failures

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -75,7 +75,10 @@ module Kubernetes
         @events ||= @client.get_events(
           namespace: namespace,
           field_selector: "involvedObject.name=#{name}"
-        )
+        ).select do |event|
+          # compare strings to avoid parsing time '2017-03-31T22:56:20Z'
+          event.metadata.creationTimestamp >= @pod.status.startTime.to_s
+        end
       end
 
       def init_containers

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -434,7 +434,8 @@ describe Kubernetes::DeployExecutor do
               {
                 type: 'Warning',
                 reason: 'FailedScheduling',
-                message: "fit failure on node (ip-1-2-3-4)\nfit failure on node (ip-2-3-4-5)"
+                message: "fit failure on node (ip-1-2-3-4)\nfit failure on node (ip-2-3-4-5)",
+                metadata: {creationTimestamp: "2017-03-31T22:56:20Z"}
               }
             ]
           }.to_json
@@ -557,12 +558,14 @@ describe Kubernetes::DeployExecutor do
                 {
                   reason: 'FailedScheduling',
                   message: "fit failure on node (ip-1-2-3-4)\nfit failure on node (ip-2-3-4-5)",
-                  count: 4
+                  count: 4,
+                  metadata: {creationTimestamp: "2017-03-31T22:56:20Z"}
                 },
                 {
                   reason: 'FailedScheduling',
                   message: "fit failure on node (ip-2-3-4-5)\nfit failure on node (ip-1-2-3-4)",
-                  count: 1
+                  count: 1,
+                  metadata: {creationTimestamp: "2017-03-31T22:56:20Z"}
                 }
               ]
             }.to_json


### PR DESCRIPTION
now that we deploy pods, they have a static name and events from the previous generation
will show up in the event list