### PR TITLE
tell user when we're deleting a docker image

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -82,7 +82,10 @@ class DockerBuilderService
         if build_image(tmp_dir) # rubocop:disable Style/IfInsideElse
           ret = true
           ret = push_image(tag_as_latest: tag_as_latest) if push
-          build.docker_image.remove(force: true) unless ENV["DOCKER_KEEP_BUILT_IMGS"] == "1"
+          unless ENV["DOCKER_KEEP_BUILT_IMGS"] == "1"
+            output.puts("Deleting docker image #{build.docker_image.id}")
+            build.docker_image.remove(force: true)
+          end
           ret
         else
           output.puts("Docker build failed (image id not found in response)")

--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -83,7 +83,7 @@ class DockerBuilderService
           ret = true
           ret = push_image(tag_as_latest: tag_as_latest) if push
           unless ENV["DOCKER_KEEP_BUILT_IMGS"] == "1"
-            output.puts("Deleting docker image #{build.docker_image.id}")
+            output.puts("### Deleting local docker image")
             build.docker_image.remove(force: true)
           end
           ret

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -74,7 +74,6 @@ describe DockerBuilderService do
 
       # simulate falling removal ... should not change return value
       build.stubs(docker_image: stub)
-      build.docker_image.expects(:id).returns(docker_image_id)
       build.docker_image.expects(:remove).with(force: true).returns(false)
 
       assert execute_job

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -74,6 +74,7 @@ describe DockerBuilderService do
 
       # simulate falling removal ... should not change return value
       build.stubs(docker_image: stub)
+      build.docker_image.expects(:id).returns(docker_image_id)
       build.docker_image.expects(:remove).with(force: true).returns(false)
 
       assert execute_job


### PR DESCRIPTION
If `DOCKER_KEEP_BUILT_IMGS` env var isn't set, tell the end user we're deleting the image.

/cc @zendesk/samson

### References
 - Jira link: https://zendesk.atlassian.net/browse/SAMSON-359

### Risks
- Level: Low
