### PR TITLE
log/notify on failure to report to slack as we do with connection errors

### DIFF
--- a/plugins/slack_webhooks/test/samson_slack_webhooks/slack_webhooks_service_test.rb
+++ b/plugins/slack_webhooks/test/samson_slack_webhooks/slack_webhooks_service_test.rb
@@ -82,5 +82,12 @@ describe SamsonSlackWebhooks::SlackWebhooksService do
       Rails.logger.expects(:error)
       service.deliver_message_via_webhook(webhook: webhook, message: "Hey", attachments: [])
     end
+
+    it "reports 404s from misconfigurations or missing channels" do
+      stub_request(:post, "http://foo.com").to_return(status: 404, body: "Oops")
+      Airbrake.expects(:notify)
+      Rails.logger.expects(:error)
+      service.deliver_message_via_webhook(webhook: webhook, message: "Hey", attachments: [])
+    end
   end
 end


### PR DESCRIPTION
got all our slack hooks silently failing with a 404 without anyone noticing ... should report that ...
