### PR TITLE
redirect to where the user came from after login

### DIFF
--- a/app/controllers/unauthorized_controller.rb
+++ b/app/controllers/unauthorized_controller.rb
@@ -25,7 +25,8 @@ class UnauthorizedController < ActionController::Metal
       end
       format.html do
         flash[:authorization_error] = message
-        redirect_to login_path
+        attempted_path = "/#{url_for(params).split("/", 4).last}" # request.fullpath is /unauthenticated
+        redirect_to login_path(redirect_to: attempted_path)
       end
     end
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module SessionsHelper
   def omniauth_path(type)
-    "/auth/#{type}?origin=#{CGI.escape(params.fetch(:origin, '/'))}"
+    origin = params[:redirect_to] || "/" # set by unauthorized_controller.rb
+    raise ArgumentError, "Hackers from #{origin} ?" unless origin.start_with?("/")
+    "/auth/#{type}?origin=#{CGI.escape(origin)}"
   end
 end

--- a/test/controllers/doorkeeper_base_controller_test.rb
+++ b/test/controllers/doorkeeper_base_controller_test.rb
@@ -7,7 +7,7 @@ describe 'DoorkeeperBaseController Integration' do
   it "cannot access as admin" do
     login_as users(:admin)
     get '/oauth/applications'
-    assert_redirected_to '/login'
+    assert_redirected_to '/login?redirect_to=%2Foauth%2Fapplications'
   end
 
   it "can access as super-admin" do

--- a/test/controllers/unauthorized_controller_test.rb
+++ b/test/controllers/unauthorized_controller_test.rb
@@ -16,14 +16,14 @@ describe 'Unauthorized' do
       let(:path) { '/' }
 
       before do
-        get path, {}, headers
+        get path, {controller: "ping", action: "show"}, headers
       end
 
       it 'redirects to the login path' do
         last_response.status.must_equal 302
 
-        # Really just '/', but Rack insists on using the full SERVER_NAME
-        last_response.headers['Location'].must_equal('http://example.org/login')
+        # Really just a path, but Rack insists on using the full SERVER_NAME
+        last_response.headers['Location'].must_equal('http://example.org/login?redirect_to=%2Fping')
       end
 
       it 'sets the flash' do
@@ -59,7 +59,7 @@ describe 'Unauthorized' do
           last_response.status.must_equal 302
 
           # Really just '/', but Rack insists on using the full SERVER_NAME
-          last_response.headers['Location'].must_equal('http://example.org/login')
+          last_response.headers['Location'].must_equal('http://example.org/login?redirect_to=%2Fping')
         end
       end
     end

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -12,8 +12,13 @@ describe SessionsHelper do
     end
 
     it "escapes fancy paths" do
-      params[:origin] = "http://foo.com/bar?x=1"
-      omniauth_path(:google).must_equal "/auth/google?origin=http%3A%2F%2Ffoo.com%2Fbar%3Fx%3D1"
+      params[:redirect_to] = "/bar?x=1"
+      omniauth_path(:google).must_equal "/auth/google?origin=%2Fbar%3Fx%3D1"
+    end
+
+    it "blows up on hacking attempts" do
+      params[:redirect_to] = "https://hackers.com/bar?x=1"
+      assert_raises(ArgumentError) { omniauth_path(:google) }
     end
   end
 end


### PR DESCRIPTION
origin param made no sense ... was also unsafe since anyone could enter anything

```
http://localhost:3000/projects/consul2dogstats/stages/staging ->
http://localhost:3000/login?redirect_to=%2Fprojects%2Fconsul2dogstats%2Fstages%2Fstaging ->
http://localhost:3000/projects/consul2dogstats/stages/staging
```
