### PR TITLE
allow scoped auth on web controllers

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -3,25 +3,6 @@ class Api::BaseController < ApplicationController
   prepend_before_action :enforce_json_format
   before_action :require_project
 
-  # default error has very little information
-  # http://stackoverflow.com/questions/33704640/how-to-render-correct-json-format-with-raised-error
-  rescue_from ActiveRecord::RecordInvalid do |exception|
-    render json: {error: exception.record.errors}, status: 422
-  end
-
-  # default error has very little information
-  # https://github.com/rails/strong_parameters/issues/157
-  rescue_from ActionController::ParameterMissing do |exception|
-    render json: {error: {exception.param => ["is required"]}}, status: :bad_request
-  end
-
-  # otherwise renders a 500 and goes to airbrake
-  # https://coderwall.com/p/ea5vtw/validating-rest-queries-with-rails
-  rescue_from ActionController::UnpermittedParameters do |exception|
-    details = exception.params.each_with_object({}) { |p, h| h[p] = ["is not permitted"] }
-    render json: {error: details}, status: :bad_request
-  end
-
   protected
 
   def paginate(scope)
@@ -32,16 +13,13 @@ class Api::BaseController < ApplicationController
     end
   end
 
-  def page
-    params.fetch(:page, 1)
-  end
-
   def current_project
     @project
   end
 
+  # FIXME: loading project by id is weird
   def require_project
-    @project = (Project.find_by_id(params[:project_id]) if params[:project_id])
+    @project = Project.find(params[:project_id]) if params[:project_id].to_s =~ /\A\d+\z/
   end
 
   # without json format 404/500 pages are rendered in html and auth will redirect
@@ -49,14 +27,12 @@ class Api::BaseController < ApplicationController
   # and raising an error somewhere ... cannot be tested with an integration test
   def enforce_json_format
     return if request.format == :json
-    render status: 415, json: {error: 'JSON only api. Use json extension or set content type application/json'}
+    render_json_error 415, 'JSON only api. Use json extension or set content type application/json'
   end
 
-  # making sure all scopes are documented
+  # remove web-ui scope
   # @override
   def store_requested_oauth_scope
-    scope = controller_name
-    raise "Add #{scope} to config/locales/en.yml" unless I18n.t('doorkeeper.applications.help.scopes') =~ /\b#{scope}\b/
-    request.env['requested_oauth_scope'] = scope
+    super.delete Warden::Strategies::Doorkeeper::WEB_UI_SCOPE
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,13 @@ class ApplicationController < ActionController::Base
   force_ssl if: :force_ssl?
 
   include CurrentUser # must be after protect_from_forgery, so that authenticate! is called
+  include JsonExceptions
 
   protected
+
+  def page
+    params.fetch(:page, 1)
+  end
 
   def force_ssl?
     ENV['FORCE_SSL'] == '1'
@@ -40,7 +45,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_requested_oauth_scope
-    request.env['requested_oauth_scope'] = Warden::Strategies::Doorkeeper::WEB_UI_SCOPE
+    request.env['requested_oauth_scopes'] = [Warden::Strategies::Doorkeeper::WEB_UI_SCOPE, controller_name]
   end
 
   def using_per_request_auth?

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -6,7 +6,7 @@ class BuildsController < ApplicationController
   before_action :find_build, only: [:show, :build_docker_image, :edit, :update]
 
   def index
-    @builds = current_project.builds.order('id desc').page(params[:page])
+    @builds = current_project.builds.order('id desc').page(page)
 
     respond_to do |format|
       format.html

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -8,7 +8,7 @@ class CommandsController < ApplicationController
   before_action :authorize_custom_project_admin!, except: PUBLIC
 
   def index
-    @commands = Command.order(:project_id).page(params[:page])
+    @commands = Command.order(:project_id).page(page)
     if search = params[:search]
       if query = search[:query].presence
         query = ActiveRecord::Base.send(:sanitize_sql_like, query)

--- a/app/controllers/concerns/json_exceptions.rb
+++ b/app/controllers/concerns/json_exceptions.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module JsonExceptions
+  def self.included(base)
+    # default error has very little information
+    # http://stackoverflow.com/questions/33704640/how-to-render-correct-json-format-with-raised-error
+    base.rescue_from ActiveRecord::RecordInvalid do |exception|
+      raise unless request.format.json?
+      render_json_error 422, exception.record.errors
+    end
+
+    # default error has very little information
+    # https://github.com/rails/strong_parameters/issues/157
+    base.rescue_from ActionController::ParameterMissing do |exception|
+      raise unless request.format.json?
+      render_json_error 400, exception.param => ["is required"]
+    end
+
+    # otherwise renders a 500 and goes to airbrake
+    # https://coderwall.com/p/ea5vtw/validating-rest-queries-with-rails
+    base.rescue_from ActionController::UnpermittedParameters do |exception|
+      raise unless request.format.json?
+      details = exception.params.each_with_object({}) { |p, h| h[p] = ["is not permitted"] }
+      render_json_error 400, details
+    end
+  end
+
+  private
+
+  # render json errors as rails does for consistency
+  def render_json_error(status, message)
+    render json: {status: status, error: message}, status: status
+  end
+end

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -160,7 +160,7 @@ class DeploysController < ApplicationController
     deploys = deploys_scope
     deploys = deploys.where(stage: stages) if stages
     deploys = deploys.where(job: jobs) if jobs
-    deploys.page(params[:page]).per(30)
+    deploys.page(page).per(30)
   end
 
   def deploy_permitted_params

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -8,7 +8,7 @@ class JobsController < ApplicationController
   before_action :find_job, only: [:show, :destroy]
 
   def index
-    @jobs = @project.jobs.non_deploy.page(params[:page])
+    @jobs = @project.jobs.non_deploy.page(page)
   end
 
   def show

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -116,9 +116,9 @@ class ProjectsController < ApplicationController
     elsif ids = current_user.starred_project_ids.presence
       # fake association sorting since order by array is hard to support in mysql+postgres+sqlite
       array = scope.all.sort_by { |p| ids.include?(p.id) ? 0 : 1 }
-      return Kaminari.paginate_array(array).page(params[:page]).per(per_page)
+      return Kaminari.paginate_array(array).page(page).per(per_page)
     end
-    scope.order(id: :desc).page(params[:page]).per(per_page)
+    scope.order(id: :desc).page(page).per(per_page)
   end
 
   # Overriding require_project from CurrentProject

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -12,7 +12,7 @@ class ReleasesController < ApplicationController
 
   def index
     @stages = @project.stages
-    @releases = @project.releases.order(id: :desc).page(params[:page])
+    @releases = @project.releases.order(id: :desc).page(page)
   end
 
   def new

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -20,7 +20,7 @@ class StagesController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        @deploys = @stage.deploys.page(params[:page])
+        @deploys = @stage.deploys.page(page)
       end
       format.svg do
         badge =

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,10 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
   doorkeeper:
     applications:
       help:
-        # Ideally make dynamic https://github.com/doorkeeper-gem/doorkeeper/issues/896
-        # and enforce inclusion ... for now keep in sync with api controllers
-        scopes: "Separate scopes with spaces. Possible: automated_deploys, builds, deploy_groups, deploys, locks, projects, stages, users, default (api/*), web-ui (non api/)"
+        scopes: "Separate scopes with spaces. Possible: any controller path (for example deploy_groups), default (api/*), web-ui (non api/)"

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,6 @@
+# API
+
+Many endpoints offer a `.json` response, open PRs for missing ones, there is also a deprecated & dedicated `/api` endpoint.
+
+Api authentication is done via OAuth tokens and scopes.
+Users can use an OAuth flow to request access or create their own personal access tokens and then use them via api clients.

--- a/test/controllers/api/locks_controller_test.rb
+++ b/test/controllers/api/locks_controller_test.rb
@@ -81,7 +81,7 @@ describe Api::LocksController do
       it "fails without parameters" do
         delete :destroy_via_resource, format: :json
         assert_response :bad_request
-        JSON.parse(response.body).must_equal "error" => {"resource_id" => ["is required"]}
+        JSON.parse(response.body).must_equal "status" => 400, "error" => {"resource_id" => ["is required"]}
       end
     end
   end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -76,7 +76,7 @@ describe ApplicationController do
   describe "#store_requested_oauth_scope" do
     it "stores the web-ui scope" do
       get :test_render, params: {test_route: true}
-      request.env['requested_oauth_scope'].must_equal 'web-ui'
+      request.env['requested_oauth_scopes'].must_equal ['web-ui', 'application_test']
     end
   end
 end

--- a/test/controllers/concerns/json_exceptions_test.rb
+++ b/test/controllers/concerns/json_exceptions_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe "Api::BaseController Integration" do
+  describe "errors" do
+    let(:user) { users(:super_admin) }
+    let(:token) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, scopes: 'default') }
+
+    def assert_json(code, message)
+      assert_response code
+      JSON.parse(response.body, symbolize_names: true).must_equal(status: code, error: message)
+    end
+
+    let(:headers) { {'Authorization' => "Bearer #{token.token}"} }
+
+    before do
+      ActionDispatch::Request.any_instance.stubs(show_exceptions?: true) # render exceptions as production would
+      stub_session_auth
+    end
+
+    it "presents validation errors" do
+      post '/api/locks.json', params: {lock: {warning: true}}, headers: headers
+      assert_json 422, description: ["can't be blank"]
+    end
+
+    it "presents missing params errors" do
+      post '/api/locks.json', params: {}, headers: headers
+      assert_json 400, lock: ["is required"]
+    end
+
+    it "presents invalid keys errors" do
+      post '/api/locks.json', params: {lock: {foo: :bar, baz: :bar}}, headers: headers
+      assert_json 400, foo: ["is not permitted"], baz: ["is not permitted"]
+    end
+  end
+end

--- a/test/lib/warden/strategies/doorkeeper_strategy_test.rb
+++ b/test/lib/warden/strategies/doorkeeper_strategy_test.rb
@@ -61,6 +61,12 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
       perform_get(valid_header)
       assert_response :success, response.body
     end
+
+    it "logs the user in when using profile token" do
+      token.update_column(:scopes, "profiles")
+      perform_get(valid_header)
+      assert_response :success, response.body
+    end
   end
 
   it "checks and fails with expired token" do


### PR DESCRIPTION
before: locks scope allows access to api/locks
after: locks scope allows access to api/locks and locks

this adds:
 - a bunch of actions / privileges that did not previously exist even though the scope was whitelisted since api was missing lots of actions ...
 - json error handling for web-ui .json endpoints