### PR TITLE
record env var history on projects

### DIFF
--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -49,6 +49,9 @@ class Command < ActiveRecord::Base
   def record_change_in_stage_audit
     old = stages.map { |s| [s, s.script] }
     yield
-    old.each { |s, script_was| s.record_script_change script_was }
+    old.each do |s, script_was|
+      s.commands.reload
+      s.record_script_change script_was
+    end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,7 +7,7 @@ class Project < ActiveRecord::Base
   include Searchable
 
   validates :name, :repository_url, presence: true
-  validate :valid_repository_url
+  validate :valid_repository_url, if: :repository_url_changed?
   validate :validate_can_release
   before_create :generate_token
   after_save :clone_repository, if: -> { saved_change_to_attribute?(:repository_url) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,20 +118,19 @@ class User < ActiveRecord::Base
     project && user_project_roles.find_by(project: project)
   end
 
-  def record_project_role_change(roles_was)
+  # assumes change is never empty
+  def record_project_role_change(role_hash_was)
     write_audit(
       action: 'update',
-      audited_changes: {
-        user_project_roles: [role_hash(roles_was), role_hash(user_project_roles.reload)]
-      }
+      audited_changes: {user_project_roles: [role_hash_was, role_hash]}
     )
   end
 
-  private
-
-  def role_hash(roles)
-    roles.map { |upr| [upr.project.permalink, upr.role_id] }.to_h
+  def role_hash
+    user_project_roles.map { |upr| [upr.project.permalink, upr.role_id] }.to_h
   end
+
+  private
 
   def set_token
     self.token = SecureRandom.hex

--- a/app/models/user_project_role.rb
+++ b/app/models/user_project_role.rb
@@ -20,8 +20,11 @@ class UserProjectRole < ActiveRecord::Base
 
   # tested via user_test.rb
   def record_change_in_user_audit
-    old = user.user_project_roles.to_a
+    old = [[user, user.role_hash]]
     yield
-    user.record_project_role_change(old)
+    old.each do |u, role_hash_was|
+      u.user_project_roles.reload
+      u.record_project_role_change(role_hash_was)
+    end
   end
 end

--- a/plugins/env/app/decorators/project_decorator.rb
+++ b/plugins/env/app/decorators/project_decorator.rb
@@ -4,4 +4,45 @@ Project.class_eval do
 
   has_many :project_environment_variable_groups
   has_many :environment_variable_groups, through: :project_environment_variable_groups, dependent: :destroy
+
+  def environment_variables_attributes=(*)
+    @environment_variables_was ||= serialized_environment_variables
+    super
+  end
+
+  def environment_variable_group_ids=(*)
+    @environment_variables_was ||= serialized_environment_variables
+    super
+  end
+
+  def audited_changes
+    super.merge(environment_variables_changes)
+  end
+
+  # Sorted as the UI displays them in _environment_variables.html.erb
+  # Combined variables as .env does it in environment_variable.rb
+  # TODO: diffing in versions UI
+  def serialized_environment_variables
+    @env_scopes ||= Environment.env_deploygroup_array # cache since each save needs them twice
+    variables = environment_variables + environment_variable_groups.flat_map(&:environment_variables)
+    sorted = variables.sort_by { |x| [x.name, @env_scopes.index { |_, s| s == x.scope_type_and_id } || 999] }
+    sorted.map do |var|
+      "#{var.name}=#{var.value.inspect} # #{var.scope&.name || "All"}"
+    end.join("\n")
+  end
+
+  def record_environment_variable_change(env_was)
+    @environment_variables_was = env_was
+    return unless changes = environment_variables_changes.presence
+    write_audit(action: 'update', audited_changes: changes)
+  end
+
+  private
+
+  def environment_variables_changes
+    return {} unless @environment_variables_was
+    environment_variables_is = serialized_environment_variables
+    return {} if environment_variables_is == @environment_variables_was
+    {"environment_variables" => [@environment_variables_was, environment_variables_is]}
+  end
 end

--- a/plugins/env/app/models/environment_variable_group.rb
+++ b/plugins/env/app/models/environment_variable_group.rb
@@ -8,4 +8,16 @@ class EnvironmentVariableGroup < ActiveRecord::Base
   has_many :projects, through: :project_environment_variable_groups
 
   validates :name, presence: true
+  around_save :record_environment_variable_change_in_projects_audits
+
+  private
+
+  def record_environment_variable_change_in_projects_audits
+    old = projects.map { |p| [p, p.serialized_environment_variables] }
+    yield
+    old.each do |p, env_was|
+      p.environment_variable_groups.reload
+      p.record_environment_variable_change env_was
+    end
+  end
 end

--- a/plugins/env/test/decorators/project_decorator_test.rb
+++ b/plugins/env/test/decorators/project_decorator_test.rb
@@ -4,4 +4,56 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe Project do
+  let(:project) { projects(:test) }
+
+  describe "auditing" do
+    let(:group) { EnvironmentVariableGroup.create!(name: "Foo", environment_variables_attributes: [env_attributes]) }
+    let(:env_attributes) { {name: "A", value: "B", scope_type_and_id: "Environment-#{environments(:production)}"} }
+
+    it "does not audit when var did not change" do
+      project.update_attributes!(name: 'Bar')
+      project.audits.map(&:audited_changes).must_equal([{'name' => ['Foo', 'Bar']}])
+    end
+
+    it "records when only env vars change" do
+      project.update_attributes!(environment_variables_attributes: [env_attributes])
+      project.audits.map(&:audited_changes).must_equal(
+        [{"environment_variables" => ["", "A=\"B\" # All"]}]
+      )
+    end
+
+    it "records when env groups change" do
+      project.update_attributes!(environment_variable_group_ids: [group.id])
+      project.audits.map(&:audited_changes).must_equal(
+        [{"environment_variables" => ["", "A=\"B\" # All"]}]
+      )
+    end
+
+    it "records when env vars of env group change" do
+      group.projects << project
+      var = group.environment_variables.first!
+      group.update_attributes!(environment_variables_attributes: [env_attributes.merge(id: var.id, value: "NEW")])
+      project.audits.map(&:audited_changes).must_equal(
+        [{"environment_variables" => ["A=\"B\" # All", "A=\"NEW\" # All"]}]
+      )
+    end
+
+    it "records when env vars and other attributes changed" do
+      project.update_attributes!(
+        name: 'Bar',
+        environment_variables_attributes: [env_attributes]
+      )
+      project.audits.map(&:audited_changes).must_equal(
+        [{'name' => ['Foo', 'Bar'], "environment_variables" => ["", "A=\"B\" # All"]}]
+      )
+    end
+
+    it "does not records when existing vars did not change" do
+      existing = project.environment_variables.create!(env_attributes)
+      project.update_attributes!(
+        environment_variables_attributes: [env_attributes.merge(id: existing.id)]
+      )
+      refute project.audits.last
+    end
+  end
 end

--- a/plugins/env/test/models/environment_variable_group_test.rb
+++ b/plugins/env/test/models/environment_variable_group_test.rb
@@ -4,4 +4,33 @@ require_relative "../test_helper"
 SingleCov.covered!
 
 describe EnvironmentVariableGroup do
+  describe "auuditing" do
+    let(:env_attributes) { {name: "A", value: "B", scope_type_and_id: "Environment-#{environments(:production)}"} }
+    let(:project) { projects(:test) }
+    let(:group) do
+      EnvironmentVariableGroup.create!(
+        name: "Foo",
+        environment_variables_attributes: [env_attributes],
+        projects: [project]
+      )
+    end
+    let(:var) { group.environment_variables.first! }
+
+    it "does not record an audit when env vars did not change" do
+      group.update_attributes!(environment_variables_attributes: [env_attributes.merge(id: var.id)])
+      project.audits.map(&:audited_changes).must_equal [
+        {"environment_variables" => ["", "A=\"B\" # All"]},
+      ]
+    end
+
+    it "record an audit on all projects when env vars did change" do
+      group.update_attributes!(environment_variables_attributes: [env_attributes.merge(id: var.id, value: 'NEW')])
+      project.audits.map(&:audited_changes).must_equal(
+        [
+          {"environment_variables" => ["", "A=\"B\" # All"]},
+          {"environment_variables" => ["A=\"B\" # All", "A=\"NEW\" # All"]}
+        ]
+      )
+    end
+  end
 end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -532,13 +532,13 @@ describe Stage do
       new = old + [commands(:global).id]
       stage.update_attributes!(command_ids: new)
       stage.audits.size.must_equal 1
-      stage.audits.first.audited_changes.must_equal "command_ids" => [old, new]
+      stage.audits.first.audited_changes.must_equal "script" => ["echo hello", "echo hello\nt"]
     end
 
     it "tracks command removal" do
       stage.update_attributes!(command_ids: [])
       stage.audits.size.must_equal 1
-      stage.audits.first.audited_changes.must_equal "command_ids" => [[commands(:echo).id], []]
+      stage.audits.first.audited_changes.must_equal "script" => ["echo hello", ""]
     end
 
     it "does not track when command does not change" do


### PR DESCRIPTION
 - fixing that stage command changes did not record script but useless command_ids
 - unifying the way association changes are handled for future extraction/sanity