### PR TITLE
Fix appending app init-containers to samson injected init-containers

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -2,6 +2,8 @@
 module Kubernetes
   module Api
     class Pod
+      INIT_CONTAINER_KEY = :'pod.beta.kubernetes.io/init-containers'
+
       def initialize(api_pod, client: nil)
         @pod = api_pod
         @client = client
@@ -86,7 +88,7 @@ module Kubernetes
       end
 
       def init_containers
-        return [] unless containers = @pod.dig(:metadata, :annotations, :'pod.alpha.kubernetes.io/init-containers')
+        return [] unless containers = @pod.dig(:metadata, :annotations, INIT_CONTAINER_KEY)
         JSON.parse(containers, symbolize_names: true)
       end
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -125,7 +125,7 @@ module Kubernetes
     # Init containers are stored as a json annotation
     # see http://kubernetes.io/docs/user-guide/production-pods/#handling-initialization
     def unshift_init_container(container)
-      key = 'pod.beta.kubernetes.io/init-containers'
+      key = Kubernetes::Api::Pod::INIT_CONTAINER_KEY
       init_containers = JSON.parse(annotations[key] || '[]')
       init_containers.unshift(container)
       annotations[key] = JSON.pretty_generate(init_containers)

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -307,7 +307,7 @@ describe Kubernetes::Api::Pod do
     end
 
     it "finds init containers" do
-      pod_attributes[:metadata][:annotations] = {"pod.alpha.kubernetes.io/init-containers": [{foo: :bar}].to_json}
+      pod_attributes[:metadata][:annotations] = {'pod.beta.kubernetes.io/init-containers': '[{"foo": "bar"}]'}
       pod.init_containers.must_equal [{foo: "bar"}]
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -47,6 +47,9 @@ describe Kubernetes::TemplateFiller do
         project: 'some-project',
         role: 'some-role'
       )
+
+      # only symbol keys used because that is what we receive from a real input
+      result.deep_symbolize_keys.must_equal result
     end
 
     it "escapes things that would not be allowed in labels or environment values" do
@@ -170,7 +173,7 @@ describe Kubernetes::TemplateFiller do
     describe "secret-puler-containers" do
       let(:secret_key) { "global/global/global/bar" }
       let(:template_env) { template.to_hash[:spec][:template][:spec][:containers].first[:env] }
-      let(:init_container_key) { 'pod.beta.kubernetes.io/init-containers' }
+      let(:init_container_key) { :'pod.beta.kubernetes.io/init-containers' }
       let(:init_containers) do
         JSON.parse(template.to_hash[:spec][:template][:metadata][:annotations][init_container_key])
       end


### PR DESCRIPTION
The init container key is stored as a symbol on the docs, and was not
being picked up properly, and thus "ignored" as samson was overwriting
the existing key.

/cc @zendesk/samson

