### PR TITLE
make visible clearer to avoid accidental usage

### DIFF
--- a/app/views/admin/secrets/show.html.erb
+++ b/app/views/admin/secrets/show.html.erb
@@ -57,7 +57,7 @@
       </div>
 
       <div class="form-group">
-        <%= label_tag 'secret[visible]', 'Visible', class: "col-lg-2 control-label", title: 'Value visible in samson edit UI' %>
+        <%= label_tag 'secret[visible]', 'Visible in UI', class: "col-lg-2 control-label" %>
         <div class="col-lg-6">
           <%= hidden_field_tag 'secret[visible]', false %>
           <%= check_box_tag 'secret[visible]', true, secret[:visible], class: "form-control", disabled: edit_disabled %>


### PR DESCRIPTION
had lots of accidentally public secrets ... maybe changing the label helps ... the title clearly did not help ...

![screen shot 2017-04-11 at 3 26 14 pm](https://cloud.githubusercontent.com/assets/11367/24933480/61dc3960-1ecb-11e7-9d63-749eb84f6f08.png)
