### PR TITLE
automated deploys need a buddy even if last deploy was bypassed

### DIFF
--- a/app/controllers/api/automated_deploys_controller.rb
+++ b/app/controllers/api/automated_deploys_controller.rb
@@ -13,7 +13,7 @@ class Api::AutomatedDeploysController < Api::BaseController
     deploy = deploy_service.deploy!(
       @stage,
       reference: @last_deploy.reference,
-      buddy_id: @last_deploy.buddy_id,
+      buddy_id: @last_deploy.buddy_id || @last_deploy.job.user_id,
       before_command: env.join("\n") << "\n",
       skip_deploy_group_validation: true
     )

--- a/test/controllers/api/automated_deploys_controller_test.rb
+++ b/test/controllers/api/automated_deploys_controller_test.rb
@@ -79,6 +79,12 @@ describe Api::AutomatedDeploysController do
       end
     end
 
+    it "uses last deploys user as buddy if it had no buddy" do
+      copied_deploy.update_column(:buddy_id, nil)
+      assert_created
+      Deploy.first.buddy_id.must_equal copied_deploy.job.user_id
+    end
+
     it "does not deploy other projects deploy" do
       Deploy.update_all(project_id: 12121)
       post_create


### PR DESCRIPTION
were seeing some errors when automated deploy needed a buddy ...
seems to be coming from the last deploy not having a buddy ... because it was bypassed or went to a stage that did not need a buddy