### PR TITLE
Export commit range in job execution

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -207,6 +207,10 @@ class JobExecution
       TAG: (@job.tag || @job.commit)
     }.merge(@env)
 
+    if deploy = @job.deploy
+      env[:COMMIT_RANGE] = deploy.changeset.commit_range
+    end
+
     env.merge!(Hash[*Samson::Hooks.fire(:job_additional_vars, @job)])
 
     base_commands(dir, env) + @job.commands

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -156,6 +156,7 @@ describe JobExecution do
     lines.must_include "[04:05:06] DEPLOYER_NAME=John Doe"
     lines.must_include "[04:05:06] REFERENCE=master"
     lines.must_include "[04:05:06] REVISION=#{job.commit}"
+    lines.must_include "[04:05:06] COMMIT_RANGE=#{job.commit}...#{job.commit}"
     lines.must_include "[04:05:06] TAG=v1"
     lines.must_include "[04:05:06] FOO=bar"
   end


### PR DESCRIPTION
* exports the deploy changeset's commit range when executing jobs, so we can work out which files have been changed / added / deleted since the previous commit.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low