### PR TITLE
make stage table have less breaks when stage names and deploy groups …

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -114,10 +114,6 @@ pre.pre-inline {
   font-weight: normal;
 }
 
-.project-stages > tbody > tr > td {
-  line-height: 37px;
-}
-
 .project-title {
   position: relative;
 

--- a/app/views/projects/_stage.html.erb
+++ b/app/views/projects/_stage.html.erb
@@ -4,11 +4,12 @@
       <%= link_to stage.name, [project, stage] %>
       <%= resource_lock_icon stage %>
       <%= stage.is_template ? stage_template_icon : '' %>
-    </td>
 
-    <% if DeployGroup.enabled? %>
-      <td><%= stage.deploy_groups.sort_by(&:natural_order).map(&:name).join(', ') %></td>
-    <% end %>
+      <% if DeployGroup.enabled? %>
+        <br/>
+        <%= stage.deploy_groups.sort_by(&:natural_order).map(&:name).join(', ') %>
+      <% end %>
+    </td>
 
     <% if deploy = stage.last_deploy %>
       <td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -9,9 +9,6 @@
     <thead>
       <tr>
         <th>Stage Name</th>
-        <% if DeployGroup.enabled? %>
-          <th>Deploy Groups</th>
-        <% end %>
         <th>Last Deploy</th>
         <th class="pull-right">
           <% if current_user.admin_for?(@project) %>


### PR DESCRIPTION
…are long

![screen shot 2017-04-18 at 10 05 16 am](https://cloud.githubusercontent.com/assets/11367/25143283/b023513c-241e-11e7-855e-666ae8921207.png)

test failures are random
