### PR TITLE
make global deploy group selectable for environments without deploy g…

### DIFF
--- a/app/views/admin/secrets/show.html.erb
+++ b/app/views/admin/secrets/show.html.erb
@@ -1,9 +1,10 @@
 <%
   id = params[:id]
-  environments = Environment.pluck(:permalink).unshift('global')
-  deploy_group_groups = DeployGroup.all.sort_by(&:natural_order).group_by { |g| g.environment.permalink }.
-    map { |env, groups| [env, groups.map(&:permalink).unshift('global')] }.
-    push(['global', ['global']])
+  environment_permalinks = Environment.pluck(:permalink).unshift('global')
+  deploy_groups = DeployGroup.all.sort_by(&:natural_order)
+  deploy_group_groups = environment_permalinks.map do |env_permalink|
+    [env_permalink, ['global'] + deploy_groups.select { |dg| dg.environment.permalink == env_permalink }.map(&:permalink)]
+  end
 %>
 <%= page_title(id ? "Edit #{id}" : "New Secret") %>
 
@@ -19,7 +20,7 @@
         <%= label_tag 'secret[environment_permalink]', "Environment", class: "col-lg-2 control-label" %>
         <div class="col-lg-4">
           <%= select_tag 'secret[environment_permalink]',
-            options_for_select(environments, secret[:environment_permalink]),
+            options_for_select(environment_permalinks, secret[:environment_permalink]),
             class: "form-control", include_blank: true, disabled: !!id %>
         </div>
       </div>


### PR DESCRIPTION
…roup

before we were grouping on deploy-groups per environment and when a environment was not represented by eny deploy group the global option was missing too ... reversing that logic to map on environments instead so nothing ever goes missing

<img width="549" alt="screen shot 2017-05-14 at 8 44 19 pm" src="https://cloud.githubusercontent.com/assets/11367/26041981/439c8aa6-38e6-11e7-95d2-bfa3cb28662a.png">

@zen-aglasman 