### PR TITLE
make sure we stop doing bad migrations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -171,6 +171,9 @@ module Samson
     ActiveModelSerializers.config.adapter = :json
 
     config.active_support.deprecation = :raise
+
+    # avoid permission errors in production and cleanliness test failures in test
+    config.active_record.dump_schema_after_migration = Rails.env.development?
   end
 
   RELEASE_NUMBER = '\d+(:?\.\d+)*'

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -20,6 +20,39 @@ describe "cleanliness" do
     File.read("db/schema.rb").wont_match /\st\.boolean.*limit: 1/
   end
 
+  it "does not have string index without limit since that breaks our mysql migrations" do
+    table_definitions = File.read("db/schema.rb").scan(/  create_table "(\S+)"(.*?)\n  end/m)
+    table_definitions.size.must_be :>, 10
+
+    bad = table_definitions.flat_map do |table, definition|
+      strings = definition.scan(/\.string "(\S+)"/).map!(&:first)
+      indexes = definition.scan(/t.index (\[(.*?)\].*$)/)
+      strings.map do |string|
+        # it is bad when a string is used in the index but no length is declared
+        if indexes.any? { |i| i[1].include?(%("#{string}")) && i[0] !~ /length: .*#{string}/ }
+          [table, string]
+        end
+      end.compact
+    end
+
+    # old tables that somehow worked
+    bad -= [
+      ["builds", "git_sha"],
+      ["builds", "dockerfile"],
+      ["environment_variable_groups", "name"],
+      ["environments", "permalink"],
+      ["jobs", "status"],
+      ["kubernetes_roles", "name"],
+      ["kubernetes_roles", "service_name"],
+      ["new_relic_applications", "name"],
+      ["releases", "number"],
+      ["users", "external_id"],
+      ["webhooks", "branch"]
+    ]
+
+    assert bad.empty?, bad.map! { |table, string| "#{table} #{string} has an index without length" }.join("\n")
+  end
+
   it "does not have 3-state booleans (nil/false/true)" do
     bad = File.read("db/schema.rb").scan(/\st\.boolean.*/).reject { |l| l .include?(" null: false") }
     assert bad.empty?, "Boolean columns missing a default or null: false\n#{bad.join("\n")}"


### PR DESCRIPTION
@irwaters @jonmoter 

... failed with "builds external_id has an index without length" ... but after rebase it's green :D