### PR TITLE
Handle long project names and long branch names more gracefully

### DIFF
--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -9,7 +9,7 @@
     <ul>
       <% project.stages.each do |stage| %>
         <% cache [stage, Lock.cache_key] do %>
-          <li>
+          <li class="clearfix">
             <%= link_to stage.name, [project, stage], class: 'stage-link' %>
             <% if deploy = stage.current_deploy %>
               <%= link_to 'Deploying', [project, deploy], class: 'label label-primary' %>


### PR DESCRIPTION
On the dashboard, a project with a long stage name and a long branch name can cause misalignment of labels.

This ensures that when there is a long stage name and a long branch name that the layout won't be as broken.

This approach was chosen because it was a fairly easy fix for something that doesn't occur too often, as opposed to trying to handle truncation or another (more involved) way of solving the problem.

Before:
![before](https://cloud.githubusercontent.com/assets/754567/26043288/759347b8-397f-11e7-8cea-ca75216a26e5.png)

After:
![after](https://cloud.githubusercontent.com/assets/754567/26043293/7a666dce-397f-11e7-9d5a-0ae6b6e51acb.png)

/cc @grosser 