### PR TITLE
request global secrets to be shared instead of sharing by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 
 ## Secret storage
 # SECRET_STORAGE_BACKEND= # optional, should be one of: SecretStorage::DbBackend (default) or SecretStorage::HashicorpVault
+# SECRET_STORAGE_SHARING_GRANTS=true # optional, instead of sharing global secrets by default, access has to be granted
 
 ## Kubernetes
 # SECRET_PULLER_IMAGE=zendesk/samson_secret_puller:latest # optional, docker image for zendesk/samson_secret_puller

--- a/app/controllers/secret_sharing_grants_controller.rb
+++ b/app/controllers/secret_sharing_grants_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+class SecretSharingGrantsController < ApplicationController
+  before_action :authorize_admin!, except: [:index, :show]
+  before_action :find_grant, only: [:show, :destroy]
+
+  def index
+    @secret_sharing_grants = SecretSharingGrant.page(page).per(25)
+  end
+
+  def new
+    @secret_sharing_grant = SecretSharingGrant.new(key: params.dig(:secret_sharing_grant, :key))
+  end
+
+  def create
+    attributes = params.require(:secret_sharing_grant).permit(:key, :project_id)
+    @secret_sharing_grant = SecretSharingGrant.create(attributes)
+    if @secret_sharing_grant.persisted?
+      redirect_back fallback_location: @secret_sharing_grant, notice: 'Grant created'
+    else
+      render :new
+    end
+  end
+
+  def show
+  end
+
+  def destroy
+    @secret_sharing_grant.destroy
+    redirect_to secret_sharing_grants_path, notice: 'Grant revoked'
+  end
+
+  private
+
+  def find_grant
+    @secret_sharing_grant = SecretSharingGrant.find(params.require(:id))
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,6 +97,7 @@ module ApplicationHelper
       name = resource.name
       name = (resource.lock.warning? ? warning_icon : lock_icon) + " " + name if resource.lock
       [name, project_stage_path(resource.project, resource)]
+    when SecretSharingGrant then [resource.key, resource]
     else
       raise ArgumentError, "Unsupported resource #{resource}"
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,6 +25,7 @@ class Project < ActiveRecord::Base
   has_many :commands, dependent: :destroy
   has_many :user_project_roles, dependent: :destroy
   has_many :users, through: :user_project_roles
+  has_many :secret_sharing_grants, dependent: :destroy
 
   belongs_to :build_command, class_name: 'Command', optional: true
 

--- a/app/models/secret_sharing_grant.rb
+++ b/app/models/secret_sharing_grant.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SecretSharingGrant < ActiveRecord::Base
+  has_paper_trail skip: [:created_at]
+  belongs_to :project
+  validates :key, uniqueness: true
+end

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -68,6 +68,10 @@ module SecretStorage
       SECRET_KEYS_PARTS.zip(key.split(SEPARATOR, SECRET_KEYS_PARTS.size)).to_h
     end
 
+    def sharing_grants?
+      ENV['SECRET_STORAGE_SHARING_GRANTS']
+    end
+
     private
 
     def modify_keys_cache

--- a/app/views/secret_sharing_grants/index.html.erb
+++ b/app/views/secret_sharing_grants/index.html.erb
@@ -1,0 +1,35 @@
+<%= page_title "Secret Sharing Grants" %>
+
+<section class="clearfix tabs">
+  <div class="table table-hover table-condensed">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Key</th>
+          <th>Project</th>
+          <th>Created</th>
+          <th></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @secret_sharing_grants.each do |grant| %>
+          <tr>
+            <td><%= link_to_resource grant %></td>
+            <td><%= link_to_resource grant.project %></td>
+            <td><%= render_time grant.created_at %></td>
+            <td><%= link_to_delete grant %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= paginate @secret_sharing_grants %>
+  </div>
+
+  <div class="admin-actions">
+    <div class="pull-right">
+      <%= link_to "New", new_secret_sharing_grant_path, class: "btn btn-default" %>
+    </div>
+  </div>
+</section>

--- a/app/views/secret_sharing_grants/new.html.erb
+++ b/app/views/secret_sharing_grants/new.html.erb
@@ -1,0 +1,17 @@
+<%= page_title "New Secret Sharing Grant" %>
+
+<section>
+  <%= form_for @secret_sharing_grant, html: { class: "form-horizontal" } do |form| %>
+    <%= redirect_to_field %>
+    <%= render 'shared/errors', object: @secret_sharing_grant %>
+
+    <%= form.input :key, required: true %>
+    <%= form.input :project_id, required: true do %>
+      <% projects = Project.pluck(:name, :id) %>
+      <%= form.select :project_id, projects, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
+    <% end %>
+    <hr>
+
+    <%= form.actions %>
+  <% end %>
+</section>

--- a/app/views/secret_sharing_grants/show.html.erb
+++ b/app/views/secret_sharing_grants/show.html.erb
@@ -1,0 +1,20 @@
+<%= page_title "Grant #{@secret_sharing_grant.key} for #{@secret_sharing_grant.project.name}" %>
+
+<section class="form-horizontal">
+  <div class="form-group">
+    <label class="col-lg-2 control-label">Key</label>
+    <div class="col-lg-4">
+      <%= link_to_resource @secret_sharing_grant %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label class="col-lg-2 control-label">Project</label>
+    <div class="col-lg-4">
+      <%= link_to_resource @secret_sharing_grant.project %>
+    </div>
+  </div>
+
+  <%= link_to_history @secret_sharing_grant %> |
+  <%= link_to "Secrets", secrets_path(search: {key: @secret_sharing_grant.key, project_permalink: 'global'}) %>
+</section>

--- a/app/views/secrets/_history.html.erb
+++ b/app/views/secrets/_history.html.erb
@@ -1,0 +1,13 @@
+<% @secret.except(:key, :value, :visible, :comment).each do |attribute, value| %>
+  <%= form.input attribute do %>
+    <% if [:creator_id, :updater_id].include?(attribute) %>
+      <% if user = User.find_by_id(value) %>
+        <%= link_to user.name_and_email, user %>
+      <% else %>
+        <%= "Unknown user id:#{value}" %>
+      <% end %>
+    <% else %>
+      <%= value %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/secrets/_sharing_grants.html.erb
+++ b/app/views/secrets/_sharing_grants.html.erb
@@ -1,0 +1,15 @@
+<%= form.input :secret_sharing_grants do %>
+  <% if grants = SecretSharingGrant.where(key: secret.fetch(:key)).presence %>
+    <% grants.each do |grant| %>
+      <ul>
+        <li>Project <%= link_to_resource grant.project %> since <%= link_to render_time(grant.created_at, params[:time_format]), grant %></li>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <% if current_user.admin? %>
+    <%= link_to "Grant sharing", new_secret_sharing_grant_path(secret_sharing_grant: {key: secret.fetch(:key)}) %>
+  <% else %>
+    Ask and admin to use this secret in your project.
+  <% end %>
+<% end %>

--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -1,6 +1,10 @@
 <% project_list = Project.pluck(:permalink, :name).to_h %>
 
-<%= page_title "Secrets" %>
+<% page_title "Secrets" %>
+<h1>
+  Secrets
+  <%= link_to "Sharing", secret_sharing_grants_path, class: "pull-right" if SecretStorage.sharing_grants? %>
+</h1>
 
 <%= search_form do %>
   <%= render 'shared/search_query' %>

--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -44,20 +44,9 @@
         <div id="value_json_warning" class="alert-danger"></div>
       <% end %>
 
-      <% if @secret %>
-        <% @secret.except(:key, :value, :visible, :comment).each do |attribute, value| %>
-          <%= form.input attribute do %>
-            <% if [:creator_id, :updater_id].include?(attribute) %>
-              <% if user = User.find_by_id(value) %>
-                <%= link_to user.name_and_email, user %>
-              <% else %>
-                <%= "Unknown user id:#{value}" %>
-              <% end %>
-            <% else %>
-              <%= value %>
-            <% end %>
-          <% end %>
-        <% end %>
+      <% if id %>
+        <%= render 'history', form: form %>
+        <%= render 'sharing_grants', form: form, secret: secret if SecretStorage.sharing_grants? && secret.fetch(:project_permalink) == "global" %>
       <% end %>
 
       <div class="form-group">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Samson::Application.routes.draw do
   end
 
   resources :secrets, except: [:edit]
+  resources :secret_sharing_grants, except: [:edit, :update]
 
   resources :users, only: [] do
     resource :user_merges, only: [:new, :create]

--- a/db/migrate/20170608174705_create_secret_sharing_grants.rb
+++ b/db/migrate/20170608174705_create_secret_sharing_grants.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class CreateSecretSharingGrants < ActiveRecord::Migration[5.1]
+  def change
+    create_table :secret_sharing_grants do |t|
+      t.string :key, null: false
+      t.integer :project_id, null: false
+      t.timestamps
+      t.index [:key]
+      t.index [:project_id, :key], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170526151018) do
+ActiveRecord::Schema.define(version: 20170608174705) do
 
   create_table "builds", id: :integer, force: :cascade do |t|
     t.integer "project_id", null: false
@@ -363,6 +363,15 @@ ActiveRecord::Schema.define(version: 20170526151018) do
     t.integer "build_id"
     t.index ["build_id"], name: "index_releases_on_build_id"
     t.index ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
+  end
+
+  create_table "secret_sharing_grants", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "project_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_secret_sharing_grants_on_key"
+    t.index ["project_id", "key"], name: "index_secret_sharing_grants_on_project_id_and_key", unique: true
   end
 
   create_table "secrets", id: false, force: :cascade do |t|

--- a/test/controllers/secret_sharing_grants_controller_test.rb
+++ b/test/controllers/secret_sharing_grants_controller_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe SecretSharingGrantsController do
+  let(:project) { projects(:test) }
+  let!(:grant) { SecretSharingGrant.create!(project: project, key: "foobar") }
+
+  as_a_viewer do
+    describe "#index" do
+      it "renders" do
+        get :index
+        assert_response :success
+      end
+    end
+
+    describe "#show" do
+      it "renders" do
+        get :show, params: {id: grant.id}
+        assert_response :success
+      end
+    end
+  end
+
+  as_a_deployer do
+    unauthorized :get, :new
+    unauthorized :post, :create
+    unauthorized :delete, :destroy, id: 1
+  end
+
+  as_an_admin do
+    describe "#new" do
+      it "renders" do
+        get :new
+        assert_response :success
+      end
+
+      it "prefills" do
+        get :new, params: {secret_sharing_grant: {key: "doobar"} }
+        assert_response :success
+        response.body.must_include 'value="doobar"'
+      end
+    end
+
+    describe "#create" do
+      let(:params) { {secret_sharing_grant: {key: "doobar", project_id: project.id}, redirect_to: "/foo" } }
+
+      it "creates" do
+        assert_difference "SecretSharingGrant.count", +1 do
+          post :create, params: params
+          assert_redirected_to "/foo"
+        end
+      end
+
+      it "renders on error" do
+        refute_difference "SecretSharingGrant.count", +1 do
+          params[:secret_sharing_grant][:key] = grant.key # duplciate
+          post :create, params: params
+          assert_template :new
+        end
+      end
+    end
+
+    describe "#destroy" do
+      it "destroys" do
+        assert_difference "SecretSharingGrant.count", -1 do
+          delete :destroy, params: {id: grant.id}
+          assert_redirected_to secret_sharing_grants_path
+        end
+      end
+    end
+  end
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -334,6 +334,11 @@ describe ApplicationHelper do
       link_to_resource(deploy_groups(:pod1)).must_equal "<a href=\"/deploy_groups/pod1\">Pod1</a>"
     end
 
+    it "links to grants" do
+      grant = SecretSharingGrant.create!(project: projects(:test), key: 'foo')
+      link_to_resource(grant).must_equal "<a href=\"/secret_sharing_grants/#{grant.id}\">foo</a>"
+    end
+
     it "fails on unknown" do
       assert_raises(ArgumentError) { link_to_resource(123) }.message.must_equal "Unsupported resource 123"
     end

--- a/test/models/secret_sharing_grant_test.rb
+++ b/test/models/secret_sharing_grant_test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe SecretSharingGrant do
+end

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -192,4 +192,16 @@ describe SecretStorage do
       SecretStorage.keys.must_equal []
     end
   end
+
+  describe ".sharing_grants?" do
+    it "is true when sharing is disabled" do
+      refute SecretStorage.sharing_grants?
+    end
+
+    it "is false when sharing is enabled" do
+      with_env SECRET_STORAGE_SHARING_GRANTS: 'true' do
+        assert SecretStorage.sharing_grants?
+      end
+    end
+  end
 end


### PR DESCRIPTION
 - User sets new `SECRET_STORAGE_SHARING_GRANTS=true`
 - Global secrets are no longer auto-resolved
 - On secret page a link appears
![screen shot 2017-06-08 at 3 30 10 pm](https://user-images.githubusercontent.com/11367/26953868-c7368a04-4c61-11e7-963f-52291662d957.png)
 - admin following the link creates a new grant (non-admin see a instruction)
![screen shot 2017-06-08 at 3 30 16 pm](https://user-images.githubusercontent.com/11367/26953894-ff4d3578-4c61-11e7-9ec4-c963bf8134d6.png)
 - ... and redirects back
![screen shot 2017-06-08 at 3 46 06 pm](https://user-images.githubusercontent.com/11367/26953903-0a8f68b6-4c62-11e7-843d-80cd8f83a314.png)
 - comes with overview page
![screen shot 2017-06-08 at 3 46 32 pm](https://user-images.githubusercontent.com/11367/26953915-169b6538-4c62-11e7-943f-1c3ed606ac0d.png)
 - history
![screen shot 2017-06-08 at 3 46 18 pm](https://user-images.githubusercontent.com/11367/26953921-1d89b96c-4c62-11e7-9188-b57d8f288b1c.png)
 - linked on secrets index page
![screen shot 2017-06-08 at 3 46 25 pm](https://user-images.githubusercontent.com/11367/26953926-2882f130-4c62-11e7-9931-e165092d3cf3.png)

@swatikri @jonmoter @irwaters 