### PR TITLE
use short reference to make tables smaller

### DIFF
--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -30,8 +30,8 @@
             <tr>
               <td><%= link_to project.name, project %></td>
               <td><%= link_to dgs.stage.name, [dgs.stage.project, dgs.stage] %></td>
-              <td><%= dgs.stage.last_successful_deploy.try(&:reference) || 'NONE' %></td>
-              <td><%= dgs.stage.template_stage&.last_successful_deploy&.reference %></td>
+              <td><%= dgs.stage.last_successful_deploy&.short_reference || 'NONE' %></td>
+              <td><%= dgs.stage.template_stage&.last_successful_deploy&.short_reference %></td>
             </tr>
           <% end %>
         <% end %>


### PR DESCRIPTION
before: tables overflowing because shas are long

![screen shot 2017-04-07 at 9 44 15 am](https://cloud.githubusercontent.com/assets/11367/24810305/cee1bbfa-1b76-11e7-8024-3dfb7c262f00.png)