### PR TITLE
use cached lookups to speedup vault queries

### DIFF
--- a/lib/samson/secrets/vault_server.rb
+++ b/lib/samson/secrets/vault_server.rb
@@ -104,7 +104,7 @@ module Samson
       end
 
       def refresh_vault_clients
-        VaultClient.client.refresh_clients
+        VaultClient.client.expire_clients
       end
     end
   end

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -248,7 +248,7 @@ module Kubernetes
     end
 
     def vault_env
-      vault_client = Samson::Secrets::VaultClient.client.client(@doc.deploy_group)
+      vault_client = Samson::Secrets::VaultClient.client.client(@doc.deploy_group.permalink)
       [
         {name: "VAULT_ADDR", value: vault_client.options.fetch(:address)},
         {name: "VAULT_SSL_VERIFY", value: vault_client.options.fetch(:ssl_verify).to_s}

--- a/test/lib/samson/secrets/vault_server_test.rb
+++ b/test/lib/samson/secrets/vault_server_test.rb
@@ -98,9 +98,9 @@ describe Samson::Secrets::VaultServer do
     let(:client) { Samson::Secrets::VaultClient.client }
 
     around do |test|
-      client.refresh_clients
+      client.expire_clients
       test.call
-      client.refresh_clients
+      client.expire_clients
     end
 
     it "adds new clients" do


### PR DESCRIPTION
before: every key we want to read/write can lead to DeployGroup/Environment queries since we need to know which vault servers we have to write to.

after: cache deploy-group/env to vault-server mapping for 1 minute

alternative approaches that did not work out:
 - persistent memory cache that gets updated when DeployGroup/Environment change ... lots of extra code and still needs to expire once in a while
 - using Rails.cache and relying on LocalCache to make things fast ... would still be slow on console and adds global dependency