### PR TITLE
Risks no longer required to be last section

### DIFF
--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -126,7 +126,7 @@ class Changeset::PullRequest
   private
 
   def parse_risks(body)
-    body.to_s.split(RISKS_SECTION, 2)[1].to_s.strip.split(SECTION_HEADING).first.presence
+    body.to_s.split(RISKS_SECTION, 2)[1].to_s.strip.split(SECTION_HEADING).first.to_s.strip.presence
   end
 
   def parse_jira_issues

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -9,6 +9,9 @@ class Changeset::PullRequest
   # Matches a markdown section heading named "Risks".
   RISKS_SECTION = /^\s*#*\s*Risks?\s*#*\s*\n(?:\s*[-=]*\s*\n)?/i
 
+  # Matches a markdown section heading
+  SECTION_HEADING = /^\s*#*\s*\w+.*\n/
+
   # Matches URLs to JIRA issues.
   JIRA_ISSUE_URL = %r[https?:\/\/[\da-z\.\-]+\.[a-z\.]{2,6}\/browse\/#{CODE_ONLY}(?=#{PUNCT}|$)]
 
@@ -123,7 +126,7 @@ class Changeset::PullRequest
   private
 
   def parse_risks(body)
-    body.to_s.split(RISKS_SECTION, 2)[1].to_s.strip.presence
+    body.to_s.split(RISKS_SECTION, 2)[1].to_s.strip.split(SECTION_HEADING).first.presence
   end
 
   def parse_jira_issues

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -10,7 +10,7 @@ class Changeset::PullRequest
   RISKS_SECTION = /^\s*#*\s*Risks?\s*#*\s*\n(?:\s*[-=]*\s*\n)?/i
 
   # Matches a markdown section heading
-  SECTION_HEADING = /^\s*#*\s*\w+.*\n/
+  SECTION_HEADING = /^\s*#*\s*\w+.*\n(?:\s*[-=]*\s*\n)?/i
 
   # Matches URLs to JIRA issues.
   JIRA_ISSUE_URL = %r[https?:\/\/[\da-z\.\-]+\.[a-z\.]{2,6}\/browse\/#{CODE_ONLY}(?=#{PUNCT}|$)]

--- a/app/views/changeset/_risks.html.erb
+++ b/app/views/changeset/_risks.html.erb
@@ -1,7 +1,7 @@
 <% if pull_requests.nil? || pull_requests.empty? %>
   <p>There are no risks described in any pull request in this <%= type %>. If you want Samson to pick up and display
-  any risks associated with your pull request, add a heading called "Risks" as the <em>last thing</em> in your
-  pull request description. Anything following that heading will be considered part of the risks section.</p>
+  any risks associated with your pull request, add a heading called "Risks" in your pull request description. Anything
+  following that heading will be considered part of the risks section.</p>
 <% else %>
   <% pull_requests.each do |pr| %>
     <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %></h5>

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -412,6 +412,18 @@ describe Changeset::PullRequest do
       pr.risks.must_equal "- Planes"
     end
 
+    it "ends the risks section if there are subsequent sections" do
+      body.replace(<<-BODY.dup.strip_heredoc)
+        # Risks
+          - Planes
+
+        # Notes
+
+        This is a great PR!
+      BODY
+      pr.risks.must_equal "- Planes"
+    end
+
     context "with nothing risky" do
       before { no_risks }
 

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -418,7 +418,19 @@ describe Changeset::PullRequest do
           - Planes
 
         # Notes
+        This is a great PR!
+      BODY
+      pr.risks.must_equal "- Planes"
+    end
 
+    it "ends the risks section if there are subsequent underline style sections" do
+      body.replace(<<-BODY.dup.strip_heredoc)
+        Risks
+        =====
+          - Planes
+
+        Notes
+        =====
         This is a great PR!
       BODY
       pr.risks.must_equal "- Planes"

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -413,7 +413,7 @@ describe Changeset::PullRequest do
     end
 
     it "ends the risks section if there are subsequent sections" do
-      body.replace(<<-BODY.dup.strip_heredoc)
+      body.replace(<<~BODY.dup)
         # Risks
           - Planes
 
@@ -424,7 +424,7 @@ describe Changeset::PullRequest do
     end
 
     it "ends the risks section if there are subsequent underline style sections" do
-      body.replace(<<-BODY.dup.strip_heredoc)
+      body.replace(<<~BODY.dup)
         Risks
         =====
           - Planes


### PR DESCRIPTION
* The risks section of the PR can now be followed by other sections
* Added unit tests for this case

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
