### PR TITLE
do not let users de-select 100+ commands

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -34,7 +34,7 @@ class StagesController < ApplicationController
   end
 
   def new
-    @stage = @project.stages.build(command_ids: Command.global.pluck(:id))
+    @stage = @project.stages.new
   end
 
   def create

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -2,7 +2,7 @@
 
 <section class="tabs">
   <p class="pull-right">
-    <%= link_to "Create Token", new_access_token_path, class: "btn btn-default" %>
+    <%= link_to "New", new_access_token_path, class: "btn btn-default" %>
   </p>
 
   <table class="table">

--- a/app/views/stages/_commands.html.erb
+++ b/app/views/stages/_commands.html.erb
@@ -1,4 +1,4 @@
-<fieldset>
+<fieldset class="unfoldable">
   <legend>Script</legend>
   <p>Select the commands you want to run when executing. Double click to edit commands.</p>
 

--- a/app/views/stages/_deploy_failure_emails.html.erb
+++ b/app/views/stages/_deploy_failure_emails.html.erb
@@ -1,0 +1,17 @@
+<fieldset>
+  <legend>Email on automated deploy failure</legend>
+  <div class="col-lg-offset-2">
+    <p>When an automated deploy initially fails, send a email to:</p>
+  </div>
+
+  <%= form.input :email_committers_on_automated_deploy_failure, as: :check_box, label: "Committers in the diff to last successful deploy" %>
+
+  <div class="col-lg-offset-2">
+    <div class="form-group">
+      <div class="col-lg-6">
+        <p>Addresses (comma separated):</p>
+        <%= form.text_field :static_emails_on_automated_deploy_failure, class: "form-control" %>
+      </div>
+    </div>
+  </div>
+</fieldset>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -1,4 +1,4 @@
-<fieldset>
+<fieldset class="unfoldable">
   <%= form.input :name, required: true %>
   <%= form.input :permalink, required: true if form.object.persisted? %>
   <%= form.input :notify_email_address,
@@ -50,31 +50,14 @@
 
 <%= render 'commands', form: form %>
 <%= render 'shared/dashboard_field', form: form %>
-
-<fieldset>
-  <legend>Email on automated deploy failure</legend>
-  <div class="col-lg-offset-2">
-    <p>When an automated deploy initially fails, send a email to:</p>
-  </div>
-
-  <%= form.input :email_committers_on_automated_deploy_failure, as: :check_box, label: "Committers in the diff to last successful deploy" %>
-
-  <div class="col-lg-offset-2">
-    <div class="form-group">
-      <div class="col-lg-6">
-        <p>Addresses (comma separated):</p>
-        <%= form.text_field :static_emails_on_automated_deploy_failure, class: "form-control" %>
-      </div>
-    </div>
-  </div>
-</fieldset>
-
+<%= render 'deploy_failure_emails', form: form %>
 <%= Samson::Hooks.render_views(:stage_form, self, form: form) %>
 
 <script>
   // fold empty fieldsets and let users unfold them to reduce clutter
+  // except for the attributes and command fieldsets
   $(function(){
-    $("fieldset").each(function(_, fieldset){
+    $("fieldset").not(".unfoldable").each(function(_, fieldset){
       var fieldset = $(fieldset);
       var form_elements = fieldset.find('> *').not('legend');
 

--- a/app/views/stages/index.html.erb
+++ b/app/views/stages/index.html.erb
@@ -20,7 +20,7 @@
   </ul>
 
   <% if admin_for_project? %>
-    <%= link_to "Add Stage", new_project_stage_path(@project), class: "btn btn-default" %>
+    <%= link_to "New", new_project_stage_path(@project), class: "btn btn-default" %>
   <% end %>
 
   <button id="error_message" class="messages btn btn-danger" disabled>

--- a/app/views/vault_servers/index.html.erb
+++ b/app/views/vault_servers/index.html.erb
@@ -37,7 +37,7 @@
 
   <div class="admin-actions">
     <div class="pull-right">
-      <%= link_to "New Server", new_vault_server_path, class: "btn btn-default" %>
+      <%= link_to "New", new_vault_server_path, class: "btn btn-default" %>
     </div>
   </div>
 </section>

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -130,8 +130,8 @@ describe StagesController do
           assert_template :new
         end
 
-        it 'adds global commands by default' do
-          assigns(:stage).command_ids.wont_be_empty
+        it 'adds no commands by default' do
+          assigns(:stage).command_ids.must_equal []
         end
       end
 


### PR DESCRIPTION
 - when there are a lot of commands then pre-selecting becomes really frustrating
 - make "New" buttons a bit more consistent
 - extract partial for mail notification to reduce clutter

@irwaters 