### PR TITLE
more can? checks

### DIFF
--- a/app/controllers/build_commands_controller.rb
+++ b/app/controllers/build_commands_controller.rb
@@ -2,7 +2,7 @@
 class BuildCommandsController < ApplicationController
   include CurrentProject
 
-  before_action :authorize_project_admin!, except: [:show]
+  before_action :authorize_resource!
   before_action :find_command
 
   def show

--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -57,8 +57,11 @@ module CurrentUser
 
   # tested via access checks in the actual controllers
   def authorize_resource!
-    action = (['index', 'show'].include?(action_name) ? :read : :write)
-    unauthorized! unless can?(action, controller_name)
+    unauthorized! unless can?(resource_action, controller_name)
+  end
+
+  def resource_action
+    (['index', 'show'].include?(action_name) ? :read : :write)
   end
 
   def can?(action, scope, project = nil)

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -4,8 +4,7 @@ class StagesController < ApplicationController
 
   skip_before_action :login_user, if: :badge?
 
-  before_action :authorize_project_deployer!, except: [:show]
-  before_action :authorize_project_admin!, except: [:index, :show]
+  before_action :authorize_resource!
   before_action :check_token, if: :badge?
   before_action :find_stage, only: [:show, :edit, :update, :destroy, :clone]
 

--- a/app/controllers/user_merges_controller.rb
+++ b/app/controllers/user_merges_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class UserMergesController < ApplicationController
-  before_action :authorize_super_admin!
+  before_action :authorize_resource!
   before_action :find_user
 
   def new

--- a/app/controllers/user_project_roles_controller.rb
+++ b/app/controllers/user_project_roles_controller.rb
@@ -2,7 +2,7 @@
 class UserProjectRolesController < ApplicationController
   include CurrentProject
 
-  before_action :authorize_project_admin!, except: [:index]
+  before_action :authorize_resource!
 
   def index
     options = params.to_unsafe_h

--- a/app/controllers/vault_servers_controller.rb
+++ b/app/controllers/vault_servers_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class VaultServersController < ApplicationController
-  before_action :authorize_super_admin!, except: [:index, :show]
+  before_action :authorize_resource!
   before_action :find_server, only: [:update, :show, :destroy, :sync]
 
   def index

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -4,7 +4,10 @@ require 'samson/integration'
 class WebhooksController < ApplicationController
   include CurrentProject
 
-  before_action :authorize_project_deployer!
+  before_action :authorize_resource!
+
+  def index
+  end
 
   def create
     webhook = current_project.webhooks.build(webhook_params)

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -3,7 +3,7 @@ class AccessControl
   class << self
     def can?(user, action, resource, project = nil)
       case resource
-      when 'builds'
+      when 'builds', 'webhooks'
         case action
         when :read then true
         when :write then user.deployer_for?(project)
@@ -20,7 +20,7 @@ class AccessControl
           end
         else raise ArgumentError, "Unsupported action #{action}"
         end
-      when 'projects'
+      when 'projects', 'build_commands', 'stages', 'user_project_roles'
         case action
         when :read then true
         when :write then user.admin_for?(project)
@@ -32,9 +32,27 @@ class AccessControl
         when :write then user.super_admin?
         else raise ArgumentError, "Unsupported action #{action}"
         end
+      when 'secrets'
+        case action
+        when :read then can_deploy_anything?(user)
+        when :write then user.admin_for?(project)
+        else raise ArgumentError, "Unsupported action #{action}"
+        end
+      when 'user_merges', 'vault_servers'
+        case action
+        when :read then true
+        when :write then user.super_admin?
+        else raise ArgumentError, "Unsupported action #{action}"
+        end
       else
         raise ArgumentError, "Unsupported resource #{resource}"
       end
+    end
+
+    private
+
+    def can_deploy_anything?(user)
+      user.deployer? || user.user_project_roles.where('role_id >= ?', Role::DEPLOYER.id).exists?
     end
   end
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -11,7 +11,7 @@
         <th>Stage Name</th>
         <th>Last Deploy</th>
         <th class="pull-right">
-          <% if current_user.admin_for?(@project) %>
+          <% if can? :write, 'stages', @project %>
             <%= link_to 'Manage', project_stages_path(@project) %>
           <% end %>
         </th>

--- a/test/controllers/concerns/current_user_test.rb
+++ b/test/controllers/concerns/current_user_test.rb
@@ -46,7 +46,7 @@ class CurrentUserConcernTest < ActionController::TestCase
       unauthorized!
     end
 
-    def resource_action
+    def resourced_action
       @project = Project.find(params[:project_id]) if params[:project_id]
       authorize_resource!
       head :ok
@@ -191,7 +191,7 @@ class CurrentUserConcernTest < ActionController::TestCase
 
   describe "#authorize_resource!" do
     def perform_get(add = {})
-      get :resource_action, params: add.merge(test_route: true)
+      get :resourced_action, params: add.merge(test_route: true)
     end
 
     before do

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -57,7 +57,6 @@ describe StagesController do
   end
 
   as_a_viewer do
-    unauthorized :get, :index, project_id: :foo
     unauthorized :get, :new, project_id: :foo
     unauthorized :post, :create, project_id: :foo
     unauthorized :get, :edit, project_id: :foo, id: 1
@@ -103,6 +102,13 @@ describe StagesController do
         end
       end
     end
+
+    describe "#index" do
+      it "renders html" do
+        get :index, params: {project_id: project}
+        assert_template 'index'
+      end
+    end
   end
 
   as_a_project_deployer do
@@ -113,13 +119,6 @@ describe StagesController do
     unauthorized :delete, :destroy, project_id: :foo, id: 1
     unauthorized :patch, :reorder, project_id: :foo, id: 1
     unauthorized :get, :clone, project_id: :foo, id: 1
-
-    describe "#index" do
-      it "renders html" do
-        get :index, params: {project_id: project}
-        assert_template 'index'
-      end
-    end
   end
 
   as_a_project_admin do

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -9,12 +9,9 @@ describe WebhooksController do
   let(:webhook) { project.webhooks.create!(stage: stage, branch: 'master', source: 'code') }
 
   as_a_viewer do
-    unauthorized :get, :index, project_id: :foo
     unauthorized :post, :create, project_id: :foo
     unauthorized :delete, :destroy, project_id: :foo, id: 1
-  end
 
-  as_a_project_deployer do
     describe '#index' do
       before { webhook } # trigger create
 
@@ -29,7 +26,9 @@ describe WebhooksController do
         assert_template :index
       end
     end
+  end
 
+  as_a_project_deployer do
     describe '#create' do
       let(:params) { { branch: "master", stage_id: stage.id, source: 'any' } }
 


### PR DESCRIPTION
some tiny perm changes that I hope are for the better:
 - anyone can view webhook setup
 - any deployer can view secrets (does not see values, but who edited it and what the comments are)
 - anyone can view stages index page (manage page ... but they won't be linked to it anyway)

seeing some reuse and patterns emerge like `super-admin resources` / `deployer-changeable-resources` so hope we are going in the right direction :)