### PR TITLE
Use batch/v1 instead of extensions/v1beta1 for jobs

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -24,6 +24,10 @@ module Kubernetes
       @extension_client ||= build_client 'extensions/v1beta1'
     end
 
+    def batch_client
+      @batch_client ||= build_client 'batch/v1'
+    end
+
     def context
       @context ||= kubeconfig.context(config_context)
     end

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -240,7 +240,7 @@ module Kubernetes
 
       # FYI per docs it is supposed to use batch api, but extension api works
       def client
-        @deploy_group.kubernetes_cluster.extension_client
+        @deploy_group.kubernetes_cluster.batch_client
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -68,6 +68,12 @@ describe Kubernetes::Cluster do
     end
   end
 
+  describe '#batch_client' do
+    it 'creates a client' do
+      cluster.batch_client.must_be_kind_of Kubeclient::Client
+    end
+  end
+
   describe "#namespaces" do
     it 'ignores kube-system because it is internal and should not be deployed too' do
       items = [{metadata: {name: 'N1'}}, {metadata: {name: 'N2'}}, {metadata: {name: 'kube-system'}}]

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -81,6 +81,7 @@ describe Kubernetes::DeployExecutor do
     let(:worker_role) { kubernetes_deploy_group_roles(:test_pod100_resque_worker) }
     let(:server_role) { kubernetes_deploy_group_roles(:test_pod100_app_server) }
     let(:deployments_url) { "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/deployments" }
+    let(:jobs_url) { "http://foobar.server/apis/batch/v1/namespaces/staging/deployments" }
     let(:service_url) { "http://foobar.server/api/v1/namespaces/staging/services/some-project" }
 
     before do
@@ -335,11 +336,11 @@ describe Kubernetes::DeployExecutor do
           returns(read_kubernetes_sample_file('kubernetes_deployment.yml'))
 
         # check if the job already exists ... it does not
-        stub_request(:get, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/jobs/test-resque-worker").
+        stub_request(:get, "http://foobar.server/apis/batch/v1/namespaces/staging/jobs/test-resque-worker").
           to_return(status: 404)
 
         # create job
-        stub_request(:post, "http://foobar.server/apis/extensions/v1beta1/namespaces/staging/jobs").
+        stub_request(:post, "http://foobar.server/apis/batch/v1/namespaces/staging/jobs").
           to_return(body: '{}')
 
         # mark the job as Succeeded

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -291,11 +291,11 @@ describe Kubernetes::Resource do
 
   describe Kubernetes::Resource::Job do
     let(:kind) { 'Job' }
-    let(:url) { "http://foobar.server/apis/extensions/v1beta1/namespaces/pod1/jobs/some-project" }
+    let(:url) { "http://foobar.server/apis/batch/v1/namespaces/pod1/jobs/some-project" }
 
     describe "#client" do
       it "uses the extension client because it is in beta" do
-        resource.send(:client).must_equal deploy_group.kubernetes_cluster.extension_client
+        resource.send(:client).must_equal deploy_group.kubernetes_cluster.batch_client
       end
     end
 

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -125,5 +125,15 @@ class ActiveSupport::TestCase
       ]
     }
     stub_request(:get, "http://foobar.server/apis/extensions/v1beta1").to_return(body: discover_v1beta1.to_json)
+
+    batch_v1 = {
+      "kind" => "APIResourceList",
+      "apiVersion" => "v1",
+      "groupVersion" => "batch/v1",
+      "resources" => [
+        {"name" => "jobs", "namespaced" => true, "kind" => "Job"}
+      ]
+    }
+    stub_request(:get, "http://foobar.server/apis/batch/v1").to_return(body: batch_v1.to_json)
   end
 end


### PR DESCRIPTION
Using `jobs` is failing in kubernetes 1.6 because the `extensions/v1beta1` support for jobs has been removed in favor of the `batch/v1`. This causes launching jobs to fail silently in samson when the target cluster is kubernetes 1.6. This happens because the `extension_client` (initialized with `extensions/v1beta1`) doesn't have the method `get_job` because it isn't supported for this api anymore.
Luckily the `batch/v1` was already supported in kubernetes 1.2, so, this change should be backward compatible.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
