### PR TITLE
PAAS-1091 deploys going to a non-deploy production stage do not need …

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -117,8 +117,9 @@ class Stage < ActiveRecord::Base
   end
 
   def deploy_requires_approval?
-    BuddyCheck.enabled? && !no_code_deployed? && production?
+    BuddyCheck.enabled? && !no_code_deployed? && production_for_approval?
   end
+  alias_method :production_for_approval?, :production?
 
   def automated_failure_emails(deploy)
     return if !email_committers_on_automated_deploy_failure? && static_emails_on_automated_deploy_failure.blank?

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -213,6 +213,7 @@ module Samson
 end
 
 module Samson::LoadDecorators
+  # TODO: should call decorator after subclass is done being defined, see https://stackoverflow.com/questions/7093992
   def inherited(subclass)
     super
     Samson::Hooks.load_decorators(subclass.name)


### PR DESCRIPTION
…approval

also fixing a few extra queries and testing deeply nested stages require a buddy approval

replaces https://github.com/zendesk/samson/pull/780 and fixes SAMSON-215 too ...