### PR TITLE
TOOLS-1907 expose project.repo_path to api users so they can find mat…

### DIFF
--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -11,6 +11,6 @@ class ChangelogsController < ApplicationController
     @start_date = Date.strptime(params[:start_date], '%Y-%m-%d')
     @end_date = Date.strptime(params[:end_date], '%Y-%m-%d')
 
-    @changeset = Changeset.new(current_project.github_repo, "master@{#{@start_date}}", "master@{#{@end_date}}")
+    @changeset = Changeset.new(current_project.repository_path, "master@{#{@start_date}}", "master@{#{@end_date}}")
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -50,7 +50,7 @@ class ProjectsController < ApplicationController
   def show
     respond_to do |format|
       format.html { @stages = @project.stages }
-      format.json { render json: @project.to_json(except: [:token, :deleted_at]) }
+      format.json { render json: @project.as_json }
     end
   end
 
@@ -122,6 +122,7 @@ class ProjectsController < ApplicationController
     @project = (Project.find_by_param!(params[:id]) if params[:id])
   end
 
+  # Avoiding N+1 queries on project index
   def last_deploy_for(project)
     @projects_last_deployed_at ||= Deploy.successful.
       last_deploys_for_projects.
@@ -131,8 +132,6 @@ class ProjectsController < ApplicationController
     @projects_last_deployed_at[project.id]
   end
 
-  # Renders a collection of projects as an array of Hashes, with the
-  # intention that #to_json be called on the result
   def projects_as_json(projects)
     projects.map do |project|
       json = project.as_json
@@ -144,7 +143,6 @@ class ProjectsController < ApplicationController
     end
   end
 
-  # Renders a collection of projects into a CSV file
   def projects_as_csv(projects)
     CSV.generate do |csv|
       header = ProjectSerializer.csv_header

--- a/app/models/changeset/code_push.rb
+++ b/app/models/changeset/code_push.rb
@@ -8,7 +8,7 @@ class Changeset::CodePush
   end
 
   def self.changeset_from_webhook(project, payload)
-    new(project.github_repo, payload)
+    new(project.repository_path, payload)
   end
 
   def self.valid_webhook?(_)

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -11,7 +11,7 @@ class Changeset::IssueComment
   end
 
   def self.changeset_from_webhook(project, payload)
-    new(project.github_repo, payload)
+    new(project.repository_path, payload)
   end
 
   def self.valid_webhook?(payload)

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -45,7 +45,7 @@ class Changeset::PullRequest
 
   def self.changeset_from_webhook(project, payload)
     data = Sawyer::Resource.new(Octokit.agent, payload.fetch('pull_request'))
-    new(project.github_repo, data)
+    new(project.repository_path, data)
   end
 
   # Webhook events that are valid should be related to a pr code push or someone adding [samson review]

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -40,7 +40,7 @@ class CommitStatus
   # need to do weird escape logic since other wise either 'foo/bar' or 'bar[].foo' do not work
   def github_status
     escaped_ref = @reference.gsub(/[^a-zA-Z\/\d_-]+/) { |v| CGI.escape(v) }
-    GITHUB.combined_status(@stage.project.user_repo_part, escaped_ref).to_h
+    GITHUB.combined_status(@stage.project.repository_path, escaped_ref).to_h
   rescue Octokit::NotFound
     {
       state: "failure",

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -88,7 +88,7 @@ class Deploy < ActiveRecord::Base
   end
 
   def changeset_to(other)
-    Changeset.new(project.github_repo, other.try(:commit), commit)
+    Changeset.new(project.repository_path, other.try(:commit), commit)
   end
 
   def production

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -21,7 +21,7 @@ class Release < ActiveRecord::Base
   end
 
   def changeset
-    @changeset ||= Changeset.new(project.github_repo, previous_release.try(:commit), commit)
+    @changeset ||= Changeset.new(project.repository_path, previous_release.try(:commit), commit)
   end
 
   def previous_release
@@ -59,11 +59,13 @@ class Release < ActiveRecord::Base
   def contains_commit?(other_commit)
     return true if other_commit == commit
     # status values documented here: http://stackoverflow.com/questions/23943855/github-api-to-compare-commits-response-status-is-diverged
-    ['behind', 'identical'].include?(GITHUB.compare(project.github_repo, commit, other_commit).status)
+    ['behind', 'identical'].include?(GITHUB.compare(project.repository_path, commit, other_commit).status)
   rescue Octokit::NotFound
     false
   rescue Octokit::Error => e
-    Airbrake.notify(e, parameters: { github_repo: project.github_repo, commit: commit, other_commit: other_commit})
+    Airbrake.notify(e, parameters: {
+      repository_path: project.repository_path, commit: commit, other_commit: other_commit
+    })
     false # Err on side of caution and cause a new release to be created.
   end
 

--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -14,7 +14,7 @@ class ReleaseService
   end
 
   def can_release?
-    GITHUB.repo(@project.user_repo_part).permissions[:push]
+    GITHUB.repo(@project.repository_path).permissions[:push]
   rescue Octokit::NotFound, Octokit::Unauthorized
     false
   end
@@ -22,7 +22,7 @@ class ReleaseService
   private
 
   def push_tag_to_git_repository(release)
-    GITHUB.create_release(@project.github_repo, release.version, target_commitish: release.commit)
+    GITHUB.create_release(@project.repository_path, release.version, target_commitish: release.commit)
   end
 
   def start_deploys(release)

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -17,7 +17,7 @@
         <% if source == 'github' && token = Integrations::GithubController.secret_token %>
           <br/>
           <% if current_user.admin_for?(@project) %>
-            (Set <%= link_to "secret token", "javascript:prompt('Copy this token', '#{token}')" %> in <%= link_to 'hook settings', "https://github.com/#{@project.user_repo_part}/settings/hooks" %>)
+            (Set <%= link_to "secret token", "javascript:prompt('Copy this token', '#{token}')" %> in <%= link_to 'hook settings', "https://github.com/#{@project.repository_path}/settings/hooks" %>)
           <% else %>
             (Secret token required, ask a project admin)
           <% end %>

--- a/plugins/github/app/models/github_deployment.rb
+++ b/plugins/github/app/models/github_deployment.rb
@@ -10,7 +10,7 @@ class GithubDeployment
   # https://developer.github.com/v3/repos/deployments/#create-a-deployment
   def create
     GITHUB.create_deployment(
-      @project.github_repo,
+      @project.repository_path,
       @deploy.job.commit,
       payload: {
         deployer: @deploy.user.attributes.slice("id", "name", "email"),

--- a/plugins/github/app/models/github_notification.rb
+++ b/plugins/github/app/models/github_notification.rb
@@ -12,7 +12,7 @@ class GithubNotification
 
     in_multiple_threads(pull_requests) do |pull_request|
       pull_id = pull_request.number
-      GITHUB.add_comment(@project.github_repo, pull_id, body)
+      GITHUB.add_comment(@project.repository_path, pull_id, body)
       Rails.logger.info "Updated GitHub PR: #{pull_id}"
     end
   end

--- a/plugins/github/test/models/github_notification_test.rb
+++ b/plugins/github/test/models/github_notification_test.rb
@@ -4,7 +4,7 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe GithubNotification do
-  let(:project) { stub(name: "Glitter", github_repo: "glitter/glitter", to_param: "3-glitter") }
+  let(:project) { stub(name: "Glitter", repository_path: "glitter/glitter", to_param: "3-glitter") }
   let(:stage) { stub(name: "staging", project: project) }
   let(:changeset) { stub_everything(commits: [], files: [], pull_requests: [pull_requests]) }
   let(:deploy) { stub(changeset: changeset, short_reference: "7e6c415", id: 18, stage: stage) }

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -38,7 +38,11 @@ describe ProjectsController do
         result = JSON.parse(response.body)
         projects = result['projects']
         projects.length.must_equal 1
-        projects.first['name'].must_equal 'Foo'
+        project = projects.first
+        project['name'].must_equal 'Foo'
+        project['repository_path'].must_equal 'bar/foo'
+        refute project.key?('deleted_at')
+        refute project.key?('token')
       end
 
       it "returns the last deploy date in JSON" do
@@ -97,8 +101,11 @@ describe ProjectsController do
         it "is json and does not include :token" do
           get :show, params: {id: project.permalink, format: :json}
           assert_response :success
-          result = JSON.parse(response.body)
-          result.keys.wont_include('token')
+          project = JSON.parse(response.body)
+          project['name'].must_equal 'Foo'
+          project['repository_path'].must_equal 'bar/foo'
+          refute project.key?('deleted_at')
+          refute project.key?('token')
         end
       end
     end

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -25,7 +25,7 @@ describe CommitStatus do
 
   let(:stage) { stages(:test_staging) }
   let(:reference) { 'master' }
-  let(:url) { "repos/#{stage.project.user_repo_part}/commits/#{reference}/status" }
+  let(:url) { "repos/#{stage.project.repository_path}/commits/#{reference}/status" }
   let(:status) { CommitStatus.new(stage, reference) }
 
   describe "#status" do
@@ -101,7 +101,7 @@ describe CommitStatus do
 
     describe "with bad ref" do
       let(:reference) { '[/r' }
-      let(:url) { "repos/#{stage.project.user_repo_part}/commits/%255B/r/status" }
+      let(:url) { "repos/#{stage.project.repository_path}/commits/%255B/r/status" }
 
       it "escapes the url" do
         failure!

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -95,33 +95,33 @@ describe Project do
     end
   end
 
-  describe "#github_repo" do
+  describe "#repository_path" do
     it "returns the user/repo part of the repository URL" do
       project = Project.new(repository_url: "git@github.com:foo/bar.git")
-      project.github_repo.must_equal "foo/bar"
+      project.repository_path.must_equal "foo/bar"
     end
 
     it "handles user, organisation and repository names with hyphens" do
       project = Project.new(repository_url: "git@github.com:inlight-media/lighthouse-ios.git")
-      project.github_repo.must_equal "inlight-media/lighthouse-ios"
+      project.repository_path.must_equal "inlight-media/lighthouse-ios"
     end
 
     it "handles repository names with dashes or dots" do
       project = Project.new(repository_url: "git@github.com:angular/angular.js.git")
-      project.github_repo.must_equal "angular/angular.js"
+      project.repository_path.must_equal "angular/angular.js"
 
       project = Project.new(repository_url: "git@github.com:zendesk/demo_apps.git")
-      project.github_repo.must_equal "zendesk/demo_apps"
+      project.repository_path.must_equal "zendesk/demo_apps"
     end
 
     it "handles https urls" do
       project = Project.new(repository_url: "https://github.com/foo/bar.git")
-      project.github_repo.must_equal "foo/bar"
+      project.repository_path.must_equal "foo/bar"
     end
 
     it "works if '.git' is not at the end" do
       project = Project.new(repository_url: "https://github.com/foo/bar")
-      project.github_repo.must_equal "foo/bar"
+      project.repository_path.must_equal "foo/bar"
     end
   end
 
@@ -460,6 +460,17 @@ describe Project do
     it "splits user input" do
       project.dockerfiles = "Dockerfile  Muh File"
       project.dockerfile_list.must_equal ["Dockerfile", "Muh", "File"]
+    end
+  end
+
+  describe "#as_json" do
+    it "does not include sensitive fields" do
+      refute project.as_json.key?("token")
+      refute project.as_json.key?("deleted_at")
+    end
+
+    it "includes repository_path" do
+      project.as_json.fetch("repository_path").must_equal "bar/foo"
     end
   end
 end

--- a/test/models/release_service_test.rb
+++ b/test/models/release_service_test.rb
@@ -29,7 +29,7 @@ describe ReleaseService do
 
     it "tags the release" do
       service.release(commit: commit, author: author)
-      assert_equal [[project.github_repo, 'v124', target_commitish: commit]], release_params_used
+      assert_equal [[project.repository_path, 'v124', target_commitish: commit]], release_params_used
     end
 
     it "deploys the commit to stages if they're configured to" do


### PR DESCRIPTION
…ching projects without having to parse urls

 - unifying the api to not expose project tokens or deleted_at
 - unifying user_repo_path + github_repo + gitlab_repo
 - naming repository_url and repository_path similarly

@jonmoter @irwaters 

### Risks
 - Low: breaking usage for people fetching project tokens via show endpoint ... that was never intended