### PR TITLE
when a resource is failed, it will never recover and we can stop trying

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -23,6 +23,10 @@ module Kubernetes
         phase == 'Succeeded'
       end
 
+      def failed?
+        phase == 'Failed'
+      end
+
       def restarted?
         @pod.status.containerStatuses.try(:any?) { |s| s.restartCount.positive? }
       end

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -213,6 +213,8 @@ module Kubernetes
           {live: false, details: "Missing", pod: pod}
         elsif pod.restarted?
           {live: false, stop: true, details: "Restarted", pod: pod}
+        elsif pod.failed?
+          {live: false, stop: true, details: "Failed", pod: pod}
         elsif release_doc.prerequisite? ? pod.completed? : pod.live?
           {live: true, details: "Live", pod: pod}
         elsif pod.events_indicate_failure?

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -83,6 +83,17 @@ describe Kubernetes::Api::Pod do
     end
   end
 
+  describe "#failed?" do
+    it "is not failed" do
+      refute pod.failed?
+    end
+
+    it "is failed when failed" do
+      pod_attributes[:status][:phase] = "Failed"
+      assert pod.failed?
+    end
+  end
+
   describe "#restarted?" do
     it "is not restarted" do
       refute pod.restarted?

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -426,6 +426,15 @@ describe Kubernetes::DeployExecutor do
       out.must_include "UNSTABLE"
     end
 
+    it "stops when detecting a failure" do
+      pod_status[:phase] = "Failed"
+
+      refute execute!
+
+      out.must_include "resque-worker: Failed\n"
+      out.must_include "UNSTABLE"
+    end
+
     it "stops when detecting a failure via events" do
       pod_status[:phase] = "Pending"
       request = stub_request(:get, %r{http://foobar.server/api/v1/namespaces/staging/events}).


### PR DESCRIPTION
this should only ever happen for pods and maybe jobs