### PR TITLE
make daemonsets not short-circuit deploy process

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -186,7 +186,6 @@ module Kubernetes
       # and the number of matches nodes could update with a changed template
       # only makes sense to call this after deploying / while waiting for pods
       def desired_pod_count
-        return 0 if @template[:spec][:replicas].to_i.zero?
         @desired_pod_count ||= begin
           desired = resource[:status][:desiredNumberScheduled]
           return desired unless desired.zero?

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -225,11 +225,6 @@ describe Kubernetes::Resource do
         end
         assert_requested request, times: 2
       end
-
-      it "returns 0 when replicas are 0 to pass deletion deploys" do
-        template[:spec][:replicas] = 0
-        resource.desired_pod_count.must_equal 0
-      end
     end
 
     describe "#revert" do


### PR DESCRIPTION
replicase was never filled in since we guard against that, so a template without the replicase set
would skip pod verification since it expected there to be 0 pods

https://samson.zende.sk/projects/kube_translation_daemon/deploys/292890