### PR TITLE
fix deploy group check boxes not working for names with spaces

### DIFF
--- a/app/assets/javascripts/stages.js
+++ b/app/assets/javascripts/stages.js
@@ -57,28 +57,27 @@ $(function() {
   });
 
   $(".env-toggle-all").each(function() {
-    $(this).change(function(toggleBox) {
-      $($(this).data('target')).each(function(index, checkBox) {
-        checkBox.checked = toggleBox.target.checked;
-      });
+    var envCheckbox = $(this);
+    var deploygroupCheckboxes = $("." + envCheckbox.data('target'));
+    var updateEnv = function(){ setEnvironmentCheckbox(envCheckbox, deploygroupCheckboxes); };
+
+    envCheckbox.change(function(e) {
+      deploygroupCheckboxes.prop("checked", $(e.target).prop('checked'));
     });
 
-    // Update top-level checkboxes if user selects subset of deploygroups
-    $($(this).data('target')).each(function() {
-      $(this).change(function() {
-        setEnvironmentCheckBox($(this).attr('class'));
-      });
-    });
+    // Update top-level checkboxes if user selects subset of deploy groups
+    deploygroupCheckboxes.change(updateEnv);
 
-    setEnvironmentCheckBox(this.id);
+    // set initial state
+    updateEnv();
   });
 
-  function setEnvironmentCheckBox(envClass) {
-    var envCheckbox = $('#' + envClass),
-        checks = _.uniq(_.pluck($("." + envClass), 'checked'));
-    if (checks.length > 1) {
+  function setEnvironmentCheckbox(envCheckbox, deploygroupCheckboxes) {
+    var checks = _.uniq(_.pluck(deploygroupCheckboxes, 'checked'));
+
+    if (checks.length == 2) { // some items checked
       envCheckbox.prop('indeterminate', true);
-    } else if (checks.length > 0) {
+    } else { // all or none checked
       envCheckbox.prop('checked', checks[0]);
       envCheckbox.prop('indeterminate', false);
     }

--- a/app/views/deploy_groups/_deploy_group_select.html.erb
+++ b/app/views/deploy_groups/_deploy_group_select.html.erb
@@ -9,7 +9,7 @@
           <% environments.each do |environment| %>
             <th>
               <%= label_tag do %>
-                <%= check_box_tag('', nil, false, { id: "#{environment.name}_checkbox", class: "env-toggle-all", data: {target: ".#{environment.name}_checkbox" } }) %>
+                <%= check_box_tag '', nil, false, class: "env-toggle-all", data: {target: "#{environment.permalink}_checkbox" } %>
                 <%= environment.name %>
               <% end %>
             </th>
@@ -25,7 +25,7 @@
                 <td>
                   <%= label_tag do %>
                     <% checked = form.object.deploy_group_ids.include?(group.id) %>
-                    <%= check_box_tag "#{form.object_name}[deploy_group_ids][]", group.id, checked, class: "#{environment.name}_checkbox" %>
+                    <%= check_box_tag "#{form.object_name}[deploy_group_ids][]", group.id, checked, class: "#{environment.permalink}_checkbox" %>
                     <%= group.name %>
                   <% end %>
                 </td>


### PR DESCRIPTION
 - use permalink since that is unique and a good selector
 - remove id logic ... only rely on data-target and class
 - use jquery properly to avoid a few iterations
