### PR TITLE
show validation errors to the user and do not send them to airbrake

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -80,9 +80,15 @@ module Kubernetes
         nil
       end
 
-      # TODO: test for actual hash / usability ...
       def request(method, *args)
         client.send("#{method}_#{@template.fetch(:kind).underscore}", *args)
+      rescue
+        message = $!.message.to_s
+        if message.include?(" is invalid:") || message.include?(" no kind ")
+          raise Samson::Hooks::UserError, "Kubernetes error: #{message}"
+        else
+          raise
+        end
       end
 
       def client

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -59,6 +59,12 @@ describe Kubernetes::Resource do
       assert resource.running?
       assert_requested get, times: 2
     end
+
+    it "shows errors to users when resource was invalid" do
+      stub_request(:get, url).to_return(status: 404)
+      stub_request(:post, base_url).to_return(body: '{"message":"Foo.extensions \"app\" is invalid:"}', status: 400)
+      assert_raises(Samson::Hooks::UserError) { resource.deploy }.message.must_include "Kubernetes error: Foo"
+    end
   end
 
   describe "#running?" do


### PR DESCRIPTION
something like 
https://zendesk.airbrake.io/projects/95346/groups/1947316460942992284/notices/1976849403603437179

"KubeException: Deployment.extensions "app-server" is invalid: [spec.template.spec.containers[0].volumeMounts[1].mountPath: Required value, spec.template.spec.containers[0].volumeMounts[2].mountPath: Invalid value: "/secrets": must be unique]
"

or "JobExecution failed: Kubernetes error: Deployment in version "v1betdssdds" cannot be handled as a Deployment: no kind "Deployment" is registered for version "extensions/v1betdssdds""
should not go into airbrake and needs to be fixed by the user