### PR TITLE
re-raise errors from forks so users can see them

### DIFF
--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 2 # fork/wait call that we skip in unit tests
+SingleCov.covered! uncovered: 4 # fork/wait call that we skip in unit tests
 
 describe DockerBuilderService do
   include GitRepoTestHelper


### PR DESCRIPTION
especially `Docker build failed: Cannot locate specified Dockerfile: Dockerfile`
which happens because the tarfile was not written

@benhass @jonmoter @irwaters @rgueldem 