### PR TITLE
Replace strip_heredoc with squiggly

### DIFF
--- a/app/controllers/oauth_test_controller.rb
+++ b/app/controllers/oauth_test_controller.rb
@@ -19,7 +19,7 @@ class OauthTestController < ActionController::Base
     # alternatively we could call whatever the oauth controller does internally directly
     access_token = oauth_client.auth_code.get_token(params[:code], redirect_uri: token_url).token
 
-    render plain: <<-TEXT.strip_heredoc
+    render plain: <<~TEXT
       Your access token is: #{access_token}
 
       You can use this to make requests:
@@ -47,7 +47,7 @@ class OauthTestController < ActionController::Base
 
   def ensure_application
     return if application
-    message = <<-TEXT.strip_heredoc
+    message = <<~TEXT
       Add an OAuth application at
 
       #{new_oauth_application_url}

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -12,7 +12,7 @@ class ProjectMailer < ApplicationMailer
 
   def build_mail(user, project, address, action)
     subject = "Samson Project #{action.titleize}: #{project.name}"
-    body = <<-TEXT.strip_heredoc
+    body = <<~TEXT
       "#{user.name_and_email} just #{action} project #{project.name}
       #{project.url}
       #{project.repository_homepage}

--- a/config/initializers/db_pool_from_env.rb
+++ b/config/initializers/db_pool_from_env.rb
@@ -8,7 +8,7 @@
 pool = Integer(ENV['DB_POOL'] || ENV['RAILS_MAX_THREADS'] || 100)
 
 if !ENV['PRECOMPILE'] && (config = Rails.application.config.database_configuration[Rails.env]) && config['pool'] != pool
-  warn <<-WARN.strip_heredoc
+  warn <<~WARN
     Currently using an evil ActiveRecord patch that will be removed soon.
      - Add to database.yml `pool: <%= ENV['RAILS_MAX_THREADS'] %>`
      - Add to environment RAILS_MAX_THREADS=100

--- a/plugins/docker_binary_builder/test/models/binary_builder_test.rb
+++ b/plugins/docker_binary_builder/test/models/binary_builder_test.rb
@@ -168,7 +168,7 @@ describe BinaryBuilder do
         end
         tarfile.close
         builder.send(:untar, tarfile.path)
-        output.string.must_equal <<-TEXT.strip_heredoc
+        output.string.must_equal <<~TEXT
           About to untar: test.tar
               > foo
               > bar/bar

--- a/plugins/flowdock/test/models/flowdock_notification_renderer_test.rb
+++ b/plugins/flowdock/test/models/flowdock_notification_renderer_test.rb
@@ -22,7 +22,7 @@ describe FlowdockNotificationRenderer do
 
     result = FlowdockNotificationRenderer.render(deploy)
 
-    result.must_equal <<-RESULT.strip_heredoc.chomp
+    result.must_equal <<~RESULT.chomp
       <p>2 commits by author1 and author2.</p>
 
       <p><strong>Files changed</strong></p>

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -261,7 +261,7 @@ describe Samson::Jenkins do
 
   describe "with auto-config flag" do
     let(:jenkins_xml_new_job) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <description>This is a test line in Description.</description>
@@ -291,7 +291,7 @@ XML
     end
 
     let(:jenkins_xml_configured) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <description>This is a test line in Description.
@@ -357,7 +357,7 @@ XML
     end
 
     let(:jenkins_xml_with_build_params_without_desc) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <description>This is a test line in Description.</description>
@@ -418,7 +418,7 @@ XML
     end
 
     let(:jenkins_xml_with_desc_without_params) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <description>This is a test line in Description.
@@ -454,7 +454,7 @@ XML
     end
 
     let(:jenkins_xml_with_string_build_params_other_then_samson) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <actions/>
@@ -500,7 +500,7 @@ XML
     end
 
     let(:jenkins_xml_configured_with_other_params) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <actions/>
@@ -581,7 +581,7 @@ XML
     end
 
     let(:jenkins_xml_with_some_samson_build_params) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <description>This is a test line in Description.
@@ -646,7 +646,7 @@ XML
     end
 
     let(:jenkins_xml_configured_with_some_samson_build_params) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <description>This is a test line in Description.
@@ -727,7 +727,7 @@ XML
     end
 
     let(:jenkins_xml_configured_with_updated_desc) do
-      <<-XML.strip_heredoc
+      <<~XML
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
   <description>This is a test line in Description.

--- a/plugins/kubernetes/test/models/kubernetes/util_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/util_test.rb
@@ -25,7 +25,7 @@ describe Kubernetes::Util do
     end
 
     it 'handles a YAML file with multiple entries' do
-      yaml_input = <<-YAML.strip_heredoc
+      yaml_input = <<~YAML
         ---
         name: foo
         value: 999

--- a/plugins/samson_ledger/lib/samson_ledger/client.rb
+++ b/plugins/samson_ledger/lib/samson_ledger/client.rb
@@ -59,7 +59,7 @@ module SamsonLedger
             "<a href='#{user.url}'><img src='#{user.avatar_url}' width=20 height=20 /></a>"
           end
 
-          <<-HTML.strip_heredoc.tr("\n", ' ')
+          <<~HTML.tr("\n", ' ')
             <li>
               #{github_users.join}
               <strong>##{pull_request.number}</strong>

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -120,7 +120,7 @@ describe SlackWebhookNotification do
 
     it "renders a nicely formatted pending notification" do
       deploy.job.status = "pending"
-      render.must_equal <<-TEXT.strip_heredoc.chomp
+      render.must_equal <<~TEXT.chomp
         :stopwatch: *[Foo] Super Admin is about to deploy staging to Staging* (<http://sams.on/url|view the deploy>)
         _<https://github.com/url|3 commits> and 2 pull requests by author1 and author2._
 
@@ -132,7 +132,7 @@ describe SlackWebhookNotification do
     end
 
     it "does not render pull requests for finished deploys" do
-      render.must_equal <<-TEXT.strip_heredoc.chomp
+      render.must_equal <<~TEXT.chomp
         :white_check_mark: *[Foo] Super Admin deployed staging to Staging* (<http://sams.on/url|view the deploy>)
         _<https://github.com/url|3 commits> and 2 pull requests by author1 and author2._
       TEXT

--- a/plugins/zendesk/test/models/zendesk_notification_renderer_test.rb
+++ b/plugins/zendesk/test/models/zendesk_notification_renderer_test.rb
@@ -23,7 +23,7 @@ describe ZendeskNotificationRenderer do
 
     result = ZendeskNotificationRenderer.render(deploy, ticket_id)
 
-    result.must_equal <<-RESULT.strip_heredoc.chomp
+    result.must_equal <<~RESULT.chomp
       A fix to Project for this issue has been deployed to Production. Deploy details: [v2.14] (http://example.org/deploys/20)
 
       **Related Commits:**

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -96,7 +96,7 @@ describe Integrations::BaseController do
       post :create, params: {test_route: true, token: token}
       assert_response :success
       result = WebhookRecorder.read(project)
-      log = <<-LOG.strip_heredoc
+      log = <<~LOG
         INFO: Branch master is release branch: true
         INFO: Deploying to 0 stages
       LOG

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -6,14 +6,14 @@ SingleCov.covered!
 describe Changeset::PullRequest do
   def add_risks
     body.replace(<<~BODY.dup)
-        # Risks
-         - Explosions
+      # Risks
+      - Explosions
     BODY
   end
 
   def no_risks
     body.replace(<<~BODY.dup)
-        Not that risky ...
+      Not that risky ...
     BODY
   end
 

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -5,14 +5,14 @@ SingleCov.covered!
 
 describe Changeset::PullRequest do
   def add_risks
-    body.replace(<<-BODY.dup.strip_heredoc)
+    body.replace(<<~BODY.dup)
         # Risks
          - Explosions
     BODY
   end
 
   def no_risks
-    body.replace(<<-BODY.dup.strip_heredoc)
+    body.replace(<<~BODY.dup)
         Not that risky ...
     BODY
   end
@@ -380,7 +380,7 @@ describe Changeset::PullRequest do
     end
 
     it "does not find - None" do
-      body.replace(<<-BODY.dup.strip_heredoc)
+      body.replace(<<~BODY.dup)
         # Risks
          - None
       BODY
@@ -388,7 +388,7 @@ describe Changeset::PullRequest do
     end
 
     it "does not find None" do
-      body.replace(<<-BODY.dup.strip_heredoc)
+      body.replace(<<~BODY.dup)
         # Risks
         None
       BODY
@@ -396,7 +396,7 @@ describe Changeset::PullRequest do
     end
 
     it "finds risks with underline style markdown headers" do
-      body.replace(<<-BODY.dup.strip_heredoc)
+      body.replace(<<~BODY.dup)
         Risks
         =====
           - Snakes
@@ -405,7 +405,7 @@ describe Changeset::PullRequest do
     end
 
     it "finds risks with closing hashes in atx style markdown headers" do
-      body.replace(<<-BODY.dup.strip_heredoc)
+      body.replace(<<~BODY.dup)
         ## Risks ##
           - Planes
       BODY


### PR DESCRIPTION
* Just replaces usages of Rails' strip_heredoc with Ruby 2.3's squiggly heredoc: https://infinum.co/the-capsized-eight/multiline-strings-ruby-2-3-0-the-squiggly-heredoc

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
