### PR TITLE
simplify restarting by discarding the ENV completely

### DIFF
--- a/app/models/restart_signal_handler.rb
+++ b/app/models/restart_signal_handler.rb
@@ -3,7 +3,7 @@
 # Self-pipe is also best practice, since signal handlers can themselves be interrupted
 class RestartSignalHandler
   LISTEN_SIGNAL = 'SIGUSR1'
-  PASSED_SIGNAL = 'SIGUSR2'
+  PASSED_SIGNAL = 'SIGTERM'
 
   class << self
     alias_method :listen, :new

--- a/config/dotenv.rb
+++ b/config/dotenv.rb
@@ -1,21 +1,11 @@
 # frozen_string_literal: true
 # Fill ENV from .env with Dotenv, to configure puma/RAILS_ENV/gems with .env
-# - Bundler::ORIGINAL_ENV does not work for resets since it breaks pumas restart handler
-# - Allows a custom puma.rb by all containing restart detection here
-# - Allows regular ENV to override .env
-# - TODO: reset ENV vars that are modified in other ways during app boot
-#
-# see https://github.com/puma/puma/issues/1258
-# test puma restart works: `puts ENV['TEST']` in application.rb, change TEST in .env and then kill -SIGUSR1 the app
-reset_dotenv = -> { ENV["SAMSON_ENV_ADDED_VIA_DOTENV"].to_s.split(',').each { |e| ENV.delete(e) } }
-reset_dotenv.call
 
 require 'dotenv'
 before = ENV.keys
 Dotenv.load(Bundler.root.join('.env'))
-ENV["SAMSON_ENV_ADDED_VIA_DOTENV"] = (ENV.keys - before).join(",")
 
 if ENV['RAILS_ENV'] == 'test'
-  reset_dotenv.call
+  (ENV.keys - before).each { |k| ENV.delete(k) } # reset what .env changed
   Dotenv.load(Bundler.root.join('.env.test'))
 end

--- a/test/models/restart_signal_handler_test.rb
+++ b/test/models/restart_signal_handler_test.rb
@@ -8,7 +8,7 @@ describe RestartSignalHandler do
     Signal.expects(:trap).with('SIGUSR1')
     handler = RestartSignalHandler.listen
 
-    Process.expects(:kill).with('SIGUSR2', Process.pid)
+    Process.expects(:kill).with('SIGTERM', Process.pid)
     handler.send(:signal_restart)
     sleep 0.1
   end
@@ -57,7 +57,7 @@ describe RestartSignalHandler do
       Airbrake.expects(:notify)
       assert_raises(RuntimeError) { handle }.message.must_equal "Whoops"
 
-      Process.kill('SIGUSR2', Process.pid) # satisfy expect from `before`
+      Process.kill('SIGTERM', Process.pid) # satisfy expect from `before`
     end
   end
 end


### PR DESCRIPTION
 - reusing the ENV is a terrible idea
 - cleaning the ENV is hard
 - restarting an app with the exact same args is hard
... let's get out of that business ...

@jonmoter 
/cc @zendesk/samson 

for more details see:
 - https://github.com/zendesk/samson/pull/1963
 - puma restart handling code
 - bundler ENV cleaning code
 - the many ways this can go wrong and is hard to reason about / test
