### PR TITLE
condense table so we can display long env vars without breaking

### DIFF
--- a/plugins/env/app/views/admin/environment_variable_groups/index.html.erb
+++ b/plugins/env/app/views/admin/environment_variable_groups/index.html.erb
@@ -13,16 +13,15 @@
   <table class="table table-hover table-condensed">
     <thead>
     <tr>
-      <th>Name</th>
-      <th>Variables</th>
+      <th></th>
       <th>Projects</th>
       <th></th>
     </tr>
     </thead>
     <% @groups.each do |group| %>
       <tr>
-        <td><%= link_to group.name, [:admin, group] %></td>
         <td>
+          <%= link_to group.name, [:admin, group] %>
           <ul>
             <% group.environment_variables.map(&:name).uniq.sort.each do |name| %>
               <li><%= name %></li>


### PR DESCRIPTION
before:
<img width="1245" alt="screen shot 2017-05-24 at 4 02 10 pm" src="https://cloud.githubusercontent.com/assets/11367/26429180/5fb295b2-409a-11e7-935e-2ce175b2fbaf.png">

after:
<img width="1094" alt="screen shot 2017-05-24 at 4 03 13 pm" src="https://cloud.githubusercontent.com/assets/11367/26429221/86d2c84c-409a-11e7-8a69-1ee25bbd3087.png">
