### PR TITLE
charts always go from 0 to 100 so we have to show percentages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -284,7 +284,7 @@ module ApplicationHelper
 
     max = values.max.round
     y_axis = [0, max / 4, max / 2, (max / 1.333333).to_i, max].map { |t| duration_text(t) }.join("|")
-    y_values = values.reverse.join(",")
+    y_values = values.reverse.map { |v| max.zero? ? max : (v * 100.0 / max).round }.join(",") # values as % of max
     params = {
       cht: "lc", # chart type
       chtt: name,

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -611,6 +611,11 @@ describe ApplicationHelper do
       chart.must_include "https://chart.googleapis.com/chart"
     end
 
+    it "renders all 0" do
+      chart = link_to_chart("Hello world", [0, 0, 0, 0, 0])
+      chart.must_include "https://chart.googleapis.com/chart"
+    end
+
     it "does not render for useless data" do
       link_to_chart("Hello world", []).must_equal nil
       link_to_chart("Hello world", [1]).must_equal nil


### PR DESCRIPTION
current charts are capped at 100 so we get weird results ... I guess they show percent by default ... tried changing the scales but that did not work ... so scaling everything to percent ...

<img width="1040" alt="screen shot 2017-09-22 at 5 33 02 pm" src="https://user-images.githubusercontent.com/11367/30769644-20001916-9fd2-11e7-96d6-6daf1269ad52.png">
