### PR TITLE
delete roles when soft-deleting a user to not have invalid records

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,8 @@ class User < ActiveRecord::Base
   validates :time_format, inclusion: { in: TIME_FORMATS }
   validates :external_id, presence: :true, unless: :integration?
 
+  before_soft_delete :destroy_user_project_roles
+
   scope :search, ->(query) {
     return self if query.blank?
     query = ActiveRecord::Base.send(:sanitize_sql_like, query)
@@ -134,5 +136,9 @@ class User < ActiveRecord::Base
 
   def set_token
     self.token = SecureRandom.hex
+  end
+
+  def destroy_user_project_roles
+    user_project_roles.each(&:destroy)
   end
 end

--- a/db/migrate/20170718083150_cleanup_bad_roles.rb
+++ b/db/migrate/20170718083150_cleanup_bad_roles.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class CleanupBadRoles < ActiveRecord::Migration[5.1]
+  class User < ActiveRecord::Base
+  end
+
+  class UserProjectRole < ActiveRecord::Base
+  end
+
+  def up
+    existing_users = User.where(deleted_at: nil).pluck(:id)
+    UserProjectRole.where.not(user_id: existing_users).delete_all
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170711174532) do
+ActiveRecord::Schema.define(version: 20170718083150) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -503,4 +503,16 @@ describe User do
       user.name_and_email.must_equal "admin@example.com"
     end
   end
+
+  describe "#user_project_roles" do
+    let(:user) { users(:project_admin) }
+
+    it "deletes them on deletion and audits as user change" do
+      assert_difference 'Audited::Audit.where(auditable_type: "User").count', +2 do
+        assert_difference 'UserProjectRole.count', -1 do
+          user.soft_delete!
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
destroying a project failed because on of the roles tried to record a change but it's user was deleted ... so make them get deleted when the user is deleted the same way we delete them when we delete a project

https://zendesk.airbrake.io/projects/95346/groups/1996872327497197303/notices/1996872326954580505?tab=notice-detail