### PR TITLE
make deploy not fail when user has no email

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -78,7 +78,7 @@ module Kubernetes
     end
 
     def set_deployer
-      annotations[:deployer] = @doc.kubernetes_release.user&.email
+      annotations[:deployer] = @doc.kubernetes_release.user&.email.to_s
     end
 
     def secret_annotations

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -90,6 +90,11 @@ describe Kubernetes::TemplateFiller do
       template.to_hash[:spec][:template][:metadata][:annotations].must_equal(deployer: "deployer@example.com")
     end
 
+    it "does not set nil deployer which breaks kubernetes api" do
+      doc.kubernetes_release.user.email = nil
+      template.to_hash[:spec][:template][:metadata][:annotations].must_equal(deployer: "")
+    end
+
     describe "containers" do
       let(:result) { template.to_hash }
       let(:container) { result.fetch(:spec).fetch(:template).fetch(:spec).fetch(:containers).first }


### PR DESCRIPTION
`[00:00:13] JobExecution failed: Pod in version "v1" cannot be handled as a Pod: [pos 420]: json: expect char '"' but got char 'n'
`

@yizhang-zen 