### PR TITLE
do not show deprecated macros tab when they are not used

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,6 +87,7 @@ task :flay do
     'app/views/admin/secrets/index.html.erb', # search box
     'plugins/slack_webhooks/app/views/samson_slack_webhooks/_fields.html.erb', # cannot reuse form.input
     'plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb', # super simple html
+    'app/views/shared/_project_tabs.html.erb', # simple html and can be removed once macros are gone
   ]
   flay = Flay.run([*files, '--mass', '25']) # mass threshold is shown mass / occurrences
   abort "Code duplication found" if flay.report.any?

--- a/app/views/shared/_project_tabs.html.erb
+++ b/app/views/shared/_project_tabs.html.erb
@@ -16,9 +16,11 @@
   <li class="<%= 'active' if active == 'jobs' %>">
     <%= link_to "Jobs", project_jobs_path(project) %>
   </li>
-  <li class="<%= 'active' if active == 'macros' %>">
-    <%= link_to "Macros", project_macros_path(project) %>
-  </li>
+  <% if project.macros.exists? %>
+    <li class="<%= 'active' if active == 'macros' %>">
+      <%= link_to "Macros", project_macros_path(project) %>
+    </li>
+  <% end %>
   <li class="<%= 'active' if active == 'webhooks' %>">
     <%= link_to "Webhooks", project_webhooks_path(project) %>
   </li>


### PR DESCRIPTION
![screen shot 2017-04-18 at 9 34 28 am](https://cloud.githubusercontent.com/assets/11367/25142041/63b249b0-241a-11e7-89ae-57f19d2b0de2.png)

should stop new users from using them ...