### PR TITLE
remove redundant direct association in preparation for multi builds PR

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -8,6 +8,9 @@ class BuildsController < ApplicationController
 
   def index
     @builds = current_project.builds.order('id desc').page(page)
+    if search = params[:search]
+      @builds = @builds.where(search.permit(*Build.column_names))
+    end
 
     respond_to do |format|
       format.html

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -9,7 +9,6 @@ class Build < ActiveRecord::Base
   belongs_to :docker_build_job, class_name: 'Job', optional: true
   belongs_to :creator, class_name: 'User', foreign_key: 'created_by'
   has_many :deploys
-  has_many :releases
 
   validates :project, presence: true
   validates :git_sha, format: SHA1_REGEX, allow_nil: true, uniqueness: true

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -5,7 +5,6 @@ class Release < ActiveRecord::Base
 
   belongs_to :project, touch: true
   belongs_to :author, polymorphic: true
-  belongs_to :build, optional: true # association is not necessary since the release commit is the same as the build sha
 
   before_validation :assign_release_number
   before_validation :covert_ref_to_sha

--- a/db/migrate/20170824174718_remove_build_from_releases.rb
+++ b/db/migrate/20170824174718_remove_build_from_releases.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class RemoveBuildFromReleases < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :releases, :build_id
+    remove_column :kubernetes_releases, :build_id
+  end
+
+  def down
+    add_column :releases, :build_id, :string
+    add_index :releases, :build_id
+    add_column :kubernetes_releases, :build_id, :string
+    add_index :kubernetes_releases, :build_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170821222130) do
+ActiveRecord::Schema.define(version: 20170824174718) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -237,13 +237,11 @@ ActiveRecord::Schema.define(version: 20170821222130) do
   create_table "kubernetes_releases", id: :integer, force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "build_id"
     t.integer "user_id"
     t.integer "project_id", null: false
     t.integer "deploy_id"
     t.string "git_sha", limit: 40, null: false
     t.string "git_ref"
-    t.index ["build_id"], name: "index_kubernetes_releases_on_build_id"
   end
 
   create_table "kubernetes_roles", id: :integer, force: :cascade do |t|
@@ -383,8 +381,6 @@ ActiveRecord::Schema.define(version: 20170821222130) do
     t.string "author_type", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "build_id"
-    t.index ["build_id"], name: "index_releases_on_build_id"
     t.index ["project_id", "number"], name: "index_releases_on_project_id_and_number", unique: true
   end
 

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -4,7 +4,6 @@ module Kubernetes
     self.table_name = 'kubernetes_releases'
 
     belongs_to :user
-    belongs_to :build, optional: true
     belongs_to :project
     belongs_to :deploy
     has_many :release_docs, class_name: 'Kubernetes::ReleaseDoc', foreign_key: 'kubernetes_release_id'
@@ -54,6 +53,10 @@ module Kubernetes
       Rails.application.routes.url_helpers.project_kubernetes_release_url(project, self)
     end
 
+    def builds
+      project.builds.where(git_sha: git_sha)
+    end
+
     private
 
     # Creates a ReleaseDoc per each DeployGroup and Role combination.
@@ -75,7 +78,7 @@ module Kubernetes
     end
 
     def validate_docker_image_in_registry
-      if build && !build.docker_repo_digest?
+      unless builds.all?(&:docker_repo_digest?)
         errors.add(:build, 'Docker image was not pushed to registry')
       end
     end

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -20,7 +20,7 @@ module Kubernetes
     attr_reader :previous_resources
 
     def build
-      kubernetes_release.try(:build)
+      kubernetes_release&.builds&.first
     end
 
     def deploy

--- a/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
@@ -35,7 +35,7 @@
               <% end %>
             </td>
             <td>
-              <%= link_to kubernetes_release.build.label, [kubernetes_release.project, kubernetes_release.build] if kubernetes_release.build %>
+              <%= link_to "Build", project_builds_path(@project, search: {git_sha: kubernetes_release.git_sha}) %>
             </td>
             <td>
               <% kubernetes_release.release_docs.map(&:deploy_group).uniq.sort_by(&:natural_order).each do |deploy_group| %>

--- a/plugins/kubernetes/app/views/kubernetes/releases/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/releases/show.html.erb
@@ -8,11 +8,7 @@
   <dl class="dl-horizontal">
     <dt>Build</dt>
     <dd>
-      <% if @kubernetes_release.build_id %>
-        <%= link_to @kubernetes_release.build_id, project_build_path(@project, @kubernetes_release.build_id) %>
-      <% else %>
-        None
-      <% end %>
+      <%= link_to "Build", project_builds_path(@project, search: {git_sha: @kubernetes_release.git_sha}) %>
     </dd>
     <dt>Deploy</dt>
     <dd>

--- a/plugins/kubernetes/test/fixtures/kubernetes/releases.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/releases.yml
@@ -1,7 +1,6 @@
 test_release:
   user: deployer
-  build: docker_build
   project: test
-  git_sha: abababababa
+  git_sha: 1a6f551a2ffa6d88e15eef5461384da0bfb1c194
   git_ref: master
   deploy: succeeded_test

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -329,7 +329,9 @@ describe Kubernetes::DeployExecutor do
         it "reuses build when told to do so" do
           previous = deploys(:failed_staging_test)
           previous.update_column(:id, deploy.id - 1) # make previous_deploy work
-          kubernetes_releases(:test_release).update_column(:deploy_id, previous.id) # find previous deploy
+          kubernetes_releases(:test_release).update_columns(
+            deploy_id: previous.id, git_sha: 'something-else'
+          ) # find previous deploy
           build.update_column(:docker_repo_digest, 'ababababab') # make build succeeded
           deploy.update_column(:kubernetes_reuse_build, true)
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -29,7 +29,7 @@ describe Kubernetes::TemplateFiller do
       spec.fetch(:uniqueLabelKey).must_equal "rc_unique_identifier"
       spec.fetch(:replicas).must_equal doc.replica_target
       spec.fetch(:template).fetch(:metadata).fetch(:labels).symbolize_keys.must_equal(
-        revision: "abababababa",
+        revision: "1a6f551a2ffa6d88e15eef5461384da0bfb1c194",
         tag: "master",
         release_id: doc.kubernetes_release_id.to_s,
         project: "some-project",
@@ -106,7 +106,7 @@ describe Kubernetes::TemplateFiller do
       end
 
       it "does not override image when no build was made" do
-        doc.kubernetes_release.build = nil
+        doc.kubernetes_release.builds.delete_all
         container.fetch(:image).must_equal(
           "docker-registry.zende.sk/truth_service:latest"
         )

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -9,7 +9,6 @@ describe BuildsController do
   let(:tmp_dir) { Dir.mktmpdir }
   let(:project_repo_url) { repo_temp_dir }
   let(:project) { projects(:test).tap { |p| p.repository_url = project_repo_url } }
-
   let(:default_build) do
     project.builds.create!(label: 'master branch', git_ref: 'master', git_sha: 'a' * 40, creator: user)
   end
@@ -30,7 +29,7 @@ describe BuildsController do
     unauthorized :post, :build_docker_image, id: 1, project_id: :foo
 
     describe '#index' do
-      it 'works with no builds' do
+      it 'works without builds' do
         get :index, params: {project_id: project.to_param}
         assert_response :ok
       end
@@ -42,6 +41,12 @@ describe BuildsController do
         assert_response :ok
         @response.body.must_include 'test branch'
         @response.body.must_include 'master branch'
+      end
+
+      it 'can search' do
+        build = builds(:docker_build)
+        get :index, params: {project_id: project.to_param, search: {git_sha: build.git_sha}}
+        assigns(:builds).must_equal [build]
       end
     end
 


### PR DESCRIPTION
don't want to add a has_many for builds ... so just remove them ... we already have a association by `same git sha`

@irwaters 