### PR TITLE
Rollbar plugin. Do not make fields required

### DIFF
--- a/plugins/rollbar/app/views/samson_rollbar/_stage_form.html.erb
+++ b/plugins/rollbar/app/views/samson_rollbar/_stage_form.html.erb
@@ -8,15 +8,15 @@
       <%= form.fields_for :rollbar_webhooks do |rollbar_field| %>
         <div class="form-group">
           <div class="col-lg-4">
-            <%= rollbar_field.url_field :webhook_url, class: "form-control", placeholder: "Webhook URL", required: true  %>
+            <%= rollbar_field.url_field :webhook_url, class: "form-control", placeholder: "Webhook URL"  %>
           </div>
 
           <div class="col-lg-3">
-            <%= rollbar_field.text_field :access_token, class: "form-control", placeholder: "Access token", required: true %>
+            <%= rollbar_field.text_field :access_token, class: "form-control", placeholder: "Access token" %>
           </div>
 
           <div class="col-lg-3">
-            <%= rollbar_field.text_field :environment, class: "form-control", placeholder: "Environment", required: true %>
+            <%= rollbar_field.text_field :environment, class: "form-control", placeholder: "Environment" %>
           </div>
 
           <%= delete_checkbox rollbar_field %>


### PR DESCRIPTION
This is regression after introducing the Rollbar plugin. https://github.com/zendesk/samson/pull/2128

Having `required: true` disables the page and users can not save without entering Rollbar information.