### PR TITLE
validate that we do not create duplciate limits for the same scope

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/usage_limit.rb
+++ b/plugins/kubernetes/app/models/kubernetes/usage_limit.rb
@@ -8,6 +8,7 @@ class Kubernetes::UsageLimit < ActiveRecord::Base
   belongs_to :scope, polymorphic: true, optional: true
 
   validates :cpu, :memory, presence: true
+  validates :scope_id, uniqueness: {scope: [:scope_type, :project_id]}
 
   def self.most_specific(project, deploy_group)
     all.sort_by { |l| l.send :priority }.detect { |l| l.send(:matches?, project, deploy_group) }

--- a/plugins/kubernetes/app/views/admin/kubernetes/usage_limits/index.html.erb
+++ b/plugins/kubernetes/app/views/admin/kubernetes/usage_limits/index.html.erb
@@ -14,8 +14,8 @@
 
       <% @usage_limits.each do |usage_limit| %>
         <tr>
-          <td><%= usage_limit.project ? link_to(usage_limit.project.name, usage_limit.project) : 'global' %></td>
-          <td><%= usage_limit.scope ? usage_limit.scope.name : 'global' %></td>
+          <td><%= usage_limit.project ? link_to(usage_limit.project.name, usage_limit.project) : 'All' %></td>
+          <td><%= usage_limit.scope ? usage_limit.scope.name : 'All' %></td>
           <td><%= usage_limit.cpu.to_f %></td>
           <td><%= usage_limit.memory %> Mi</td>
           <td><%= link_to "Edit", [:admin, usage_limit] %></td>

--- a/plugins/kubernetes/test/models/kubernetes/usage_limit_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/usage_limit_test.rb
@@ -11,6 +11,21 @@ describe Kubernetes::UsageLimit do
   let(:project) { projects(:test) }
   let(:deploy_group) { deploy_groups(:pod100) }
 
+  describe "validations" do
+    it "does not allow duplicate limits in the same scope" do
+      create_limit
+      limit = Kubernetes::UsageLimit.new(cpu: 1, memory: 2)
+      refute_valid limit
+      limit.errors.full_messages.must_equal ["Scope has already been taken"]
+    end
+
+    it "allows duplicate limits in different scope" do
+      create_limit
+      limit = Kubernetes::UsageLimit.new(cpu: 1, memory: 2, scope: environments(:staging))
+      assert_valid limit
+    end
+  end
+
   describe ".most_specific" do
     let!(:usage_limit) { create_limit }
 


### PR DESCRIPTION
atm fails loudly with sql error ... and not at all for nils ... 
https://zendesk.airbrake.io/projects/95346/groups/1962670930245660362/notices/1962670925424667550

<img width="618" alt="screen shot 2017-05-31 at 5 12 51 pm" src="https://cloud.githubusercontent.com/assets/11367/26659382/169df4bc-4625-11e7-96c1-4bc9e33d200f.png">

also making show and index consistently display `All`
<img width="1067" alt="screen shot 2017-05-31 at 5 17 37 pm" src="https://cloud.githubusercontent.com/assets/11367/26659381/168d1700-4625-11e7-9e07-612849fb41a4.png">
