### PR TITLE
use monospaced font for command entry

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,3 +51,7 @@ a.no-hover:hover {
 a.btn.disabled[title] {
   pointer-events: auto;
 }
+
+#command_command {
+  font-family: monospace;
+}


### PR DESCRIPTION
before:
<img width="163" alt="screen shot 2017-04-22 at 8 58 17 am" src="https://cloud.githubusercontent.com/assets/11367/25306003/38827f26-273a-11e7-8648-0d473ce8fefc.png">


after:
<img width="222" alt="screen shot 2017-04-22 at 8 58 43 am" src="https://cloud.githubusercontent.com/assets/11367/25306004/3a9fcf66-273a-11e7-80ee-95ab56523032.png">

@tmcinerney 