### PR TITLE
do not blow up when rendering users unknown to github

### DIFF
--- a/app/models/changeset/github_user.rb
+++ b/app/models/changeset/github_user.rb
@@ -1,24 +1,31 @@
 # frozen_string_literal: true
 require 'uri'
 
+# unknown users are considered the same since we do not have any identifying information in the user data
+# and we don't want to show 10 'unknown' users on the release show page
 class Changeset::GithubUser
   def initialize(data)
     @data = data
   end
 
   def avatar_url(size = 20)
-    uri = URI(@data.avatar_url)
-    params = URI.decode_www_form(uri.query || [])
+    url = @data.avatar_url
+    if url
+      uri = URI(@data.avatar_url)
+      params = URI.decode_www_form(uri.query || [])
 
-    # The `s` parameter controls the size of the avatar.
-    params << ["s", size.to_s]
+      # The `s` parameter controls the size of the avatar.
+      params << ["s", size.to_s]
 
-    uri.query = URI.encode_www_form(params)
-    uri.to_s
+      uri.query = URI.encode_www_form(params)
+      uri.to_s
+    else
+      'https://assets-cdn.github.com/images/gravatars/gravatar-user-420.png'
+    end
   end
 
   def url
-    "#{Rails.application.config.samson.github.web_url}/#{login}"
+    "#{Rails.application.config.samson.github.web_url}/#{login}" if login
   end
 
   def login
@@ -26,7 +33,7 @@ class Changeset::GithubUser
   end
 
   def identifier
-    "@#{login}"
+    "@#{login}" if login
   end
 
   def eql?(other)
@@ -34,6 +41,6 @@ class Changeset::GithubUser
   end
 
   def hash
-    login.hash
+    login&.hash || 123456789
   end
 end

--- a/test/models/changeset/github_user_test.rb
+++ b/test/models/changeset/github_user_test.rb
@@ -13,16 +13,26 @@ describe Changeset::GithubUser do
       )
     )
   end
+  # comitter with email unknown to github
+  let(:unknown_user) { Changeset::GithubUser.new(stub("data", login: nil, avatar_url: nil)) }
 
   describe "#avatar_url" do
     it "returns the URL for the user's avatar" do
       user.avatar_url.must_equal "https://avatars.githubusercontent.com/u/1337?v=2&s=20"
+    end
+
+    it "returns default avatar when user is unknown" do
+      unknown_user.avatar_url.must_equal "https://assets-cdn.github.com/images/gravatars/gravatar-user-420.png"
     end
   end
 
   describe "#url" do
     it "returns an url" do
       user.url.must_equal "https://github.com/foo"
+    end
+
+    it "returns nil when user is unknown" do
+      unknown_user.url.must_be_nil
     end
   end
 
@@ -36,6 +46,10 @@ describe Changeset::GithubUser do
     it "returns an identifier" do
       user.identifier.must_equal "@foo"
     end
+
+    it "returns nil an identifier" do
+      unknown_user.identifier.must_equal nil
+    end
   end
 
   describe "#eql?" do
@@ -48,11 +62,24 @@ describe Changeset::GithubUser do
       other = Changeset::GithubUser.new(stub("data", login: "bar "))
       user.eql?(other).must_equal false
     end
+
+    it "is equal if both users are unknown" do
+      other = Changeset::GithubUser.new(stub("data", login: nil))
+      unknown_user.eql?(other).must_equal true
+    end
+
+    it "is equal for same unknown user" do
+      unknown_user.eql?(unknown_user).must_equal true
+    end
   end
 
   describe "#hash" do
     it "returns the hash of a login" do
       user.hash.must_equal "foo".hash
+    end
+
+    it "returns static id for unknown" do
+      unknown_user.hash.must_equal 123456789
     end
   end
 end


### PR DESCRIPTION
https://zendesk.airbrake.io/projects/95346/groups/2018746099833448961

`ActionView::Template::Error: bad argument (expected URI object or URI string)`
