### PR TITLE
show what is currently deployed and not misleading stage deploy info

### DIFF
--- a/app/controllers/api/automated_deploys_controller.rb
+++ b/app/controllers/api/automated_deploys_controller.rb
@@ -61,7 +61,7 @@ class Api::AutomatedDeploysController < Api::BaseController
   end
 
   def find_last_deploy
-    influencing_stages = DeployGroupsStage.where(deploy_group: @deploy_group).pluck(:stage_id)
+    influencing_stages = @deploy_group.pluck_stage_ids
     unless @last_deploy = Deploy.where(project_id: @stage.project_id, stage_id: influencing_stages).successful.first
       failed!("Unable to find successful deploy for #{@stage.name}")
     end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -165,12 +165,8 @@ class Deploy < ActiveRecord::Base
   end
 
   def self.last_deploys_for_projects
-    deploy_ids = select('deploys.project_id, MAX(deploys.id) as last_deploy_id').
-      group(:project_id).
-      reorder(:project_id).
-      map(&:last_deploy_id)
-
-    where(id: deploy_ids)
+    deploy_ids = group(:project_id).reorder("max(deploys.id)").pluck('max(deploys.id)')
+    where(id: deploy_ids) # extra select so we get all columns from the correct deploy without group functions
   end
 
   def buddy_name

--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -31,6 +31,11 @@ class DeployGroup < ActiveRecord::Base
     Samson::NaturalOrder.convert(name)
   end
 
+  # faster alternative to stage_ids way of getting stage_ids
+  def pluck_stage_ids
+    deploy_groups_stages.pluck(:stage_id)
+  end
+
   private
 
   def permalink_base

--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -15,23 +15,40 @@
     </div>
   </div>
 
+  <% deploys = Deploy.successful.where(stage_id: @deploy_group.pluck_stage_ids).last_deploys_for_projects %>
+  <div class="form-group row">
+    <label class="col-lg-2 control-label">Deployed</label>
+    <div class="col-lg-10">
+      <table class="table-condensed">
+        <tr>
+          <th>Project</th>
+          <th>Version</th>
+          <th></th>
+        </tr>
+        <% deploys.each do |deploy| %>
+          <tr>
+            <td><%= link_to deploy.project.name, deploy.project %></td>
+            <td><%= link_to deploy.short_reference, [deploy.project, deploy] %></td>
+            <td><%= render_time(deploy.start_time, params[:time_format]) %></td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  </div>
+
   <div class="form-group row">
     <label class="col-lg-2 control-label">Used by</label>
     <div class="col-lg-10">
-      <table class="table">
+      <table class="table-condensed">
         <tr>
           <th>Project</th>
           <th>Stage</th>
-          <th>Last Successful</th>
-          <th>Template</th>
         </tr>
         <% @deploy_group.deploy_groups_stages.group_by { |dgs| dgs.stage.project }.each do |project, dgs_group| %>
           <% dgs_group.each do |dgs| %>
             <tr>
               <td><%= link_to project.name, project %></td>
               <td><%= link_to dgs.stage.name, [dgs.stage.project, dgs.stage] %></td>
-              <td><%= dgs.stage.last_successful_deploy&.short_reference || 'NONE' %></td>
-              <td><%= dgs.stage.template_stage&.last_successful_deploy&.short_reference %></td>
             </tr>
           <% end %>
         <% end %>

--- a/test/models/deploy_group_test.rb
+++ b/test/models/deploy_group_test.rb
@@ -170,4 +170,13 @@ describe DeployGroup do
       assert deploy_group.valid?
     end
   end
+
+  describe "#pluck_stage_ids" do
+    it "uses 1 cheap query" do
+      deploy_group
+      queries = sql_queries { deploy_group.pluck_stage_ids.to_a }
+      queries.size.must_equal 1
+      queries.first.wont_include "JOIN"
+    end
+  end
 end


### PR DESCRIPTION

<img width="694" alt="screen shot 2017-06-02 at 8 10 35 pm" src="https://cloud.githubusercontent.com/assets/11367/26750116/951943cc-47cf-11e7-970e-06984d819dff.png">


/cc @pswadi-zendesk @irwaters 