### PR TITLE
allow updating secret comments without having to know the secret

### DIFF
--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -12,7 +12,6 @@
   <% url = (id ? secret_path(id) : secrets_path) %>
   <% method = (id ? :put : :post) %>
   <% secret = (id ? @secret.merge(SecretStorage.parse_id(id)) : (params[:secret] || {})) %>
-  <% edit_disabled = id && !secret[:visible] # prevent users from accidentally updating with an empty value %>
 
   <%= form_for OpenStruct.new(secret), as: :secret, url: url, method: method, html: {class: "form-horizontal"} do |form| %>
     <fieldset>
@@ -35,12 +34,12 @@
 
       <%= form.input :key, input_html: {disabled: !!id}, required: true %>
 
-      <%= form.input :comment, as: :text_area, input_html: {disabled: edit_disabled, class: "form-control disabled-on-edit", rows: secret[:comment].to_s.count("\n") + 1} %>
+      <%= form.input :comment, as: :text_area, input_html: {rows: secret[:comment].to_s.count("\n") + 1} %>
 
-      <%= form.input :visible, as: :check_box, input_html: {disabled: edit_disabled} %>
+      <%= form.input :visible, as: :check_box %>
 
       <%= form.input :value do %>
-        <%= form.text_area :value, class: "form-control", rows: 10, placeholder: '-- hidden, click to replace --', disabled: edit_disabled %>
+        <%= form.text_area :value, class: "form-control", rows: 10, placeholder: ('-- hidden --' if id), required: !id %>
         <div id="value_json_warning" class="alert-danger"></div>
       <% end %>
 
@@ -103,14 +102,6 @@ $(function () {
       }
     }
   }).trigger("keyup");
-
-  // when a user decides to edit show all the fields that will be changed at once
-  // DOM events on disabled elements do not work, so attaching to parents
-  var disabled = $('#secret_comment, #secret_visible, #secret_value');
-  disabled.parent().one('click', function(){
-    disabled.attr('disabled', false);
-    disabled.attr('placeholder', '');
-  });
 });
 
 </script>


### PR DESCRIPTION
this will be the basis for adding the deprecated field later

<img width="573" alt="screen shot 2017-07-27 at 12 15 37 pm" src="https://user-images.githubusercontent.com/11367/28688799-03188d74-72c8-11e7-9234-d5c1d453388a.png">
<img width="330" alt="screen shot 2017-07-27 at 12 15 31 pm" src="https://user-images.githubusercontent.com/11367/28688801-0320a810-72c8-11e7-9e90-2a0d8a071957.png">

now users can update comments ... but cannot make a invisible secret visible