### PR TITLE
Fix broken outbound_webhooks migration

### DIFF
--- a/db/migrate/20160815185747_create_outbound_webhooks.rb
+++ b/db/migrate/20160815185747_create_outbound_webhooks.rb
@@ -3,7 +3,7 @@ class CreateOutboundWebhooks < ActiveRecord::Migration[4.2]
   def change
     create_table :outbound_webhooks do |t|
       t.timestamps null: false
-      t.timestamp :deleted_at, default: nil
+      t.timestamp :deleted_at
 
       t.integer :project_id, null: false
       t.integer :stage_id, null: false


### PR DESCRIPTION
When `default: nil` is set on `deleted_at`, Rails attempts to create a `timestamp
DEFAULT NULL` field, which causes an error when run against a MySQL database.

This commit removes the default value so that the field is generated as
`timestamp NULL DEFAULT NULL`.

/cc @zendesk/samson @zendesk/vulcan 

### Tasks
 - [ ] :+1: from team

### References
 - JIRA link: https://zendesk.atlassian.net/browse/VULCAN-374

### Risks
- Level: Low