### PR TITLE
update logic for finding docker registry config secrets

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -361,7 +361,7 @@ module Kubernetes
       client = @doc.deploy_group.kubernetes_cluster.client
       secrets = client.get_secrets(namespace: template.dig_fetch(:metadata, :namespace))
       docker_credentials = secrets.
-        select { |secret| secret.type == "kubernetes.io/dockercfg" }.
+        select { |secret| ['kubernetes.io/dockercfg', 'kubernetes.io/dockerconfigjson'].include? secret.type }.
         map! { |c| {name: c.metadata.name} }
 
       return if docker_credentials.empty?

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -82,7 +82,8 @@ describe Kubernetes::TemplateFiller do
         items: [
           {type: "kubernetes.io/dockercfg", metadata: {name: 'a'}},
           {type: "kubernetes.io/nope", metadata: {name: 'b'}},
-          {type: "kubernetes.io/dockercfg", metadata: {name: 'c'}}
+          {type: "kubernetes.io/dockerconfigjson", metadata: {name: 'c'}},
+          {type: "kubernetes.io/dockerNotValidConfigThing", metadata: {name: 'd'}}
         ]
       }
       stub_request(:get, "http://foobar.server/api/v1/namespaces/pod1/secrets").to_return(body: reply.to_json)


### PR DESCRIPTION
At some point, Kubernetes changed some logic so that to authenticate with a remote registry, the name of the data item in the secret should be `kubernetes.io/dockerconfigjson`.  See docs [here](https://kubernetes.io/docs/concepts/containers/images/#bypassing-kubectl-create-secrets).

Currently, Samson only finds secrets where the type is `kubernetes.io/dockercfg`. This whitelists both those values.

/cc @zendesk/samson, @henders 

### Risks
- Level: Low
