### PR TITLE
make long stage names not push down their label

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -76,6 +76,12 @@
 
   .stage-link {
     color: #333;
+
+    // make long stage names not push their labels down
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: inline-block;
+    max-width: 70%;
   }
 
   .status {


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/1950

<img width="376" alt="screen shot 2017-04-29 at 5 51 14 pm" src="https://cloud.githubusercontent.com/assets/11367/25560286/d6ba25d4-2d04-11e7-8303-ca07f2dc80b0.png">
<img width="597" alt="screen shot 2017-04-29 at 5 51 19 pm" src="https://cloud.githubusercontent.com/assets/11367/25560288/d925c59e-2d04-11e7-85a7-5357619ceae9.png">

@craig-day 