### PR TITLE
fix binay builder using the return value of create-image which change…

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -21,7 +21,8 @@ class DockerBuilderService
           *login_commands,
           executor.verbose_command(build)
         )
-        output.to_s[/Successfully built (\S+)/, 1]
+        image_id = output.to_s[/Successfully built (\S+)/, 1]
+        Docker::Image.get(image_id) if image_id
       end
     end
 
@@ -140,8 +141,7 @@ class DockerBuilderService
 
     before_docker_build(tmp_dir)
 
-    image_id = DockerBuilderService.build_docker_image(tmp_dir, output)
-    build.docker_image = (image_id ? Docker::Image.get(image_id) : nil)
+    build.docker_image = DockerBuilderService.build_docker_image(tmp_dir, output)
   end
   add_method_tracer :build_image
 


### PR DESCRIPTION
…d to string

https://zendesk.airbrake.io/projects/95346/groups/1997945422576299012/notices/1997945422030589408

`TypeError: wrong argument type Hash (expected Regexp)`


