### PR TITLE
dont use list_with_show_more if display_limit is nil

### DIFF
--- a/plugins/env/app/views/environment_variable_groups/_projects.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/_projects.html.erb
@@ -1,4 +1,14 @@
-<% projects = group.projects.to_a %>
-<%= list_with_show_more(projects.sort_by(&:name), display_limit, link_to("+ #{projects.size - display_limit} More")) do |project| %>
-  <li><%= link_to project.name, project %></li>
+<% projects = group.projects.to_a.sort_by(&:name) %>
+
+<%# The index page has a limit, but the show page should display all projects %>
+<% if display_limit %>
+  <%= list_with_show_more(projects, display_limit, link_to("+ #{projects.size - display_limit} More")) do |project| %>
+    <li><%= link_to project.name, project %></li>
+  <% end %>
+<% else %>
+  <ul>
+    <% projects.each do |project| %>
+      <li><%= link_to project.name, project %></li>
+    <% end %>
+  </ul>
 <% end %>


### PR DESCRIPTION
Small fix from a bug introduced in https://github.com/zendesk/samson/pull/2127

For environment variable groups, the index page can be compact but the show page should list all of the projects using a group. This will not use the `list_with_show_more` helper if the display_limit is nil.

/cc @zendesk/samson

### References
 - https://zendesk.airbrake.io/projects/95346/groups/1998865137687537194?tab=overview

### Risks
- Level: Low. The Environment Variable Groups page is broken as-is.
