### PR TITLE
ignore all failures while reading so we get some useable results on l…

### DIFF
--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -30,7 +30,7 @@ module Samson
               if value = read(key)
                 found[key] = value
               end
-            rescue VaultClient::VaultServerNotConfigured # deploy group has no vault server
+            rescue # deploy group has no vault server or deploy group no longer exists
               nil
             end
           end

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -70,6 +70,10 @@ describe Samson::Secrets::HashicorpVaultBackend do
     it "leaves out vaules from deploy groups that have no vault server so KeyResolver works" do
       backend.read_multi(['production/foo/pod100/bar']).must_equal({})
     end
+
+    it "leaves out vaules from unknown deploy groups" do
+      backend.read_multi(['production/foo/pod1nope/bar']).must_equal({})
+    end
   end
 
   describe ".delete" do


### PR DESCRIPTION
…arge sets

with filter_keys_by_value we search for a ton of keys ... some of them are invalid/broken
so to get some useable results we have to ignore errors