### PR TITLE
Add `local_user` Rollbar parameter

### DIFF
--- a/plugins/rollbar/app/models/rollbar_notification.rb
+++ b/plugins/rollbar/app/models/rollbar_notification.rb
@@ -15,7 +15,8 @@ class RollbarNotification
       @webhook_url,
       access_token: @access_token,
       environment: @environment,
-      revision: @revision
+      revision: @revision,
+      local_username: 'Samson'
     )
 
     if response.success?

--- a/plugins/rollbar/test/models/rollbar_notification_test.rb
+++ b/plugins/rollbar/test/models/rollbar_notification_test.rb
@@ -20,7 +20,8 @@ describe RollbarNotification do
         body: {
           access_token: 'token',
           environment: 'test',
-          revision: 'v1'
+          revision: 'v1',
+          local_username: 'Samson'
         }
       )
 


### PR DESCRIPTION
### Description
**NOTE:** Currently a WIP as I've not being able to get Samson working in Dev to run tests.

I noticed that Rollbar is saying "unknown user" in the Deploys section in Rollbar. Their [API](https://rollbar-us.zendesk.com/Zendesk/Classic/deploys/) seems to allow passing the `local_username` parameter, which defines the "User who deployed.".

This PR sets the value to "Samson". 

/cc @zendesk/samson

### Tasks
 - [x] :+1: from team

### Risks
- Level: Low
