### PR TITLE
SAMSON-358 do not fail to list keys if some vault servers are unresponsive

### DIFF
--- a/lib/samson/secrets/vault_client.rb
+++ b/lib/samson/secrets/vault_client.rb
@@ -21,7 +21,12 @@ module Samson
       def list_recursive(path)
         path = wrap_key(path)
         all = Samson::Parallelizer.map(clients.values) do |vault|
-          with_retries { vault.logical.list_recursive(path) }
+          begin
+            with_retries { vault.logical.list_recursive(path) }
+          rescue
+            Airbrake.notify($!, error_message: "Error talking to vault server #{vault.address} during list_recursive")
+            []
+          end
         end.flatten(1)
         all.uniq!
         all

--- a/test/lib/samson/secrets/vault_client_test.rb
+++ b/test/lib/samson/secrets/vault_client_test.rb
@@ -70,6 +70,13 @@ describe Samson::Secrets::VaultClient do
         client.list_recursive('').must_equal ['abc']
       end
     end
+
+    it "does not fail when a single server fails" do
+      Airbrake.expects(:notify).times(2)
+      assert_vault_request :get, '?list=true', status: 500, times: 2 do
+        client.list_recursive('').must_equal []
+      end
+    end
   end
 
   describe "#renew_token" do


### PR DESCRIPTION
previously if a single vault server was down/unresponsive .keys would fail
and everything would stop working, now we still send the error to Airbrake but
continue executing

https://zendesk.airbrake.io/projects/95346/groups/1958152296001382773