### PR TITLE
Remove release validation that build project is same as release project

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -12,7 +12,6 @@ module Kubernetes
 
     validates :project, :git_sha, :git_ref, presence: true
     validate :validate_docker_image_in_registry, on: :create
-    validate :validate_project_ids_are_in_sync
 
     def user
       super || NullUser.new(user_id)
@@ -78,12 +77,6 @@ module Kubernetes
     def validate_docker_image_in_registry
       if build && !build.docker_repo_digest?
         errors.add(:build, 'Docker image was not pushed to registry')
-      end
-    end
-
-    def validate_project_ids_are_in_sync
-      if build && build.project_id != project_id
-        errors.add(:build, 'build.project_id is out of sync with project_id')
       end
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -141,13 +141,6 @@ describe Kubernetes::Release do
     end
   end
 
-  describe "#validate_project_ids_are_in_sync" do
-    it 'ensures project ids are in sync' do
-      release.project_id = 123
-      refute_valid(release, :build)
-    end
-  end
-
   describe '#validate_docker_image_in_registry' do
     it 'ensures image is in registry' do
       release.build = builds(:staging) # does not have a docker image pushed


### PR DESCRIPTION
Allow build to be deployed in project that it was not created in so that
we can deploy the same build with different environment variables in
different projects.

Other solutions considered:
1. making builds unique on project AND sha but this meant having to
build the same sha twice which seemed kind of wasteful
2. use multiple stages, and leave a role unset for a stage. this does
not work because roles are configured per deploy group

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-1059

### Risks
- Level: Med - I have low familiarity with this codebase and critical review is appreciated
