### PR TITLE
try hunting down always-active builds again

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -80,10 +80,6 @@ class DockerBuilderService
         run_build_image_job(job, push: push, tag_as_latest: tag_as_latest)
       else
         if build_image(tmp_dir) # rubocop:disable Style/IfInsideElse
-          if !Rails.env.test? && !JobExecution.find_by_id(job.id)
-            Airbrake.notify("Unable to find docker build in job execution", job: job.id)
-          end
-
           ret = true
           ret = push_image(tag_as_latest: tag_as_latest) if push
           unless ENV["DOCKER_KEEP_BUILT_IMGS"] == "1"

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -36,6 +36,13 @@ class JobExecution
     @repository.executor = @executor
 
     on_finish do
+      # weird issue we are seeing with docker builds never finishing
+      if !Rails.env.test? && !JobExecution.find_by_id(@job.id) && @job.active?
+        Airbrake.notify("Active but not running job found", job: @job.id)
+        @output.write("Active but not running job found")
+        @job.failed!
+      end
+
       @output.write('', :finished)
       @output.close
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -2,7 +2,7 @@
 require_relative '../test_helper'
 require 'ar_multi_threaded_transactional_tests'
 
-SingleCov.covered! uncovered: 5 # randomly says it only has 4 ... keep at 5
+SingleCov.covered! uncovered: 8 # randomly says it only has 7 ... keep at 8
 
 describe JobExecution do
   include GitRepoTestHelper


### PR DESCRIPTION
followup to https://github.com/zendesk/samson/pull/2244 which did not work :/

storing the output does work, so it must not update the status before that ...

@irwaters 