### PR TITLE
check initial ref when page is opened with ref=

### DIFF
--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -94,4 +94,7 @@ function refStatusTypeahead(options){
       status_check_timeout = setTimeout(function() { check_status(ref); }, 200);
     }
   });
+
+  // check initial ref on page load
+  $reference.trigger('input');
 }


### PR DESCRIPTION
@dasch 

so now on page load it shows status errors ... that should solve most of #1925 ?
<img width="529" alt="screen shot 2017-04-22 at 7 11 51 pm" src="https://cloud.githubusercontent.com/assets/11367/25310019/ac1e9302-278f-11e7-9105-3c90b3795822.png">
