### PR TITLE
reset bundler ENV vars before restarting so new server boots with cor…

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 require 'bundler/setup'
+raise "ENV clearing failed" if File.expand_path(ENV.fetch("BUNDLE_GEMFILE")) != File.expand_path("Gemfile")
 require_relative 'dotenv'
 require 'bootscale/setup' if ['development', 'test'].include?(ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development')

--- a/config/dotenv.rb
+++ b/config/dotenv.rb
@@ -1,21 +1,12 @@
 # frozen_string_literal: true
 # Fill ENV from .env with Dotenv, to configure puma/RAILS_ENV/gems with .env
-# - Bundler::ORIGINAL_ENV does not work for resets since it breaks pumas restart handler
-# - Allows a custom puma.rb by all containing restart detection here
-# - Allows regular ENV to override .env
-# - TODO: reset ENV vars that are modified in other ways during app boot
-#
-# see https://github.com/puma/puma/issues/1258
-# test puma restart works: `puts ENV['TEST']` in application.rb, change TEST in .env and then kill -SIGUSR1 the app
-reset_dotenv = -> { ENV["SAMSON_ENV_ADDED_VIA_DOTENV"].to_s.split(',').each { |e| ENV.delete(e) } }
-reset_dotenv.call
-
 require 'dotenv'
 before = ENV.keys
 Dotenv.load(Bundler.root.join('.env'))
-ENV["SAMSON_ENV_ADDED_VIA_DOTENV"] = (ENV.keys - before).join(",")
 
+# when we run rake we load the dev environment first and then the test env
+# so we need to reset what .env changed to be able to load .env.test without ignoring system ENV
 if ENV['RAILS_ENV'] == 'test'
-  reset_dotenv.call
+  (ENV.keys - before).each { |k| ENV.delete(k) }
   Dotenv.load(Bundler.root.join('.env.test'))
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,3 +11,23 @@ port = 9080
 port = 3000 if (ENV["RAILS_ENV"] || "development") == "development"
 
 bind "tcp://0.0.0.0:#{port}"
+
+# make puma restart reset modified ENV vars and BUNDLE_GEMFILE/RUBYLIB which are set via `bundle exec puma`
+# Bundler.original_env will not do since it already has a hardcoded BUNDLE_GEMFILE
+# that cannot change when the server is restarted (via exec -> with copied ENV)
+# see https://github.com/puma/puma/pull/1282
+#
+# test basic puma restart works:
+# - `puts "T #{ENV['TEST'] ||= "X"}"` after `require_relative 'dotenv'` in `config/boot.rb`
+# - boot via `bundle exec puma -C config/puma.rb`
+# - change TEST in .env
+# - kill -SIGUSR1 <puma-pid>
+# - should see `B <nothing>` and `TEST <value from .env>`
+#
+# test bundler reload works: always checked in `config/boot.rb`
+Puma::Runner.prepend(Module.new do
+  def before_restart
+    ENV.replace(Bundler.clean_env)
+    super
+  end
+end)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,6 +39,14 @@ Set up a production block in database.yml with the settings to connect to your D
 
 Configure `config/puma.rb` as you need. See [puma's documentation](https://github.com/puma/puma/) for details. You can start the server using this file by doing `puma -C config/puma.rb`.
 
+### 0-Downtime restarts
+
+Use this to create a server that can receive `kill -SIGUSR1` and perform a clean restart without dropping any requests.
+
+```
+bundle exec --keep-file-descriptors puma --restart-command "bundle exec --keep-file-descriptors puma"
+```
+
 ## Settings
 
 Set the following variables in your `.env` file or set them as environment variables in the shell you spawn the webserver from:


### PR DESCRIPTION
…rect Gemfile

had fun errors like: https://zendesk.airbrake.io/projects/95346/groups/1942179845832648326?tab=notice-detail

`NameError: uninitialized constant PaperTrail::RecordTrail` which came from new gems not being available after restart ... finally tracked that down ...

proper fix will be here https://github.com/puma/puma/pull/1282