### PR TITLE
return id from locks api reply so we can delete a specific lock and u…

### DIFF
--- a/app/controllers/api/locks_controller.rb
+++ b/app/controllers/api/locks_controller.rb
@@ -7,8 +7,8 @@ class Api::LocksController < Api::BaseController
   end
 
   def create
-    Lock.create!(params.require(:lock).permit(Lock::ASSIGNABLE_KEYS).merge(user: current_user))
-    head :created
+    lock = Lock.create!(params.require(:lock).permit(Lock::ASSIGNABLE_KEYS).merge(user: current_user))
+    render json: lock
   end
 
   def destroy

--- a/test/controllers/api/locks_controller_test.rb
+++ b/test/controllers/api/locks_controller_test.rb
@@ -35,6 +35,7 @@ describe Api::LocksController do
           post :create, params: {lock: {description: "foo"}}, format: :json
         end
         assert_response :success
+        JSON.parse(response.body).fetch("lock").fetch("id").must_equal Lock.last.id
       end
     end
 


### PR DESCRIPTION
…nblock having multiple warnings later on

this way we can prepare our api clients to delete the specific lock/warning they had set and not some random other warning/lock that is currently active ... will also be needed if we ever allow multiple warnings

/cc @bcolferzd 