### PR TITLE
[AHA-1249] Change .env files permission to 0600

### DIFF
--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -36,6 +36,7 @@ module SamsonEnv
       groups.each do |suffix, data|
         generated_file = "#{base_file}#{suffix}"
         File.write(generated_file, generate_dotenv(data))
+        File.chmod(0600, generated_file)
       end
     end
 

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -35,8 +35,7 @@ module SamsonEnv
 
       groups.each do |suffix, data|
         generated_file = "#{base_file}#{suffix}"
-        File.write(generated_file, generate_dotenv(data))
-        File.chmod(0o600, generated_file)
+        File.write(generated_file, generate_dotenv(data), 0, perm: 0o600)
       end
     end
 

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -36,7 +36,7 @@ module SamsonEnv
       groups.each do |suffix, data|
         generated_file = "#{base_file}#{suffix}"
         File.write(generated_file, generate_dotenv(data))
-        File.chmod(0600, generated_file)
+        File.chmod(0o600, generated_file)
       end
     end
 

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -44,7 +44,7 @@ describe SamsonEnv do
         it "writes to .env" do
           fire
           File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
-          sprintf("%o", File.stat(".env").mode).must_equal "100600"
+          ("%o" % File.stat(".env").mode).must_equal "100600"
         end
       end
 
@@ -74,7 +74,7 @@ describe SamsonEnv do
     it "writes to .env" do
       fire
       File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
-      sprintf("%o", File.stat(".env").mode).must_equal "100600"
+      ("%o" % File.stat(".env").mode).must_equal "100600"
     end
   end
 

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -44,6 +44,7 @@ describe SamsonEnv do
         it "writes to .env" do
           fire
           File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
+          sprintf("%o", File.stat(".env").mode).must_equal "100600"
         end
       end
 
@@ -73,6 +74,7 @@ describe SamsonEnv do
     it "writes to .env" do
       fire
       File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
+      sprintf("%o", File.stat(".env").mode).must_equal "100600"
     end
   end
 


### PR DESCRIPTION
`.env` files could potentially contain secrets but the default file permission is `0644` which allows the world to read its contents. Changing the default `.env` file permission to `0600`.

/cc @zendesk/samson @zendesk/bunyip-numbat 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/AHA-1249

### Risks
- Level: Med - Could be a problem if application expects the `.env` file to be readable by other than file owner
