### PR TITLE
Rollbar plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,11 @@ PATH
     samson_pipelines (0.0.0)
 
 PATH
+  remote: plugins/rollbar
+  specs:
+    samson_rollbar (0.0.0)
+
+PATH
   remote: plugins/samson_ledger
   specs:
     samson_ledger (0.0.1)
@@ -577,6 +582,7 @@ DEPENDENCIES
   samson_ledger!
   samson_new_relic!
   samson_pipelines!
+  samson_rollbar!
   samson_slack_app!
   samson_slack_webhooks!
   samson_zendesk!

--- a/config/initializers/00_filter_parameter_logging.rb
+++ b/config/initializers/00_filter_parameter_logging.rb
@@ -2,4 +2,4 @@
 # Configure sensitive parameters which will be filtered from the log file
 # Used in airbrake.rb but does not support the 'foo.bar' syntax as rails does
 # https://github.com/airbrake/airbrake-ruby/issues/137
-Rails.application.config.filter_parameters.concat [:password, :value, :token]
+Rails.application.config.filter_parameters.concat [:password, :value, :token, :access_token]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622010111) do
+ActiveRecord::Schema.define(version: 20170711174532) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -385,6 +385,16 @@ ActiveRecord::Schema.define(version: 20170622010111) do
     t.integer "build_id"
     t.index ["build_id"], name: "index_releases_on_build_id"
     t.index ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
+  end
+
+  create_table "rollbar_webhooks", force: :cascade do |t|
+    t.text "webhook_url", null: false
+    t.string "access_token", null: false
+    t.string "environment", null: false
+    t.integer "stage_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["stage_id"], name: "index_rollbar_webhooks_on_stage_id"
   end
 
   create_table "secret_sharing_grants", force: :cascade do |t|

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -26,6 +26,7 @@ Available plugins:
  - [Slack deploys](https://github.com/zendesk/samson/tree/master/plugins/slack_app)
  - [Slack notifications](https://github.com/zendesk/samson/tree/master/plugins/slack_webhooks)
  - [Zendesk notifications](https://github.com/zendesk/samson/tree/master/plugins/zendesk)
+ - [Rollbar notifications on deploy](https://github.com/zendesk/samson/tree/master/plugins/rollbar)
  - Add yours here!
 
 To create your own plugin run:

--- a/plugins/rollbar/README.md
+++ b/plugins/rollbar/README.md
@@ -1,0 +1,8 @@
+# Rollbar Plugin
+
+This plugin adds deploy tracking to [Rollbar](https://rollbar.com/)
+
+1. The webhook URL is `https://api.rollbar.com/api/1/deploy/` unless it's a self-hosted instance.
+2. Sign in to Rollbar and go to the "Deploys" area.
+3. c/p the `access_token` to Samson.
+4. The `environment` name must match one from Rollbar "Settings > General > Environments".

--- a/plugins/rollbar/README.md
+++ b/plugins/rollbar/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds deploy tracking to [Rollbar](https://rollbar.com/)
 
-1. The webhook URL is `https://api.rollbar.com/api/1/deploy/` unless it's a self-hosted instance.
+1. Add `https://api.rollbar.com/api/1/deploy/` to the the webhook URL, unless you're using a self-hosted instance of Rollbar.
 2. Sign in to Rollbar and go to the "Deploys" area.
 3. c/p the `access_token` to Samson.
 4. The `environment` name must match one from Rollbar "Settings > General > Environments".

--- a/plugins/rollbar/app/decorators/stage_decorator.rb
+++ b/plugins/rollbar/app/decorators/stage_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+Stage.class_eval do
+  has_many :rollbar_webhooks
+  accepts_nested_attributes_for :rollbar_webhooks, allow_destroy: true, reject_if: ->(a) {
+    a.fetch(:webhook_url).blank?
+  }
+end

--- a/plugins/rollbar/app/models/rollbar_notification.rb
+++ b/plugins/rollbar/app/models/rollbar_notification.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'faraday'
+
+class RollbarNotification
+  def initialize(webhook_url:, access_token:, environment:, revision:)
+    @webhook_url = webhook_url
+    @access_token = access_token
+    @environment = environment
+    @revision = revision
+  end
+
+  def deliver
+    Rails.logger.info "Sending Rollbar notification..."
+    response = Faraday.post(
+      @webhook_url,
+      access_token: @access_token,
+      environment: @environment,
+      revision: @revision
+    )
+
+    if response.success?
+      Rails.logger.info "Sent Rollbar notification"
+    else
+      Rails.logger.info "Failed to send Rollbar notification. HTTP #{response.status}: #{response.body}"
+    end
+  end
+end

--- a/plugins/rollbar/app/models/rollbar_webhook.rb
+++ b/plugins/rollbar/app/models/rollbar_webhook.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class RollbarWebhook < ActiveRecord::Base
+  belongs_to :stage
+end

--- a/plugins/rollbar/app/views/samson_rollbar/_stage_form.html.erb
+++ b/plugins/rollbar/app/views/samson_rollbar/_stage_form.html.erb
@@ -8,15 +8,15 @@
       <%= form.fields_for :rollbar_webhooks do |rollbar_field| %>
         <div class="form-group">
           <div class="col-lg-4">
-            <%= rollbar_field.url_field :webhook_url, class: "form-control", placeholder: "Webhook URL" %>
+            <%= rollbar_field.url_field :webhook_url, class: "form-control", placeholder: "Webhook URL", required: true  %>
           </div>
 
           <div class="col-lg-3">
-            <%= rollbar_field.text_field :access_token, class: "form-control", placeholder: "Access token" %>
+            <%= rollbar_field.text_field :access_token, class: "form-control", placeholder: "Access token", required: true %>
           </div>
 
           <div class="col-lg-3">
-            <%= rollbar_field.text_field :environment, class: "form-control", placeholder: "Environment" %>
+            <%= rollbar_field.text_field :environment, class: "form-control", placeholder: "Environment", required: true %>
           </div>
 
           <%= delete_checkbox rollbar_field %>

--- a/plugins/rollbar/app/views/samson_rollbar/_stage_form.html.erb
+++ b/plugins/rollbar/app/views/samson_rollbar/_stage_form.html.erb
@@ -1,0 +1,27 @@
+<% if DeployGroup.enabled? %>
+  <fieldset>
+    <legend>Rollbar</legend>
+    <% stage = form.object %>
+    <% stage.rollbar_webhooks.build %>
+
+    <div class="col-lg-offset-2">
+      <%= form.fields_for :rollbar_webhooks do |rollbar_field| %>
+        <div class="form-group">
+          <div class="col-lg-4">
+            <%= rollbar_field.url_field :webhook_url, class: "form-control", placeholder: "Webhook URL" %>
+          </div>
+
+          <div class="col-lg-3">
+            <%= rollbar_field.text_field :access_token, class: "form-control", placeholder: "Access token" %>
+          </div>
+
+          <div class="col-lg-3">
+            <%= rollbar_field.text_field :environment, class: "form-control", placeholder: "Environment" %>
+          </div>
+
+          <%= delete_checkbox rollbar_field %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+<% end %>

--- a/plugins/rollbar/db/migrate/20170711174532_create_rollbar_webhooks.rb
+++ b/plugins/rollbar/db/migrate/20170711174532_create_rollbar_webhooks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class CreateRollbarWebhooks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :rollbar_webhooks do |t|
+      t.text :webhook_url, null: false
+      t.string :access_token, null: false
+      t.string :environment, null: false
+      t.integer :stage_id, null: false
+      t.timestamps
+
+      t.index :stage_id
+    end
+  end
+end

--- a/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
+++ b/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
@@ -1,0 +1,122 @@
+module SamsonRollbar
+  class Engine < Rails::Engine
+  end
+end
+
+# To add in your own UI for a hook, e.g., for the stage edit page:
+# - Create app/views/samson_rollbar/_my_fields.html.erb
+# - Add this line to this file, note the lack of leading underscore and extension:
+#   Samson::Hooks.view :stage_form, 'samson_rollbar/my_fields'
+
+
+#Samson::Hooks.view :stage_form, '<view path>'
+
+#Samson::Hooks.view :stage_show, '<view path>'
+
+#Samson::Hooks.view :project_form, '<view path>'
+
+#Samson::Hooks.view :build_new, '<view path>'
+
+#Samson::Hooks.view :deploy_group_show, '<view path>'
+
+#Samson::Hooks.view :deploy_group_form, '<view path>'
+
+#Samson::Hooks.view :deploy_group_table_header, '<view path>'
+
+#Samson::Hooks.view :deploy_group_table_cell, '<view path>'
+
+#Samson::Hooks.view :deploys_header, '<view path>'
+
+#Samson::Hooks.view :deploy_tab_nav, '<view path>'
+
+#Samson::Hooks.view :deploy_tab_body, '<view path>'
+
+#Samson::Hooks.view :deploy_view, '<view path>'
+
+#Samson::Hooks.view :deploy_form, '<view path>'
+
+#Samson::Hooks.view :admin_menu, '<view path>'
+
+#Samson::Hooks.view :manage_menu, '<view path>'
+
+#Samson::Hooks.view :project_tabs_view, '<view path>'
+
+
+# Possible callbacks are listed below, delete any unused ones.
+
+#Samson::Hooks.callback :stage_clone do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :stage_permitted_params do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :deploy_permitted_params do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :project_permitted_params do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :deploy_group_permitted_params do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :build_permitted_params do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :buddy_request do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :before_deploy do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :after_deploy_setup do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :after_deploy do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :before_docker_repository_usage do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :before_docker_build do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :after_docker_build do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :after_job_execution do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :job_additional_vars do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :buildkite_release_params do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :release_deploy_conditions do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :deploy_group_env do
+  # Do stuff in here
+#end
+
+#Samson::Hooks.callback :link_parts_for_resource do
+  # Do stuff in here
+#end
+

--- a/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
+++ b/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
@@ -1,122 +1,33 @@
+# frozen_string_literal: true
 module SamsonRollbar
   class Engine < Rails::Engine
   end
 end
 
-# To add in your own UI for a hook, e.g., for the stage edit page:
-# - Create app/views/samson_rollbar/_my_fields.html.erb
-# - Add this line to this file, note the lack of leading underscore and extension:
-#   Samson::Hooks.view :stage_form, 'samson_rollbar/my_fields'
+Samson::Hooks.view :stage_form, 'samson_rollbar/stage_form'
 
+Samson::Hooks.callback :stage_permitted_params do
+  {
+    rollbar_webhooks_attributes: [
+      :id, :_destroy,
+      :webhook_url, :access_token, :environment
+    ]
+  }
+end
 
-#Samson::Hooks.view :stage_form, '<view path>'
+Samson::Hooks.callback :after_deploy do |deploy|
+  deploy.stage.rollbar_webhooks.each do |webhook|
+    RollbarNotification.new(
+      webhook_url: webhook.webhook_url,
+      access_token: webhook.access_token,
+      environment: webhook.environment,
+      revision: deploy.reference
+    ).deliver
+  end
+end
 
-#Samson::Hooks.view :stage_show, '<view path>'
-
-#Samson::Hooks.view :project_form, '<view path>'
-
-#Samson::Hooks.view :build_new, '<view path>'
-
-#Samson::Hooks.view :deploy_group_show, '<view path>'
-
-#Samson::Hooks.view :deploy_group_form, '<view path>'
-
-#Samson::Hooks.view :deploy_group_table_header, '<view path>'
-
-#Samson::Hooks.view :deploy_group_table_cell, '<view path>'
-
-#Samson::Hooks.view :deploys_header, '<view path>'
-
-#Samson::Hooks.view :deploy_tab_nav, '<view path>'
-
-#Samson::Hooks.view :deploy_tab_body, '<view path>'
-
-#Samson::Hooks.view :deploy_view, '<view path>'
-
-#Samson::Hooks.view :deploy_form, '<view path>'
-
-#Samson::Hooks.view :admin_menu, '<view path>'
-
-#Samson::Hooks.view :manage_menu, '<view path>'
-
-#Samson::Hooks.view :project_tabs_view, '<view path>'
-
-
-# Possible callbacks are listed below, delete any unused ones.
-
-#Samson::Hooks.callback :stage_clone do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :stage_permitted_params do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :deploy_permitted_params do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :project_permitted_params do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :deploy_group_permitted_params do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :build_permitted_params do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :buddy_request do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :before_deploy do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :after_deploy_setup do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :after_deploy do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :before_docker_repository_usage do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :before_docker_build do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :after_docker_build do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :after_job_execution do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :job_additional_vars do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :buildkite_release_params do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :release_deploy_conditions do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :deploy_group_env do
-  # Do stuff in here
-#end
-
-#Samson::Hooks.callback :link_parts_for_resource do
-  # Do stuff in here
-#end
-
+Samson::Hooks.callback :stage_clone do |old_stage, new_stage|
+  new_stage.rollbar_webhooks.build(
+    old_stage.rollbar_webhooks.map { |s| s.attributes.except("id", "created_at", "updated_at") }
+  )
+end

--- a/plugins/rollbar/samson_rollbar.gemspec
+++ b/plugins/rollbar/samson_rollbar.gemspec
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 Gem::Specification.new 'samson_rollbar', '0.0.0' do |s|
   s.summary = 'Samson Rollbar plugin'
   s.authors = ['Henrik Jorgensen']
-  s.email = ['henrikj@me.com']
+  s.email = ['hjorgensen@zendesk.com']
   s.files = Dir['{app,config,db,lib}/**/*']
 end

--- a/plugins/rollbar/samson_rollbar.gemspec
+++ b/plugins/rollbar/samson_rollbar.gemspec
@@ -1,0 +1,6 @@
+Gem::Specification.new 'samson_rollbar', '0.0.0' do |s|
+  s.summary = 'Samson Rollbar plugin'
+  s.authors = ['Henrik Jorgensen']
+  s.email = ['henrikj@me.com']
+  s.files = Dir['{app,config,db,lib}/**/*']
+end

--- a/plugins/rollbar/test/decorators/stage_decorator_test.rb
+++ b/plugins/rollbar/test/decorators/stage_decorator_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe Stage do
+  let(:stage) { stages(:test_staging) }
+
+  describe "assigning rollbar attributes" do
+    it "assigns" do
+      stage.attributes = { rollbar_webhooks_attributes: { 0 => { webhook_url: 'xxxx' } } }
+      stage.rollbar_webhooks.size.must_equal 1
+    end
+
+    it "does not assign without url" do
+      stage.attributes = { rollbar_webhooks_attributes: { 0 => { webhook_url: '' } } }
+      stage.rollbar_webhooks.size.must_equal 0
+    end
+  end
+end

--- a/plugins/rollbar/test/models/rollbar_notification_test.rb
+++ b/plugins/rollbar/test/models/rollbar_notification_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered! uncovered: 2
+
+describe RollbarNotification do
+  let(:endpoint) { 'https://rollbar.com' }
+  let(:notification) do
+    RollbarNotification.new(
+      webhook_url: endpoint,
+      access_token: 'token',
+      environment: 'test',
+      revision: 'v1'
+    )
+  end
+
+  describe '#deliver' do
+    it 'notifies rollbar' do
+      request = stub_request(:post, endpoint).with(
+        body: {
+          access_token: 'token',
+          environment: 'test',
+          revision: 'v1'
+        }
+      )
+
+      notification.deliver
+      assert_requested request
+    end
+  end
+end

--- a/plugins/rollbar/test/models/rollbar_notification_test.rb
+++ b/plugins/rollbar/test/models/rollbar_notification_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 2
+SingleCov.covered!
 
 describe RollbarNotification do
   let(:endpoint) { 'https://rollbar.com' }
@@ -26,6 +26,18 @@ describe RollbarNotification do
 
       notification.deliver
       assert_requested request
+    end
+
+    it 'shows an error message' do
+      stub_request(:post, endpoint).to_return(
+        status: [500, "Internal Server Error"],
+        body: 'oops..'
+      )
+
+      Rails.logger.expects(:info).with("Sending Rollbar notification...")
+      Rails.logger.expects(:info).with("Failed to send Rollbar notification. HTTP 500: oops..")
+
+      notification.deliver
     end
   end
 end

--- a/plugins/rollbar/test/models/rollbar_webhook_test.rb
+++ b/plugins/rollbar/test/models/rollbar_webhook_test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe RollbarWebhook do
+end

--- a/plugins/rollbar/test/samson_rollbar/samson_plugin_test.rb
+++ b/plugins/rollbar/test/samson_rollbar/samson_plugin_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe SamsonRollbar do
+  let(:deploy) { deploys(:succeeded_test) }
+  let(:stage) { deploy.stage }
+
+  describe :after_deploy do
+    it "sends notification on after hook" do
+      stage.rollbar_webhooks.build(webhook_url: 'https://rollbar.com', access_token: 'token', environment: 'test')
+      RollbarNotification.any_instance.expects(:deliver)
+      Samson::Hooks.fire(:after_deploy, deploy, nil)
+    end
+  end
+
+  describe :stage_permitted_params do
+    it "includes our params" do
+      Samson::Hooks.fire(:stage_permitted_params).must_include(
+        rollbar_webhooks_attributes: [
+          :id, :_destroy,
+          :webhook_url, :access_token, :environment
+        ]
+      )
+    end
+  end
+
+  describe :stage_clone do
+    it "copies all attributes except id" do
+      stage.rollbar_webhooks = [RollbarWebhook.new(
+        webhook_url: 'http://example.com',
+        access_token: 'token',
+        environment: 'test'
+      )]
+      new_stage = Stage.new
+      Samson::Hooks.fire(:stage_clone, stage, new_stage)
+      new_stage.rollbar_webhooks.map(&:attributes).must_equal [{
+        "id" => nil,
+        "webhook_url" => "http://example.com",
+        "access_token" => "token",
+        "environment" => "test",
+        "stage_id" => nil,
+        "created_at" => nil,
+        "updated_at" => nil,
+      }]
+    end
+  end
+end

--- a/plugins/rollbar/test/test_helper.rb
+++ b/plugins/rollbar/test/test_helper.rb
@@ -1,0 +1,1 @@
+require_relative '../../../test/test_helper'

--- a/plugins/rollbar/test/test_helper.rb
+++ b/plugins/rollbar/test/test_helper.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require_relative '../../../test/test_helper'


### PR DESCRIPTION
Send deploy notifications to [Rollbar](https://www.rollbar.com) after deploy. It's configurable to N number of webhooks if users have multiple Rollbar instances around the globe. 

Screenshot:
![image](https://user-images.githubusercontent.com/465996/28091143-c143ef46-6643-11e7-96c1-8e285b767181.png)

/cc @zendesk/samson @craig-day 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low