### PR TITLE
also detect squasch merge commits if they include the pr number as pr…

### DIFF
--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Changeset::Commit
   PULL_REQUEST_MERGE_MESSAGE = /\AMerge pull request #(\d+)/
+  PULL_REQUEST_SQUASH_MESSAGE = /\A.*\(#(\d+)\)$/
 
   def initialize(repo, data)
     @repo = repo
@@ -33,7 +34,9 @@ class Changeset::Commit
   end
 
   def pull_request_number
-    Integer(Regexp.last_match(1)) if summary =~ PULL_REQUEST_MERGE_MESSAGE
+    if number = summary[PULL_REQUEST_MERGE_MESSAGE, 1] || summary[PULL_REQUEST_SQUASH_MESSAGE, 1]
+      Integer(number)
+    end
   end
 
   def url

--- a/test/models/changeset/commit_test.rb
+++ b/test/models/changeset/commit_test.rb
@@ -63,6 +63,21 @@ describe Changeset::Commit do
       commit.pull_request_number.must_equal 136
     end
 
+    it "returns the PR number of a squasch merge" do
+      commit_data.stubs(:message).returns("Something very good (#136)")
+      commit.pull_request_number.must_equal 136
+    end
+
+    it "returns the PR number of a long squasch merge" do
+      commit_data.stubs(:message).returns("Something very good (#136)\nfoobar")
+      commit.pull_request_number.must_equal 136
+    end
+
+    it "does not fetch random other numbers" do
+      commit_data.stubs(:message).returns("Something very bad (#136) here")
+      commit.pull_request_number.must_equal nil
+    end
+
     it "returns nil if the commit is not a Pull Request merge" do
       commit_data.stubs(:message).returns("Add another bug")
       commit.pull_request_number.must_be_nil


### PR DESCRIPTION
…oposed by github UI

copied from https://github.com/zendesk/changes_since/pull/25

not super reliable but hopefully better then not supporting it at all ...
asked github support if we can get proper api

<img width="450" alt="screen shot 2017-07-21 at 11 29 34 am" src="https://user-images.githubusercontent.com/11367/28457838-e1b6e924-6e07-11e7-9001-11ca1a11f6bd.png">


@said-abidi 