### PR TITLE
User ::Rails in case Airbrake::Rails exists

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -36,10 +36,10 @@ if defined?(Airbrake) && key = ENV['AIRBRAKE_API_KEY']
 else
   module Airbrake
     def self.notify(ex, *_args)
-      if Rails.env.test?
+      if ::Rails.env.test?
         raise ex # tests have to use Airbrake.expects(:notify) to not hide unintented errors
       else
-        Rails.logger.error "AIRBRAKE: #{ex.class} - #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
+        ::Rails.logger.error "AIRBRAKE: #{ex.class} - #{ex.message} - #{ex.backtrace[0..5].join("\n")}"
         nil
       end
     end


### PR DESCRIPTION
Hi! We aren't using airbrake, but, because our Dockerfile is based on your image, the gem 'airbrake' gets installed and **loaded** by bundler. 
Loading the Airbrake gem defines `Airbrake::Rails`, which makes the patch in `config/initializers/airbrake.rb` that redefines `Airbrake.notify` fail, because `Airbrake::Rails` doesn't have the method `.env`.
This changes disambiguates the costant lookup to explicitly use `::Rails`.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
