### PR TITLE
allow deprecating keys so we stop resolving them but do not break run…

### DIFF
--- a/app/models/secret_storage.rb
+++ b/app/models/secret_storage.rb
@@ -5,7 +5,7 @@ module SecretStorage
   ID_PARTS = [:environment_permalink, :project_permalink, :deploy_group_permalink, :key].freeze
   ID_PART_SEPARATOR = "/"
   SECRET_ID_REGEX = %r{[\w\/-]+}
-  SECRET_LOOKUP_CACHE = 'secret_lookup_cache'
+  SECRET_LOOKUP_CACHE = 'secret_lookup_cache_v2'
   SECRET_LOOKUP_CACHE_MUTEX = Mutex.new
 
   def self.allowed_project_prefixes(user)
@@ -86,8 +86,6 @@ module SecretStorage
       ENV['SECRET_STORAGE_SHARING_GRANTS']
     end
 
-    private
-
     def lookup_cache
       SECRET_LOOKUP_CACHE_MUTEX.synchronize do
         Rails.cache.fetch(SECRET_LOOKUP_CACHE) do
@@ -100,9 +98,13 @@ module SecretStorage
       end
     end
 
+    private
+
     def lookup_cache_value(secret)
       {
-        value_hashed: hash_value(secret.fetch(:value))
+        deprecated_at: secret[:deprecated_at],
+        value_hashed: hash_value(secret.fetch(:value)),
+        visible: secret[:visible]
       }
     end
 

--- a/app/views/secrets/_history.html.erb
+++ b/app/views/secrets/_history.html.erb
@@ -1,4 +1,4 @@
-<% @secret.except(:key, :value, :visible, :comment).each do |attribute, value| %>
+<% @secret.except(:key, :value, :visible, :comment, :deprecated_at).each do |attribute, value| %>
   <%= form.input attribute do %>
     <% if [:creator_id, :updater_id].include?(attribute) %>
       <% if user = User.find_by_id(value) %>

--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -42,7 +42,7 @@
     </thead>
 
     <tbody>
-      <% @secret_ids.each do |id, parts| %>
+      <% @secrets.each do |id, parts, secret_stub| %>
         <tr>
           <td><%= parts.fetch(:environment_permalink) %></td>
           <td>
@@ -59,7 +59,12 @@
           <td title="<%= id %>"><%= parts.fetch(:key) %></td>
           <td>
             <%= link_to "Edit", secret_path(id) %> |
-            <%= link_to_delete(secret_path(id), remove_container: 'tr') %>
+            <%= link_to_delete(secret_path(id), remove_container: 'tr') %> |
+            <%= content_tag :span, icon_tag("eye-open"), title: "Visible" if secret_stub.fetch(:visible) %>
+            <%= if deprecated_at = secret_stub[:deprecated_at]
+                  content_tag :span, icon_tag("warning-sign"), title: "Deprecated #{deprecated_at}"
+                end
+            %>
           </td>
         </tr>
       <% end %>

--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -5,13 +5,17 @@
   deploy_group_groups = environment_permalinks.map do |env_permalink|
     [env_permalink, ['global'] + deploy_groups.select { |dg| dg.environment.permalink == env_permalink }.map(&:permalink)]
   end
+  secret = (id ? @secret.merge(SecretStorage.parse_id(id)) : (params[:secret] || {}))
 %>
 <%= page_title(id ? "Edit #{id}" : "New Secret") %>
+
+<% if id && secret[:deprecated_at] %>
+  <div class="alert alert-danger">DEPRECATED: will no longer be resolved for new deploys.</div>
+<% end %>
 
 <section>
   <% url = (id ? secret_path(id) : secrets_path) %>
   <% method = (id ? :put : :post) %>
-  <% secret = (id ? @secret.merge(SecretStorage.parse_id(id)) : (params[:secret] || {})) %>
 
   <%= form_for OpenStruct.new(secret), as: :secret, url: url, method: method, html: {class: "form-horizontal"} do |form| %>
     <fieldset>
@@ -37,6 +41,10 @@
       <%= form.input :comment, as: :text_area, input_html: {rows: secret[:comment].to_s.count("\n") + 1} %>
 
       <%= form.input :visible, as: :check_box %>
+
+      <%= form.input :deprecated, as: :check_box, label: "Deprecated #{secret[:deprecated_at]}" do %>
+        <%= form.check_box :deprecated_at, {}, secret[:deprecated_at] || Time.now.to_s(:db), "0" %>
+      <% end %>
 
       <%= form.input :value do %>
         <%= form.text_area :value, class: "form-control", rows: 10, placeholder: ('-- hidden --' if id), required: !id %>

--- a/db/migrate/20170727181942_add_deprecated_at_to_secret.rb
+++ b/db/migrate/20170727181942_add_deprecated_at_to_secret.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddDeprecatedAtToSecret < ActiveRecord::Migration[5.1]
+  def change
+    add_column :secrets, :deprecated_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170718083150) do
+ActiveRecord::Schema.define(version: 20170727181942) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -417,6 +417,7 @@ ActiveRecord::Schema.define(version: 20170718083150) do
     t.datetime "updated_at", null: false
     t.boolean "visible", default: false, null: false
     t.string "comment"
+    t.timestamp "deprecated_at"
     t.index ["id"], name: "index_secrets_on_id", unique: true, length: { id: 191 }
   end
 

--- a/lib/samson/secrets/db_backend.rb
+++ b/lib/samson/secrets/db_backend.rb
@@ -30,6 +30,7 @@ module Samson
           secret = Secret.where(id: id).first_or_initialize
           secret.value = data.fetch(:value)
           secret.visible = data.fetch(:visible)
+          secret.deprecated_at = data.fetch(:deprecated_at)
           secret.comment = data.fetch(:comment)
           secret.updater_id = data.fetch(:user_id)
           secret.creator_id ||= data.fetch(:user_id)
@@ -54,6 +55,7 @@ module Samson
           {
             value: secret.value,
             visible: secret.visible,
+            deprecated_at: secret.deprecated_at&.to_s(:db),
             comment: secret.comment,
             updater_id: secret.updater_id,
             creator_id: secret.creator_id,

--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -10,6 +10,7 @@ module Samson
       # / means diretory in vault and we want to keep all the ids in the same folder
       DIRECTORY_SEPARATOR = "/"
       ID_SEGMENTS = 4
+      IMPORTANT_COLUMNS = [:visible, :deprecated_at, :comment, :creator_id, :updater_id].freeze
 
       class << self
         def read(id)
@@ -81,8 +82,9 @@ module Samson
           nil # ignore errors in here
         end
 
+        # write to the backend ... but exclude metadata from a read/write update cycle
         def deep_write(id, data)
-          important = {vault: data.fetch(:value)}.merge(data.slice(:visible, :comment, :creator_id, :updater_id))
+          important = {vault: data.fetch(:value)}.merge(data.slice(*IMPORTANT_COLUMNS))
           vault_action(:write, vault_path(id, :encode), important)
         end
 

--- a/test/lib/samson/secrets/key_resolver_test.rb
+++ b/test/lib/samson/secrets/key_resolver_test.rb
@@ -46,6 +46,18 @@ describe Samson::Secrets::KeyResolver do
       )
     end
 
+    it "does not find deprecated" do
+      SecretStorage.write(
+        "global/global/global/bar",
+        value: 'dsffd',
+        comment: '',
+        deprecated_at: Time.now.to_s(:db),
+        user_id: users(:admin).id,
+        visible: true
+      )
+      resolver.expand('ABC', 'bar').must_equal []
+    end
+
     describe "wildcards" do
       it "fails when only name has wildcard" do
         resolver.expand('ABC_*', 'ba').must_equal []

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -17,7 +17,9 @@ describe SecretStorage do
   end
 
   describe ".write" do
-    let(:attributes) { {value: '111', user_id: users(:admin).id, visible: false, comment: 'comment'} }
+    let(:attributes) do
+      {value: '111', user_id: users(:admin).id, visible: false, comment: 'comment', deprecated_at: nil}
+    end
 
     it "writes" do
       id = 'production/foo/pod2/hello'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -109,7 +109,8 @@ class ActiveSupport::TestCase
       value: 'MY-SECRET',
       visible: false,
       comment: 'this is secret',
-      user_id: users(:admin).id
+      user_id: users(:admin).id,
+      deprecated_at: nil
     )
     SecretStorage::DbBackend::Secret.find(id) # TODO: just return id
   end


### PR DESCRIPTION
…ning pods

Replacing used secrets is tricky atm: they will be instantly deleted and running pods can no longer restart,
so all projects that use the secret need to be re-deployed which is dangerous and brittle.

This PR will make new deploys fail during resolve phase and old deploys able to restart
once a id is deprecated a while it should be able to be deleted without side-effects

@irwaters @jonmoter @craig-day 
