### PR TITLE
do not hardcode strategies since they might not be available

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -19,7 +19,7 @@ require 'warden/strategies/basic_strategy'
 require "warden/strategies/doorkeeper_strategy"
 
 Rails.application.config.middleware.insert_after(ActionDispatch::Flash, Warden::Manager) do |manager|
-  manager.default_strategies :basic, :doorkeeper
+  manager.default_strategies *manager.strategies._strategies.keys
   manager.failure_app = UnauthorizedController
   manager.intercept_401 = false # doorkeeper sends direct 401s
 end


### PR DESCRIPTION
phasing out basic atm

RuntimeError: Invalid strategy basic
app/controllers/application_controller.rb:53 in using_per_request_auth?
https://zendesk.airbrake.io/projects/95346/groups/1984304689843743640
