### PR TITLE
multiply usage by replicas to allow skipping limits

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
@@ -79,11 +79,17 @@ module Kubernetes
 
     def requests_below_usage_limits
       return unless limit = UsageLimit.most_specific(project, deploy_group)
-      if requests_cpu > limit.cpu
-        errors.add :requests_cpu, "must be less than or equal to the usage limit #{limit.cpu}"
+      if requests_cpu * replicas > limit.cpu
+        errors.add(
+          :requests_cpu,
+          "(#{requests_cpu} * #{replicas}) must be less than or equal to the usage limit #{limit.cpu}"
+        )
       end
-      if requests_memory > limit.memory
-        errors.add :requests_memory, "must be less than or equal to the usage limit #{limit.memory}"
+      if requests_memory * replicas > limit.memory
+        errors.add(
+          :requests_memory,
+          "(#{requests_memory} * #{replicas}) must be less than or equal to the usage limit #{limit.memory}"
+        )
       end
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
@@ -8,7 +8,7 @@ describe Kubernetes::DeployGroupRole do
   let(:deploy_group_role) { kubernetes_deploy_group_roles(:test_pod1_app_server) }
   let(:deploy_group) { deploy_group_role.deploy_group }
   let(:project) { stage.project }
-  let(:usage_limit) { Kubernetes::UsageLimit.create!(scope: deploy_group, project: project, cpu: 1, memory: 200) }
+  let(:usage_limit) { Kubernetes::UsageLimit.create!(scope: deploy_group, project: project, cpu: 1, memory: 400) }
 
   describe "validations" do
     it "is valid" do
@@ -158,13 +158,13 @@ describe Kubernetes::DeployGroupRole do
     end
 
     it "is not valid when requests are above usage_limit" do
-      deploy_group_role.requests_cpu = deploy_group_role.limits_cpu = 2
-      deploy_group_role.requests_memory = 300
+      deploy_group_role.requests_cpu = deploy_group_role.limits_cpu = 1
+      deploy_group_role.requests_memory = 200
       refute_valid deploy_group_role
       deploy_group_role.errors.full_messages.must_equal(
         [
-          "Requests cpu must be less than or equal to the usage limit 1.0",
-          "Requests memory must be less than or equal to the usage limit 200"
+          "Requests cpu (1.0 * 3) must be less than or equal to the usage limit 1.0",
+          "Requests memory (200 * 3) must be less than or equal to the usage limit 400"
         ]
       )
     end


### PR DESCRIPTION
before users could use the same cpu/memory and 10 replicas to avoid the limits