### PR TITLE
refactor secret forms

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -95,6 +95,7 @@ class SecretsController < ApplicationController
 
   def find_secret
     @secret = SecretStorage.read(key, include_value: true)
+    @secret[:value] = nil unless @secret.fetch(:visible)
   end
 
   def find_project_permalinks

--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -14,81 +14,49 @@
   <% secret = (id ? @secret.merge(SecretStorage.parse_secret_key(id)) : (params[:secret] || {})) %>
   <% edit_disabled = id && !secret[:visible] # prevent users from accidentally updating with an empty value %>
 
-  <%= form_tag url, class: "form-horizontal", method: method do %>
+  <%= form_for OpenStruct.new(secret), as: :secret, url: url, method: method, html: {class: "form-horizontal"} do |form| %>
     <fieldset>
-      <div class="form-group">
-        <%= label_tag 'secret[environment_permalink]', "Environment", class: "col-lg-2 control-label" %>
-        <div class="col-lg-4">
-          <%= select_tag 'secret[environment_permalink]',
-            options_for_select(environment_permalinks, secret[:environment_permalink]),
-            class: "form-control", include_blank: true, required: true, disabled: !!id %>
-        </div>
-      </div>
+      <%= form.input :environment_permalink, label: "Environment" do %>
+        <%= form.select :environment_permalink,
+          options_for_select(environment_permalinks, secret[:environment_permalink]),
+          {include_blank: true}, class: "form-control", required: true, disabled: !!id %>
+      <% end %>
 
-      <div class="form-group">
-        <%= label_tag 'secret[project_permalink]', "Project", class: "col-lg-2 control-label" %>
-        <div class="col-lg-4">
-          <%= live_select_tag 'secret[project_permalink]',
-            options_for_select(@project_permalinks, secret[:project_permalink]), include_blank: true, required: true, disabled: !!id %>
-        </div>
-      </div>
+      <%= form.input :project_permalink, label: "Project" do %>
+        <%= live_select_tag 'secret[project_permalink]',
+          options_for_select(@project_permalinks, secret[:project_permalink]), include_blank: true, required: true, disabled: !!id %>
+      <% end %>
 
-      <div class="form-group">
-        <%= label_tag 'secret[deploy_group_permalink]', "Deploy Group", class: "col-lg-2 control-label" %>
-        <div class="col-lg-4">
-          <%= select_tag 'secret[deploy_group_permalink]',
-            options_for_select([['Loading ...', secret[:deploy_group_permalink]]], secret[:deploy_group_permalink]),
-            class: "form-control", required: true, include_blank: true, disabled: !!id %>
-        </div>
-      </div>
+      <%= form.input :deploy_group_permalink, label: "Deploy Group" do %>
+        <%= form.select :deploy_group_permalink,
+          options_for_select([['Loading ...', secret[:deploy_group_permalink]]], secret[:deploy_group_permalink]),
+          {include_blank: true}, class: "form-control", required: true, disabled: !!id %>
+      <% end %>
 
-      <div class="form-group">
-        <%= label_tag 'secret[key]', 'Key', class: "col-lg-2 control-label" %>
-        <div class="col-lg-6">
-          <%= text_field_tag 'secret[key]', secret[:key], class: "form-control", disabled: !!id %>
-        </div>
-      </div>
+      <%= form.input :key, input_html: {disabled: !!id} %>
 
-      <div class="form-group">
-        <%= label_tag 'secret[comment]', 'Comment', class: "col-lg-2 control-label" %>
-        <div class="col-lg-6">
-          <%= text_area_tag 'secret[comment]', secret[:comment], class: "form-control disabled-on-edit", rows: secret[:comment].to_s.count("\n") + 1, disabled: edit_disabled %>
-        </div>
-      </div>
+      <%= form.input :comment, as: :text_area, input_html: {disabled: edit_disabled, class: "form-control disabled-on-edit", rows: secret[:comment].to_s.count("\n") + 1} %>
 
-      <div class="form-group">
-        <%= label_tag 'secret[visible]', 'Visible in UI', class: "col-lg-2 control-label" %>
-        <div class="col-lg-6">
-          <%= hidden_field_tag 'secret[visible]', false %>
-          <%= check_box_tag 'secret[visible]', true, secret[:visible], class: "form-control", disabled: edit_disabled %>
-        </div>
-      </div>
+      <%= form.input :visible, as: :check_box, input_html: {disabled: edit_disabled} %>
 
-      <div class="form-group">
-        <%= label_tag 'secret[value]', 'Value', class: "col-lg-2 control-label" %>
-        <div class="col-lg-6">
-          <% value = secret[:value] if secret[:visible] %>
-          <%= text_area_tag 'secret[value]', value, class: "form-control", rows: 10, placeholder: '-- hidden, click to replace --', disabled: edit_disabled %>
-          <div id="value_json_warning" class="alert-danger"></div>
-        </div>
-      </div>
+      <%= form.input :value do %>
+        <%= form.text_area :value, class: "form-control", rows: 10, placeholder: '-- hidden, click to replace --', disabled: edit_disabled %>
+        <div id="value_json_warning" class="alert-danger"></div>
+      <% end %>
 
       <% if @secret %>
         <% @secret.except(:key, :value, :visible, :comment).each do |attribute, value| %>
-          <div class="form-group">
-            <%= label_tag attribute, attribute.to_s.titlecase, class: "col-lg-2 control-label" %>
-            <div class="col-lg-6">
-              <% if [:creator_id, :updater_id].include?(attribute) %>
-                <% if user = User.find_by_id(value) %>
-                  <%= link_to user.name_and_email, user %>
-                <% else %>
-                  <%= "Unknown user id:#{value}" %>
-                <% end %>
+          <%= form.input attribute do %>
+            <% if [:creator_id, :updater_id].include?(attribute) %>
+              <% if user = User.find_by_id(value) %>
+                <%= link_to user.name_and_email, user %>
               <% else %>
-                <%= value %>
+                <%= "Unknown user id:#{value}" %>
               <% end %>
-            </div>
-          </div>
+            <% else %>
+              <%= value %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -191,6 +191,11 @@ describe SecretsController do
       it 'renders for local secret as project-admin' do
         get :show, params: {id: secret}
         assert_template :show
+      end
+
+      it 'hides invisible secrets' do
+        get :show, params: {id: secret}
+        refute assigns(:secret).fetch(:value)
         response.body.wont_include secret.value
       end
 


### PR DESCRIPTION
use form_for so we can input and dry up all the html structure
also made the controller safer by not even including the secret value

@swatikri 