### PR TITLE
fix zendesk commenting blowing up on error

### DIFF
--- a/plugins/zendesk/app/models/zendesk_notification.rb
+++ b/plugins/zendesk/app/models/zendesk_notification.rb
@@ -25,7 +25,7 @@ class ZendeskNotification
         if zendesk_client.tickets.update(attributes)
           Rails.logger.info "Updated Zendesk ticket: #{ticket_id} with a comment"
         else
-          Rails.logger.warn "Failed to modify ticket with GitHub update: #{ticket.errors}"
+          Rails.logger.warn "Failed to modify ticket with GitHub update: #{ticket_id}"
         end
       end
     else

--- a/plugins/zendesk/test/models/zendesk_notification_test.rb
+++ b/plugins/zendesk/test/models/zendesk_notification_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 2
+SingleCov.covered!
 
 describe ZendeskNotification do
   def commit(message)
@@ -11,18 +11,18 @@ describe ZendeskNotification do
   let(:stage) { stub(name: "Production") }
   let(:user) { stub(email: "deploys@example.org") }
   let(:changeset) { stub("changeset", commits: [commit("ZD#18 this fixes a very bad bug")]) }
-  let(:deploy) { stub(changeset: changeset, user: user, stage: stage) }
+  let(:deploy) { stub(changeset: changeset, user: user, stage: stage, short_reference: 'abc') }
   let(:notification) { ZendeskNotification.new(deploy) }
   let(:api_response_headers) { {headers: {content_type: "application/json"}} }
 
-  describe 'when commit messages include Zendesk tickets' do
+  describe '#deliver' do
     before do
       ZendeskNotificationRenderer.stubs(:render).returns(
         "A fix to project has been deployed to Production. Deploy details: v2.14"
       )
     end
 
-    it "comments on the ticket" do
+    it "comments on the zendesk ticket" do
       comment = stub_api_request(:put, "api/v2/tickets/18").
         with(
           body: {
@@ -34,6 +34,18 @@ describe ZendeskNotification do
         )
       notification.deliver
 
+      assert_requested comment
+    end
+
+    it "does not comment when no tickets where referenced" do
+      changeset.commits.first.instance_variable_get(:@data).commit.message = "Nope"
+      notification.deliver
+    end
+
+    it "warns when ticket notification failed" do
+      comment = stub_api_request(:put, "api/v2/tickets/18", timeout: true)
+      Rails.logger.expects(:warn).with("Failed to modify ticket with GitHub update: 18")
+      notification.deliver
       assert_requested comment
     end
   end
@@ -57,10 +69,15 @@ describe ZendeskNotification do
 
   private
 
-  def stub_api_request(method, path)
-    url = ENV['ZENDESK_URL']
+  def stub_api_request(method, path, timeout: false)
+    url = ENV.fetch('ZENDESK_URL')
     body = '{ "ticket": { "id": 18, "comment": {"value": "Comment body", "public": true }, "status": "open"}}'
 
-    stub_request(method, "#{url}/#{path}").to_return(api_response_headers.merge(status: 200, body: body))
+    stub = stub_request(method, "#{url}/#{path}")
+    if timeout
+      stub.to_timeout
+    else
+      stub.to_return(api_response_headers.merge(status: 200, body: body))
+    end
   end
 end


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/1998408638766982045

`NameError: undefined local variable or method `ticket' for #<ZendeskNotification:0x007fd2c20e9970>`