### PR TITLE
creating deployment for a merged commit fails

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,1 +1,4 @@
-Github comments on deploy or deployment api.
+Github integration.
+
+ - comments on PRs when they are deployed
+ - adds deployment for each commit that is deployed via Github deployment api

--- a/plugins/github/test/models/github_deployment_test.rb
+++ b/plugins/github/test/models/github_deployment_test.rb
@@ -19,22 +19,18 @@ describe GithubDeployment do
       body = {
         payload: {
           deployer: {id: deploy.user.id, name: deploy.user.name, email: deploy.user.email},
-          buddy: nil,
-          production: false
+          buddy: nil
         },
         environment: "Staging",
         description: "Super Admin deployed staging to Staging",
+        production_environment: false,
+        auto_merge: false,
+        required_contexts: [],
         ref: "abcabc1"
       }
       create = stub_request(:post, endpoint).with(body: body.to_json)
       github_deployment.create
       assert_requested create
-    end
-
-    it "returns nil when deployment for this tag already existed" do
-      deploy = stub_request(:post, endpoint).to_return(status: 409)
-      github_deployment.create.must_equal nil
-      assert_requested deploy
     end
   end
 


### PR DESCRIPTION
@hkjorgensen 

for example here the deployment is not visible ... but at least it exists ... https://github.com/zendesk/samson/commit/a0f289ff3baf61bdf40145302adf4d78abb22d8b
https://api.github.com/repos/zendesk/samson/deployments/33187646

we could make that work by adding the deployment to the last commit in the PR like https://github.com/zendesk/samson/pull/1882 ... reached out to github to see if they can fix it somehow ...

if they don't have a solution we can add it to the parent commit or the last commit in the PR ...