### PR TITLE
remove cyclic dependencies between job-execution and job-queue

### DIFF
--- a/app/models/deploy_service.rb
+++ b/app/models/deploy_service.rb
@@ -40,7 +40,7 @@ class DeployService
       send_after_notifications(deploy)
     end
 
-    JobExecution.start_job(job_execution, queue: deploy.job_execution_queue_name)
+    JobExecution.perform_later(job_execution, queue: deploy.job_execution_queue_name)
 
     send_sse_deploy_update('start', deploy)
   end

--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -102,7 +102,7 @@ class DockerBuilderService
       send_after_notifications
     end
 
-    JobExecution.start_job(@execution)
+    JobExecution.perform_later(@execution)
   end
 
   private

--- a/app/models/job_queue.rb
+++ b/app/models/job_queue.rb
@@ -28,58 +28,65 @@ class JobQueue
     LOCK.synchronize { executing?(id) || queued?(id) }
   end
 
-  # Assumes executing threads will be closed by themselves
-  def clear
-    LOCK.synchronize do
-      @queue.each { |_, jes| jes.each(&:close) }
-      @queue.clear
-    end
-  end
-
   # when no queue is given jobs run in parallel (each in their own queue) and start instantly
   # when samson is restarting we do not start jobs, but leave them pending
   def add(job_execution, queue: nil)
     queue ||= job_execution.id
-    job_execution.on_finish { delete_and_enqueue_next(queue, job_execution) }
 
-    LOCK.synchronize do
-      if JobExecution.enabled
+    if JobExecution.enabled
+      LOCK.synchronize do
         if @executing[queue]
           @queue[queue] << job_execution
+          false
         else
-          start_job(job_execution, queue)
+          @executing[queue] = job_execution
+          perform_job(job_execution, queue)
+          true
         end
       end
     end
 
     instrument
-
-    job_execution
   end
 
   def debug
     [@executing, @queue]
   end
 
-  private
-
-  def start_job(job_execution, queue)
-    @executing[queue] = job_execution
-    job_execution.start
+  def clear
+    raise unless Rails.env.test?
+    @executing.clear
+    @queue.clear
   end
 
-  def delete_and_enqueue_next(queue_name, job_execution)
+  private
+
+  # assign the thread first so we do not get into a state where the execution is findable but has no thread
+  # so our mutex guarantees that all jobs/queues are in a valid state
+  # ideally the job_execution should not know about it's thread and we would call cancel/wait on the job-queue instead
+  def perform_job(job_execution, queue)
+    job_execution.thread = Thread.new do
+      begin
+        job_execution.perform
+      ensure
+        delete_and_enqueue_next(job_execution, queue)
+      end
+    end
+  end
+
+  def delete_and_enqueue_next(job_execution, queue)
     LOCK.synchronize do
-      previous = @executing.delete(queue_name)
+      previous = @executing.delete(queue)
       unless job_execution == previous
-        raise "Unexpected executing job found in queue #{queue_name}: expected #{job_execution&.id} got #{previous&.id}"
+        raise "Unexpected executing job found in queue #{queue}: expected #{job_execution&.id} got #{previous&.id}"
       end
 
-      if JobExecution.enabled && (job_execution = @queue[queue_name].shift)
-        start_job(job_execution, queue_name)
+      if JobExecution.enabled && (next_execution = @queue[queue].shift)
+        @executing[queue] = next_execution
+        perform_job(next_execution, queue)
       end
 
-      @queue.delete(queue_name) if @queue[queue_name].empty? # save memory, and time when iterating all queues
+      @queue.delete(queue) if @queue[queue].empty? # save memory, and time when iterating all queues
     end
 
     instrument

--- a/app/models/restart_signal_handler.rb
+++ b/app/models/restart_signal_handler.rb
@@ -18,7 +18,7 @@ class RestartSignalHandler
 
         # start all non-deploys jobs waiting for restart
         Job.non_deploy.pending.each do |job|
-          JobExecution.start_job(JobExecution.new(job.commit, job))
+          JobExecution.perform_later(JobExecution.new(job.commit, job))
         end
 
         # start all ready deploy jobs waiting for restart

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -142,7 +142,7 @@ describe DeployService do
 
   describe "#confirm_deploy!" do
     it "starts a job execution" do
-      JobExecution.expects(:start_job).returns(mock).once
+      JobExecution.expects(:perform_later).returns(mock).once
       service.confirm_deploy(deploy)
     end
 
@@ -154,7 +154,7 @@ describe DeployService do
       it "immediately starts the job" do
         job_execution
         JobExecution.stubs(:new).returns(job_execution)
-        JobExecution.expects(:start_job).with(job_execution, queue: nil)
+        JobExecution.expects(:perform_later).with(job_execution, queue: nil)
         deploy.buddy = user
         service.confirm_deploy(deploy)
       end
@@ -164,7 +164,7 @@ describe DeployService do
       it "will be queued on the stage id" do
         job_execution
         JobExecution.stubs(:new).returns(job_execution)
-        JobExecution.expects(:start_job).with(job_execution, queue: "stage-#{stage.id}")
+        JobExecution.expects(:perform_later).with(job_execution, queue: "stage-#{stage.id}")
         deploy.buddy = user
         service.confirm_deploy(deploy)
       end
@@ -183,7 +183,7 @@ describe DeployService do
 
       it "starts a job execution" do
         stub_request(:get, "https://api.github.com/repos/bar/foo/compare/staging...staging")
-        JobExecution.expects(:start_job).returns(mock).once
+        JobExecution.expects(:perform_later).returns(mock).once
         DeployMailer.expects(:bypass_email).never
         deploy.buddy = other_user
         service.confirm_deploy(deploy)
@@ -191,7 +191,7 @@ describe DeployService do
 
       it "reports bypass via mail" do
         stub_request(:get, "https://api.github.com/repos/bar/foo/compare/staging...staging")
-        JobExecution.expects(:start_job).returns(mock).once
+        JobExecution.expects(:perform_later).returns(mock).once
         DeployMailer.expects(bypass_email: stub(deliver_now: true))
         deploy.buddy = user
         service.confirm_deploy(deploy)

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -23,7 +23,7 @@ describe DockerBuilderService do
 
   describe "#run" do
     def call(options = {})
-      JobExecution.expects(:start_job).capture(start_jobs)
+      JobExecution.expects(:perform_later).capture(perform_laters)
       service.run(options)
     end
 
@@ -31,11 +31,11 @@ describe DockerBuilderService do
       job.instance_variable_get(:@execution_block).call(job, Dir.mktmpdir)
     end
 
-    let(:start_jobs) { [] }
-    let(:job) { start_jobs[0][0] }
+    let(:perform_laters) { [] }
+    let(:job) { perform_laters[0][0] }
 
     it "skips when already running to combat racey parallel deploys/builds" do
-      JobExecution.expects(:start_job).never
+      JobExecution.expects(:perform_later).never
       Rails.cache.write("build-service-#{build.id}", true)
       service.run
     end

--- a/test/models/job_queue_test.rb
+++ b/test/models/job_queue_test.rb
@@ -4,188 +4,205 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe JobQueue do
-  # JobExecution is very complicated ... so we stub it out
+  # JobExecution is slow/complicated ... so we stub it out
   fake_execution = Class.new do
     attr_reader :id
+    attr_writer :thread
     def initialize(id)
       @id = id
     end
 
-    def on_finish(&block)
-      @on_finish = block
-    end
-
-    def finish
-      @on_finish.call
+    # when expectations fail we need to know what failed
+    def inspect
+      "job-#{id}"
     end
   end
 
+  def wait_for_jobs_to_finish
+    sleep 0.01 until subject.debug == [{}, {}]
+  end
+
   def with_executing_job
-    job_execution.expects(:start)
+    job_execution.expects(:perform).with { active_lock.synchronize { true } }
 
     with_job_execution do
-      subject.add(job_execution)
-      yield
+      locked do
+        subject.add(job_execution)
+        yield
+      end
     end
   end
 
   def with_a_queued_job
-    job_execution.stubs(:start)
+    # keep executing until unlocked
+    job_execution.expects(:perform).with { active_lock.synchronize { true } }
+    queued_job_execution.expects(:perform).with { queued_lock.synchronize { true } }
 
     with_job_execution do
-      subject.add(job_execution, queue: :x)
-      subject.add(queued_job_execution, queue: :x)
-      yield
+      locked do
+        subject.add(job_execution, queue: queue_name)
+        subject.add(queued_job_execution, queue: queue_name)
+        yield
+      end
     end
   end
 
-  def self.with_a_queued_job
-    around { |t| with_a_queued_job(&t) }
+  def locked
+    locks = [active_lock, queued_lock]
+    locks.each(&:lock) # stall jobs
+
+    yield
+
+    # let jobs finish
+    locks.each { |l| l.unlock if l.locked? }
+    wait_for_jobs_to_finish
   end
 
   let(:subject) { JobQueue.new }
-  let(:job_execution) { fake_execution.new(1) }
-  let(:queued_job_execution) { fake_execution.new(2) }
+  let(:job_execution) { fake_execution.new(:active) }
+  let(:queued_job_execution) { fake_execution.new(:queued) }
+  let(:active_lock) { Mutex.new }
+  let(:queued_lock) { Mutex.new }
+  let(:queue_name) { :my_queue }
 
   before do
     JobExecution.stubs(:new).returns(job_execution).returns(queued_job_execution)
   end
 
   describe "#add" do
-    it 'immediately starts a job when executing is empty' do
+    it 'immediately performs a job when executing is empty' do
       with_executing_job do
-        assert subject.executing?(1)
-        refute subject.queued?(1)
-        subject.find_by_id(1).must_equal(job_execution)
+        assert subject.executing?(:active)
+        refute subject.queued?(:active)
+        subject.find_by_id(:active).must_equal(job_execution)
       end
     end
 
-    it 'starts parallel jobs when they are in different queues' do
-      [job_execution, queued_job_execution].each do |job|
-        job.expects(:start)
+    it 'performs parallel jobs when they are in different queues' do
+      locked do
+        [job_execution, queued_job_execution].each do |job|
+          job.expects(:perform).with { active_lock.synchronize { true } }
 
-        with_job_execution { subject.add(job) }
+          with_job_execution { subject.add(job) }
 
-        assert subject.executing?(job.id)
+          assert subject.executing?(job.id)
+        end
       end
     end
 
-    it 'does not start a job if job execution is disabled' do
+    it 'does not perform a job if job execution is disabled' do
       JobExecution.enabled = false
-      job_execution.expects(:start).never
+      job_execution.expects(:perform).never
 
       subject.add(job_execution)
 
-      refute subject.executing?(1)
-      refute subject.queued?(1)
-      refute subject.find_by_id(1)
+      refute subject.executing?(:active)
+      refute subject.queued?(:active)
+      refute subject.find_by_id(:active)
     end
 
     it 'does not queue a job if job execution is disabled' do
       with_executing_job do
         JobExecution.enabled = false
-        subject.add(queued_job_execution, queue: :x)
+        subject.add(queued_job_execution, queue: queue_name)
 
-        refute subject.executing?(2)
-        refute subject.queued?(2)
-        refute subject.find_by_id(2)
+        refute subject.executing?(:queued)
+        refute subject.queued?(:queued)
+        refute subject.find_by_id(:queued)
       end
     end
 
     it 'reports to airbrake when executing jobs were in an unexpected state' do
-      job_execution.stubs(:start)
-
       with_job_execution do
-        subject.add(job_execution, queue: :x)
+        subject.instance_variable_get(:@executing)[queue_name] = job_execution
 
         e = assert_raises RuntimeError do
-          subject.send(:delete_and_enqueue_next, :x, queued_job_execution)
+          subject.send(:delete_and_enqueue_next, queued_job_execution, queue_name)
         end
-        e.message.must_equal 'Unexpected executing job found in queue x: expected 2 got 1'
+        e.message.must_equal 'Unexpected executing job found in queue my_queue: expected queued got active'
       end
     end
 
     it 'reports queue length' do
-      ActiveSupport::Notifications.expects(:instrument).with("job_queue.samson", threads: 1, queued: 0)
-      ActiveSupport::Notifications.expects(:instrument).with("job_queue.samson", threads: 1, queued: 1)
+      states = [
+        [1, 0], # add active
+        [1, 1], # add queued
+        [1, 0], # done active ... enqueue queued
+        [0, 0], # done queued
+      ]
+      states.each do |t, q|
+        ActiveSupport::Notifications.expects(:instrument).with("job_queue.samson", threads: t, queued: q)
+      end
       with_a_queued_job {} # noop
     end
 
     describe 'with queued job' do
-      with_a_queued_job
-
       it 'has a queued job' do
-        refute subject.executing?(2)
-        assert subject.queued?(2)
-        subject.find_by_id(2).must_equal(queued_job_execution)
-      end
-
-      it 'starts then next job when executing job completes' do
-        queued_job_execution.expects(:start)
-
-        with_job_execution { job_execution.finish }
-
-        refute subject.find_by_id(1)
-        assert subject.executing?(2)
-        refute subject.queued?(2)
-      end
-
-      it 'does not start the next job when job execution is disabled' do
-        JobExecution.enabled = false
-        queued_job_execution.expects(:start).never
-
-        job_execution.finish
-
-        refute subject.find_by_id(1)
-        refute subject.executing?(2)
-        assert subject.queued?(2)
-      end
-
-      it 'does not start the next job when queue is empty' do
-        queued_job_execution.expects(:start)
-
-        with_job_execution do
-          job_execution.finish
-          queued_job_execution.finish
+        with_a_queued_job do
+          refute subject.executing?(:queued)
+          assert subject.queued?(:queued)
+          subject.find_by_id(:queued).must_equal(queued_job_execution)
         end
+      end
 
-        refute subject.find_by_id(1)
-        refute subject.find_by_id(2)
+      it 'performs then next job when executing job completes' do
+        with_a_queued_job do
+          active_lock.unlock
+          sleep 0.01 while subject.executing?(:active)
 
-        # make sure we cleaned up nicely
-        subject.instance_variable_get(:@executing).must_equal({})
-        subject.instance_variable_get(:@queue).must_equal({})
+          refute subject.find_by_id(:active)
+          assert subject.executing?(:queued)
+          refute subject.queued?(:queued)
+        end
+      end
+
+      it 'does not perform the next job when job execution is disabled' do
+        with_a_queued_job do
+          JobExecution.enabled = false
+
+          queued_job_execution.unstub(:perform)
+          queued_job_execution.expects(:perform).never
+
+          active_lock.unlock
+          sleep 0.01 while subject.executing?(:active)
+
+          refute subject.find_by_id(:active)
+          refute subject.executing?(:queued)
+          assert subject.queued?(:queued)
+          subject.debug.each(&:clear)
+        end
+      end
+
+      it 'does not fail when queue is empty' do
+        with_a_queued_job do
+          active_lock.unlock
+          queued_lock.unlock
+          wait_for_jobs_to_finish
+
+          refute subject.find_by_id(:active)
+          refute subject.find_by_id(:queued)
+
+          # make sure we cleaned up nicely
+          subject.instance_variable_get(:@executing).must_equal({})
+          subject.instance_variable_get(:@queue).must_equal({})
+        end
       end
     end
   end
 
   describe "#dequeue" do
-    with_a_queued_job
-
     it "removes a job from the queue" do
-      assert subject.dequeue(queued_job_execution.id)
-      refute subject.queued?(queued_job_execution.id)
-    end
-
-    it "does not remove a job when it is not queued" do
-      refute subject.dequeue(job_execution.id)
-      refute subject.queued?(job_execution.id)
-    end
-  end
-
-  describe "#clear" do
-    it "removes all queues" do
       with_a_queued_job do
-        queued_job_execution.expects(:close)
-        subject.clear
-        refute subject.queued?(queued_job_execution)
+        queued_job_execution.unstub(:perform)
+        assert subject.dequeue(queued_job_execution.id)
+        refute subject.queued?(queued_job_execution.id)
       end
     end
 
-    it "keeps executing since they will complete on their own" do
-      with_executing_job do
-        subject.clear
-        assert subject.executing?(1)
+    it "does not remove a job when it is not queued" do
+      with_a_queued_job do
+        refute subject.dequeue(job_execution.id)
+        refute subject.queued?(job_execution.id)
       end
     end
   end
@@ -193,6 +210,14 @@ describe JobQueue do
   describe "#debug" do
     it "returns executing and queued" do
       subject.debug.must_equal([{}, {}])
+    end
+  end
+
+  describe "#clear" do
+    it "clears" do
+      subject.debug.each { |q| q[:x] = 1 }
+      subject.clear
+      subject.debug.must_equal [{}, {}]
     end
   end
 end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -266,7 +266,7 @@ describe Job do
     it "has a pid when running" do
       job.command = 'sleep 0.5'
       job_execution = JobExecution.new('master', job)
-      JobExecution.start_job(job_execution)
+      JobExecution.perform_later(job_execution)
       sleep 0.5
       job.pid.wont_be_nil
       job_execution.wait
@@ -282,7 +282,7 @@ describe Job do
 
     it "cancels an executing job" do
       ex = JobExecution.new('master', job) { sleep 10 }
-      JobExecution.start_job(ex)
+      JobExecution.perform_later(ex)
       sleep 0.1 # make the job spin up properly
 
       assert JobExecution.executing?(ex.id)
@@ -308,11 +308,11 @@ describe Job do
     it "cancels a queued job" do
       executing_job = project.jobs.create!(command: 'cat foo', user: user, project: project, commit: 'master')
       executing = JobExecution.new('master', executing_job) { sleep 10 }
-      JobExecution.start_job(executing, queue: 'foo')
+      JobExecution.perform_later(executing, queue: 'foo')
       assert JobExecution.executing?(executing.id)
 
       queued = JobExecution.new('master', job) { sleep 10 }
-      JobExecution.start_job(queued, queue: 'foo')
+      JobExecution.perform_later(queued, queue: 'foo')
       assert JobExecution.queued?(queued.id)
 
       sleep 0.1 # let jobs spin up

--- a/test/models/restart_signal_handler_test.rb
+++ b/test/models/restart_signal_handler_test.rb
@@ -76,7 +76,7 @@ describe RestartSignalHandler do
 
     it "starts pending jobs" do
       jobs(:running_test).update_column(:status, 'pending')
-      JobExecution.expects(:start_job)
+      JobExecution.expects(:perform_later)
       RestartSignalHandler.after_restart
     end
   end

--- a/test/support/thread_checker.rb
+++ b/test/support/thread_checker.rb
@@ -15,7 +15,7 @@ ActiveSupport::TestCase.class_eval do
   end
 
   def wait_for_threads
-    sleep 0.1 while extra_threads.any?
+    sleep 0.01 while extra_threads.any?
   end
 
   def kill_extra_threads


### PR DESCRIPTION
job_queue should not know about job_execution / not interact with it except calling`perform`

before: execution adds to queue ... queue calls execution ... execution calls queue
after: execution adds to queue ... queue calls execution

 - makes things more active-job-ish ... maybe can unify later or write our own backend
 - makes tests have less stubs and more real executions via locks
 - making sure each executing or enqueued job-execution knows it's thread

@irwaters @jonmoter 
/cc @lisacf 