### PR TITLE
jobs were running in before-deploy but checked for stability

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -16,11 +16,7 @@ module Kubernetes
       end
 
       def live?
-        if prerequisite?
-          completed?
-        else
-          completed? || (phase == 'Running' && ready?)
-        end
+        completed? || (phase == 'Running' && ready?)
       end
 
       def completed?
@@ -91,10 +87,6 @@ module Kubernetes
       end
 
       private
-
-      def prerequisite?
-        @pod.dig(*RoleConfigFile::PREREQUISITE)
-      end
 
       # if the pod is still running we stream the logs until it times out to get as much info as possible
       # necessary since logs often hang for a while even if the pod is already done

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -64,6 +64,7 @@ module Kubernetes
     # check all pods and see if they are running
     # once they are running check if they are stable (for apps only, since jobs are finished and will not change)
     def wait_for_resources_to_complete(release, release_docs)
+      raise "prerequisites should not check for stability" if @testing_for_stability
       @wait_start_time = Time.now
       stable_ticks = CHECK_STABLE / TICK
       @output.puts "Waiting for pods to be created"
@@ -212,7 +213,7 @@ module Kubernetes
           {live: false, details: "Missing", pod: pod}
         elsif pod.restarted?
           {live: false, stop: true, details: "Restarted", pod: pod}
-        elsif pod.live?
+        elsif release_doc.prerequisite? ? pod.completed? : pod.live?
           {live: true, details: "Live", pod: pod}
         elsif pod.events_indicate_failure?
           {live: false, stop: true, details: "Error", pod: pod}

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -18,9 +18,8 @@ module Kubernetes
       end
 
       # should it be deployed before all other things get deployed ?
-      # TODO: remove Job support here and only reply on prerequisite
       def prerequisite?
-        @template.fetch(:kind) == "Job" || @template.dig(*RoleConfigFile::PREREQUISITE)
+        @template.dig(*RoleConfigFile::PREREQUISITE)
       end
 
       def primary?

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -69,20 +69,6 @@ describe Kubernetes::Api::Pod do
       pod_attributes[:status][:phase] = "Succeeded"
       assert pod.live?
     end
-
-    describe "prerequisite" do
-      before { pod_attributes[:metadata][:annotations] = {"samson/prerequisite": "true" } }
-
-      it "is not live when running since we are waiting for it to finish" do
-        pod_attributes[:status][:phase] = "Running"
-        refute pod.live?
-      end
-
-      it "is live when succeeded" do
-        pod_attributes[:status][:phase] = "Succeeded"
-        assert pod.live?
-      end
-    end
   end
 
   describe "#completed?" do

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -113,12 +113,6 @@ describe Kubernetes::Resource do
       template[:metadata][:annotations] = {"samson/prerequisite": true}
       assert resource.prerequisite?
     end
-
-    # testing legacy behavior ... ScheduledJob etc should not be prerequisites
-    it "is a prerequisite when it is a job" do
-      template[:kind] = "Job"
-      assert resource.prerequisite?
-    end
   end
 
   describe "#primary?" do


### PR DESCRIPTION
that lead to the second run of wait_for_resources_to_complete to start at the stability test and
then crash instantly

also adding sanity check, so if this ever happens in the future we will get a nice error

this will lead to weird situations when someone is not using prerequisite, but we have to migrate that at some point anyway ... so why not now ...