### PR TITLE
overload with .env.test for consistent test environment

### DIFF
--- a/config/dotenv.rb
+++ b/config/dotenv.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 # Fill ENV from .env with Dotenv, to configure puma/RAILS_ENV/gems with .env
 require 'dotenv'
-before = ENV.keys
 Dotenv.load(Bundler.root.join('.env'))
 
-# when we run rake we load the dev environment first and then the test env
-# so we need to reset what .env changed to be able to load .env.test without ignoring system ENV
-if ENV['RAILS_ENV'] == 'test'
-  (ENV.keys - before).each { |k| ENV.delete(k) }
-  Dotenv.load(Bundler.root.join('.env.test'))
-end
+# when we run rake we load the dev environment first and fork to load the test env
+# so we need to overload what .env changed, load .env.test, and ignore system ENV
+Dotenv.overload(Bundler.root.join('.env.test')) if ENV['RAILS_ENV'] == 'test'


### PR DESCRIPTION
used to work before, but broke during puma ENV madness refactor
