### PR TITLE
show cancel button for deploys that are queued or invalid status

### DIFF
--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -37,7 +37,7 @@
   </div>
 </section>
 
-<% if @deploy.job.executing? %>
+<% if @deploy.job.active? %>
   <script>
     toggleOutputToolbar();
     startStream();


### PR DESCRIPTION
saw a few cases where threads just died and then there was no way of cancelling the job
 - docker builds
 - deploy timing out and getting killed while being hung