### PR TITLE
validate that environment variables are unique to prevent sql errors …

### DIFF
--- a/plugins/env/app/models/concerns/accepts_environment_variables.rb
+++ b/plugins/env/app/models/concerns/accepts_environment_variables.rb
@@ -6,6 +6,19 @@ module AcceptsEnvironmentVariables
     base.class_eval do
       has_many :environment_variables, as: :parent, dependent: :destroy, inverse_of: :parent
       accepts_nested_attributes_for :environment_variables, allow_destroy: true, reject_if: ->(a) { a[:name].blank? }
+      validate :validate_unique_environment_variables
+
+      private
+
+      def validate_unique_environment_variables
+        return if persisted? && !environment_variables.proxy_association.loaded?
+
+        grouped = environment_variables.group_by { |e| [e.name, e.scope_type, e.scope_id, e.parent_type, e.parent_id] }
+        return if grouped.size == environment_variables.size
+
+        bad = grouped.select { |_, g| g.size > 1 }
+        errors.add :base, "Non-Unique environment variables found for: #{bad.map(&:first).map(&:first).join(", ")}"
+      end
     end
   end
 end

--- a/plugins/env/test/models/concerns/accepts_environment_variables_test.rb
+++ b/plugins/env/test/models/concerns/accepts_environment_variables_test.rb
@@ -17,4 +17,26 @@ describe AcceptsEnvironmentVariables do
     group = EnvironmentVariableGroup.new(environment_variables_attributes: {0 => {name: ''}})
     group.environment_variables.map(&:name).must_equal []
   end
+
+  describe "#validate_unique_environment_variables" do
+    let(:group) do
+      EnvironmentVariableGroup.new(name: 'foo', environment_variables_attributes: {0 => {name: 'foo', value: 'bar'}})
+    end
+
+    it "is valid with unique env vars" do
+      assert_valid group
+    end
+
+    it "is invalid with duplicate environment_variables" do
+      group.environment_variables.build(name: 'foo', value: 'bar2')
+      refute_valid group
+      group.errors.full_messages.must_equal ["Non-Unique environment variables found for: foo"]
+    end
+
+    it "does not check when environment_variables were not changed" do
+      group.save!
+      group.reload
+      assert_sql_queries(0) { assert_valid group }
+    end
+  end
 end


### PR DESCRIPTION
…from showing to users

could not be done on the model itself since at the save-time each row is validated,
against the current DB state ... which passes ... but adding 2 non-unique rows still fails when
saving ... so using a inline check ... and trying to prevent queries when nothing was assigned
and the association is not even loaded.

<img width="444" alt="screen shot 2017-07-25 at 9 08 41 pm" src="https://user-images.githubusercontent.com/11367/28604258-32082950-717e-11e7-9703-686cee5cdf00.png">

fixing https://zendesk.airbrake.io/projects/95346/groups/1991349101560014761

`Duplicate entry '257-Project-AWS_REDIS-DeployGroup-72' for key 'environment_variables_unique_scope': INSERT INTO `environment_variable`