### PR TITLE
speed up secret search by value

### DIFF
--- a/lib/samson/secrets/db_backend.rb
+++ b/lib/samson/secrets/db_backend.rb
@@ -44,12 +44,6 @@ module Samson
           Secret.order(:id).pluck(:id)
         end
 
-        def filter_ids_by_value(ids, value)
-          ids.each_slice(1000).flat_map do |group|
-            Secret.where(id: group).select { |s| Rack::Utils.secure_compare(s.value, value) }.map(&:id)
-          end
-        end
-
         def deploy_groups
           DeployGroup.all
         end

--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -65,11 +65,6 @@ module Samson
           ids.map! { |secret_path| vault_path(secret_path, :decode) }
         end
 
-        def filter_ids_by_value(ids, value)
-          all = read_multi(ids)
-          all.map { |k, v| k if Rack::Utils.secure_compare(v.fetch(:value), value) }.compact
-        end
-
         def deploy_groups
           DeployGroup.where.not(vault_server_id: nil)
         end

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -57,7 +57,7 @@ describe SecretsController do
         create_secret 'production/global/pod2/bar'
         get :index, params: {search: {environment_permalink: 'production'}}
         assert_template :index
-        assigns[:secret_ids].map(&:first).must_equal ["production/global/pod2/bar", "production/global/pod2/foo"]
+        assigns[:secret_ids].map(&:first).sort.must_equal ["production/global/pod2/bar", "production/global/pod2/foo"]
       end
 
       it 'can filter by project' do
@@ -71,7 +71,7 @@ describe SecretsController do
         create_secret 'production/global/pod2/bar'
         get :index, params: {search: {deploy_group_permalink: 'pod2'}}
         assert_template :index
-        assigns[:secret_ids].map(&:first).must_equal ["production/global/pod2/bar", "production/global/pod2/foo"]
+        assigns[:secret_ids].map(&:first).sort.must_equal ["production/global/pod2/bar", "production/global/pod2/foo"]
       end
 
       it 'can filter by key' do
@@ -83,8 +83,8 @@ describe SecretsController do
 
       it 'can filter by value' do
         other = create_secret 'production/global/pod2/baz'
-        other.update_attribute(:value, 'other')
-        get :index, params: {search: {value: other.value}}
+        SecretStorage.write other.id, value: 'other', user_id: 1, visible: true, comment: nil
+        get :index, params: {search: {value: 'other'}}
         assert_template :index
         assigns[:secret_ids].map(&:first).must_equal [other.id]
       end

--- a/test/lib/samson/secrets/db_backend_test.rb
+++ b/test/lib/samson/secrets/db_backend_test.rb
@@ -48,14 +48,6 @@ describe Samson::Secrets::DbBackend do
     end
   end
 
-  describe ".filter_ids_by_value" do
-    it "filters ids" do
-      id = secret.id
-      Samson::Secrets::DbBackend.filter_ids_by_value([id], 'NOPE').must_equal []
-      Samson::Secrets::DbBackend.filter_ids_by_value([id], secret.value).must_equal [id]
-    end
-  end
-
   describe ".delete" do
     it "deletes" do
       Samson::Secrets::DbBackend.delete(secret.id)

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -159,25 +159,6 @@ describe Samson::Secrets::HashicorpVaultBackend do
     end
   end
 
-  describe ".filter_ids_by_value" do
-    let(:id) { "production/foo/pod2/bar" }
-
-    it "ignore non-matching" do
-      assert_vault_request :get, id, body: {data: { vault: "SECRET"}}.to_json do
-        backend.filter_ids_by_value([id], 'NOPE').must_equal []
-      end
-    end
-
-    it "finds matching" do
-      missing = "production/foo/pod2/nope"
-      assert_vault_request :get, id, body: {data: { vault: "SECRET"}}.to_json do
-        assert_vault_request :get, missing, status: 404 do
-          backend.filter_ids_by_value([id, missing], "SECRET").must_equal [id]
-        end
-      end
-    end
-  end
-
   describe "raises BackendError when a vault instance is down/unreachable" do
     let(:client) { Samson::Secrets::VaultClient.client }
 

--- a/test/models/secret_storage_test.rb
+++ b/test/models/secret_storage_test.rb
@@ -173,14 +173,26 @@ describe SecretStorage do
       SecretStorage.ids.must_equal []
     end
 
-    it "does not cache when cache did not exist" do
+    it "caches when cache did not exist" do
       SecretStorage.backend.expects(:ids).never # block call
       SecretStorage.delete(secret.id)
-      Rails.cache.read(SecretStorage::SECRET_IDS_CACHE).must_be_nil
+      Rails.cache.read(SecretStorage::SECRET_LOOKUP_CACHE).must_equal({})
     end
   end
 
   describe ".ids" do
+    # raw insert to bypass cache
+    let(:secret) do
+      SecretStorage::DbBackend::Secret.create!(
+        id: 'production/foo/pod2/hello',
+        value: 'MY-SECRET',
+        visible: false,
+        comment: 'this is secret',
+        updater_id: users(:admin).id,
+        creator_id: users(:admin).id
+      )
+    end
+
     it "lists ids" do
       secret # trigger creation
       SecretStorage.ids.must_equal ['production/foo/pod2/hello']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -103,15 +103,15 @@ class ActiveSupport::TestCase
     undef :test
   end
 
-  def create_secret(key)
-    SecretStorage::DbBackend::Secret.create!(
-      id: key,
+  def create_secret(id)
+    SecretStorage.write(
+      id,
       value: 'MY-SECRET',
       visible: false,
       comment: 'this is secret',
-      updater_id: users(:admin).id,
-      creator_id: users(:admin).id
+      user_id: users(:admin).id
     )
+    SecretStorage::DbBackend::Secret.find(id) # TODO: just return id
   end
 
   def create_vault_server(overrides = {})


### PR DESCRIPTION
instead of caching just the ids switch to caching selected metadata ... being careful not to keep secret values in memory

 - prepares duplication check on save ... since now it can be fast
 - prepared deprecated secrets ... since now we can store `deprecated` it in this cache
 - prepares showing more metadata in index page (visible/deprecated/has-comment etc)