### PR TITLE
remove deprecated db pool hacks

### DIFF
--- a/config/initializers/db_pool_from_env.rb
+++ b/config/initializers/db_pool_from_env.rb
@@ -8,7 +8,7 @@
 pool = Integer(ENV['DB_POOL'] || ENV['RAILS_MAX_THREADS'] || 100)
 
 if !ENV['PRECOMPILE'] && (config = Rails.application.config.database_configuration[Rails.env]) && config['pool'] != pool
-  warn <<-WARN.strip_heredoc
+  raise <<-WARN.strip_heredoc
     Currently using an evil ActiveRecord patch that will be removed soon.
      - Add to database.yml `pool: <%= ENV['RAILS_MAX_THREADS'] %>`
      - Add to environment RAILS_MAX_THREADS=100
@@ -16,13 +16,4 @@ if !ENV['PRECOMPILE'] && (config = Rails.application.config.database_configurati
     See https://devcenter.heroku.com/articles/concurrency-and-database-connections
     From: config/initializers/db_pool_from_env.rb
   WARN
-
-  Rails.application.config.after_initialize do
-    ActiveRecord::Base.connection_pool.disconnect!
-
-    ActiveSupport.on_load(:active_record) do
-      config['pool'] = pool
-      ActiveRecord::Base.establish_connection(config)
-    end
-  end
 end


### PR DESCRIPTION
users had plenty warning ... now we blow up ... better then just removing since they will know what needs to be changed