### PR TITLE
small UI tweaks for instances with lots projects or env

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -266,12 +266,10 @@ module ApplicationHelper
     result
   end
 
-  def list_with_show_more(items, display_limit, show_more_tag = nil, ul_options = {}, &block)
+  def list_with_show_more(items, display_limit, show_more_tag, ul_options = {}, &block)
     li_tags = items.first(display_limit).map { |i| capture(i, &block) }
     li_tags << show_more_tag if items.size > display_limit
 
-    content_tag(:ul, ul_options) do
-      li_tags.join.html_safe
-    end
+    content_tag(:ul, li_tags.join.html_safe, ul_options)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -265,4 +265,13 @@ module ApplicationHelper
     result << " #{objects.total_count} records" if objects.total_pages > 1
     result
   end
+
+  def list_with_show_more(items, display_limit, show_more_tag = nil, ul_options = {}, &block)
+    li_tags = items.first(display_limit).map { |i| capture(i, &block) }
+    li_tags << show_more_tag if items.size > display_limit
+
+    content_tag(:ul, ul_options) do
+      li_tags.join.html_safe
+    end
+  end
 end

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,4 +1,5 @@
 <%# Is expired on deploy because job touches project (job->deploy->stage->project) %>
+<% max_display_projects = 5 %>
 <% cache [project, Lock.cache_key] do %>
   <div class="col-sm-4 project-tile">
     <h2>
@@ -6,36 +7,31 @@
       <%= repository_web_link(project) %>
     </h2>
 
-    <ul>
-      <% project.stages.first(8).each do |stage| %>
-        <% cache [stage, Lock.cache_key] do %>
-          <li class="clearfix">
-            <%= link_to stage.name, [project, stage], class: 'stage-link' %>
-            <% if deploy = stage.current_deploy %>
-              <%= link_to 'Deploying', [project, deploy], class: 'label label-primary' %>
+    <% show_more_link = content_tag(:li, link_to("+ #{project.stages.count - max_display_projects} More", project), class: 'clearfix', style: 'text-align:center') %>
+
+    <%= list_with_show_more(project.stages, max_display_projects, show_more_link) do |stage| %>
+      <% cache [stage, Lock.cache_key] do %>
+        <li class="clearfix">
+          <%= link_to stage.name, [project, stage], class: 'stage-link' %>
+          <% if deploy = stage.current_deploy %>
+            <%= link_to 'Deploying', [project, deploy], class: 'label label-primary' %>
+          <% end %>
+          <%= resource_lock_icon stage %>
+          <%= stage_template_icon if stage.is_template %>
+
+          <div class="pull-right">
+            <% if (deploy = stage.last_deploy) && deploy.failed? %>
+              <%= link_to [project, deploy], class: 'no-hover' do %>
+                <%= content_tag :i, '', class: 'fa fa-exclamation-triangle deployment-alert', title: deployment_alert_title(deploy) %>
+              <% end %>
             <% end %>
-            <%= resource_lock_icon stage %>
-            <%= stage_template_icon if stage.is_template %>
 
-            <div class="pull-right">
-              <% if (deploy = stage.last_deploy) && deploy.failed? %>
-                <%= link_to [project, deploy], class: 'no-hover' do %>
-                  <%= content_tag :i, '', class: 'fa fa-exclamation-triangle deployment-alert', title: deployment_alert_title(deploy) %>
-                <% end %>
-              <% end %>
-
-              <% if deploy = stage.last_successful_deploy %>
-                <%= link_to deploy.short_reference, [project, deploy], class: "status label #{status_label(deploy.status)}" %>
-              <% end %>
-            </div>
-          </li>
-        <% end %>
-      <% end %>
-      <% if project.stages.count > 8 %>
-        <li class="clearfix" style="text-align: center">
-          <%= link_to "+ #{project.stages.count - 8} More", project %>
+            <% if deploy = stage.last_successful_deploy %>
+              <%= link_to deploy.short_reference, [project, deploy], class: "status label #{status_label(deploy.status)}" %>
+            <% end %>
+          </div>
         </li>
       <% end %>
-    </ul>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -7,9 +7,10 @@
       <%= repository_web_link(project) %>
     </h2>
 
-    <% show_more_link = content_tag(:li, link_to("+ #{project.stages.count - max_display_projects} More", project), class: 'clearfix', style: 'text-align:center') %>
+    <% stages = project.stages.to_a %>
+    <% show_more_link = content_tag(:li, link_to("+ #{stages.count - max_display_projects} More", project), class: 'clearfix', style: 'text-align:center') %>
 
-    <%= list_with_show_more(project.stages, max_display_projects, show_more_link) do |stage| %>
+    <%= list_with_show_more(stages, max_display_projects, show_more_link) do |stage| %>
       <% cache [stage, Lock.cache_key] do %>
         <li class="clearfix">
           <%= link_to stage.name, [project, stage], class: 'stage-link' %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -7,7 +7,7 @@
     </h2>
 
     <ul>
-      <% project.stages.each do |stage| %>
+      <% project.stages.first(8).each do |stage| %>
         <% cache [stage, Lock.cache_key] do %>
           <li class="clearfix">
             <%= link_to stage.name, [project, stage], class: 'stage-link' %>
@@ -30,6 +30,11 @@
             </div>
           </li>
         <% end %>
+      <% end %>
+      <% if project.stages.count > 8 %>
+        <li class="clearfix" style="text-align: center">
+          <%= link_to "+ #{project.stages.count - 8} More", project %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/plugins/env/app/views/environment_variable_groups/_projects.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/_projects.html.erb
@@ -1,3 +1,4 @@
-<%= list_with_show_more(group.projects.sort_by(&:name), display_limit, link_to("+ #{group.projects.size - display_limit} More")) do |project| %>
+<% projects = group.projects.to_a %>
+<%= list_with_show_more(projects.sort_by(&:name), display_limit, link_to("+ #{projects.size - display_limit} More")) do |project| %>
   <li><%= link_to project.name, project %></li>
 <% end %>

--- a/plugins/env/app/views/environment_variable_groups/_projects.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/_projects.html.erb
@@ -1,5 +1,14 @@
 <ul>
-  <% group.projects.sort_by(&:name).each do |project| %>
-    <li><%= link_to project.name, project %></li>
+  <% if display_limit %>
+    <% group.projects.first(display_limit).sort_by(&:name).each do |project| %>
+      <li><%= link_to project.name, project %></li>
+    <% end %>
+    <% if group.projects.count > display_limit %>
+      <li><%= link_to "+ #{group.projects.count - display_limit} More", group %></li>
+    <% end %>
+  <% else %>
+    <% group.projects.sort_by(&:name).each do |project| %>
+      <li><%= link_to project.name, project %></li>
+    <% end %>
   <% end %>
 </ul>

--- a/plugins/env/app/views/environment_variable_groups/_projects.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/_projects.html.erb
@@ -1,14 +1,3 @@
-<ul>
-  <% if display_limit %>
-    <% group.projects.first(display_limit).sort_by(&:name).each do |project| %>
-      <li><%= link_to project.name, project %></li>
-    <% end %>
-    <% if group.projects.count > display_limit %>
-      <li><%= link_to "+ #{group.projects.count - display_limit} More", group %></li>
-    <% end %>
-  <% else %>
-    <% group.projects.sort_by(&:name).each do |project| %>
-      <li><%= link_to project.name, project %></li>
-    <% end %>
-  <% end %>
-</ul>
+<%= list_with_show_more(group.projects.sort_by(&:name), display_limit, link_to("+ #{group.projects.size - display_limit} More")) do |project| %>
+  <li><%= link_to project.name, project %></li>
+<% end %>

--- a/plugins/env/app/views/environment_variable_groups/form.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/form.html.erb
@@ -19,7 +19,7 @@
     <% if @group.projects.length > 0 %>
       <fieldset>
         <legend>Usages</legend>
-        <%= render 'projects', group: @group %>
+        <%= render 'projects', group: @group, display_limit: nil %>
       </fieldset>
     <% end %>
 

--- a/plugins/env/app/views/environment_variable_groups/index.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/index.html.erb
@@ -10,6 +10,10 @@
 </h1>
 
 <section class="clearfix">
+  <div class="pull-right">
+    <%= link_to "New", new_environment_variable_group_path, class: "btn btn-default" %>
+  </div>
+  <div class="clearfix"></div>
   <table class="table table-hover table-condensed">
     <thead>
     <tr>
@@ -19,16 +23,20 @@
     </tr>
     </thead>
     <% @groups.each do |group| %>
+      <% sorted_vars = group.environment_variables.map(&:name).uniq.sort %>
       <tr>
         <td>
           <%= link_to group.name, group %>
           <ul>
-            <% group.environment_variables.map(&:name).uniq.sort.each do |name| %>
+            <% sorted_vars.first(5).each do |name| %>
               <li><%= name %></li>
+            <% end %>
+            <% if sorted_vars.count > 5 %>
+              <li><%= link_to "+ #{sorted_vars.count - 5} More", group %></li>
             <% end %>
           </ul>
         </td>
-        <td><%= render 'projects', group: group %></td>
+        <td><%= render 'projects', group: group, display_limit: 7 %></td>
         <td>
           <% if group.projects.any? %>
             <%= link_to "Delete", "#", data: {confirm: "Cannot be deleted when still in use."} %>
@@ -39,8 +47,4 @@
       </tr>
     <% end %>
   </table>
-
-  <div class="pull-right">
-    <%= link_to "New", new_environment_variable_group_path, class: "btn btn-default" %>
-  </div>
 </section>

--- a/plugins/env/app/views/environment_variable_groups/index.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/index.html.erb
@@ -23,18 +23,13 @@
     </tr>
     </thead>
     <% @groups.each do |group| %>
-      <% sorted_vars = group.environment_variables.map(&:name).uniq.sort %>
+      <% sorted_vars = group.environment_variables.sort_by(&:id).map(&:name).uniq %>
       <tr>
         <td>
           <%= link_to group.name, group %>
-          <ul>
-            <% sorted_vars.first(5).each do |name| %>
-              <li><%= name %></li>
-            <% end %>
-            <% if sorted_vars.count > 5 %>
-              <li><%= link_to "+ #{sorted_vars.count - 5} More", group %></li>
-            <% end %>
-          </ul>
+          <%= list_with_show_more(sorted_vars, 5, link_to("+ #{sorted_vars.count - 5} More", group)) do |name| %>
+            <li><%= name %></li>
+          <% end %>
         </td>
         <td><%= render 'projects', group: group, display_limit: 7 %></td>
         <td>

--- a/plugins/env/app/views/environment_variable_groups/index.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/index.html.erb
@@ -1,4 +1,6 @@
 <% title = "Environment variable groups" %>
+<% max_display_variables = 5 %>
+<% max_display_projects = 7 %>
 
 <%= breadcrumb(title) %>
 
@@ -27,11 +29,11 @@
       <tr>
         <td>
           <%= link_to group.name, group %>
-          <%= list_with_show_more(sorted_vars, 5, link_to("+ #{sorted_vars.count - 5} More", group)) do |name| %>
+          <%= list_with_show_more(sorted_vars, max_display_variables, link_to("+ #{sorted_vars.count - max_display_variables} More", group)) do |name| %>
             <li><%= name %></li>
           <% end %>
         </td>
-        <td><%= render 'projects', group: group, display_limit: 7 %></td>
+        <td><%= render 'projects', group: group, display_limit: max_display_projects %></td>
         <td>
           <% if group.projects.any? %>
             <%= link_to "Delete", "#", data: {confirm: "Cannot be deleted when still in use."} %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -572,4 +572,24 @@ describe ApplicationHelper do
       paginate(User.where("1=2").page(1).per(1)).wont_include " records"
     end
   end
+
+  describe '#list_with_show_more' do
+    let(:items) { %w[foo bar baz] }
+
+    it 'only shows `display_limit` records' do
+      tag = list_with_show_more(items, 2, content_tag(:li, 'More')) do |item|
+        content_tag(:li, item)
+      end
+
+      tag.must_equal '<ul><li>foo</li><li>bar</li><li>More</li></ul>'
+    end
+
+    it 'passes through any HTML options' do
+      tag = list_with_show_more(items, 2, content_tag(:li, 'More'), class: 'show-more') do |item|
+        content_tag(:li, item)
+      end
+
+      tag.must_equal '<ul class="show-more"><li>foo</li><li>bar</li><li>More</li></ul>'
+    end
+  end
 end


### PR DESCRIPTION
This modifies two places, the home page which lists projects, and the environment variable groups page. It puts a limit on the max number of stages display on the projects page and max number of env vars or projects displayed in each env var group row.

#### Projects page with a show more link
<img width="1172" alt="screen shot 2017-07-10 at 7 18 33 pm" src="https://user-images.githubusercontent.com/6731804/28048306-f25d7a88-65a4-11e7-97ff-55383ebaf533.png">

#### Env var groups page with show more links
<img width="1164" alt="screen shot 2017-07-10 at 7 11 14 pm" src="https://user-images.githubusercontent.com/6731804/28048313-0201142c-65a5-11e7-980c-5545125ca80e.png">


/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low. Only updating the UI index pages.
