### PR TITLE
Periodical deploy feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,8 @@ GITHUB_TOKEN=
 # remove_expired_locks:10
 # renew_vault_token:86400
 # report_system_stats:60
-PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60
+# periodical_deploy:86400
+PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,periodical_deploy:86400
 
 ## Buddy Check feature: deploys to production require a buddy
 # BUDDY_CHECK_FEATURE=1 # optional, enable

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -117,6 +117,7 @@ class StagesController < ApplicationController
       :is_template,
       :run_in_parallel,
       :cancel_queued_deploys,
+      :periodical_deploy,
       :no_reference_selection,
       {
         deploy_group_ids: [],

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -32,6 +32,8 @@
 
   <%= form.input :no_reference_selection, as: :check_box, label: "Disable reference selection", help: no_ref_label %>
 
+  <%= form.input :periodical_deploy, as: :check_box, help: "Deploy periodically if last deploy succeeded, enable automated deploy failure email to be alerted " if Samson::Periodical.enabled?(:periodical_deploy) %>
+
   <% if @project.releases.any? %>
     <%= form.input :deploy_on_release, as: :check_box, label: "Automatically deploy new releases" %>
   <% end %>

--- a/config/initializers/periodical.rb
+++ b/config/initializers/periodical.rb
@@ -29,6 +29,13 @@ Samson::Periodical.register :report_system_stats, "Report system stats" do
   )
 end
 
+Samson::Periodical.register :periodical_deploy, "Deploy periodical stages" do |execution_interval|
+  time_to_next_execution = execution_interval - (Time.now.to_i % execution_interval)
+  Concurrent::ScheduledTask.execute(time_to_next_execution) do
+    Samson::PeriodicalDeploy.run
+  end
+end
+
 if ENV['SERVER_MODE']
   Rails.application.config.after_initialize { Samson::Periodical.run }
 end

--- a/db/migrate/20170728231915_add_daily_deploymemnt_to_stages.rb
+++ b/db/migrate/20170728231915_add_daily_deploymemnt_to_stages.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class AddDailyDeploymemntToStages < ActiveRecord::Migration[5.1]
+  EXTERNAL_ID = Samson::PeriodicalDeploy::EXTERNAL_ID
+
+  class User < ActiveRecord::Base
+  end
+
+  def up
+    add_column :stages, :periodical_deploy, :boolean, default: false, null: false
+    User.create!(
+      external_id: EXTERNAL_ID,
+      name: "Periodical Deployer",
+      integration: true,
+      role_id: Role::DEPLOYER.id
+    )
+    write "Created user #{EXTERNAL_ID}"
+  end
+
+  def down
+    remove_column :stages, :periodical_deploy
+    User.where(external_id: EXTERNAL_ID).first&.soft_delete!(validate: false)
+    write "Deleted user #{EXTERNAL_ID}"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170727181942) do
+ActiveRecord::Schema.define(version: 20170728231915) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -497,6 +497,7 @@ ActiveRecord::Schema.define(version: 20170727181942) do
     t.boolean "jenkins_build_params", default: false, null: false
     t.boolean "cancel_queued_deploys", default: false, null: false
     t.boolean "no_reference_selection", default: false, null: false
+    t.boolean "periodical_deploy", default: false, null: false
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end

--- a/lib/samson/periodical_deploy.rb
+++ b/lib/samson/periodical_deploy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Samson
+  module PeriodicalDeploy
+    # do not change, used in db/migrate/20170728231915_add_daily_deploymemnt_to_stages.rb
+    EXTERNAL_ID = "periodical deploy"
+
+    def self.run
+      # find all periodical stages
+      Stage.where(periodical_deploy: true).all.each do |stage|
+        # find out the latest deploy version
+        next unless deploy = stage.last_deploy
+        next unless deploy.succeeded?
+
+        deployer = User.where(external_id: EXTERNAL_ID).first!
+        DeployService.new(deployer).deploy!(
+          stage,
+          reference: deploy.reference,
+          buddy_id: deploy.buddy_id || deploy.job.user_id
+        )
+      end
+    end
+  end
+end

--- a/test/lib/samson/periodical_deploy_test.rb
+++ b/test/lib/samson/periodical_deploy_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::PeriodicalDeploy do
+  describe ".run" do
+    let(:stage) { stages(:test_staging) }
+    let!(:deployer) do
+      # must be in sync with db/migrate/20170728231915_add_daily_deploymemnt_to_stages.rb
+      User.create!(
+        external_id: Samson::PeriodicalDeploy::EXTERNAL_ID,
+        name: "Periodical Deployer",
+        integration: true,
+        role_id: Role::DEPLOYER.id
+      )
+    end
+
+    before do
+      stage.update_column :periodical_deploy, true
+      stage.last_deploy.job.update_column :status, 'succeeded'
+      stage.last_deploy.update_column :buddy_id, users(:admin).id
+    end
+
+    it "deploys periodical stages" do
+      assert_difference "stage.deploys.count", +1 do
+        Samson::PeriodicalDeploy.run
+      end
+      deploy = stage.deploys.first
+      deploy.reference.must_equal "staging"
+      deploy.buddy.must_equal users(:admin)
+    end
+
+    it "does not deploy failed deploys" do
+      stage.last_deploy.job.update_column :status, 'failed'
+      refute_difference "stage.deploys.count" do
+        Samson::PeriodicalDeploy.run
+      end
+    end
+
+    it "does not deploy if stage was never deployed" do
+      stage.deploys.delete_all
+      refute_difference "stage.deploys.count" do
+        Samson::PeriodicalDeploy.run
+      end
+    end
+
+    it "fails when there is no periodical deploy user" do
+      deployer.delete
+      assert_raises ActiveRecord::RecordNotFound do
+        Samson::PeriodicalDeploy.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
Problem: Hardware or network changes may cause deploys that previously worked to fail.
Solution: Period deploys quickly show that deploys are broken, so that deployers don't find errors when something has to be deployed. It also helps Ops to find bad changes faster.

Relies on automated failure notification to alert.

/cc @zendesk/samson 

### Risks
- Level: None--new opt-in feature added
