### PR TITLE
make token copy-pasteable

### DIFF
--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -17,7 +17,7 @@
         <% if source == 'github' && token = Integrations::GithubController.secret_token %>
           <br/>
           <% if current_user.admin_for?(@project) %>
-            (Set <%= link_to "secret token", "javascript:alert('#{token}')" %> in <%= link_to 'hook settings', "https://github.com/#{@project.user_repo_part}/settings/hooks" %>)
+            (Set <%= link_to "secret token", "javascript:prompt('Copy this token', '#{token}')" %> in <%= link_to 'hook settings', "https://github.com/#{@project.user_repo_part}/settings/hooks" %>)
           <% else %>
             (Secret token required, ask a project admin)
           <% end %>


### PR DESCRIPTION
chrome somehow broke/disabled copy on alert windows ... so using prompt now ...

![screen shot 2017-06-12 at 1 31 25 pm](https://user-images.githubusercontent.com/11367/27053811-95823b1a-4f73-11e7-99df-c801480fa035.png)
