### PR TITLE
Add API ping endpoint

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -27,7 +27,7 @@ class Api::BaseController < ApplicationController
   # and raising an error somewhere ... cannot be tested with an integration test
   def enforce_json_format
     return if request.format == :json
-    render_json_error 415, 'JSON only api. Use json extension or set content type application/json'
+    render_json_error 415, 'JSON only api. Use json extension or set Accept header to application/json'
   end
 
   # remove web-ui scope

--- a/app/controllers/api/ping_controller.rb
+++ b/app/controllers/api/ping_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Api::PingController < Api::BaseController
+  before_action :authorize_resource!
+
+  def index
+    head :ok
+  end
+end

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -44,6 +44,11 @@ class AccessControl
         when :write then user.super_admin?
         else raise ArgumentError, "Unsupported action #{action}"
         end
+      when 'ping'
+        case action
+        when :read then true
+        else raise ArgumentError, "Unsupported action #{action}"
+        end
       else
         raise ArgumentError, "Unsupported resource #{resource}"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Samson::Application.routes.draw do
     delete '/locks', to: 'locks#destroy_via_resource'
 
     resources :users, only: [:destroy]
+
+    resources :ping, only: [:index]
   end
 
   resources :projects do

--- a/test/controllers/api/ping_controller_test.rb
+++ b/test/controllers/api/ping_controller_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Api::PingController do
+  oauth_setup!
+
+  before { @request_format = :json }
+
+  as_a_viewer do
+    describe "#index" do
+      it "succeeds" do
+        get :index, format: :json
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/models/access_control_test.rb
+++ b/test/models/access_control_test.rb
@@ -192,4 +192,16 @@ describe AccessControl do
       end
     end
   end
+
+  describe "ping" do
+    it "fails on unknown action" do
+      assert_raises(ArgumentError) { can?(admin, :fooo) }
+    end
+
+    describe :read do
+      it "allows anyone to read" do
+        assert can?(viewer, :read)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new `/api/ping` endpoint that can be used to verify the OAuth access token, and also test the API's availability (albeit, at a very basic level)

/cc @zendesk/samson @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
