### PR TITLE
Add more information to the github deployments payload

### DIFF
--- a/plugins/github/app/models/github_deployment.rb
+++ b/plugins/github/app/models/github_deployment.rb
@@ -26,9 +26,19 @@ class GithubDeployment
     {
       accept: DEPLOYMENTS_PREVIEW_MEDIA_TYPE,
       force: true,
-      payload: {deployer: @deploy.user.name}.to_json,
+      payload: payload.to_json,
       environment: @stage.name,
       description: @deploy.summary
+    }
+  end
+
+  def payload
+    {
+      deployer: @deploy.user.name,
+      deployer_email: @deploy.user.email,
+      buddy: @deploy.buddy_name,
+      buddy_email: @deploy.buddy_email,
+      production: @stage.production?
     }
   end
 


### PR DESCRIPTION
Extend the Github plugin, so it provides more information; "user_email" (?string), "buddy" (?string), "buddy_email" (?string) and "production" (bool)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team @zendesk/samson 
