### PR TITLE
fix url-encoded webhooks failing

### DIFF
--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -44,7 +44,7 @@ class Changeset::PullRequest
   end
 
   def self.changeset_from_webhook(project, payload)
-    data = Sawyer::Resource.new(Octokit.agent, payload.fetch(:pull_request))
+    data = Sawyer::Resource.new(Octokit.agent, payload.fetch('pull_request'))
     new(project.github_repo, data)
   end
 

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -46,16 +46,16 @@ describe Changeset::PullRequest do
 
   describe ".changeset_from_webhook" do
     it 'finds the pull request' do
-      params = ActionController::Parameters.new(
-        number: 42,
-        pull_request: {
-          state: 'open',
-          head: ActionController::Parameters.new(
-            ref: 'a/ref',
-            sha: 'abcd123'
-          )
+      params = {
+        "number" => 42,
+        "pull_request" => {
+          "state" => 'open',
+          "head" => {
+            "ref" => 'a/ref',
+            "sha" => 'abcd123'
+          }
         }
-      )
+      }
       pr = Changeset::PullRequest.changeset_from_webhook(project, params)
       pr.state.must_equal 'open'
       pr.branch.must_equal 'a/ref'
@@ -66,32 +66,32 @@ describe Changeset::PullRequest do
   describe ".valid_webhook?" do
     let(:webhook_data) do
       {
-        number: 1,
-        pull_request: {
-          state: 'open',
-          body: 'pr description [samson review]'
+        "number" => 1,
+        "pull_request" => {
+          "state" => 'open',
+          "body" => 'pr description [samson review]'
         },
-        github: {
-          action: 'opened'
+        "github" => {
+          "action" => 'opened'
         }
-      }.with_indifferent_access
+      }
     end
 
     it "is invalid for PRs that had its label changed" do
-      webhook_data.deep_merge!(action: 'labeled')
+      webhook_data.deep_merge!("action" => 'labeled')
       Changeset::PullRequest.valid_webhook?(webhook_data).must_equal false
     end
 
     describe "PR change that is an edit" do
-      before { webhook_data.deep_merge!(action: 'edited') }
+      before { webhook_data.deep_merge!("action" => 'edited') }
 
       it 'is valid if [samson review] was not in the previous description' do
-        webhook_data.deep_merge!(changes: {body: {from: 'a desc'}})
+        webhook_data.deep_merge!("changes" => {"body" => {"from" => 'a desc'}})
         Changeset::PullRequest.valid_webhook?(webhook_data).must_equal true
       end
 
       it 'is invalid if [samson review] was in the previous description' do
-        webhook_data.deep_merge!(changes: {body: {from: '[samson review]'}})
+        webhook_data.deep_merge!("changes" => {"body" => {"from" => '[samson review]'}})
         Changeset::PullRequest.valid_webhook?(webhook_data).must_equal false
       end
 


### PR DESCRIPTION
webhook payload is either from url-encoded and a regular hash
or from request.POST/GET and a HashWithIndifferentAccess
so we can only ever use string keys

https://zendesk.airbrake.io/projects/95346/groups/1972496904801952412

fallout from https://github.com/zendesk/samson/pull/2055