### PR TITLE
fix failing docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY app /app/app
 COPY lib /app/lib
 
 # Assets
+COPY vendor/assets /app/vendor/assets
 RUN echo "takes 5 minute" && RAILS_ENV=production PRECOMPILE=1 bundle exec rake assets:precompile
 
 EXPOSE 9080


### PR DESCRIPTION
Docker build was failing with this error:

```
Sprockets::FileNotFound: couldn't find file 'tableHeaderFixer' with type 'application/javascript'
```

That's cause we weren't adding the `vendor/assets` directory into the docker image.

/cc @zendesk/samson, @tmcinerney 

### Risks
- Level: Low
