### PR TITLE
fix current versions displaying a random reference

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -123,6 +123,11 @@ class Project < ActiveRecord::Base
     releases.map { |group_id, deploys| [group_id, deploys.sort_by(&:updated_at).last] }.to_h
   end
 
+  def last_deploy_by_stage
+    return unless found = deploys.select('max(deploys.id) as id').reorder(nil).group(:stage_id).successful.presence
+    Deploy.find(found.map(&:id)).select(&:stage).sort_by { |d| d.stage.order }.presence
+  end
+
   def url
     Rails.application.routes.url_helpers.project_url(self)
   end

--- a/app/views/deploys/_currently_deployed.html.erb
+++ b/app/views/deploys/_currently_deployed.html.erb
@@ -1,4 +1,4 @@
-<% if !ActiveRecord::Base.connection.class.name.downcase.include?('postgres') && deployed = @project.deploys.group(:stage_id).successful.select(&:stage).sort_by { |d| d.stage.order }.presence %>
+<% if deployed = @project.last_deploy_by_stage %>
   <div class="form-group" class="clickable-releases">
     <label class="col-lg-2 control-label">Currently deployed</label>
     <div class="col-lg-4">

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -262,6 +262,22 @@ describe Project do
     end
   end
 
+  describe '#last_deploy_by_stage' do
+    it "finds 1 deploy per stage" do
+      project.last_deploy_by_stage.must_equal([deploys(:succeeded_test), deploys(:succeeded_production_test)])
+    end
+
+    it "ignores deleted stages" do
+      deploys(:succeeded_test).stage.soft_delete!
+      project.last_deploy_by_stage.must_equal([deploys(:succeeded_production_test)])
+    end
+
+    it "returns nil when nothing was found" do
+      Stage.update_all(deleted_at: Time.now)
+      project.last_deploy_by_stage.must_be_nil
+    end
+  end
+
   describe '#ordered_for_user' do
     it 'returns unstarred projects in alphabetical order' do
       Project.create!(name: 'A', repository_url: url)


### PR DESCRIPTION
group + order seems to not get a reliable reference on top ... so get max(id) and then find them :(