### PR TITLE
bump docker read timeout back up and make it configureable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # DOCKER_REGISTRIES=https://user:pass@my.registry/some-namespace # required, where to push/pull your docker images
 # DOCKER_HOST= # e.g. tcp://my-docker-registry.example.com:2375
 # DOCKER_KEEP_BUILT_IMGS # optional. Set to 1 to keep built images for cache. Fills the disk so some cleanup machanism is needed
+# DOCKER_READ_TIMEOUT=600 # optional. How long to wait on docker reads.
 
 # FLOWDOCK_API_TOKEN= # optional. only required for the flowdock integration user mention autocomplete in the buddy approval request form (when BUDDY_CHECK_FEATURE=1). Buddy approval notification would still work without this
 

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -9,7 +9,7 @@ if !Rails.env.test? && !ENV['PRECOMPILE'] && ENV['DOCKER_FEATURE']
     Docker.url = url
   end
 
-  Docker.options = { read_timeout: 2, connect_timeout: 2 }
+  Docker.options = { read_timeout: Integer(ENV['DOCKER_READ_TIMEOUT'] || '10'), connect_timeout: 2 }
   begin
     Docker.validate_version! # Confirm the Docker daemon is a recent enough version
   rescue Docker::Error::TimeoutError


### PR DESCRIPTION
FYI https://github.com/zendesk/samson/pull/490 lied ... long build steps work just fine ... just uploading to ECR seems to fail