### PR TITLE
return the last successful deploy of each project in JSON/CSV

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -164,6 +164,14 @@ class Deploy < ActiveRecord::Base
     joins(:job).where(jobs: { user: user })
   end
 
+  # Return a hash of project_id => Deploy objects, where each Deploy is
+  # the last Deploy completed for that Project. You can use Deploy scopes,
+  # such as Deploy.successful.last_deploys_for_projects
+  def self.last_deploys_for_projects
+    deploy_ids = select('deploys.project_id, MAX(deploys.id) as last_deploy_id').group(:project_id).reorder(:project_id).map(&:last_deploy_id)
+    where(id: deploy_ids).index_by(&:project_id)
+  end
+
   def buddy_name
     user.id == buddy_id ? "bypassed" : buddy.try(:name)
   end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -170,6 +170,7 @@ class Deploy < ActiveRecord::Base
   def self.last_deploys_for_projects
     deploy_ids = select('deploys.project_id, MAX(deploys.id) as last_deploy_id').
       group(:project_id).
+      reorder(:project_id).
       map(&:last_deploy_id)
 
     where(id: deploy_ids).index_by(&:project_id)

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -168,7 +168,10 @@ class Deploy < ActiveRecord::Base
   # the last Deploy completed for that Project. You can use Deploy scopes,
   # such as Deploy.successful.last_deploys_for_projects
   def self.last_deploys_for_projects
-    deploy_ids = select('deploys.project_id, MAX(deploys.id) as last_deploy_id').group(:project_id).reorder(:project_id).map(&:last_deploy_id)
+    deploy_ids = select('deploys.project_id, MAX(deploys.id) as last_deploy_id').
+      group(:project_id).
+      map(&:last_deploy_id)
+
     where(id: deploy_ids).index_by(&:project_id)
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -52,14 +52,14 @@ describe ProjectsController do
         result = JSON.parse(response.body)
         projects = result['projects']
         projects.length.must_equal 1
-        projects.first['name'].must_equal 'foo'
+        projects.first['name'].must_equal 'Foo'
       end
 
       it "returns the last deploy date in JSON" do
         get :index, params: {format: 'json'}
         result = JSON.parse(response.body)
         project = result['projects'].first
-        project['last_deployed_at'].must_start_with '2014-01'
+        project['last_deployed_at'].must_include '2014-01'
       end
 
       it "responds to CSV requests" do
@@ -72,6 +72,7 @@ describe ProjectsController do
             row.headers.must_include attr
           end
           row['Id'].must_equal all_projects[idx].id.to_s
+          row['Last Deploy At'].must_include '2014-01'
         end
       end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -50,7 +50,16 @@ describe ProjectsController do
       it "responds to json requests" do
         get :index, params: {format: 'json'}
         result = JSON.parse(response.body)
-        result['projects'].map(&:symbolize_keys!).map { |obj| obj[:name] }.must_equal ['Foo']
+        projects = result['projects']
+        projects.length.must_equal 1
+        projects.first['name'].must_equal 'foo'
+      end
+
+      it "returns the last deploy date in JSON" do
+        get :index, params: {format: 'json'}
+        result = JSON.parse(response.body)
+        project = result['projects'].first
+        project['last_deployed_at'].must_start_with '2014-01'
       end
 
       it "responds to CSV requests" do

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -395,8 +395,20 @@ describe Deploy do
   end
 
   describe ".last_deploys_for_projects" do
+    before do
+      Project.any_instance.stubs(:valid_repository_url).returns(true)
+    end
+
+    let!(:project_b) { Project.create!(name: "hello", repository_url: "git://foo.com:hello/world.git") }
+
     it "returns Deploys indexed by project id" do
-      # TODO: implement this test
+      create_deploy!(project: project_b)
+
+      result = Deploy.last_deploys_for_projects
+      result.must_be_instance_of Hash
+      result.keys.sort.must_equal [project.id, project_b.id].sort
+      result.values.each { |d| d.must_be_instance_of Deploy }
+      result[project.id].id.must_equal project.deploys.map(&:id).max
     end
   end
 

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -394,6 +394,12 @@ describe Deploy do
     end
   end
 
+  describe ".last_deploys_for_projects" do
+    it "returns Deploys indexed by project id" do
+      # TODO: implement this test
+    end
+  end
+
   describe "#url" do
     it 'builds an address for a deploy' do
       deploy.url.must_equal "http://www.test-url.com/projects/foo/deploys/#{deploy.id}"


### PR DESCRIPTION
When dumping Samson data into a spreadsheet, it's handy to know the last time a project was successfully deployed, so you can figure out whether the project is still being used.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
