### PR TITLE
fix refs with / cannot be found

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -37,8 +37,10 @@ class CommitStatus
     a
   end
 
+  # need to do weird escape logic since other wise either 'foo/bar' or 'bar[].foo' do not work
   def github_status
-    GITHUB.combined_status(@stage.project.user_repo_part, CGI.escape(@reference)).to_h
+    escaped_ref = @reference.gsub(/[^a-zA-Z\/\d_-]+/) { |v| CGI.escape(v) }
+    GITHUB.combined_status(@stage.project.user_repo_part, escaped_ref).to_h
   rescue Octokit::NotFound
     {
       state: "failure",

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -101,7 +101,7 @@ describe CommitStatus do
 
     describe "with bad ref" do
       let(:reference) { '[/r' }
-      let(:url) { "repos/#{stage.project.user_repo_part}/commits/%255B%252Fr/status" }
+      let(:url) { "repos/#{stage.project.user_repo_part}/commits/%255B/r/status" }
 
       it "escapes the url" do
         failure!


### PR DESCRIPTION
reached out to github too, don't expect a useful reply ...

not using escape means `[]..foo` will fail ... so only allow / through

<img width="505" alt="screen shot 2017-04-07 at 1 55 09 pm" src="https://cloud.githubusercontent.com/assets/11367/24819570/fcf714e0-1b99-11e7-9a13-14258559908b.png">
