### PR TITLE
move evil delete to the right to avoid fat-finger issues

### DIFF
--- a/lib/samson/form_builder.rb
+++ b/lib/samson/form_builder.rb
@@ -46,8 +46,8 @@ module Samson
         content_tag :div, class: "col-lg-offset-2 col-lg-10" do
           content = submit label, class: "btn btn-primary"
           resource = (delete.is_a?(Array) ? delete : object)
-          content << SPACER << @template.link_to_delete(resource) if delete && object.persisted?
           content << @template.capture(&block) if block
+          content << SPACER << @template.link_to_delete(resource, class: 'pull-right') if delete && object.persisted?
           content
         end
       end


### PR DESCRIPTION
needs more fixes, but as general idea we could have it on the right ... otherwise turn it 

<img width="1108" alt="screen shot 2017-06-09 at 3 01 30 pm" src="https://user-images.githubusercontent.com/11367/26996004-b05dc1c6-4d24-11e7-965a-3f347746708d.png">

@irwaters @mikehuston 