### PR TITLE
do not let users run into weird errors

### DIFF
--- a/app/views/admin/secrets/show.html.erb
+++ b/app/views/admin/secrets/show.html.erb
@@ -1,6 +1,6 @@
 <%
   id = params[:id]
-  environment_permalinks = Environment.pluck(:permalink).unshift('global')
+  environment_permalinks = ['global'] + Environment.pluck(:permalink)
   deploy_groups = DeployGroup.all.sort_by(&:natural_order)
   deploy_group_groups = environment_permalinks.map do |env_permalink|
     [env_permalink, ['global'] + deploy_groups.select { |dg| dg.environment.permalink == env_permalink }.map(&:permalink)]
@@ -21,7 +21,7 @@
         <div class="col-lg-4">
           <%= select_tag 'secret[environment_permalink]',
             options_for_select(environment_permalinks, secret[:environment_permalink]),
-            class: "form-control", include_blank: true, disabled: !!id %>
+            class: "form-control", include_blank: true, required: true, disabled: !!id %>
         </div>
       </div>
 
@@ -29,7 +29,7 @@
         <%= label_tag 'secret[project_permalink]', "Project", class: "col-lg-2 control-label" %>
         <div class="col-lg-4">
           <%= live_select_tag 'secret[project_permalink]',
-            options_for_select(@project_permalinks, secret[:project_permalink]), include_blank: true, disabled: !!id %>
+            options_for_select(@project_permalinks, secret[:project_permalink]), include_blank: true, required: true, disabled: !!id %>
         </div>
       </div>
 
@@ -38,7 +38,7 @@
         <div class="col-lg-4">
           <%= select_tag 'secret[deploy_group_permalink]',
             options_for_select([['Loading ...', secret[:deploy_group_permalink]]], secret[:deploy_group_permalink]),
-            class: "form-control", include_blank: true, disabled: !!id %>
+            class: "form-control", required: true, include_blank: true, disabled: !!id %>
         </div>
       </div>
 


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/1950390882704762062/notices/1950390879802683001?tab=notice-detail

happened because the submitted value was nil ... and then require blows up ... now users will be stoppd in their browsers before submitting
<img width="532" alt="screen shot 2017-05-14 at 6 53 49 pm" src="https://cloud.githubusercontent.com/assets/11367/26040090/e38e384e-38d6-11e7-9c1c-33ac159eb8c8.png">

@zen-aglasman 