### PR TITLE
reuse commandexecutor and add timeout for deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DEFAULT_URL=http://localhost:3000
 SECRET_TOKEN={bundle exec rake secret}
 RAILS_MIN_THREADS=5
 RAILS_MAX_THREADS=10
+DEPLOY_TIMEOUT=3600 # seconds after which deploys killed
 
 # Required token to fetch commit diff / PR status / create tags etc
 GITHUB_TOKEN=

--- a/test/lib/samson/command_executor_test.rb
+++ b/test/lib/samson/command_executor_test.rb
@@ -84,5 +84,13 @@ describe Samson::CommandExecutor do
           must_equal [true, "bar\n"]
       end
     end
+
+    it "can run as a block" do
+      success, out = Samson::CommandExecutor.execute("echo", "11", timeout: 1) do |pio|
+        pio.read(256) + "MOOH"
+      end
+      success.must_equal true
+      out.must_equal "11\nMOOH"
+    end
   end
 end

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered!
+SingleCov.covered! uncovered: 1
 
 describe TerminalExecutor do
   let(:output) { StringIO.new }
@@ -38,13 +38,6 @@ describe TerminalExecutor do
       subject.execute!('echo "hi"').must_equal(true)
     end
 
-    it 'shows a nice message when child could not be found' do
-      Process.expects(:wait2).raises(Errno::ECHILD) # No child processes found
-      subject.execute!('blah').must_equal(false)
-      out = output.string.sub(/.*blah: /, '').sub('command ', '') # linux has a different message
-      out.must_equal "not found\r\nErrno::ECHILD: No child processes\n"
-    end
-
     it 'does not expose env secrets' do
       with_env MY_SECRET: 'XYZ' do
         subject.execute!('env')
@@ -75,11 +68,6 @@ describe TerminalExecutor do
     it "ignores getpgid failures since they mean the program finished early" do
       Process.expects(:getpgid).raises(Errno::ESRCH)
       subject.execute!('sleep 0.1').must_equal true
-    end
-
-    it "ignores closed output errors that happen on linux" do
-      output.expects(:write).raises(Errno::EIO) # it is actually the .each call that raises it, but that is hard to stub
-      subject.execute!('echo "hi"').must_equal(true)
     end
 
     it "keeps pid while executing" do


### PR DESCRIPTION
 - remove duplication of code execution and all the error handling that comes with it
 - allow setting timeouts for deploys

Current issues:
 - <del>`script` messes up the log stream and the test output ... </del>
 - <del>cannot use `script` with `pgroup: true` or IO.read just hangs... have to verify if kill still works cleanly</del>

@henders 