### PR TITLE
simplify permissions: default -> api / web-ui -> default

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -33,6 +33,6 @@ class Api::BaseController < ApplicationController
   # remove web-ui scope
   # @override
   def store_requested_oauth_scope
-    super.delete Warden::Strategies::Doorkeeper::WEB_UI_SCOPE
+    super << 'api'
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_requested_oauth_scope
-    request.env['requested_oauth_scopes'] = [Warden::Strategies::Doorkeeper::WEB_UI_SCOPE, controller_name]
+    request.env['requested_oauth_scopes'] = ['default', controller_name]
   end
 
   def using_per_request_auth?

--- a/db/migrate/20170622010111_move_scopes.rb
+++ b/db/migrate/20170622010111_move_scopes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class MoveScopes < ActiveRecord::Migration[5.1]
+  class OauthAccessToken < ActiveRecord::Base
+  end
+
+  def up
+    each_scope { |s| s.sub(/\bdefault\b/, "api").sub(/\bweb-ui\b/, "default") }
+  end
+
+  def down
+    each_scope { |t| t.sub(/\bdefault\b/, "web-ui").sub(/\bapi\b/, "default") }
+  end
+
+  def each_scope
+    OauthAccessToken.find_each do |token|
+      token.scopes = yield token.scopes
+      token.save if token.scopes_changed?
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170616180533) do
+ActiveRecord::Schema.define(version: 20170622010111) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -83,7 +83,7 @@ describe Api::BaseController do
     it "stores the controller scope" do
       get :test_render, params: {test_route: true}, format: :json
       assert_response :unauthorized
-      request.env['requested_oauth_scopes'].must_equal ['api_base_test']
+      request.env['requested_oauth_scopes'].must_equal ['default', 'api_base_test', 'api']
     end
   end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -76,7 +76,7 @@ describe ApplicationController do
   describe "#store_requested_oauth_scope" do
     it "stores the web-ui scope" do
       get :test_render, params: {test_route: true}
-      request.env['requested_oauth_scopes'].must_equal ['web-ui', 'application_test']
+      request.env['requested_oauth_scopes'].must_equal ['default', 'application_test']
     end
   end
 end

--- a/test/lib/warden/strategies/doorkeeper_strategy_test.rb
+++ b/test/lib/warden/strategies/doorkeeper_strategy_test.rb
@@ -11,7 +11,7 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
 
   let(:path) { "/api/deploys/active_count.json".dup }
   let!(:user) { users(:admin) }
-  let(:token) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, scopes: 'default') }
+  let(:token) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, scopes: 'api') }
   let!(:valid_header) { "Bearer #{token.token}" }
 
   it "logs the user in" do
@@ -56,13 +56,13 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
       assert_response :unauthorized
     end
 
-    it "logs the user in when using web-ui token" do
-      token.update_column(:scopes, "web-ui")
+    it "logs the user in when using efault token" do
+      token.update_column(:scopes, "default")
       perform_get(valid_header)
       assert_response :success, response.body
     end
 
-    it "logs the user in when using profile token" do
+    it "logs the user in when using controller specific token" do
       token.update_column(:scopes, "profiles")
       perform_get(valid_header)
       assert_response :success, response.body


### PR DESCRIPTION
before:
 - default scope allows access to the api (mostly deprecated endpoints)
 - web-ui allows access to none-api (much more powerful / feature-rich / the future)

after:
 - default allows access to everything
 - api allows access to only api

risk: migration is a slight rights expansion since it gives web-ui users access to the api, but is ok since the api endpoints are all less powerful then the web-ui is