### PR TITLE
replace docker image building via gem with shellout

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -52,6 +52,10 @@ class TerminalExecutor
     system('kill', "-#{signal}", "-#{pgid}") if pgid
   end
 
+  def verbose_command(c)
+    "echo » #{c.shellescape}\n#{resolve_secrets(c)}"
+  end
+
   private
 
   def timeout(&block)
@@ -72,7 +76,7 @@ class TerminalExecutor
   def script(commands)
     commands.map! do |c|
       if @verbose
-        "echo » #{c.shellescape}\n#{resolve_secrets(c)}"
+        verbose_command(c)
       else
         resolve_secrets(c)
       end

--- a/plugins/docker_binary_builder/app/models/binary_builder.rb
+++ b/plugins/docker_binary_builder/app/models/binary_builder.rb
@@ -141,11 +141,7 @@ class BinaryBuilder
   end
 
   def create_build_image
-    build_options = {
-      'dockerfile' => DOCKER_BUILD_FILE,
-      't' => image_name
-    }
-    DockerBuilderService.build_docker_image(@dir, build_options, @output)
+    DockerBuilderService.build_docker_image(@dir, @output, dockerfile: DOCKER_BUILD_FILE, tag: image_name)
   end
 
   def docker_api_version


### PR DESCRIPTION
also make all credentials available during build phase

@jonmoter @irwaters POC ... need some sanity check ...

I guess switching home is not an option ... so need to find something better for temp credentials ...
guess we cold just use `docker login` so the deploy user stays logged in ...