### PR TITLE
Fix uniqueness to be scoped on project

### DIFF
--- a/app/models/secret_sharing_grant.rb
+++ b/app/models/secret_sharing_grant.rb
@@ -2,5 +2,5 @@
 class SecretSharingGrant < ActiveRecord::Base
   has_paper_trail skip: [:created_at]
   belongs_to :project
-  validates :key, uniqueness: true
+  validates :key, uniqueness: { scope: :project }
 end


### PR DESCRIPTION
This key is already added to the database, but the app needs to know
that this uniqueness is scoped as well.

I'm no AR expert, but from gleaning docs this is what i came up
with.

/cc @zendesk/samson