### PR TITLE
tell users to cancel bad deploys so they do not wait forever

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -102,7 +102,7 @@ class Job < ActiveRecord::Base
   end
 
   def queued?
-    pending? && JobExecution.queued?(id)
+    JobExecution.queued?(id)
   end
 
   def active?
@@ -110,7 +110,7 @@ class Job < ActiveRecord::Base
   end
 
   def executing?
-    active? || JobExecution.active?(id)
+    JobExecution.executing?(id)
   end
 
   def waiting_for_restart?

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -254,8 +254,8 @@ class JobExecution
       job_queue.find_by_id(id)
     end
 
-    def active?(id)
-      job_queue.active?(id)
+    def executing?(id)
+      job_queue.executing?(id)
     end
 
     def queued?(id)
@@ -270,8 +270,8 @@ class JobExecution
       job_queue.add(*args)
     end
 
-    def active
-      job_queue.active
+    def executing
+      job_queue.executing
     end
 
     def debug

--- a/app/models/restart_signal_handler.rb
+++ b/app/models/restart_signal_handler.rb
@@ -62,12 +62,12 @@ class RestartSignalHandler
   def wait_for_active_jobs_to_finish
     loop do
       # dup-ing to avoid racing with other threads
-      active = JobExecution.active.dup
+      executing = JobExecution.executing.dup
       locks = MultiLock.locks.dup
-      break if active.empty? && locks.empty?
+      break if executing.empty? && locks.empty?
 
       info = {
-        jobs: active.map do |job_exec|
+        jobs: executing.map do |job_exec|
           {
             job_id: job_exec.id,
             pid: job_exec.pid,

--- a/app/views/deploys/_queued.html.erb
+++ b/app/views/deploys/_queued.html.erb
@@ -1,10 +1,14 @@
 <div class="row deploy-check">
   <p>
-    This deploy is queued, it will be started when
-    <% if JobExecution.enabled %>
-      previous deploys have finished.
+    <% if @deploy.job.executing? %>
+      Deploy is running, refresh this page.
+    <% elsif @deploy.job.queued? %>
+      Deploy is queued and it will be started when previous deploys have finished.
+    <% elsif JobExecution.enabled %>
+      Deploy is pending but not queued or executing, so it will never start.
+      Something went wrong during job creation, cancel it and try again.
     <% else %>
-      Samson has restarted.
+      Deploy is queued and will be started when Samson finishes restarting.
     <% end %>
   </p>
 

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -47,23 +47,23 @@ describe DeploysController do
         end
       end
 
-      it "renders debug output with job/deploy and active/queued" do
+      it "renders debug output with job/deploy and executing/queued" do
         JobExecution.any_instance.expects(:on_finish).times(4)
         JobExecution.any_instance.expects(:start)
         with_job_execution do
           # start 1 job and queue another
-          active = Job.create!(project: project, command: "echo 1", user: user) { |j| j.id = 123321 }
-          active.stubs(:deploy).returns(deploy)
+          executing = Job.create!(project: project, command: "echo 1", user: user) { |j| j.id = 123321 }
+          executing.stubs(:deploy).returns(deploy)
           queued = Job.create!(project: project, command: "echo 1", user: user) { |j| j.id = 234432 }
-          JobExecution.start_job(JobExecution.new('master', active), queue: :x)
+          JobExecution.start_job(JobExecution.new('master', executing), queue: :x)
           JobExecution.start_job(JobExecution.new('master', queued), queue: :x)
-          JobExecution.active.size.must_equal 1
+          JobExecution.executing.size.must_equal 1
           assert JobExecution.queued?(queued.id)
 
           get :active, params: {debug: '1'}
 
-          response.body.wont_include active.id.to_s
-          response.body.must_include active.deploy.id.to_s # renders as deploy
+          response.body.wont_include executing.id.to_s
+          response.body.must_include executing.deploy.id.to_s # renders as deploy
           response.body.must_include queued.id.to_s # renders as job
         end
       end

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -28,11 +28,25 @@ describe DeploysHelper do
 
       it "renders restart warning when deploy is waiting for restart" do
         result.wont_include output
-        result.must_include 'Samson has restarted'
+        result.must_include 'Deploy is queued and will be started when Samson finishes restarting'
       end
 
-      it "renders queued warning when job is waiting to be executed" do
-        with_job_execution do
+      describe "when jobs are executing" do
+        with_job_execution
+
+        it "renders error when job is pending but not queued" do
+          result.wont_include output
+          result.must_include 'Deploy is pending but not queued or executing, so it will never start.'
+        end
+
+        it "renders active warning when job is active" do
+          deploy.job.stubs(executing?: true)
+          result.wont_include output
+          result.must_include 'Deploy is running, refresh this page'
+        end
+
+        it "renders queued warning when job is waiting to be executed" do
+          deploy.job.stubs(queued?: true)
           result.wont_include output
           result.must_include 'previous deploys have finished'
         end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -280,7 +280,7 @@ describe JobExecution do
 
     JobExecution.find_by_id(job.id).must_be_nil
     JobExecution.queued?(job.id).must_be_nil
-    JobExecution.active?(job.id).must_be_nil
+    JobExecution.executing?(job.id).must_be_nil
   end
 
   it 'can run with a block' do

--- a/test/models/restart_signal_handler_test.rb
+++ b/test/models/restart_signal_handler_test.rb
@@ -46,7 +46,7 @@ describe RestartSignalHandler do
       job_exec = stub(id: 123, pid: 444, pgid: 5555, descriptor: 'Job thingy')
 
       # we call it twice in each iteration
-      job_queue.expects(:active).times(2).returns [job_exec], []
+      job_queue.expects(:executing).times(2).returns [job_exec], []
 
       RestartSignalHandler.any_instance.expects(:sleep).with(5)
       handle

--- a/test/support/job_queue_support.rb
+++ b/test/support/job_queue_support.rb
@@ -8,7 +8,7 @@ ActiveSupport::TestCase.class_eval do
     yield
   ensure
     JobExecution.send(:job_queue).instance_variable_get(:@queue).clear
-    JobExecution.send(:job_queue).instance_variable_get(:@active).clear
+    JobExecution.send(:job_queue).instance_variable_get(:@executing).clear
     JobExecution.enabled = false
   end
 


### PR DESCRIPTION
for https://github.com/zendesk/samson/issues/2176#issuecomment-326464560

better than telling users everything is ok and they wait forever ... maybe later either airbrake or auto-cancel ... not sure ... 

@jacobbednarz @irwaters 