### PR TITLE
Update Samson to support StatefulSets

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -27,6 +27,10 @@ module Kubernetes
       @extension_client ||= build_client 'extensions/v1beta1'
     end
 
+    def apps_client
+      @extension_client ||= build_client 'apps/v1beta1'
+    end
+
     def batch_client
       @batch_client ||= build_client 'batch/v1'
     end

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 module Kubernetes
   # abstraction for interacting with kubernetes resources
-  # ... could be merged with Kubernetes::Api counterparts
+  #
+  # Add a new resource:
+  # run an example file through `kubectl create/replace/delete -f test.yml -v8`
+  # and see what it does internally ... simple create/update/delete requests or special magic ?
   module Resource
     class Base
       def initialize(template, deploy_group)
@@ -241,6 +244,18 @@ module Kubernetes
           return if no_pods_running?
         end
         raise Samson::Hooks::UserError, "Unable to terminate previous DaemonSet because it still has pods"
+      end
+    end
+
+    class StatefulSet < Base
+      def desired_pod_count
+        @template[:spec][:replicas]
+      end
+
+      private
+
+      def client
+        @deploy_group.kubernetes_cluster.apps_client
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -6,7 +6,7 @@ module Kubernetes
   class RoleConfigFile
     attr_reader :path, :elements
 
-    DEPLOY_KINDS = ['Deployment', 'DaemonSet'].freeze
+    DEPLOY_KINDS = ['Deployment', 'DaemonSet', 'StatefulSet'].freeze
     JOB_KINDS = ['Job'].freeze
     PRIMARY_KINDS = (DEPLOY_KINDS + JOB_KINDS + ['Pod']).freeze
     SERVICE_KINDS = ['Service'].freeze

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -68,6 +68,12 @@ describe Kubernetes::Cluster do
     end
   end
 
+  describe '#apps_client' do
+    it 'creates a client' do
+      cluster.apps_client.must_be_kind_of Kubeclient::Client
+    end
+  end
+
   describe '#batch_client' do
     it 'creates a client' do
       cluster.batch_client.must_be_kind_of Kubeclient::Client

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -345,6 +345,34 @@ describe Kubernetes::Resource do
     end
   end
 
+  describe Kubernetes::Resource::StatefulSet do
+    def deployment_stub(replica_count)
+      stub(
+        "StatefulSet",
+        to_hash: {
+          spec: {},
+          status: {replicas: replica_count}
+        }
+      )
+    end
+
+    let(:kind) { 'StatefulSet' }
+    let(:url) { "http://foobar.server/apis/apps/v1beta1/namespaces/pod1/statefulsets/some-project" }
+
+    describe "#client" do
+      it "uses the apps client because it is in beta" do
+        resource.send(:client).must_equal deploy_group.kubernetes_cluster.apps_client
+      end
+    end
+
+    describe "#desired_pod_count" do
+      it "reads the value from config" do
+        template[:spec] = {replicas: 3}
+        resource.desired_pod_count.must_equal 3
+      end
+    end
+  end
+
   describe Kubernetes::Resource::Job do
     let(:kind) { 'Job' }
     let(:url) { "http://foobar.server/apis/batch/v1/namespaces/pod1/jobs/some-project" }


### PR DESCRIPTION
Samson doesn't whitelist StatefulSet as a supported object in Kubernetes. Now that we're on K8S 1.5, we should allow that.

Not sure this is enough @grosser let me know

JIRA: https://zendesk.atlassian.net/browse/TOOLS-1865

cc: @jonmoter 