### PR TITLE
Revert "[AHA-1249] Change .env files permission to 0600 (#2277)"

### DIFF
--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -35,7 +35,7 @@ module SamsonEnv
 
       groups.each do |suffix, data|
         generated_file = "#{base_file}#{suffix}"
-        File.write(generated_file, generate_dotenv(data), 0, perm: 0o600)
+        File.write(generated_file, generate_dotenv(data))
       end
     end
 

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -44,7 +44,6 @@ describe SamsonEnv do
         it "writes to .env" do
           fire
           File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
-          ("%o" % File.stat(".env").mode).must_equal "100600"
         end
       end
 
@@ -74,7 +73,6 @@ describe SamsonEnv do
     it "writes to .env" do
       fire
       File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
-      ("%o" % File.stat(".env").mode).must_equal "100600"
     end
   end
 


### PR DESCRIPTION
This reverts commit d39bf328174cfa63ccddbf13a45036a476e75b66.

*Only valid if we couldn't resolve the other issue*
The previous PR on changing the default `.env` file permission is causing problem with other tools. Roll back that change.

/cc @zendesk/samson  @zendesk/bunyip-numbat 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/AHA-1215

### Risks
- Level: Low - reverting previous change
