### PR TITLE
do not blow up when id is missing or anything else is misconfigured s…

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -248,8 +248,9 @@ class JobExecution
       parameters: {job_id: @job.id}
     )
 
-    raise 'unable to find url' unless url = Airbrake.user_information[/['"](http.*?)['"]/, 1]
-    raise 'unable to find error' unless url.sub!('{{error_id}}', notice['id'])
+    return 'Airbrake did not return an error id' unless id = notice['id']
+    return 'Unable to find Airbrake url' unless url = Airbrake.user_information[/['"](http.*?)['"]/, 1]
+    return 'Unable to find error_id placeholder' unless url.sub!('{{error_id}}', id)
     "Error #{url}"
   end
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -356,6 +356,17 @@ describe JobExecution do
         execution.output.to_s.must_include "http://foo.com/12345"
       end
     end
+
+    it "shows warnings to users when things went wrong instead of blowing up" do
+      with_hidden_errors do
+        Airbrake.expects(:notify_sync).returns({})
+        job.expects(:run!).raises("Oh boy")
+        execution.start!
+        execution.wait!
+        execution.output.to_s.must_include "JobExecution failed: Oh boy"
+        execution.output.to_s.must_include "Airbrake did not return an error id"
+      end
+    end
   end
 
   describe "#stop!" do


### PR DESCRIPTION
…nce the end-users will just think samson is broken

got weirdly failing deploys ... and then saw this in the logs

```
app/models/job_execution.rb:252:in `sub!': no implicit conversion of nil into String (TypeError)
	app/models/job_execution.rb:252:in `report_to_airbrake'
	app/models/job_execution.rb:111:in `error!'
```