### PR TITLE
do not load releases on every boot

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 class Release < ActiveRecord::Base
-  NUMBER = '\d+(:?\.\d+)*'
-  NUMBER_REGEX = /\A#{NUMBER}\z/
-  VERSION_REGEX = /\Av(#{NUMBER})\z/
-  ROUTE_REGEX = /v(#{NUMBER})/
+  NUMBER_REGEX = /\A#{Samson::RELEASE_NUMBER}\z/
+  VERSION_REGEX = /\Av(#{Samson::RELEASE_NUMBER})\z/
 
   belongs_to :project, touch: true
   belongs_to :author, polymorphic: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -170,6 +170,8 @@ module Samson
 
     config.active_support.deprecation = :raise
   end
+
+  RELEASE_NUMBER = '\d+(:?\.\d+)*'
 end
 
 require 'samson/hooks'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Samson::Application.routes.draw do
       end
     end
 
-    resources :releases, only: [:show, :index, :new, :create], id: Release::ROUTE_REGEX
+    resources :releases, only: [:show, :index, :new, :create], id: /v(#{Samson::RELEASE_NUMBER})/
 
     resources :stages do
       collection do


### PR DESCRIPTION
it's slow and might trigger db queries which we don't want
boot_check.rb:22:in `block in check': Release should not be loaded (RuntimeError)

found by https://github.com/zendesk/samson/pull/2111 which moved the hook to after the routes