### PR TITLE
fix compose auth to work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       - "9080:9080"
     environment:
       DATABASE_URL: "sqlite3://db/development.sqlite"
+      # test application samson-compose from some-public-token user (192.168.42.45:9080)
+      DEFAULT_URL: "http://192.168.42.45:9080"
+      GITHUB_CLIENT_ID: "b2e12de0cb7d301d6158"
+      GITHUB_SECRET: "4346472f3d168fb72ca540a04d2d277c0cb8f247"
+
       RAILS_LOG_TO_STDOUT: 1
     env_file: .env.bootstrap
     command: "bash -c 'rake db:setup && puma -C config/puma.rb'"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,6 +7,8 @@ docker-compose up
 open http://$DOCKER_HOST_IP:9080
 ```
 
+When not running on `192.168.42.45` use a different auth provider, the IP is hardcoded.
+
 ### Local
 ```bash
 script/bootstrap # Run the bootstrap script to use the test credentials.


### PR DESCRIPTION
ideally we'd be able to use localhost:3000 and reuse regular credentials or make the credentials not care where we redirect to ... but those don't work either ... could use a different default auth maybe ... or a bogus auth provider ...

@davidreuss 