### PR TITLE
no need to ensure repos when we do not interact with them

### DIFF
--- a/app/controllers/api/builds_controller.rb
+++ b/app/controllers/api/builds_controller.rb
@@ -8,19 +8,13 @@ class Api::BuildsController < Api::BaseController
     build_params = params.require(:build)
     digest = extract_param(build_params, :docker_repo_digest)
     sha = extract_param(build_params, :git_sha)
-
-    Samson::Hooks.fire(:before_docker_repository_usage, current_project)
-
-    build = current_project.builds.create!(
+    current_project.builds.create!(
       build_params.permit(*Build::ASSIGNABLE_KEYS).merge(
         creator: current_user,
         docker_repo_digest: digest,
         git_sha: sha
       )
     )
-
-    Samson::Hooks.fire(:after_docker_build, build)
-
     head :created
   end
 


### PR DESCRIPTION
fixes bug introduced in https://github.com/zendesk/samson/pull/2213
where the hook expected a build and not a project to get passed

https://zendesk.airbrake.io/projects/95346/groups/2028423451945412726?tab=notice-detail

`NoMethodError: undefined method `project' for #<Project:0x007fe3b2757130>`

### Risks:
 - Low: weird errors when repo was not setup .. idk why that code was there ...