### PR TITLE
avoid all caching round-trips and allow caching arbitrary data per model

### DIFF
--- a/lib/samson/model_cache.rb
+++ b/lib/samson/model_cache.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+# cache values depending on if a model changes, without adding callback-soup
+# this only works because samson is 1-process app
+# and otherwise would need a cache-store to synchronize
+# we expire the cache every 5 minutes to be safe from untracked caches
+# or changes on the commandline/cron/db etc
+module Samson
+  module ModelCache
+    # every model has to register itself when getting loaded
+    # so we clear the cache on auto-reload
+    def self.track(model)
+      @caches ||= {}
+      model.after_save { Samson::ModelCache.expire(model) }
+      model.after_destroy { Samson::ModelCache.expire(model) }
+      expire(model)
+    end
+
+    def self.cache(model, key, &block)
+      model_cache = @caches.fetch(model.name.to_sym)
+      model_cache.fetch(key, &block)
+    end
+
+    def self.expire(model = nil)
+      keys = (model ? [model.name.to_sym] : (@caches || {}).keys)
+      keys.each do |key|
+        @caches[key] = ActiveSupport::Cache::MemoryStore.new(expires_in: 5.minutes)
+      end
+    end
+  end
+end

--- a/test/lib/samson/model_cache_test.rb
+++ b/test/lib/samson/model_cache_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::ModelCache do
+  describe ".track" do
+    it "auto-triggers" do
+      Lock.name
+      Samson::ModelCache.instance_variable_get(:@caches).keys.must_include(:Lock)
+    end
+  end
+
+  describe ".cache" do
+    it "caches" do
+      calls = []
+      3.times { Samson::ModelCache.cache(Lock, :foo) { calls << 1 }.must_equal [1] }
+      calls.must_equal [1]
+    end
+
+    it "caches nil" do
+      calls = []
+      3.times { Samson::ModelCache.cache(Lock, :foo) { calls << 1; nil }.must_equal nil }
+      calls.must_equal [1]
+    end
+
+    it "can expire" do
+      calls = []
+      Samson::ModelCache.cache(Lock, :foo) { calls << 1 }
+      Lock.create! user: users(:admin)
+      Samson::ModelCache.cache(Lock, :foo) { calls << 2 }
+      calls.must_equal [1, 2]
+    end
+  end
+
+  describe ".expire" do
+    it "can expire all" do
+      calls = []
+      Samson::ModelCache.cache(Lock, :foo) { calls << 1 }
+      Samson::ModelCache.expire
+      Samson::ModelCache.cache(Lock, :foo) { calls << 2 }
+      calls.must_equal [1, 2]
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,6 +64,7 @@ class ActiveSupport::TestCase
 
   before do
     Rails.cache.clear
+    Samson::ModelCache.expire
     create_default_stubs
   end
 


### PR DESCRIPTION
will use this to cache commen lookups like all deploy-group/env permalinks
and vault_server_ids to avoid memcache and db requests for simple data
without having to add cache-expire callbacks to all places that want to
cache that data