### PR TITLE
Add API user search endpoint

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,7 +3,13 @@ class Api::UsersController < Api::BaseController
   before_action :authorize_resource!
 
   def destroy
-    User.find(params.require(:id)).soft_delete!
-    head :ok
+    user = User.where(id: params.require(:id)).first
+
+    if user
+      user.soft_delete!
+      head :ok
+    else
+      head :not_found
+    end
   end
 end

--- a/app/controllers/api/users_search_controller.rb
+++ b/app/controllers/api/users_search_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class Api::UsersSearchController < Api::BaseController
+  before_action :authorize_resource!
+
+  def index
+    user = User.where(email: params.require(:email)).first
+    if user
+      render json: user
+    else
+      render json: {}, status: :not_found
+    end
+  end
+end

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -32,6 +32,11 @@ class AccessControl
         when :write then user.super_admin?
         else raise ArgumentError, "Unsupported action #{action}"
         end
+      when 'users_search'
+        case action
+        when :read then user.super_admin?
+        else raise ArgumentError, "Unsupported action #{action}"
+        end
       when 'secrets'
         case action
         when :read then can_deploy_anything?(user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Samson::Application.routes.draw do
     delete '/locks', to: 'locks#destroy_via_resource'
 
     resources :users, only: [:destroy]
+
+    resources :users_search, only: [:index]
   end
 
   resources :projects do

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -14,6 +14,11 @@ describe Api::UsersController do
 
   as_a_super_admin do
     describe "#destroy" do
+      it "returns 404" do
+        delete :destroy, params: {id: -1}, format: :json
+        assert_response :not_found
+      end
+
       it "deletes" do
         delete :destroy, params: {id: users(:admin)}, format: :json
         assert_response :success

--- a/test/controllers/api/users_search_controller_test.rb
+++ b/test/controllers/api/users_search_controller_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Api::UsersSearchController do
+  oauth_setup!
+
+  before { @request_format = :json }
+
+  as_an_admin do
+    unauthorized :get, :index, params: {email: "no-matter@example.com"}, format: :json
+  end
+
+  as_a_super_admin do
+    describe "#create" do
+      it "returns 404" do
+        get :index, params: {email: 'unknown@example.com'}, format: :json
+
+        data = JSON.parse(response.body)
+        assert_response :not_found
+        assert_equal data, {}
+      end
+
+      it "returns a match" do
+        get :index, params: {email: users(:admin).email}, format: :json
+
+        data = JSON.parse(response.body)
+        assert_response :success
+        assert_equal data, "user" => {
+          "id" => 135138680, "name" => "Admin", "email" => "admin@example.com",
+          "role_id" => 2,
+          "gravatar_url" => "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61",
+          "time_format" => "relative"
+        }
+      end
+    end
+  end
+end

--- a/test/models/access_control_test.rb
+++ b/test/models/access_control_test.rb
@@ -192,4 +192,20 @@ describe AccessControl do
       end
     end
   end
+
+  describe "users_search" do
+    it "fails on unknown action" do
+      assert_raises(ArgumentError) { can?(admin, :fooo) }
+    end
+
+    describe :read do
+      it "allows super-admins to search" do
+        assert can?(super_admin, :read)
+      end
+
+      it "forbids admins to search" do
+        refute can?(admin, :read)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new `/api/user_search` endpoint that allows one to search for a user given their email address.

/cc @zendesk/samson @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
