### PR TITLE
send details for failing webhook to airbrake

### DIFF
--- a/plugins/slack_webhooks/lib/samson_slack_webhooks/slack_webhooks_service.rb
+++ b/plugins/slack_webhooks/lib/samson_slack_webhooks/slack_webhooks_service.rb
@@ -44,8 +44,8 @@ module SamsonSlackWebhooks
         response = Faraday.post(webhook.webhook_url, payload: payload.to_json)
         raise "Error #{response.status} #{response.body.to_s[0..100]}" if response.status >= 300
       rescue Faraday::ClientError, RuntimeError => e
-        Airbrake.notify(e)
-        Rails.logger.error("Could not deliver slack message to webhook #{webhook.webhook_url}: #{e.message}")
+        Airbrake.notify(e, webhook_id: webhook.id, channel: webhook.channel)
+        Rails.logger.error("Could not deliver slack message to webhook #{webhook.id}: #{e.message}")
       end
     end
 


### PR DESCRIPTION
currently there is nothing to identify which one failed
also we should not log the url since that semi secret and also not unique

https://zendesk.airbrake.io/projects/95346/groups/1935269624765950541/notices/1936412159657697160?tab=overview