### PR TITLE
display active jobs properly in the active tab

### DIFF
--- a/app/views/deploys/_deploy.html.erb
+++ b/app/views/deploys/_deploy.html.erb
@@ -5,7 +5,7 @@
     <% end %>
     <td><%= render_time(deploy.start_time) %></td>
     <td>
-      <%= link_to "#{deploy.summary}", [@project || deploy.project, deploy] %>
+      <%= link_to deploy.summary, [@project || deploy.project, deploy] %>
     </td>
     <% unless @stage %>
       <td><%= link_to deploy.stage.name, [deploy.project, deploy.stage] %></td>

--- a/app/views/deploys/_job_executions.html.erb
+++ b/app/views/deploys/_job_executions.html.erb
@@ -14,10 +14,17 @@
     <% job_executions.each do |queue, job_exs| %>
       <tr><td colspan="6">Queue <%= queue %></td></tr>
       <% Array(job_exs).each do |job_ex| %>
-        <% if deploy = job_ex.job.deploy %>
+        <% job = job_ex.job %>
+        <% if deploy = job.deploy %>
           <%= render deploy %>
         <% else %>
-          <%= link_to job_ex.id, project_job_path(job_ex.job.project, job_ex.job) %>
+          <tr>
+            <td><%= link_to_resource job.project %></td>
+            <td><%= render_time(job.created_at) %></td>
+            <td><%= link_to "#{job.summary}", [job.project, job] %></td>
+            <td></td>
+            <td><%= job_status_badge job %></td>
+          </tr>
         <% end %>
       <% end %>
     <% end %>

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -52,9 +52,9 @@ describe DeploysController do
         JobExecution.any_instance.expects(:start!)
         with_job_execution do
           # start 1 job and queue another
-          active = Job.new(project: project) { |j| j.id = 123321 }
+          active = Job.create!(project: project, command: "echo 1", user: user) { |j| j.id = 123321 }
           active.stubs(:deploy).returns(deploy)
-          queued = Job.new(project: project) { |j| j.id = 234432 }
+          queued = Job.create!(project: project, command: "echo 1", user: user) { |j| j.id = 234432 }
           JobExecution.start_job(JobExecution.new('master', active), queue: :x)
           JobExecution.start_job(JobExecution.new('master', queued), queue: :x)
           JobExecution.active.size.must_equal 1


### PR DESCRIPTION
before:
![screen shot 2017-07-28 at 11 32 12 am](https://user-images.githubusercontent.com/11367/28731361-6d084b3c-7388-11e7-868d-966f9b895876.png)


after:
![screen shot 2017-07-28 at 11 30 57 am](https://user-images.githubusercontent.com/11367/28731355-646f9976-7388-11e7-9c9b-565253c299aa.png)
