### PR TITLE
rename probe

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -121,7 +121,7 @@ module Kubernetes
         probe =
           case event.message
           when /\AReadiness/ then :readinessProbe
-          when /\ALiveliness/ then :livelinessProbe
+          when /\ALiveness/ then :livenessProbe
           else raise("Unknown probe #{event.message}")
           end
         event.count >= failure_threshold(probe)

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -286,8 +286,8 @@ describe Kubernetes::Api::Pod do
         end
       end
 
-      it "is true with multiple Liveliness events" do
-        assert event[:message].sub!('Readiness', 'Liveliness')
+      it "is true with multiple Liveness events" do
+        assert event[:message].sub!('Readiness', 'Liveness')
         event[:count] = 20
         assert events_indicate_failure?
       end


### PR DESCRIPTION
just got that name wrong ... https://zendesk.airbrake.io/projects/95346/groups/1952032228658063533/notices/1952032227303544668?tab=notice-detail and kubernetes docs agree that it should be Liveness