### PR TITLE
make js testsy not doing an .on inside of a .ready

### DIFF
--- a/plugins/new_relic/app/assets/javascripts/new_relic/application.js
+++ b/plugins/new_relic/app/assets/javascripts/new_relic/application.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).ready(function($) {
   var newrelic_loaded = false;
 
   $('#newrelic-tab').on('shown.bs.tab', function(e) {


### PR DESCRIPTION
```
PhantomJS 2.1.1 (Mac OS X 0.0.0) currentDeployBadgeCtrl init hides badge if there are no deploys FAILED
  TypeError: undefined is not a constructor (evaluating '$('#newrelic-tab').on') thrown
```

randomly started failing on master without any related change ... removing npm_modules caused it to happen locally as well