### PR TITLE
PAAS-972 show old version warning when selecting a release by clicking it

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -68,11 +68,12 @@ $(function () {
   }
 
   // When user clicks a release label, fill the deploy reference field with that version
+  // also trigger version check ... see ref_status_typeahead.js
   $("#recent-releases .release-label").on('click', function(event){
     event.preventDefault();
     // Get version number from link href
     var version = event.target.href.substring(event.target.href.lastIndexOf('/') + 1);
-    $("#deploy_reference").val(version);
+    $("#deploy_reference").val(version).trigger('input');
   });
 
   $form.submit(function(event) {

--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -1,4 +1,5 @@
 // when user types into the field offer completion and show selected commit status
+// TODO: show 500 errors to the user
 function refStatusTypeahead(options){
   var $reference = $("#deploy_reference");
   var $ref_status_container = $("#ref-problem-warning");
@@ -79,6 +80,7 @@ function refStatusTypeahead(options){
 
   initializeTypeahead();
 
+  // TODO: clean up by wrapping this in a limiter function
   $reference.on('input', function(e) {
     $ref_status_container.addClass("hidden");
     $tag_form_group.removeClass("has-success has-warning has-error");

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -16,7 +16,7 @@ class ReleasesController < ApplicationController
   end
 
   def new
-    @release = @project.releases.build
+    @release = Release.new(project: @project)
     @release.assign_release_number
   end
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -24,7 +24,7 @@
         <% end %>
       <% else %>
         <tr>
-          <td rowspan="4">
+          <td colspan="3">
             No stages found, use the <b>Manage</b> link up top to add the first stage!
           </td>
         </tr>

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -72,6 +72,7 @@ describe ReleasesController do
       it "renders" do
         get :new, params: {project_id: project.to_param}
         assert_response :success
+        assigns(:release).number.must_equal "124" # next after 123
       end
     end
   end


### PR DESCRIPTION
... and various other drive-by fixes

![screen shot 2017-05-15 at 9 11 36 am](https://cloud.githubusercontent.com/assets/11367/26071267/5798b928-395c-11e7-904c-cacc44831ba3.png)

2nd commit should fix duplicate release bug: https://zendesk.airbrake.io/projects/95346/groups/1950405747603353546?tab=overview