### PR TITLE
prevent cloning from reading secrets which can cause db queries

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'pty'
-require 'secret_storage' # can be removed if `docker-compose up` works
 
 # Executes commands in a fake terminal. The output will be streamed to a
 # specified IO-like object.
@@ -82,6 +81,7 @@ class TerminalExecutor
   end
 
   def resolve_secrets(command)
+    return command unless command.include?(SECRET_PREFIX)
     deploy_groups = @deploy&.stage&.deploy_groups || []
     resolver = Samson::Secrets::KeyResolver.new(@project, deploy_groups)
 

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -179,6 +179,11 @@ describe TerminalExecutor do
         end
       end
 
+      it "does not try to resolve secrets when none are used to avoid doing db lookups while being in a clone thread" do
+        Samson::Secrets::KeyResolver.expects(:new).never
+        subject.execute!('echo "nothing"')
+      end
+
       it "cannot use specific secrets without a deploy" do
         refute_resolves "global/#{deploy.project.permalink}/global/bar"
       end


### PR DESCRIPTION
solves mystery test threading erros and fixes docker-compose up since that failed during secret loading too
fixes https://github.com/zendesk/samson/issues/1924
@dasch 