### PR TITLE
increase sleep to avoid flaky tests

### DIFF
--- a/test/lib/samson/parallelizer_test.rb
+++ b/test/lib/samson/parallelizer_test.rb
@@ -25,7 +25,7 @@ describe Samson::Parallelizer do
       Samson::Parallelizer.map(Array.new(20)) do
         list << Thread.current.object_id
         Thread.pass
-        sleep 0.01
+        sleep 0.05
       end
       list.uniq.size.must_equal 10
     end


### PR DESCRIPTION
```
Failure:
Samson::Parallelizer::.map#test_0004_works in reused threads [/home/travis/build/zendesk/samson/test/lib/samson/parallelizer_test.rb:30]:
Expected: 10
  Actual: 9
bin/rails test test/lib/samson/parallelizer_test.rb:23
```
