### PR TITLE
make access token a bit more obvious and prevent users from clicking …

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -17,7 +17,7 @@ class AccessTokensController < ApplicationController
     )
     redirect_to(
       {action: :index},
-      notice: "Token created: copy this token, it will not be shown again: #{token.token}"
+      notice: "Token created: copy this token, it will not be shown again: <b>#{token.token}</b>".html_safe
     )
   end
 

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -8,8 +8,8 @@
   <table class="table">
     <thead>
     <tr>
-      <th>Application</th>
       <th>Description</th>
+      <th>Application</th>
       <th>Scope</th>
       <th>Last used</th>
       <th>Created</th>
@@ -20,8 +20,8 @@
     <tbody>
     <% @access_tokens.each do |token| %>
     <tr>
+      <td><%= token.description.presence || "No Description" %></td>
       <td><%= link_to_if current_user.super_admin?, token.application.name, oauth_application_path(token.application) %></td>
-      <td><%= token.description %></td>
       <td><%= token.scopes.to_a.join(", ") %></td>
       <td><%= token.last_used_at ? relative_time(token.last_used_at) : "Never" %></td>
       <td><%= relative_time token.created_at %></td>


### PR DESCRIPTION
…on the oauth application

old view was misleading users to think the app is the link to the token ... hopefully better now ...
![screen shot 2017-09-08 at 11 28 13 am](https://user-images.githubusercontent.com/11367/30226085-a53e16c2-9489-11e7-956b-c7eb9eb51415.png)

![screen shot 2017-09-08 at 11 34 49 am](https://user-images.githubusercontent.com/11367/30226108-bdc944dc-9489-11e7-99f8-0684bd9164cd.png)


making the token bold so it stands out more and is not overlooked as yet another flash:
![screen shot 2017-09-08 at 11 32 05 am](https://user-images.githubusercontent.com/11367/30226086-a547b84e-9489-11e7-88a4-c4ca821eec2c.png)
