### PR TITLE
cache templates to avoid disk IO

### DIFF
--- a/config/initializers/cached_templates.rb
+++ b/config/initializers/cached_templates.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# Samson often gets slow because deploys are IO heavy
+# avoid loading 10+ templates per page render from disk
+# test by booting the server, requesting the homepage and then sudo chmod -R -r app/views and refresh
+unless Rails.env.development?
+  class ActionView::PathResolver
+    class File < ::File
+      def self.binread(path)
+        (@@binread_cache ||= {})[path] ||= super(path)
+      end
+    end
+
+    prepend(Module.new do
+      def find_template_paths(query)
+        (@@find_template_paths_cache ||= {})[query] ||= super
+      end
+    end)
+  end
+end


### PR DESCRIPTION
tested with `sudo chmod -R -r app/views` 

made local rendering (with caching/eager load etc enabled) go from 150ms -> 80s and not touch a single file, that should be a good speed bump for prod when it's under high IO load