### PR TITLE
paper_trail captures the previous version, so we also have to store t…

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -4,7 +4,7 @@ class VersionsController < ApplicationController
     versions = PaperTrail::Version.where(
       item_id: params.require(:item_id),
       item_type: params.require(:item_type)
-    ).order('created_at desc')
+    ).order(id: :desc)
     @versions = versions_with_diff(versions)
   end
 

--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -50,6 +50,9 @@ class Command < ActiveRecord::Base
   private
 
   def trigger_stage_change
-    stages.each(&:record_script_change)
+    stages.each do |stage|
+      stage.commands.detect { |c| c == self }.raw_write_attribute :command, command_was
+      stage.record_script_change
+    end
   end
 end

--- a/app/models/concerns/has_commands.rb
+++ b/app/models/concerns/has_commands.rb
@@ -8,8 +8,9 @@ module HasCommands
     end
   end
 
-  def script
-    commands.map(&:command).join("\n")
+  def script(previous: false)
+    method = (previous ? :command_was : :command)
+    commands.map(&method).join("\n")
   end
 
   def command_ids=(new_command_ids)

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -204,7 +204,7 @@ class Stage < ActiveRecord::Base
 
   # overwrites papertrail to record script
   def object_attrs_for_paper_trail(attributes)
-    super(attributes.merge('script' => script))
+    super(attributes.merge('script' => script(previous: true)))
   end
 
   # DeployGroupsStage has no ids so the default dependent: :destroy fails

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -459,9 +459,10 @@ describe Stage do
       stage.versions.size.must_equal 1
     end
 
-    it "tracks command changes" do
+    it "tracks command changes by storing the previous version" do
       stage.commands.first.update_attributes!(command: "Foo")
       stage.versions.size.must_equal 1
+      YAML.load(stage.versions.last.object).fetch('script').must_equal "echo hello"
     end
 
     it "tracks command additions" do


### PR DESCRIPTION
…he previous command

found via: https://github.com/zendesk/samson/pull/1953

before: updates to commands store the current state so the diff is empty
![screen shot 2017-05-01 at 10 24 57 am](https://cloud.githubusercontent.com/assets/11367/25587353/8750112a-2e58-11e7-9b01-b97b34101c26.png)

after: updates to commands store the previous state, so diff works
![screen shot 2017-05-01 at 10 23 11 am](https://cloud.githubusercontent.com/assets/11367/25587363/942199d2-2e58-11e7-898b-9c45161a410b.png)
