### PR TITLE
Don't use 'kubernetes' column if plugin is not enabled

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -163,7 +163,7 @@ class JobExecution
 
     ActiveSupport::Notifications.instrument("execute_job.samson", payload) do
       payload[:success] =
-        if stage&.kubernetes
+        if defined?(Kubernetes::DeployExecutor) && stage&.kubernetes
           @executor = Kubernetes::DeployExecutor.new(@output, job: @job, reference: @reference)
           @executor.execute!
         else


### PR DESCRIPTION
If samson is run without PLUGINS=kubernetes it still checks for the column during deploy, which causes the deploy to fail.

/cc @zendesk/samson @grosser @zendesk/vulcan 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
