### PR TITLE
do not fail when before deploy hook already failed

### DIFF
--- a/plugins/github/lib/samson_github/samson_plugin.rb
+++ b/plugins/github/lib/samson_github/samson_plugin.rb
@@ -24,7 +24,7 @@ Samson::Hooks.callback :after_deploy do |deploy, _buddy|
     GithubNotification.new(deploy).deliver
   end
 
-  if deploy.stage.use_github_deployment_api?
-    GithubDeployment.new(deploy).update_github_deployment_status(deploy.instance_variable_get(:@deployment))
+  if deploy.stage.use_github_deployment_api? && deployment = deploy.instance_variable_get(:@deployment)
+    GithubDeployment.new(deploy).update_github_deployment_status(deployment)
   end
 end


### PR DESCRIPTION
silence this url for nil error
https://zendesk.airbrake.io/projects/95346/groups/1921876863085912318?tab=overview

caused by before book failing
https://zendesk.airbrake.io/projects/95346/groups/1921876863002026234?tab=overview
