### PR TITLE
support builds for multiple dockerfiles

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -95,6 +95,7 @@ class ProjectsController < ApplicationController
         :release_branch,
         :release_source,
         :docker_release_branch,
+        :dockerfiles,
         :docker_image_building_disabled,
         :include_new_deploy_groups,
         :dashboard,

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -3,7 +3,8 @@ class Build < ActiveRecord::Base
   SHA1_REGEX = /\A[0-9a-f]{40}\Z/i
   SHA256_REGEX = /\A(sha256:)?[0-9a-f]{64}\Z/i
   DIGEST_REGEX = /\A[\w.-]+[\w\/-]*@sha256:[0-9a-f]{64}\Z/i
-  ASSIGNABLE_KEYS = [:git_ref, :label, :description, :source_url] + Samson::Hooks.fire(:build_permitted_params)
+  ASSIGNABLE_KEYS = [:git_ref, :label, :description, :source_url, :dockerfile] +
+    Samson::Hooks.fire(:build_permitted_params)
 
   belongs_to :project
   belongs_to :docker_build_job, class_name: 'Job', optional: true
@@ -11,7 +12,7 @@ class Build < ActiveRecord::Base
   has_many :deploys
 
   validates :project, presence: true
-  validates :git_sha, format: SHA1_REGEX, allow_nil: true, uniqueness: true
+  validates :git_sha, format: SHA1_REGEX, allow_nil: true, uniqueness: {scope: :dockerfile}
   validates :docker_image_id, format: SHA256_REGEX, allow_nil: true
   validates :docker_repo_digest, format: DIGEST_REGEX, allow_nil: true
   validates :source_url, format: /\Ahttps?:\/\/\S+\z/, allow_nil: true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -47,8 +47,16 @@ class Project < ActiveRecord::Base
 
   scope :search, ->(name) { where("name like ?", "%#{name}%") }
 
-  def docker_repo(registry)
-    File.join(registry.base, permalink_base)
+  def docker_repo(registry, dockerfile)
+    repo = File.join(registry.base, permalink_base)
+    if suffix = dockerfile.gsub(/^Dockerfile\.?|\/Dockerfile\.?/, '').presence
+      repo << "-#{suffix.parameterize}"
+    end
+    repo
+  end
+
+  def dockerfile_list
+    dockerfiles.to_s.split(/\s+/).presence || ["Dockerfile"]
   end
 
   # Whether to create new releases when the branch is updated.

--- a/app/views/builds/_build.html.erb
+++ b/app/views/builds/_build.html.erb
@@ -8,5 +8,6 @@
   <td><%= build.creator&.name || "Trigger" %></td>
   <td><%= duration_text job.duration if job %></td>
   <td><%= git_ref_and_sha_for(build) %></td>
+  <td><%= build.dockerfile %></td>
   <td><%= job ? job_status_badge(job) : build.docker_status %></td>
 </tr>

--- a/app/views/builds/edit.html.erb
+++ b/app/views/builds/edit.html.erb
@@ -17,6 +17,9 @@
     <%= form.input :git_ref, label: 'Git Reference' do %>
       <p class="form-control-static"><%= git_ref_and_sha_for(@build) %></p>
     <% end %>
+    <%= form.input :dockerfile do %>
+      <p class="form-control-static"><%= @build.dockerfile %></p>
+    <% end %>
     <%= form.input :docker_repo_digest, label: 'Docker Digest' do %>
       <p class="form-control-static"><%= @build.docker_repo_digest %></p>
     <% end %>

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -24,7 +24,8 @@
         <%= link_to_chart "Build duration", @builds.map { |b| b.docker_build_job&.duration }.compact %>
       </th>
       <th>Git Ref</th>
-      <th>Docker Build</th>
+      <th>Dockerfile</th>
+      <th>Status</th>
     </tr>
     </thead>
 

--- a/app/views/builds/new.html.erb
+++ b/app/views/builds/new.html.erb
@@ -17,6 +17,7 @@
       </div>
     <% end %>
 
+    <%= form.input :dockerfile, input_html: {placeholder: 'Dockerfile'} %>
     <%= form.input :label %>
     <%= form.input :description, input_html: {row: 3} %>
 

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -45,6 +45,9 @@
     <dt>Git Ref</dt>
     <dd><%= git_ref_and_sha_for(@build, make_link: true) %></dd>
 
+    <dt>Dockerfile</dt>
+    <dd><%= @build.dockerfile %></dd>
+
     <dt>Docker Job Status</dt>
     <dd><%= @build.docker_status %></dd>
 

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -17,6 +17,7 @@
     <% end %>
     <% if ENV['DOCKER_FEATURE'] %>
       <%= form.input :docker_release_branch, help: 'New commits on this branch will cause a docker image to be built when a webhook arrives.' %>
+      <%= form.input :dockerfiles, help: 'Space separated list of dockerfiles to build, default: Dockerfile' %>
       <%= form.input :docker_image_building_disabled, as: :check_box, help: 'Disable building of docker images, they must be added via api.' %>
     <% end %>
     <% if DeployGroup.enabled? %>

--- a/db/migrate/20170824004459_enable_multiple_dockerfiles.rb
+++ b/db/migrate/20170824004459_enable_multiple_dockerfiles.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class EnableMultipleDockerfiles < ActiveRecord::Migration[5.1]
+  def up
+    add_column :projects, :dockerfiles, :string
+
+    add_column :builds, :dockerfile, :string, default: 'Dockerfile', null: false
+    add_index :builds, [:git_sha, :dockerfile], unique: true, length: { git_sha: 80, dockerfile: 80 }
+    remove_index :builds, :git_sha
+  end
+
+  def down
+    remove_column :projects, :dockerfiles
+
+    add_index :builds, :git_sha, unique: true, length: { git_sha: 80 }
+    remove_index :builds, [:git_sha, :dockerfile]
+    remove_column :builds, :dockerfile
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,8 +52,9 @@ ActiveRecord::Schema.define(version: 20170824174718) do
     t.datetime "started_at"
     t.datetime "finished_at"
     t.string "source_url"
+    t.string "dockerfile", default: "Dockerfile", null: false
     t.index ["created_by"], name: "index_builds_on_created_by"
-    t.index ["git_sha"], name: "index_builds_on_git_sha", unique: true
+    t.index ["git_sha", "dockerfile"], name: "index_builds_on_git_sha_and_dockerfile", unique: true
     t.index ["project_id"], name: "index_builds_on_project_id"
   end
 
@@ -368,6 +369,7 @@ ActiveRecord::Schema.define(version: 20170824174718) do
     t.integer "build_command_id"
     t.text "dashboard"
     t.boolean "docker_image_building_disabled", default: false, null: false
+    t.string "dockerfiles"
     t.index ["build_command_id"], name: "index_projects_on_build_command_id"
     t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: { permalink: 191 }
     t.index ["token"], name: "index_projects_on_token", unique: true, length: { token: 191 }

--- a/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
+++ b/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
@@ -9,10 +9,10 @@ module SamsonAwsEcr
       # we make sure the repo exists so pushes do not fail
       # - ignores if the repo already exists
       # - ignores if the repo cannot be created due to permission problems
-      def ensure_repositories(project)
+      def ensure_repositories(build)
         DockerRegistry.all.each do |registry|
           next unless client = ecr_client(registry)
-          name = project.docker_repo(registry).split('/', 2).last
+          name = build.project.docker_repo(registry, build.dockerfile).split('/', 2).last
 
           begin
             begin
@@ -63,7 +63,7 @@ end
 
 # need credentials to pull (via Dockerfile FROM) and push images
 # ATM this only authenticates the default docker registry and not any extra registries
-Samson::Hooks.callback :before_docker_repository_usage do |project|
-  SamsonAwsEcr::Engine.ensure_repositories(project)
+Samson::Hooks.callback :before_docker_repository_usage do |build|
+  SamsonAwsEcr::Engine.ensure_repositories(build)
   SamsonAwsEcr::Engine.refresh_credentials
 end

--- a/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
+++ b/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
@@ -35,7 +35,7 @@ describe SamsonAwsEcr::Engine do
 
   describe :before_docker_repository_usage do
     def fire
-      Samson::Hooks.fire(:before_docker_repository_usage, builds(:docker_build).project)
+      Samson::Hooks.fire(:before_docker_repository_usage, builds(:docker_build))
     end
 
     run_inside_of_temp_directory

--- a/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/build_job_executor.rb
@@ -81,7 +81,7 @@ module Kubernetes
       container_params = {
         env: [{name: 'DOCKER_REGISTRY', value: @registry.host }],
         args: [
-          project.repository_url, build.git_sha, project.docker_repo(@registry), docker_tag,
+          project.repository_url, build.git_sha, project.docker_repo(@registry, build.dockerfile), docker_tag,
           push ? "yes" : "no",
           tag_as_latest ? "yes" : "no"
         ]

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -19,10 +19,6 @@ module Kubernetes
 
     attr_reader :previous_resources
 
-    def build
-      kubernetes_release&.builds&.first
-    end
-
     def deploy
       @previous_resources = resources.map(&:resource)
       resources.each(&:deploy)
@@ -115,7 +111,7 @@ module Kubernetes
     end
 
     def validate_config_file
-      return if !build || !kubernetes_role
+      return unless kubernetes_role
       raw_template # trigger RoleConfigFile validations
     rescue Samson::Hooks::UserError
       errors.add(:kubernetes_release, $!.message)

--- a/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/build_job_executor_test.rb
@@ -88,14 +88,22 @@ describe Kubernetes::BuildJobExecutor do
           build_config.primary[:spec][:template][:metadata][:labels]
         ]
         labels_config.each do |v|
-          assert_equal v[:project], project_name_dash
-          assert_equal v[:role], 'docker-build-job'
-          assert_equal v[:foo], 'bar'
+          v[:project].must_equal project_name_dash
+          v[:role].must_equal 'docker-build-job'
+          v[:foo].must_equal 'bar'
         end
 
-        assert_equal build_config.primary[:spec][:template][:spec][:containers][0][:args],
-          [project.repository_url, build.git_sha, project.docker_repo(DockerRegistry.first), 'latest', 'no', 'no']
-        assert_equal build_config.primary[:spec][:template][:spec][:containers][0][:env].length, 1
+        build_config.primary[:spec][:template][:spec][:containers][0][:args].must_equal(
+          [
+            project.repository_url,
+            build.git_sha,
+            project.docker_repo(DockerRegistry.first, 'Dockerfile'),
+            'latest',
+            'no',
+            'no'
+          ]
+        )
+        build_config.primary[:spec][:template][:spec][:containers][0][:env].length.must_equal 1
       end
 
       it "rescues internal errors" do

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -137,7 +137,7 @@ describe Kubernetes::DeployExecutor do
 
       refute_difference 'Build.count' do
         assert execute
-        out.must_include "Not creating a Build"
+        out.must_include "Not creating builds"
         out.must_include "resque-worker: Live\n"
         out.must_include "SUCCESS"
       end
@@ -322,7 +322,7 @@ describe Kubernetes::DeployExecutor do
           end
           assert execute
           out.must_include "SUCCESS"
-          out.must_include "Creating Build for #{job.commit}"
+          out.must_include "Creating builds for #{job.commit}"
           out.must_include "Build #{Build.last.url} is looking good"
         end
 
@@ -351,14 +351,14 @@ describe Kubernetes::DeployExecutor do
             execute
           end
           e.message.must_equal "Build #{Build.last.url} is cancelled, rerun it manually."
-          out.must_include "Creating Build for #{job.commit}.\n"
+          out.must_include "Creating builds for #{job.commit}.\n"
         end
 
         it "stops when deploy is cancelled by user" do
           executor.cancel('FAKE-SIGNAL')
           DockerBuilderService.any_instance.expects(:run).returns(true)
           refute execute
-          out.scan(/.*Build.*/).must_equal ["Creating Build for #{job.commit}."] # not waiting for build
+          out.scan(/.*build.*/).must_equal ["Creating builds for #{job.commit}."] # not waiting for build
           out.must_include "STOPPED"
         end
       end

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -212,7 +212,7 @@ describe Kubernetes::ReleaseDoc do
 
   describe "#build" do
     it "fetches the build" do
-      doc.build.must_equal builds(:docker_build)
+      doc.kubernetes_release.builds.must_equal [builds(:docker_build)]
     end
   end
 

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -33,9 +33,13 @@ describe Build do
     it 'validates git sha' do
       Dir.chdir(repo_temp_dir) do
         assert_valid(valid_build(git_ref: nil, git_sha: current_commit))
-        refute_valid(valid_build(git_ref: nil, git_sha: '0123456789012345678901234567890123456789'))
+        refute_valid(valid_build(git_ref: nil, git_sha: '0123456789012345678901234567890123456789')) # sha no in repo
         refute_valid(valid_build(git_ref: nil, git_sha: 'This is a string of 40 characters.......'))
         refute_valid(valid_build(git_ref: nil, git_sha: 'abc'))
+
+        build.update_column(:git_sha, current_commit)
+        refute_valid(valid_build(git_ref: nil, git_sha: current_commit)) # not unique
+        assert_valid(valid_build(git_ref: nil, git_sha: current_commit, dockerfile: 'Other'))
       end
     end
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -325,7 +325,15 @@ describe Project do
     with_registries ["docker-registry.example.com/bar"]
 
     it "builds" do
-      project.docker_repo(DockerRegistry.first).must_equal "docker-registry.example.com/bar/foo"
+      project.docker_repo(DockerRegistry.first, "Dockerfile").must_equal "docker-registry.example.com/bar/foo"
+    end
+
+    it "builds nonstandard" do
+      project.docker_repo(DockerRegistry.first, "Dockerfile.baz").must_equal "docker-registry.example.com/bar/foo-baz"
+    end
+
+    it "builds folders" do
+      project.docker_repo(DockerRegistry.first, "baz/Dockerfile").must_equal "docker-registry.example.com/bar/foo-baz"
     end
   end
 
@@ -405,6 +413,7 @@ describe Project do
         project.docker_release_branch = 'master'
         project.release_branch = 'master-of-puppets'
       end
+
       it 'returns false for the wrong branch' do
         refute project.build_docker_image_for_branch?('master-of-puppets')
       end
@@ -419,6 +428,7 @@ describe Project do
         project.docker_release_branch = nil
         project.release_branch = 'master-of-puppets'
       end
+
       it 'returns false' do
         refute project.build_docker_image_for_branch?(nil)
         refute project.build_docker_image_for_branch?('master-of-puppets')
@@ -439,6 +449,17 @@ describe Project do
   describe "#url" do
     it "builds a url" do
       project.url.must_equal "http://www.test-url.com/projects/foo"
+    end
+  end
+
+  describe "#dockerfile_list" do
+    it "is Dockerfile by default" do
+      project.dockerfile_list.must_equal ["Dockerfile"]
+    end
+
+    it "splits user input" do
+      project.dockerfiles = "Dockerfile  Muh File"
+      project.dockerfile_list.must_equal ["Dockerfile", "Muh", "File"]
     end
   end
 end


### PR DESCRIPTION
support builds for multiple dockerfiles (just 2nd commit, first commit is from https://github.com/zendesk/samson/pull/2212)

@jonmoter @zenhao @irwaters 

in the container add `samson/dockerfile: Dockerfile.foobar`
tested this in master and it does not break deployment, so we should be fine to use that ...

for non-kubernetes the project gets a `dockerfiles` attribute that can be set to what dockerfiles should be built ... builds will then get queued for each dockerfile ... and have a the dockerfile suffix appended to their repo ... so foobar + Dockerfile.new -> foobar-new

the current workflow is a bit shitty ... user needs to set `dockerfiles` in the project to make everything work ... but that should only be an issue for those needing multiple dockerfiles ... so good enough until there is more trouble ...

first multi-stage deploy: https://samsontest.zende.sk/projects/truth_service/deploys/4624