### PR TITLE
[AHA-1273] Change .env file permission to 640

### DIFF
--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -35,7 +35,7 @@ module SamsonEnv
 
       groups.each do |suffix, data|
         generated_file = "#{base_file}#{suffix}"
-        File.write(generated_file, generate_dotenv(data), 0, perm: 0o600)
+        File.write(generated_file, generate_dotenv(data), 0, perm: 0o640)
       end
     end
 

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -44,7 +44,7 @@ describe SamsonEnv do
         it "writes to .env" do
           fire
           File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
-          ("%o" % File.stat(".env").mode).must_equal "100600"
+          ("%o" % File.stat(".env").mode).must_equal "100640"
         end
       end
 
@@ -74,7 +74,7 @@ describe SamsonEnv do
     it "writes to .env" do
       fire
       File.read(".env").must_equal "HELLO=\"world\"\nWORLD=\"hello\"\n"
-      ("%o" % File.stat(".env").mode).must_equal "100600"
+      ("%o" % File.stat(".env").mode).must_equal "100640"
     end
   end
 


### PR DESCRIPTION
Tools require `.env` file to be readable by group.

/cc @zendesk/samson @zendesk/bunyip-numbat 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/AHA-1273

### Risks
- Level: Med - Bug fix but might still cause other permission related issues
