### PR TITLE
Show and destroy users via API with email support

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,6 +2,19 @@
 class Api::UsersController < Api::BaseController
   before_action :authorize_resource!
 
+  def show
+    render json: User.find(params.require(:id))
+  end
+
+  def show_via_resource
+    user = User.search_by_criteria(
+      search: "",
+      email: params.fetch(:email).presence
+    ).first!
+
+    render json: user
+  end
+
   def destroy
     User.find(params.require(:id)).soft_delete!
     head :ok

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,8 @@ Samson::Application.routes.draw do
     resources :locks, only: [:index, :create, :destroy]
     delete '/locks', to: 'locks#destroy_via_resource'
 
-    resources :users, only: [:destroy]
+    resources :users, only: [:show, :destroy]
+    get '/users', to: 'users#show_via_resource'
   end
 
   resources :projects do

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -8,11 +8,45 @@ describe Api::UsersController do
 
   before { @request_format = :json }
 
+  as_a_deployer do
+    unauthorized :get, :show, id: 1, format: :json
+    unauthorized :get, :show_via_resource, email: 'no-matter@example.com', format: :json
+    unauthorized :delete, :destroy, id: 1, format: :json
+  end
+
   as_an_admin do
+    describe "#show" do
+      it "shows" do
+        get :show, params: {id: users(:admin)}, format: :json
+        assert_response :success
+      end
+    end
+
+    unauthorized :get, :show_via_resource, email: 'no-matter@example.com', format: :json
     unauthorized :delete, :destroy, id: 1, format: :json
   end
 
   as_a_super_admin do
+    describe "#show" do
+      it "shows" do
+        get :show, params: {id: users(:admin)}, format: :json
+        data = JSON.parse(response.body)
+
+        assert_response :success
+        assert_equal data['user']['id'], 135138680
+      end
+    end
+
+    describe "#show_via_resource" do
+      it "shows" do
+        get :show_via_resource, params: {email: users(:admin).email}, format: :json
+        data = JSON.parse(response.body)
+
+        assert_response :success
+        assert_equal data['user']['email'], 'admin@example.com'
+      end
+    end
+
     describe "#destroy" do
       it "deletes" do
         delete :destroy, params: {id: users(:admin)}, format: :json


### PR DESCRIPTION
This PR enhances `/api/users` to support `show`ng using the user's email address.

This extends the work merged in https://github.com/zendesk/samson/pull/2161

/cc @zendesk/samson @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
