### PR TITLE
add the required imagePullPolicy for initContainers in k8s 1.5

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -95,6 +95,7 @@ module Kubernetes
       secret_vol = { mountPath: "/secrets", name: "secrets-volume" }
       unshift_init_container(
         image: SECRET_PULLER_IMAGE,
+        imagePullPolicy: 'IfNotPresent',
         name: 'secret-puller',
         volumeMounts: [
           { mountPath: "/vault-auth", name: "vaultauth" },


### PR DESCRIPTION
Newer versions of kubernetes require an `imagePullPolicy` for init containers. Lets set one for secrets. 

```
Kubernetes error: Deployment.extensions "classic-worker" is invalid: spec.template.spec.initContainers[0].imagePullPolicy: Required value
```

/cc @zendesk/samson

### Risks
- Level: Low. Only adding what was the default pull policy to be explicit for secrets container.
