### PR TITLE
Make the release details wider

### DIFF
--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -22,6 +22,5 @@
   </td>
 </tr>
 <tr class="release-info collapse" data-url="<%= url_for [@project, release] %>">
-  <td></td>
-  <td colspan="2"></td>
+  <td colspan="4"></td>
 </tr>


### PR DESCRIPTION
It's useful to have more space to see e.g. diffs.

