### PR TITLE
reverse search secrets by value

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -14,10 +14,7 @@ class SecretsController < ApplicationController
   def index
     @secret_keys = SecretStorage.keys.map { |key| [key, SecretStorage.parse_secret_key(key)] }
     @keys = @secret_keys.map { |_key, parts| parts.fetch(:key) }.uniq.sort
-    if query = params.dig(:search, :query).presence
-      @secret_keys.select! { |key, _parts| key.include?(query) }
-    end
-    [:key, :project_permalink].each do |part|
+    SecretStorage::SECRET_KEYS_PARTS.each do |part|
       if value = params.dig(:search, part).presence
         @secret_keys.select! { |_key, parts| parts.fetch(part) == value }
       end

--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -56,6 +56,10 @@ module SecretStorage
       Rails.cache.fetch(SECRET_KEYS_CACHE) { backend.keys }
     end
 
+    def filter_keys_by_value(*args)
+      backend.filter_keys_by_value(*args)
+    end
+
     def backend
       BACKEND
     end

--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -18,6 +18,11 @@
 
   <%= search_select :key, @keys, live: true %>
 
+  <div class="col-sm-2" style="padding-left: 0;">
+    <%= label_tag "Value" %>
+    <%= password_field_tag 'search[value]', params.dig(:search, :value), class: "form-control" %>
+  </div>
+
   <div class="pull-right">
     <label>&nbsp;</label>
     <%= link_to "New", new_secret_path, class: "btn btn-default", style: "display: block" %>

--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -7,10 +7,14 @@
 </h1>
 
 <%= search_form do %>
-  <%= render 'shared/search_query' %>
+  <% environments = [['global']] + Environment.pluck(:permalink) %>
+  <%= search_select :environment_permalink, environments, live: true, label: "Environment" %>
 
   <% projects = [['global']] + Project.order(:permalink).pluck(:permalink) %>
   <%= search_select :project_permalink, projects, live: true, label: "Project" %>
+
+  <% deploy_groups = [['global']] + SecretStorage.backend.deploy_groups.sort_by(&:natural_order).map(&:permalink) %>
+  <%= search_select :deploy_group_permalink, deploy_groups, live: true, label: "Deploy Group" %>
 
   <%= search_select :key, @keys, live: true %>
 

--- a/lib/samson/secrets/db_backend.rb
+++ b/lib/samson/secrets/db_backend.rb
@@ -44,6 +44,12 @@ module Samson
           Secret.order(:id).pluck(:id)
         end
 
+        def filter_keys_by_value(keys, value)
+          keys.each_slice(1000).flat_map do |group|
+            Secret.where(id: group).select { |s| Rack::Utils.secure_compare(s.value, value) }.map(&:id)
+          end
+        end
+
         def deploy_groups
           DeployGroup.all
         end

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -81,6 +81,14 @@ describe SecretsController do
         assigns[:secret_keys].map(&:first).must_equal ['production/foo-bar/pod2/bar']
       end
 
+      it 'can filter by value' do
+        other = create_secret 'production/global/pod2/baz'
+        other.update_attribute(:value, 'other')
+        get :index, params: {search: {value: other.value}}
+        assert_template :index
+        assigns[:secret_keys].map(&:first).must_equal [other.id]
+      end
+
       it 'raises when vault server is broken' do
         SecretStorage.expects(:keys).raises(Samson::Secrets::BackendError.new('this is my error'))
         get :index

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -53,11 +53,11 @@ describe SecretsController do
         response.body.wont_include secret.value
       end
 
-      it 'can filter by query' do
+      it 'can filter by environment' do
         create_secret 'production/global/pod2/bar'
-        get :index, params: {search: {query: 'bar'}}
+        get :index, params: {search: {environment_permalink: 'production'}}
         assert_template :index
-        assigns[:secret_keys].map(&:first).must_equal ['production/global/pod2/bar']
+        assigns[:secret_keys].map(&:first).must_equal ["production/global/pod2/bar", "production/global/pod2/foo"]
       end
 
       it 'can filter by project' do
@@ -65,6 +65,13 @@ describe SecretsController do
         get :index, params: {search: {project_permalink: 'foo-bar'}}
         assert_template :index
         assigns[:secret_keys].map(&:first).must_equal ['production/foo-bar/pod2/bar']
+      end
+
+      it 'can filter by deploy group' do
+        create_secret 'production/global/pod2/bar'
+        get :index, params: {search: {deploy_group_permalink: 'pod2'}}
+        assert_template :index
+        assigns[:secret_keys].map(&:first).must_equal ["production/global/pod2/bar", "production/global/pod2/foo"]
       end
 
       it 'can filter by key' do

--- a/test/lib/samson/secrets/db_backend_test.rb
+++ b/test/lib/samson/secrets/db_backend_test.rb
@@ -48,6 +48,14 @@ describe Samson::Secrets::DbBackend do
     end
   end
 
+  describe ".filter_keys_by_value" do
+    it "filters keys" do
+      key = secret.id
+      Samson::Secrets::DbBackend.filter_keys_by_value([key], 'NOPE').must_equal []
+      Samson::Secrets::DbBackend.filter_keys_by_value([key], secret.value).must_equal [key]
+    end
+  end
+
   describe ".delete" do
     it "deletes" do
       Samson::Secrets::DbBackend.delete(secret.id)

--- a/test/lib/samson/secrets/vault_client_test.rb
+++ b/test/lib/samson/secrets/vault_client_test.rb
@@ -36,6 +36,7 @@ describe Samson::Secrets::VaultClient do
       Samson::Secrets::VaultClient.parallel_map(Array.new(20)) do
         list << Thread.current.object_id
         Thread.pass
+        sleep 0.01
       end
       list.uniq.size.must_equal 10
     end

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -193,6 +193,14 @@ describe SecretStorage do
     end
   end
 
+  describe ".filter_keys_by_value" do
+    it "filters keys" do
+      key = secret.id
+      SecretStorage.filter_keys_by_value([key], 'NOPE').must_equal []
+      SecretStorage.filter_keys_by_value([key], secret.value).must_equal [key]
+    end
+  end
+
   describe ".sharing_grants?" do
     it "is true when sharing is disabled" do
       refute SecretStorage.sharing_grants?


### PR DESCRIPTION
 - super slow
 - can speed up by pre-filtering keys
 - hiding query value in the view by treating it as password field
 - `value` is not logged
 - only unsafe component is the query URL possibly getting stored in nginx logs or browser history ... could encrypt on the browser or so ... maybe that's overkill ...
 - opened a vault topic to see if they might add this as a feature, but doubt they'll respond https://groups.google.com/forum/#!msg/vault-tool/Jo6nw7X5Lhc/OS1K_HB2AgAJ

reworked search to has specific fields for all:
![screen shot 2017-06-13 at 1 50 35 pm](https://user-images.githubusercontent.com/11367/27107781-cf680522-504e-11e7-94a1-77390e8a5b91.png)

then added value:
![screen shot 2017-06-13 at 3 46 09 pm](https://user-images.githubusercontent.com/11367/27107892-70daf64e-504f-11e7-9ba0-375af5791398.png)


@zendesk/paas 