### PR TITLE
key needs to be required since vaul does not show nice error messages

### DIFF
--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -33,7 +33,7 @@
           {include_blank: true}, class: "form-control", required: true, disabled: !!id %>
       <% end %>
 
-      <%= form.input :key, input_html: {disabled: !!id} %>
+      <%= form.input :key, input_html: {disabled: !!id}, required: true %>
 
       <%= form.input :comment, as: :text_area, input_html: {disabled: edit_disabled, class: "form-control disabled-on-edit", rows: secret[:comment].to_s.count("\n") + 1} %>
 


### PR DESCRIPTION
<img width="429" alt="screen shot 2017-07-07 at 12 34 32 pm" src="https://user-images.githubusercontent.com/11367/27954575-e353581e-6310-11e7-9d4b-5f47f4981c0a.png">

`Vault::HTTPClientError: The Vault server at responded with a 400. Any additional information the server supplied is shown below: * cannot write to a path ending in '/' Please refer to the documentation for help.`

https://zendesk.airbrake.io/projects/95346/groups/1989053080897266315/notices