### PR TITLE
Improve project search

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -107,8 +107,7 @@ class ProjectsController < ApplicationController
     per_page = 9 # 3 or 1 column layout depending on size
     scope = Project.alphabetical
     if query = params.dig(:search, :query).presence
-      query = ActiveRecord::Base.send(:sanitize_sql_like, query)
-      scope = scope.where('name like ?', "%#{query}%")
+      scope = scope.search(query)
     elsif ids = current_user.starred_project_ids.presence
       # fake association sorting since order by array is hard to support in mysql+postgres+sqlite
       array = scope.all.sort_by { |p| ids.include?(p.id) ? 0 : 1 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -45,7 +45,13 @@ class Project < ActiveRecord::Base
       alphabetical
   }
 
-  scope :search, ->(name) { where("name like ?", "%#{name}%") }
+  scope :search, ->(query) {
+    scope = self
+    sanitize_sql_like(query).split(' ').each do |word|
+      scope = scope.where(Project.arel_table[:name].matches("%#{word}%"))
+    end
+    scope
+  }
 
   def docker_repo(registry, dockerfile)
     repo = File.join(registry.base, permalink_base)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -321,6 +321,30 @@ describe Project do
     end
   end
 
+  describe '#search' do
+    it 'filters and returns projects by name' do
+      Project.create!(name: 'Test #1', repository_url: url)
+      Project.create!(name: 'Test #2', repository_url: url)
+      Project.create!(name: 'random name', repository_url: url)
+
+      Project.search('Test #').map(&:name).must_equal ['Test #1', 'Test #2']
+    end
+
+    it 'is case insensitive' do
+      Project.create!(name: 'PROJECT ONE', repository_url: url)
+      Project.create!(name: 'pRoJeCt TwO', repository_url: url)
+
+      Project.search('project').map(&:name).must_equal ['PROJECT ONE', 'pRoJeCt TwO']
+    end
+
+    it 'returns empty relation when no results are found' do
+      Project.create!(name: 'PROJECT ONE', repository_url: url)
+      Project.create!(name: 'pRoJeCt TwO', repository_url: url)
+
+      Project.search('no match').must_equal []
+    end
+  end
+
   describe '#docker_repo' do
     with_registries ["docker-registry.example.com/bar"]
 


### PR DESCRIPTION
Currently, searching for projects behaves inconsistently between mysql and
postgres based deployments because the SQL query is hardcoded to use `LIKE`.
This results in search being case sensitive for postgres but case insensitive
for mysql.

This PR:
- makes the project search scope case insensitive for postgres by extending it
  to use the appropriate SQL syntax, based on the DB being used. E.g. `ILIKE`
  for postgres, otherwise `LIKE`.
- makes the project search scope fuzzier by splitting the query argument into
  multiple strings and adding a separate expression to the SQL query for each

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
