### PR TITLE
change job in the same thread so we do not get into race conditions

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -60,11 +60,13 @@ class JobExecution
 
   def cancel
     @cancelled = true
+    @job.cancelling!
     @executor.cancel 'INT'
     unless @thread.join(cancel_timeout)
       @executor.cancel 'KILL'
       @thread.join(cancel_timeout) || @thread.kill
     end
+    @job.cancelled!
     finish
   end
 

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -312,6 +312,13 @@ describe Job do
       job.canceller.must_equal user
     end
 
+    it "does not cancel finished job" do
+      job.failed!
+      job.cancel(user)
+      assert job.failed?
+      job.canceller.must_be_nil
+    end
+
     it "cancels a queued job" do
       active_job = project.jobs.new(command: 'cat foo', user: user, project: project, commit: 'master')
       active = JobExecution.new('master', active_job) { sleep 10 }


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/2004339734687985309

after_deploy hook gets called on running deploys since we update the job
in a different thread

/cc @zendesk/samson 