### PR TITLE
move admin controllers into regular namespace

### DIFF
--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Admin::CommandsController < ApplicationController
+class CommandsController < ApplicationController
   include CurrentProject
 
   PUBLIC = [:index, :show, :new].freeze
@@ -66,7 +66,7 @@ class Admin::CommandsController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:notice] = notice
-        redirect_to admin_commands_path
+        redirect_to commands_path
       end
       format.js { render json: {} }
     end

--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Admin::EnvironmentsController < ApplicationController
+class EnvironmentsController < ApplicationController
   before_action :authorize_super_admin!, except: [:index]
   before_action :environment, only: [:show, :update, :destroy]
 

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Admin::SecretsController < ApplicationController
+class SecretsController < ApplicationController
   ADD_MORE = 'Save and add another'
 
   include CurrentProject
@@ -82,7 +82,7 @@ class Admin::SecretsController < ApplicationController
   def successful_response(notice)
     flash[:notice] = notice
     if params[:commit] == ADD_MORE
-      redirect_to new_admin_secret_path(secret: params[:secret].except(:value).to_unsafe_h)
+      redirect_to new_secret_path(secret: params[:secret].except(:value).to_unsafe_h)
     else
       redirect_to action: :index
     end

--- a/app/controllers/user_merges_controller.rb
+++ b/app/controllers/user_merges_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Admin::UserMergesController < ApplicationController
+class UserMergesController < ApplicationController
   before_action :authorize_super_admin!
   before_action :find_user
 

--- a/app/controllers/vault_servers_controller.rb
+++ b/app/controllers/vault_servers_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Admin::VaultServersController < ApplicationController
+class VaultServersController < ApplicationController
   before_action :authorize_super_admin!, except: [:index, :show]
   before_action :find_server, only: [:update, :show, :destroy, :sync]
 

--- a/app/helpers/stages_helper.rb
+++ b/app/helpers/stages_helper.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 module StagesHelper
   def edit_command_link(command)
-    edit_url = [:admin, command]
-    if command.global?
-      link_to "", edit_url, title: "Edit global command", class: "edit-command glyphicon glyphicon-globe no-hover"
-    else
-      link_to "", edit_url, title: "Edit", class: "edit-command glyphicon glyphicon-edit no-hover"
-    end
+    title = (command.global? ? "Edit global command" : "Edit")
+    icon = (command.global? ? "glyphicon-globe" : "glyphicon-edit")
+    link_to "", command, title: title, class: "edit-command glyphicon #{icon} no-hover"
   end
 
   def stage_template_icon

--- a/app/views/admin/deploy_groups/index.html.erb
+++ b/app/views/admin/deploy_groups/index.html.erb
@@ -17,7 +17,7 @@
         <% @deploy_groups.each do |deploy_group| %>
           <tr>
             <td><%= link_to deploy_group.name, [:admin, deploy_group] %></td>
-            <td><%= link_to deploy_group.environment.name, [:admin, deploy_group.environment] %></td>
+            <td><%= link_to deploy_group.environment.name, deploy_group.environment %></td>
             <td><%= deploy_group.env_value %></td>
             <%= Samson::Hooks.render_views(:deploy_group_table_cell, self, deploy_group: deploy_group) %>
             <td>

--- a/app/views/admin/deploy_groups/show.html.erb
+++ b/app/views/admin/deploy_groups/show.html.erb
@@ -11,7 +11,7 @@
   <div class="form-group">
     <label class="col-lg-2 control-label">Environment</label>
     <div class="col-lg-4">
-      <p class="form-control-static"><%= link_to @deploy_group.environment.name, [:admin, @deploy_group.environment] %></p>
+      <p class="form-control-static"><%= link_to @deploy_group.environment.name, @deploy_group.environment %></p>
     </div>
   </div>
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -2,7 +2,7 @@
 
 <section id="user-description" class="clearfix">
   <div class="pull-right">
-    <%= link_to "Merge", new_admin_user_user_merges_path(@user) %>
+    <%= link_to "Merge", new_user_user_merges_path(@user) %>
   </div>
 
   <dl class="dl-horizontal">

--- a/app/views/commands/index.html.erb
+++ b/app/views/commands/index.html.erb
@@ -24,13 +24,13 @@
           </td>
           <td><%= command.project.try(:name) ? command.project.name : "Global" %></td>
           <td>
-            <%= link_to "Edit", [:admin, command] %>
+            <%= link_to "Edit", command %>
             |
             <% used = usage_ids.count(command.id) %>
             <% if used > 0 %>
               <%= content_tag :span, "Used by #{used}", title: "Click Edit to see usage details" %>
             <% else %>
-              <%= link_to_delete([:admin, command], remove_container: 'tr') %>
+              <%= link_to_delete(command, remove_container: 'tr') %>
             <% end %>
           </td>
         </tr>
@@ -40,7 +40,7 @@
 
   <div class="admin-actions">
     <div class="pull-right">
-      <%= link_to "New", new_admin_command_path, class: "btn btn-default" %>
+      <%= link_to "New", new_command_path, class: "btn btn-default" %>
     </div>
 
     <%= paginate @commands %>

--- a/app/views/commands/show.html.erb
+++ b/app/views/commands/show.html.erb
@@ -2,7 +2,7 @@
 <% usages = @command.usages.presence %>
 
 <section>
-  <%= form_for [:admin, @command], html: { class: "form-horizontal" } do |form| %>
+  <%= form_for @command, html: { class: "form-horizontal" } do |form| %>
     <fieldset>
       <%= render 'shared/errors', object: @command %>
 
@@ -37,7 +37,7 @@
 
       <%= form.actions do %>
         <% disabled = "Can only delete unused commands." if usages %>
-        <%= link_to_delete([:admin, @command], disabled: disabled) if @command.persisted? %> |
+        <%= link_to_delete(@command, disabled: disabled) if @command.persisted? %> |
         <%= link_to_history(@command) %>
       <% end %>
     </fieldset>

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -20,9 +20,9 @@
             </td>
             <td><%= env.production ? 'Yes' : 'No' %></td>
             <td>
-              <%= link_to "Edit", [:admin, env] %>
+              <%= link_to "Edit", env %>
               |
-              <%= link_to_delete([:admin, env]) %>
+              <%= link_to_delete env %>
             </td>
           </tr>
         <% end %>
@@ -32,7 +32,7 @@
 
   <div class="admin-actions">
     <div class="pull-right">
-      <%= link_to "New", new_admin_environment_path, class: "btn btn-default" %>
+      <%= link_to "New", new_environment_path, class: "btn btn-default" %>
     </div>
   </div>
 </section>

--- a/app/views/environments/show.html.erb
+++ b/app/views/environments/show.html.erb
@@ -3,7 +3,7 @@
 <%= render_lock @environment %>
 
 <section>
-  <%= form_for [:admin, @environment], html: { class: "form-horizontal" } do |form| %>
+  <%= form_for @environment, html: { class: "form-horizontal" } do |form| %>
     <%= render 'shared/errors', object: @environment %>
 
     <%= form.input :name, required: true %>

--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -12,7 +12,7 @@
 
   <div class="pull-right">
     <label>&nbsp;</label>
-    <%= link_to "New", new_admin_secret_path, class: "btn btn-default", style: "display: block" %>
+    <%= link_to "New", new_secret_path, class: "btn btn-default", style: "display: block" %>
   </div>
 <% end %>
 
@@ -45,8 +45,8 @@
           <td><%= parts.fetch(:deploy_group_permalink) %></td>
           <td title="<%= key %>"><%= parts.fetch(:key) %></td>
           <td>
-            <%= link_to "Edit", admin_secret_path(key) %> |
-            <%= link_to_delete(admin_secret_path(key), remove_container: 'tr') %>
+            <%= link_to "Edit", secret_path(key) %> |
+            <%= link_to_delete(secret_path(key), remove_container: 'tr') %>
           </td>
         </tr>
       <% end %>

--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -9,7 +9,7 @@
 <%= page_title(id ? "Edit #{id}" : "New Secret") %>
 
 <section>
-  <% url = (id ? admin_secret_path(id) : admin_secrets_path) %>
+  <% url = (id ? secret_path(id) : secrets_path) %>
   <% method = (id ? :put : :post) %>
   <% secret = (id ? @secret.merge(SecretStorage.parse_secret_key(id)) : (params[:secret] || {})) %>
   <% edit_disabled = id && !secret[:visible] # prevent users from accidentally updating with an empty value %>
@@ -96,9 +96,9 @@
         <div class="col-lg-offset-2 col-lg-10">
           <%= submit_tag 'Save', class: 'btn btn-primary' %>
           <% if id %>
-            <%= link_to_delete admin_secret_path(id) %>
+            <%= link_to_delete secret_path(id) %>
           <% else %>
-            <%= submit_tag Admin::SecretsController::ADD_MORE, class: 'btn btn-default' %>
+            <%= submit_tag SecretsController::ADD_MORE, class: 'btn btn-default' %>
           <% end %>
         </div>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -70,7 +70,7 @@
           <% if current_user.try(:admin?) %>
             <li><%= link_to "Projects", admin_projects_path %></li>
           <% end %>
-          <li><%= link_to "Commands", admin_commands_path %></li>
+          <li><%= link_to "Commands", Command %></li>
           <% if current_user.try(:admin?) %>
             <li><%= link_to "Users", admin_users_path %></li>
             <%= Samson::Hooks.render_views(:admin_menu, self) %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -78,7 +78,7 @@
           <% end %>
           <li><%= link_to "Secrets", secrets_path %></li>
           <% if SecretStorage.backend == Samson::Secrets::HashicorpVaultBackend %>
-            <li><%= link_to "Vault Servers", admin_vault_servers_path %></li>
+            <li><%= link_to "Vault Servers", vault_servers_path %></li>
           <% end %>
           <li><%= link_to "Reports", csv_exports_path %></li>
           <% if current_user&.super_admin? %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -76,7 +76,7 @@
             <%= Samson::Hooks.render_views(:admin_menu, self) %>
             <li class="divider"></li>
           <% end %>
-          <li><%= link_to "Secrets", admin_secrets_path %></li>
+          <li><%= link_to "Secrets", secrets_path %></li>
           <% if SecretStorage.backend == Samson::Secrets::HashicorpVaultBackend %>
             <li><%= link_to "Vault Servers", admin_vault_servers_path %></li>
           <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -64,7 +64,7 @@
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">Manage <b class="caret"></b></a>
         <ul class="dropdown-menu">
           <% if DeployGroup.enabled? %>
-            <li><%= link_to "Environments", admin_environments_path %></li>
+            <li><%= link_to "Environments", environments_path %></li>
             <li><%= link_to "Deploy Groups", admin_deploy_groups_path %></li>
           <% end %>
           <% if current_user.try(:admin?) %>

--- a/app/views/stages/_commands.html.erb
+++ b/app/views/stages/_commands.html.erb
@@ -15,7 +15,7 @@
         </div>
         <div class="col-lg-8">
           <% klass = "pre-command pre-inline #{command.global? ? 'global' : 'local'} #{'others' if others_warning}" %>
-          <pre data-type="textarea" data-others-warning="<%= others_warning %>" data-url="<%= admin_command_path(b.value) %>" class="<%= klass %>"><%= b.text %></pre>
+          <pre data-type="textarea" data-others-warning="<%= others_warning %>" data-url="<%= command_path(b.value) %>" class="<%= klass %>"><%= b.text %></pre>
         </div>
         <%= edit_command_link command %>
         <%= content_tag :span, others, title: others_warning + " use this. Click edit for details.", class: 'glyphicon glyphicon-lock' if others_warning %>

--- a/app/views/user_merges/new.html.erb
+++ b/app/views/user_merges/new.html.erb
@@ -13,7 +13,7 @@ Delete selected empty user and change #<%= @user.id %> <%= @user.name_and_email 
   </ul>
 <% end %>
 
-<%= form_for @user, url: admin_user_user_merges_path(@user), method: :post do |f| %>
+<%= form_for @user, url: user_user_merges_path(@user), method: :post do |f| %>
   <div class="form-group">
     <label class="col-lg-2 control-label">Destroy and take login credentials from user id</label>
     <div class="col-lg-4">

--- a/app/views/vault_servers/index.html.erb
+++ b/app/views/vault_servers/index.html.erb
@@ -27,8 +27,8 @@
             <% end %>
           </td>
           <td>
-            <%= link_to "Edit", [:admin, vault_server] %> |
-            <%= link_to_delete [:admin, vault_server] %>
+            <%= link_to "Edit", vault_server %> |
+            <%= link_to_delete vault_server %>
           </td>
         </tr>
       <% end %>
@@ -37,7 +37,7 @@
 
   <div class="admin-actions">
     <div class="pull-right">
-      <%= link_to "New Server", new_admin_vault_server_path, class: "btn btn-default" %>
+      <%= link_to "New Server", new_vault_server_path, class: "btn btn-default" %>
     </div>
   </div>
 </section>

--- a/app/views/vault_servers/show.html.erb
+++ b/app/views/vault_servers/show.html.erb
@@ -12,7 +12,7 @@
 %>
 
 <section>
-  <%= form_for [:admin, @vault_server], html: { class: "form-horizontal" } do |form| %>
+  <%= form_for @vault_server, html: { class: "form-horizontal" } do |form| %>
     <fieldset>
       <%= render 'shared/errors', object: @vault_server %>
 
@@ -22,7 +22,7 @@
       <%= form.input :tls_verify, as: :check_box %>
       <%= form.input :ca_cert, as: :text_area, input_html: {size: '80x5', style: 'width: auto'} %>
 
-      <%= form.actions delete: [:admin, @vault_server] do %>
+      <%= form.actions delete: @vault_server do %>
         | <%= link_to_history @vault_server %>
         <% if sync_targets %>
           | <%= link_to "Sync", "#", data: {target: "#sync_dialog"}, class: 'toggle' %>
@@ -33,7 +33,7 @@
 
   <% if sync_targets %>
     <div style="display: none;" id="sync_dialog">
-      <%= form_tag sync_admin_vault_server_path(@vault_server) do %>
+      <%= form_tag sync_vault_server_path(@vault_server) do %>
         <fieldset>
           Copy eligible secrets from
           <%= select_tag :other_id, options_from_collection_for_select(sync_targets, :id, :name), class: 'form-control', style: 'width: auto; display: inline-block' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,8 @@ Samson::Application.routes.draw do
 
   resources :access_tokens, only: [:index, :new, :create, :destroy]
 
+  resources :environments, except: [:edit]
+
   resources :versions, only: [:index]
 
   resources :commands, except: [:edit]
@@ -138,7 +140,6 @@ Samson::Application.routes.draw do
   namespace :admin do
     resources :users, only: [:index, :show, :update, :destroy]
     resources :projects, only: [:index, :destroy]
-    resources :environments, except: [:edit]
     resources :deploy_groups do
       member do
         post :deploy_all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,8 @@ Samson::Application.routes.draw do
 
   resources :commands, except: [:edit]
 
+  resources :secrets, except: [:edit]
+
   get '/auth/github/callback', to: 'sessions#github'
   get '/auth/google/callback', to: 'sessions#google'
   post '/auth/ldap/callback', to: 'sessions#ldap'
@@ -128,7 +130,6 @@ Samson::Application.routes.draw do
       resource :user_merges, only: [:new, :create]
     end
     resources :projects, only: [:index, :destroy]
-    resources :secrets, except: [:edit]
     resources :vault_servers, except: [:edit] do
       member do
         post :sync

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,10 @@ Samson::Application.routes.draw do
 
   resources :secrets, except: [:edit]
 
+  resources :users, only: [] do
+    resource :user_merges, only: [:new, :create]
+  end
+
   get '/auth/github/callback', to: 'sessions#github'
   get '/auth/google/callback', to: 'sessions#google'
   post '/auth/ldap/callback', to: 'sessions#ldap'
@@ -126,9 +130,7 @@ Samson::Application.routes.draw do
   end
 
   namespace :admin do
-    resources :users, only: [:index, :show, :update, :destroy] do
-      resource :user_merges, only: [:new, :create]
-    end
+    resources :users, only: [:index, :show, :update, :destroy]
     resources :projects, only: [:index, :destroy]
     resources :vault_servers, except: [:edit] do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,12 @@ Samson::Application.routes.draw do
     resource :user_merges, only: [:new, :create]
   end
 
+  resources :vault_servers, except: [:edit] do
+    member do
+      post :sync
+    end
+  end
+
   get '/auth/github/callback', to: 'sessions#github'
   get '/auth/google/callback', to: 'sessions#google'
   post '/auth/ldap/callback', to: 'sessions#ldap'
@@ -132,11 +138,6 @@ Samson::Application.routes.draw do
   namespace :admin do
     resources :users, only: [:index, :show, :update, :destroy]
     resources :projects, only: [:index, :destroy]
-    resources :vault_servers, except: [:edit] do
-      member do
-        post :sync
-      end
-    end
     resources :environments, except: [:edit]
     resources :deploy_groups do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Samson::Application.routes.draw do
 
   resources :versions, only: [:index]
 
+  resources :commands, except: [:edit]
+
   get '/auth/github/callback', to: 'sessions#github'
   get '/auth/google/callback', to: 'sessions#google'
   post '/auth/ldap/callback', to: 'sessions#ldap'
@@ -126,7 +128,6 @@ Samson::Application.routes.draw do
       resource :user_merges, only: [:new, :create]
     end
     resources :projects, only: [:index, :destroy]
-    resources :commands, except: [:edit]
     resources :secrets, except: [:edit]
     resources :vault_servers, except: [:edit] do
       member do

--- a/test/controllers/commands_controller_test.rb
+++ b/test/controllers/commands_controller_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require_relative '../../test_helper'
+require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe Admin::CommandsController do
+describe CommandsController do
   let(:project) { projects(:test) }
   let(:other_project) do
     p = project.dup
@@ -68,7 +68,7 @@ describe Admin::CommandsController do
       it "can create a command for an allowed project" do
         post :create, params: params
         flash[:notice].wont_be_nil
-        assert_redirected_to admin_commands_path
+        assert_redirected_to commands_path
       end
 
       it "fails for invalid command" do
@@ -89,7 +89,7 @@ describe Admin::CommandsController do
 
       it "can update html" do
         patch :update, params: params
-        assert_redirected_to admin_commands_path
+        assert_redirected_to commands_path
         flash[:notice].wont_be_nil
       end
 
@@ -115,7 +115,7 @@ describe Admin::CommandsController do
         it "can update when admin of both" do
           UserProjectRole.create!(role_id: Role::ADMIN.id, project: other_project, user: user)
           patch :update, params: params
-          assert_redirected_to admin_commands_path
+          assert_redirected_to commands_path
         end
       end
 
@@ -137,7 +137,7 @@ describe Admin::CommandsController do
     describe "#destroy" do
       it "can delete command for an allowed project" do
         delete :destroy, params: {id: commands(:echo)}
-        assert_redirected_to admin_commands_path
+        assert_redirected_to commands_path
       end
 
       it "cannot delete global commands" do
@@ -151,19 +151,19 @@ describe Admin::CommandsController do
     describe "#create" do
       it "cannot create for a global project" do
         post :create, params: {command: {command: "hello"}}
-        assert_redirected_to admin_commands_path
+        assert_redirected_to commands_path
       end
     end
 
     describe '#update' do
       it "updates a project" do
         put :update, params: {id: commands(:echo).id, command: { command: 'echo hi', project_id: other_project.id }}
-        assert_redirected_to admin_commands_path
+        assert_redirected_to commands_path
       end
 
       it "updates a global commands" do
         put :update, params: {id: commands(:global).id, command: { command: 'echo hi' }}
-        assert_redirected_to admin_commands_path
+        assert_redirected_to commands_path
       end
     end
 
@@ -182,7 +182,7 @@ describe Admin::CommandsController do
 
           it 'redirects' do
             flash[:notice].wont_be_nil
-            assert_redirected_to admin_commands_path
+            assert_redirected_to commands_path
           end
 
           it 'removes the command' do

--- a/test/controllers/environments_controller_test.rb
+++ b/test/controllers/environments_controller_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require_relative '../../test_helper'
+require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe Admin::EnvironmentsController do
+describe EnvironmentsController do
   as_a_viewer do
     describe "#index" do
       it 'renders' do
@@ -41,7 +41,7 @@ describe Admin::EnvironmentsController do
       it 'creates an environment' do
         assert_difference 'Environment.count', +1 do
           post :create, params: {environment: {name: 'gamma', production: true}}
-          assert_redirected_to admin_environments_path
+          assert_redirected_to environments_path
         end
       end
 
@@ -64,7 +64,7 @@ describe Admin::EnvironmentsController do
       it 'succeeds' do
         env = environments(:production)
         delete :destroy, params: {id: env}
-        assert_redirected_to admin_environments_path
+        assert_redirected_to environments_path
         Environment.where(id: env.id).must_equal []
       end
 
@@ -78,11 +78,11 @@ describe Admin::EnvironmentsController do
     describe '#update' do
       let(:environment) { environments(:production) }
 
-      before { request.env["HTTP_REFERER"] = admin_environments_url }
+      before { request.env["HTTP_REFERER"] = environments_url }
 
       it 'save' do
         post :update, params: {environment: {name: 'Test Update', production: false, permalink: 'foo'}, id: environment}
-        assert_redirected_to admin_environments_path
+        assert_redirected_to environments_path
         environment.reload
         environment.name.must_equal 'Test Update'
         environment.permalink.must_equal 'foo'

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require_relative '../../test_helper'
+require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe Admin::SecretsController do
+describe SecretsController do
   def create_global
     create_secret 'production/global/pod2/foo'
   end
@@ -144,7 +144,7 @@ describe Admin::SecretsController do
       it 'creates a secret' do
         post :create, params: {secret: attributes.merge(visible: 'false')}
         assert flash[:notice]
-        assert_redirected_to admin_secrets_path
+        assert_redirected_to secrets_path
         secret = SecretStorage::DbBackend::Secret.find('production/foo/pod2/hi')
         secret.updater_id.must_equal user.id
         secret.creator_id.must_equal user.id
@@ -162,9 +162,9 @@ describe Admin::SecretsController do
       end
 
       it "redirects to new form when user wants to create another secret" do
-        post :create, params: {secret: attributes, commit: Admin::SecretsController::ADD_MORE}
+        post :create, params: {secret: attributes, commit: SecretsController::ADD_MORE}
         flash[:notice].wont_be_nil
-        assert_redirected_to "/admin/secrets/new?#{{secret: attributes.except(:value)}.to_query}"
+        assert_redirected_to "/secrets/new?#{{secret: attributes.except(:value)}.to_query}"
       end
 
       it 'renders and sets the flash when invalid' do
@@ -225,7 +225,7 @@ describe Admin::SecretsController do
 
       it 'updates' do
         flash[:notice].wont_be_nil
-        assert_redirected_to admin_secrets_path
+        assert_redirected_to secrets_path
         secret.reload
         secret.updater_id.must_equal user.id
         secret.creator_id.must_equal users(:admin).id
@@ -248,7 +248,7 @@ describe Admin::SecretsController do
         end
 
         it "is not supported" do
-          assert_redirected_to admin_secrets_path
+          assert_redirected_to secrets_path
           secret.reload.id.must_equal 'production/foo/pod2/some_key'
         end
       end
@@ -273,7 +273,7 @@ describe Admin::SecretsController do
     describe "#destroy" do
       it "deletes project secret" do
         delete :destroy, params: {id: secret}
-        assert_redirected_to "/admin/secrets"
+        assert_redirected_to "/secrets"
         SecretStorage::DbBackend::Secret.exists?(secret.id).must_equal(false)
       end
 
@@ -299,7 +299,7 @@ describe Admin::SecretsController do
       end
 
       it 'redirects and sets the flash' do
-        assert_redirected_to admin_secrets_path
+        assert_redirected_to secrets_path
         flash[:notice].wont_be_nil
       end
     end
@@ -320,21 +320,21 @@ describe Admin::SecretsController do
     describe '#update' do
       it "updates" do
         put :update, params: {id: secret, secret: attributes.except(*SecretStorage::SECRET_KEYS_PARTS)}
-        assert_redirected_to admin_secrets_path
+        assert_redirected_to secrets_path
       end
     end
 
     describe '#destroy' do
       it 'deletes global secret' do
         delete :destroy, params: {id: secret.id}
-        assert_redirected_to "/admin/secrets"
+        assert_redirected_to "/secrets"
         SecretStorage::DbBackend::Secret.exists?(secret.id).must_equal(false)
       end
 
       it "works with unknown project" do
         secret.update_column(:id, 'oops/bar')
         delete :destroy, params: {id: secret.id}
-        assert_redirected_to "/admin/secrets"
+        assert_redirected_to "/secrets"
         SecretStorage::DbBackend::Secret.exists?(secret.id).must_equal(false)
       end
     end

--- a/test/controllers/user_merges_controller_test.rb
+++ b/test/controllers/user_merges_controller_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require_relative '../../test_helper'
+require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe Admin::UserMergesController do
+describe UserMergesController do
   as_a_admin do
     unauthorized :get, :new, user_id: 1
     unauthorized :post, :create, user_id: 1

--- a/test/controllers/vault_servers_controller_test.rb
+++ b/test/controllers/vault_servers_controller_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require_relative '../../test_helper'
+require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe Admin::VaultServersController do
+describe VaultServersController do
   let!(:server) do
     Samson::Secrets::VaultServer.any_instance.stubs(:validate_connection)
     Samson::Secrets::VaultServer.create!(name: 'pod1', address: 'http://vault-land.com', token: 'TOKEN2')
@@ -68,7 +68,7 @@ describe Admin::VaultServersController do
 
         post :sync, params: {id: server.id, other_id: other.id}
 
-        assert_redirected_to admin_vault_server_path(server)
+        assert_redirected_to vault_server_path(server)
         flash[:notice].must_equal "Synced 3 values!"
       end
     end

--- a/test/helpers/stages_helper_test.rb
+++ b/test/helpers/stages_helper_test.rb
@@ -13,13 +13,13 @@ describe StagesHelper do
     it "links to global edit" do
       command = commands(:global)
       html = edit_command_link(command)
-      html.must_equal "<a title=\"Edit global command\" class=\"edit-command glyphicon glyphicon-globe no-hover\" href=\"/admin/commands/#{command.id}\"></a>"
+      html.must_equal "<a title=\"Edit global command\" class=\"edit-command glyphicon glyphicon-globe no-hover\" href=\"/commands/#{command.id}\"></a>"
     end
 
     it "links to local edit" do
       command = commands(:echo)
       html = edit_command_link(command)
-      html.must_equal "<a title=\"Edit\" class=\"edit-command glyphicon glyphicon-edit no-hover\" href=\"/admin/commands/#{command.id}\"></a>"
+      html.must_equal "<a title=\"Edit\" class=\"edit-command glyphicon glyphicon-edit no-hover\" href=\"/commands/#{command.id}\"></a>"
     end
   end
 


### PR DESCRIPTION
 - admin controllers mix admin and non-admin already
 - having to remember special namespaces / not being able to use generic is annoying
 - having different routes is confusing, especially if we want to treat them as api
 - make access controls more flexible by allowing admin gating anywhere without moving

@jonmoter @irwaters 