### PR TITLE
PAAS-924 show who cancelled a deploy

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -146,7 +146,7 @@ class DeploysController < ApplicationController
 
   def destroy
     if @deploy.can_be_stopped_by?(current_user)
-      @deploy.stop!
+      @deploy.stop!(current_user)
     else
       flash[:error] = "You do not have privileges to stop this deploy."
     end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -33,7 +33,7 @@ class JobsController < ApplicationController
 
   def destroy
     if @job.can_be_stopped_by?(current_user)
-      @job.stop!
+      @job.stop!(current_user)
       flash[:notice] = "Cancelled!"
     else
       flash[:error] = "You are not allowed to stop this job."

--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -14,10 +14,8 @@ class DeployService
       send_sse_deploy_update('new', deploy)
 
       if stage.cancel_queued_deploys?
-        stage.deploys.pending.prior_to(deploy).for_user(user).each do |queued_deploy|
-          if JobExecution.dequeue(queued_deploy.job.id)
-            queued_deploy.job.cancelled!
-          end
+        stage.deploys.pending.prior_to(deploy).for_user(user).each do |deploy|
+          deploy.job.stop!(user) if deploy.job.queued? # tiny race condition, might cancel jobs that have just started
         end
       end
 

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -66,8 +66,6 @@ class JobExecution
       @executor.stop! 'KILL'
       @thread.join(stop_timeout) || @thread.kill
     end
-
-    @job.cancelled!
     finish
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -153,7 +153,7 @@ module Samson
       if !Rails.env.test? && ENV['SERVER_MODE'] && !ENV['PRECOMPILE']
         JobExecution.enabled = true
 
-        Job.running.each(&:stop!)
+        Job.running.each { |j| j.stop!(nil) }
 
         Job.non_deploy.pending.each do |job|
           JobExecution.start_job(JobExecution.new(job.commit, job))

--- a/db/migrate/20170407001330_add_canceller_to_jobs.rb
+++ b/db/migrate/20170407001330_add_canceller_to_jobs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddCancellerToJobs < ActiveRecord::Migration[5.0]
+  def change
+    add_column :jobs, :canceller_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170328214722) do
+ActiveRecord::Schema.define(version: 20170407001330) do
 
   create_table "builds", force: :cascade do |t|
     t.integer  "project_id",                                       null: false
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 20170328214722) do
     t.datetime "updated_at"
     t.string   "commit"
     t.string   "tag"
+    t.integer  "canceller_id"
     t.index ["project_id"], name: "index_jobs_on_project_id", using: :btree
     t.index ["status"], name: "index_jobs_on_status", length: { status: 191 }, using: :btree
     t.index ["user_id"], name: "index_jobs_on_user_id", using: :btree

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -118,6 +118,7 @@ describe DeployService do
         deploy_one = create_deployment(user, 'v1', stage, 'running')
         deploy_two = create_deployment(user, 'v2', stage, 'pending')
 
+        JobExecution.expects(:queued?).with(deploy_two.job.id).returns(true)
         JobExecution.expects(:dequeue).with(deploy_two.job.id).returns(true)
 
         service.deploy!(stage, reference: reference)

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -54,6 +54,12 @@ describe Deploy do
       end
     end
 
+    it "shows canceller when it was regularly cancelled" do
+      deploy.job.status = "cancelled"
+      deploy.job.canceller = users(:admin)
+      deploy.summary.must_equal "Admin cancelled deploy baz to Staging"
+    end
+
     describe "when buddy was required" do
       before { Stage.any_instance.stubs(:deploy_requires_approval?).returns true }
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -223,8 +223,7 @@ describe JobExecution do
     execution.on_complete { called_subscriber = true }
     execution.stop!
 
-    assert_equal true, called_subscriber
-    assert_equal 'cancelled', job.status
+    assert called_subscriber
   end
 
   it 'saves job output before calling subscriber' do
@@ -389,7 +388,6 @@ describe JobExecution do
         true
       end
       execution.stop!
-      job.reload.status.must_equal 'cancelled'
     end
 
     it "stops the execution with kill if job did not respond to interrupt" do
@@ -400,7 +398,6 @@ describe JobExecution do
         true
       end
       execution.stop!
-      job.reload.status.must_equal 'cancelled'
     end
 
     it "calls on_complete hooks once when killing stuck thread" do
@@ -422,14 +419,6 @@ describe JobExecution do
       end
       execution.stop!
       called.must_equal [1]
-    end
-
-    it "marks the execution as cancelled when it was already stopped since we always need to enqueu the next" do
-      execution.start!
-      lock.unlock
-      sleep 0.1
-      execution.stop!
-      job.reload.status.must_equal 'cancelled'
     end
   end
 


### PR DESCRIPTION
it is nice to be able to reach out to whoever cancelled your deploy

fixes https://github.com/zendesk/samson/issues/1880
relates to https://github.com/zendesk/samson/pull/1881

<img width="658" alt="screen shot 2017-04-06 at 8 48 14 pm" src="https://cloud.githubusercontent.com/assets/11367/24784913/a6601d82-1b0a-11e7-8a32-16122c2589ad.png">

also:
 - make cancel! and cancelling! private
 - disentangle job from jobexecution ... before job would call execution which called job
 - simplify waiting_for_restart which was wrong (basically said `active? && (!active? && !running?)` before which is impossible ... so fixed to check pending)
 - add missing test cases
