### PR TITLE
show commit status to buddies

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -69,7 +69,7 @@ $(function () {
 
   // When user clicks a release label, fill the deploy reference field with that version
   // also trigger version check ... see ref_status_typeahead.js
-  $("#recent-releases .release-label").on('click', function(event){
+  $(".clickable-releases .release-label").on('click', function(event){
     event.preventDefault();
     // Get version number from link href
     var version = event.target.href.substring(event.target.href.lastIndexOf('/') + 1);

--- a/app/views/deploys/_buddy_check.html.erb
+++ b/app/views/deploys/_buddy_check.html.erb
@@ -1,9 +1,22 @@
 <div class="row deploy-check">
+  <% if status = CommitStatus.new(@deploy.stage, @deploy.reference) rescue nil %>
+    <p>
+      Commit status for <%= short_sha @deploy.reference %>: <%= status.status %><br/>
+      <% status.status_list.each do |info| %>
+        <%= info.fetch(:state) %>: <%= info.fetch(:description) %><br/>
+      <% end %>
+    </p>
+  <% else %>
+    <p>Error fetching commit status.</p>
+  <% end %>
+  <br/><br/>
+
   <% if @deploy.started_by?(current_user) %>
     <p>This deploy requires a buddy since it is going to production. Please have another engineer with deploy rights visit this URL to kick off the deploy.</p>
     <% if details = ENV["BYPASS_DETAILS"].presence %>
       <p><%= details.html_safe %></p>
     <% end %>
+
     <div class="deployer-stop">
       <%= stop_button deploy: @deploy, project: @project %>
       or

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -39,6 +39,7 @@ describe DeploysHelper do
       end
 
       it "renders buddy check when waiting for buddy" do
+        stub_github_api "repos/bar/foo/commits/staging/status", state: "success", statuses: {}
         deploy.expects(:waiting_for_buddy?).returns(true)
         result.wont_include output
         result.must_include 'This deploy requires a buddy.'


### PR DESCRIPTION
currently the buddy does not know if travis is failing / the deploy is behind what is already live or any other of these checks ... let's change that ...

![screen shot 2017-05-23 at 4 04 30 pm](https://cloud.githubusercontent.com/assets/11367/26380131/9420e70a-3fd1-11e7-892e-3a3e9ca98844.png)
