### PR TITLE
do not add email flag on newer docker clients

### DIFF
--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -10,6 +10,7 @@ if !Rails.env.test? && !ENV['PRECOMPILE'] && ENV['DOCKER_FEATURE']
   end
 
   Docker.options = { read_timeout: Integer(ENV['DOCKER_READ_TIMEOUT'] || '10'), connect_timeout: 2 }
+
   begin
     Docker.validate_version! # Confirm the Docker daemon is a recent enough version
   rescue Docker::Error::TimeoutError, Excon::Error::Socket


### PR DESCRIPTION
`[22:06:28] Flag --email has been deprecated, will be removed in 17.06.`
