### PR TITLE
rename OAuth menu item to Access Tokens

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -93,7 +93,7 @@
           </a>
           <ul class="dropdown-menu">
             <li><%= link_to "Profile", profile_path %></li>
-            <li><%= link_to "OAuth", access_tokens_path %></li>
+            <li><%= link_to "Access Tokens", access_tokens_path %></li>
             <li><%= link_to "Logout", logout_path %></li>
           </ul>
         </li>


### PR DESCRIPTION
makes more sense and follows github conventions
<img width="160" alt="screen shot 2017-07-04 at 11 53 11 am" src="https://user-images.githubusercontent.com/11367/27825330-72bca532-60af-11e7-8c51-6c2c2b0eece2.png">