### PR TITLE
better names for Datadog logging

### DIFF
--- a/config/initializers/datadog_apm.rb
+++ b/config/initializers/datadog_apm.rb
@@ -4,9 +4,17 @@
 if ENV.fetch('DATADOG_ENABLE_APM', 'false') != 'false'
   require 'ddtrace'
 
+  Rails.logger.info("Enabling Datadog APM tracer")
+
   Rails.configuration.datadog_trace = {
     auto_instrument: true,
     default_service: 'samson',
-    trace_agent_hostname: ENV.fetch('STATSD_HOST', 'localhost')
+    default_controller_service: 'samson-rails-controller',
+    default_cache_service: 'samson-cache',
+    default_database_service: 'samson-mysql',
+    trace_agent_hostname: ENV.fetch('STATSD_HOST', 'localhost'),
+    tags: {
+      project: 'samson'
+    }
   }
 end


### PR DESCRIPTION
By default Datadog creates names like "mysql", "rails-cache", and "rails-controller". Give them names specific to Samson.

![service_list__env_production____datadog](https://user-images.githubusercontent.com/1056506/30826007-b79c7922-a1e9-11e7-8bb9-b1a1a9f29b97.jpg)

/cc @zendesk/samson, @craig-day 

### Risks
- Level: Low
