### PR TITLE
fix params so we get actual domain verification

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -26,7 +26,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       name:   "google",
       scope:  "email,profile",
       prompt: "select_account",
-      hg: ENV['EMAIL_DOMAIN']
+      hd: ENV['EMAIL_DOMAIN']
     )
   end
 


### PR DESCRIPTION
previously would show all domains and then fail when you picked a non-zendesk domain
