### PR TITLE
builds and deploys compete for the same build

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -45,6 +45,7 @@ class DockerBuilderService
   end
 
   def run!(push: false, tag_as_latest: false)
+    return unless Rails.cache.write("build-service-#{build.id}", true, unless_exist: true, expires_in: 10.seconds)
     build.docker_build_job&.destroy # if there's an old build job, delete it
     build.docker_tag = build.label.try(:parameterize).presence || 'latest'
     build.started_at = Time.now

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -33,6 +33,12 @@ describe DockerBuilderService do
     let(:start_jobs) { [] }
     let(:job) { start_jobs[0][0] }
 
+    it "skips when already running to combat racey parallel deploys/builds" do
+      JobExecution.expects(:start_job).never
+      Rails.cache.write("build-service-#{build.id}", true)
+      service.run!
+    end
+
     it "deletes previous build job" do
       build.docker_build_job = jobs(:succeeded_test)
       run!


### PR DESCRIPTION
the builds do the actual tagging, so we make the deploys wait if builds are set up
otherwise we might end up with builds not getting tagged randomly

should fix these:
`JobExecution failed: Couldn't find Job with 'id'=304440`
https://samson.zende.sk/projects/zendesk_inbox/deploys/288147#L16

and the kubernetes builds just sitting with seemingly no output

@staugaard 