### PR TITLE
rework git-repo to avoid race conditions and simplify logic

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -94,10 +94,6 @@ class BuildsController < ApplicationController
   end
 
   def git_sha
-    @git_sha ||= begin
-      # Create/update local cache to avoid getting a stale reference
-      current_project.repository.exclusive(holder: 'BuildsController#create', &:update_local_cache!)
-      current_project.repository.commit_from_ref(new_build_params[:git_ref])
-    end
+    @git_sha ||= current_project.repository.commit_from_ref(new_build_params[:git_ref])
   end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -72,12 +72,6 @@ class Build < ActiveRecord::Base
 
     return if errors.include?(:git_ref) || errors.include?(:git_sha)
 
-    unless project.repository.last_pulled
-      project.repository.exclusive holder: 'Build reference validation' do
-        project.repository.update_local_cache!
-      end
-    end
-
     if git_ref.present?
       commit = project.repository.commit_from_ref(git_ref)
       if commit

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -97,9 +97,6 @@ class Release < ActiveRecord::Base
 
   def covert_ref_to_sha
     return if commit.blank? || commit =~ Build::SHA1_REGEX
-
-    # Create/update local cache to avoid getting a stale reference
-    project.repository.exclusive(holder: 'Release#covert_ref_to_sha', &:update_local_cache!)
     self.commit = project.repository.commit_from_ref(commit)
   end
 end

--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -25,6 +25,7 @@ class TerminalExecutor
     @stopped = false
   end
 
+  # TODO: rename to execute since it does not blow up on failure
   def execute!(*commands)
     return false if @stopped
     options = {in: '/dev/null', unsetenv_others: true}

--- a/lib/references_service.rb
+++ b/lib/references_service.rb
@@ -27,16 +27,6 @@ class ReferencesService
   end
 
   def references_from_cached_repo
-    git_references = nil
-    lock_project do
-      return unless repository.update_local_cache! # TODO: test this ...
-      tags = repository.tags
-      git_references = repository.branches.push(*tags).sort_by { |ref| [-ref.length, ref] }.reverse
-    end
-    git_references
-  end
-
-  def lock_project(&block)
-    project.with_lock(holder: 'autocomplete', timeout: lock_timeout, &block)
+    (repository.branches + repository.tags).sort_by { |ref| [-ref.length, ref] }.reverse
   end
 end

--- a/test/controllers/api/builds_controller_test.rb
+++ b/test/controllers/api/builds_controller_test.rb
@@ -24,7 +24,6 @@ describe Api::BuildsController do
       end
 
       before do
-        GitRepository.any_instance.stubs(:update_local_cache!)
         GitRepository.any_instance.stubs(:commit_from_ref).with('reff').returns('some-commit')
       end
 

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -19,7 +19,6 @@ describe BuildsController do
   end
 
   def stub_git_reference_check(returns: false)
-    GitRepository.any_instance.stubs(:update_local_cache!).returns(true)
     GitRepository.any_instance.stubs(:commit_from_ref).returns(returns)
   end
 

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -47,7 +47,6 @@ describe ReleasesController do
     describe "#create" do
       let(:release_params) { { commit: "abcd" } }
       before do
-        GitRepository.any_instance.expects(:update_local_cache!)
         GitRepository.any_instance.expects(:commit_from_ref).with('abcd').returns('a' * 40)
         GITHUB.stubs(:create_release)
       end

--- a/test/lib/references_service_test.rb
+++ b/test/lib/references_service_test.rb
@@ -13,10 +13,6 @@ describe ReferencesService do
 
   let!(:project) { Project.create!(name: 'test_project', repository_url: repo_temp_dir) }
 
-  before do
-    project.repository.update_local_cache!
-  end
-
   after do
     FileUtils.rm_rf(repo_temp_dir)
     project.repository.clean!

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -2,7 +2,7 @@
 require_relative '../test_helper'
 require 'ar_multi_threaded_transactional_tests'
 
-SingleCov.covered! uncovered: 7
+SingleCov.covered! uncovered: 5
 
 describe JobExecution do
   include GitRepoTestHelper
@@ -37,7 +37,7 @@ describe JobExecution do
     Project.any_instance.stubs(:valid_repository_url).returns(true)
     user.name = 'John Doe'
     user.email = 'jdoe@test.com'
-    project.repository.update_local_cache!
+    project.repository.send(:clone!)
     job.deploy = deploy
     freeze_time
   end
@@ -114,6 +114,9 @@ describe JobExecution do
     execute_job 'safari'
 
     assert_equal '[04:05:06] tiger', last_line_of_output
+
+    # pretend we are in a new request
+    project.repository.instance_variable_set(:@mirror_current, nil)
 
     execute_on_remote_repo <<-SHELL
       git checkout safari

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -56,14 +56,12 @@ describe Release do
     end
 
     it "converts refs to commits so we later know what exactly was deployed" do
-      GitRepository.any_instance.expects(:update_local_cache!).at_least_once
       GitRepository.any_instance.expects(:commit_from_ref).with('master').returns(commit)
       release = project.releases.create!(author: author, commit: 'master')
       release.commit.must_equal commit
     end
 
     it "fails with unresolvable ref" do
-      GitRepository.any_instance.expects(:update_local_cache!).at_least_once
       GitRepository.any_instance.expects(:commit_from_ref).with('master').returns(nil)
       e = assert_raises ActiveRecord::RecordInvalid do
         project.releases.create!(author: author, commit: 'master')

--- a/test/support/git_repo_test_support.rb
+++ b/test/support/git_repo_test_support.rb
@@ -48,9 +48,8 @@ module GitRepoTestHelper
     SHELL
   end
 
-  def create_repo_with_submodule
+  def add_submodule_to_repo
     create_submodule_repo
-    create_repo_without_tags
     execute_on_remote_repo <<-SHELL
       git submodule add #{submodule_temp_dir} submodule
       git add .gitmodules


### PR DESCRIPTION
 - always use exclusive around update/clone
 - hide 'is it current' state inside of git-repository

... solves double clone bugs and hopefully more random errors ... also simplifies the code a bit

@jonmoter @irwaters 

### Risk:
 - Medium fallout around clones not working or tags not being found because things are stale