### PR TITLE
do not blow up when airbrake is loaded but no key was given

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -52,7 +52,7 @@ else
       "Nope"
     end
 
-    def self.add_filter
+    def self.add_filter(*)
     end
   end
 end


### PR DESCRIPTION
```
      rake aborted!
       ArgumentError: wrong number of arguments (given 2, expected 0)
       /tmp/build_a81d7ec587e8f12d7871cc058091b30c/zendesk-samson-528f2b1/config/initializers/airbrake.rb:55:in `add_filter'
       /tmp/build_a81d7ec587e8f12d7871cc058091b30c/zendesk-samson-528f2b1/vendor/bundle/ruby/2.3.0/gems/airbrake-5.7.1/lib/airbrake/rack/middleware.rb:40:in `block in initialize'
       /tmp/build_a81d7ec587e8f12d7871cc058091b30c/zendesk-samson-528f2b1/vendor/bundle/ruby/2.3.0/gems/airbrake-5.7.1/lib/airbrake/rack/middleware.rb:39:in `each'
       /tmp/build_a81d7ec587e8f12d7871cc058091b30c/zendesk-samson-528f2b1/vendor/bundle/ruby/2.3.0/gems/airbrake-5.7.1/lib/airbrake/rack/middleware.rb:39:in `initialize'
```