### PR TITLE
record request params too in case the payload is not in the body

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -5,6 +5,7 @@ class Integrations::BaseController < ApplicationController
   before_action :validate_token
   before_action :validate_request
   after_action :record_webhook
+  wrap_parameters format: [] # wrapped params make debugging messy, avoid
 
   def create
     unless deploy?

--- a/app/controllers/integrations/circleci_controller.rb
+++ b/app/controllers/integrations/circleci_controller.rb
@@ -3,7 +3,7 @@ class Integrations::CircleciController < Integrations::BaseController
   protected
 
   def payload
-    @payload ||= params.fetch('payload', '{}')
+    @payload ||= params.fetch('payload', {})
   end
 
   def deploy?

--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -15,9 +15,11 @@ class Integrations::GithubController < Integrations::BaseController
 
   def payload
     if payload = params[:payload]
+      # web request with :payload as json
       JSON.parse(payload)
     else
-      params
+      # json post request for comments sends 'action' too, so use raw POST params
+      request.GET.merge(request.POST)
     end
   end
 

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -15,7 +15,7 @@ class Changeset::IssueComment
   end
 
   def self.valid_webhook?(payload)
-    return false unless VALID_ACTIONS.include? payload.dig('github', 'action')
+    return false unless VALID_ACTIONS.include? payload['action']
     payload.dig('comment', 'body') =~ Changeset::PullRequest::WEBHOOK_FILTER
   end
 

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -44,7 +44,7 @@ class Changeset::PullRequest
   end
 
   def self.changeset_from_webhook(project, payload)
-    data = Sawyer::Resource.new(Octokit.agent, payload.require(:pull_request).to_unsafe_h)
+    data = Sawyer::Resource.new(Octokit.agent, payload.fetch(:pull_request))
     new(project.github_repo, data)
   end
 
@@ -54,11 +54,11 @@ class Changeset::PullRequest
   # should only be when the edit is related to adding the text [samson review]
   def self.valid_webhook?(payload)
     data = payload['pull_request'] || {}
-    action = payload.dig('github', 'action')
+    action = payload['action']
     return false if data['state'] != 'open' || !VALID_ACTIONS.include?(action)
 
     if action == 'edited'
-      previous_desc = payload.dig('github', 'changes', 'body', 'from')
+      previous_desc = payload.dig('changes', 'body', 'from')
       return false if !previous_desc || (previous_desc =~ WEBHOOK_FILTER && data['body'] =~ WEBHOOK_FILTER)
     end
 

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -19,7 +19,7 @@
           <% if current_user.admin_for?(@project) %>
             (Set <%= link_to "secret token", "javascript:alert('#{token}')" %> in <%= link_to 'hook settings', "https://github.com/#{@project.user_repo_part}/settings/hooks" %>)
           <% else %>
-            (Secret token required, ask a super-admin)
+            (Secret token required, ask a project admin)
           <% end %>
         <% end %>
       </dd>
@@ -71,9 +71,9 @@
         <th>Request</th>
         <td>
           <% if current_user.admin_for?(current_project) %>
-            <pre><%= hook.fetch(:request).map { |k,v| "#{k}: #{v}" }.join("\n") %></pre>
-            Body:
-            <pre><%= hook.fetch(:request_body, '') %></pre>
+            <pre><%= hook.fetch(:request_headers).map { |k,v| "#{k}: #{v}" }.join("\n") %></pre>
+            Raw params:
+            <pre><%= JSON.pretty_generate(hook.fetch(:request_params)) %></pre>
           <% else %>
             ... visible for admins ...
           <% end %>
@@ -82,9 +82,9 @@
       <tr>
         <th>Response</th>
         <td>
-          Status: <%= hook.fetch(:status_code) %><br/>
+          Status: <%= hook.fetch(:response_code) %><br/>
           Body:
-          <% body = hook.fetch(:body) %>
+          <% body = hook.fetch(:response_body) %>
           <pre><%= body.start_with?('{') ? (JSON.pretty_generate(JSON.parse(body)) rescue body) : body %></pre>
         </td>
       </tr>

--- a/config/initializers/00_filter_parameter_logging.rb
+++ b/config/initializers/00_filter_parameter_logging.rb
@@ -2,4 +2,4 @@
 # Configure sensitive parameters which will be filtered from the log file
 # Used in airbrake.rb but does not support the 'foo.bar' syntax as rails does
 # https://github.com/airbrake/airbrake-ruby/issues/137
-Rails.application.config.filter_parameters.concat [:password, :value]
+Rails.application.config.filter_parameters.concat [:password, :value, :token]

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -93,7 +93,7 @@ describe Integrations::BaseController do
     end
 
     it 'records the request' do
-      post :create, params: {test_route: true, token: token}
+      post :create, params: {test_route: true, token: token, foo: "bar"}
       assert_response :success
       result = WebhookRecorder.read(project)
       log = <<-LOG.strip_heredoc
@@ -101,8 +101,9 @@ describe Integrations::BaseController do
         INFO: Deploying to 0 stages
       LOG
       result.fetch(:log).must_equal log
-      result.fetch(:status_code).must_equal 200
-      result.fetch(:body).must_equal log
+      result.fetch(:response_code).must_equal 200
+      result.fetch(:response_body).must_equal log
+      result.fetch(:request_params).must_equal("token" => "[FILTERED]", "foo" => "bar")
     end
 
     it 'creates a release and a connected build' do

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -52,6 +52,12 @@ describe Integrations::GithubController do
 
     let(:payload) do
       {
+        action: 'edited',
+        changes: {
+          body: {
+            from: 'something'
+          }
+        },
         after: commit,
         number: '42',
         pull_request: {
@@ -61,14 +67,6 @@ describe Integrations::GithubController do
           },
           state: 'open',
           body: 'imafixwolves [samson review]'
-        },
-        github: {
-          action: 'edited',
-          changes: {
-            body: {
-              from: 'something'
-            }
-          }
         }
       }.with_indifferent_access
     end
@@ -87,9 +85,7 @@ describe Integrations::GithubController do
   describe 'with a pull issue comment' do
     let(:payload) do
       {
-        github: {
-          action: 'created'
-        },
+        action: 'created',
         comment: {body: '[samson review]'},
         issue: {number: 123}
       }.with_indifferent_access

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -27,7 +27,6 @@ describe Changeset::IssueComment do
   describe ".valid_webhook?" do
     let(:webhook_data) do
       {
-        github: {},
         comment: {
           body: '[samson review]'
         },
@@ -35,17 +34,17 @@ describe Changeset::IssueComment do
     end
 
     it 'is valid for new comments' do
-      webhook_data[:github][:action] = 'created'
+      webhook_data[:action] = 'created'
       assert Changeset::IssueComment.valid_webhook?(webhook_data)
     end
 
     it 'is not valid for deleted comments' do
-      webhook_data[:github][:action] = 'deleted'
+      webhook_data[:action] = 'deleted'
       refute Changeset::IssueComment.valid_webhook?(webhook_data)
     end
 
     it 'is not valid for edited comments' do
-      webhook_data[:github][:action] = 'edited'
+      webhook_data[:action] = 'edited'
       refute Changeset::IssueComment.valid_webhook?(webhook_data)
     end
   end

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -78,20 +78,20 @@ describe Changeset::PullRequest do
     end
 
     it "is invalid for PRs that had its label changed" do
-      webhook_data.deep_merge!(github: {action: 'labeled'})
+      webhook_data.deep_merge!(action: 'labeled')
       Changeset::PullRequest.valid_webhook?(webhook_data).must_equal false
     end
 
     describe "PR change that is an edit" do
-      before { webhook_data.deep_merge!(github: {action: 'edited'}) }
+      before { webhook_data.deep_merge!(action: 'edited') }
 
       it 'is valid if [samson review] was not in the previous description' do
-        webhook_data.deep_merge!(github: {changes: {body: {from: 'a desc'}}})
+        webhook_data.deep_merge!(changes: {body: {from: 'a desc'}})
         Changeset::PullRequest.valid_webhook?(webhook_data).must_equal true
       end
 
       it 'is invalid if [samson review] was in the previous description' do
-        webhook_data.deep_merge!(github: {changes: {body: {from: '[samson review]'}}})
+        webhook_data.deep_merge!(changes: {body: {from: '[samson review]'}})
         Changeset::PullRequest.valid_webhook?(webhook_data).must_equal false
       end
 

--- a/test/support/integration_controller_test_helper.rb
+++ b/test/support/integration_controller_test_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module IntegrationsControllerTestHelper
   def test_regular_commit(user_name, options, &block)
-    describe "normal" do
+    describe "regular commit" do
       before(&block) if block
 
       it "triggers a deploy if there is a webhook mapping for the branch" do


### PR DESCRIPTION
also fixing json payload to correctly finding it's action since it is not nested in github as
params are due to rails wrap_parameters

@flochaz 

so rails wraps json post params into a controller prefix, in this case `github` but when payload is sent in the wrapping step does not take place, so all the code that tried to access `github` in pull_request never worked on json payload or when fetching data directly via the api