### PR TITLE
consolidate on "M" k8s resource units

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -107,12 +107,12 @@ module Kubernetes
       return unless limits = spec.dig(:containers, 0, :resources, :limits)
       return unless limits_cpu = parse_resource_value(limits[:cpu])
       return unless limits_memory = parse_resource_value(limits[:memory])
-      limits_memory /= 1024**2 # we store megabyte
+      limits_memory /= 1000**2 # we store megabyte
 
       if requests = spec.dig(:containers, 0, :resources, :requests)
         requests_cpu = parse_resource_value(requests[:cpu])
         if requests_memory = parse_resource_value(requests[:memory])
-          requests_memory /= 1024**2 # we store megabyte
+          requests_memory /= 1000**2 # we store megabyte
         end
       end
 

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -3,15 +3,19 @@ require 'soft_deletion'
 
 module Kubernetes
   class Role < ActiveRecord::Base
+    # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+    # TL;DR:
+    # You can express memory as a plain integer or as a fixed-point integer using one of these
+    # suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
     KUBE_RESOURCE_VALUES = {
       "" => 1,
       'm' => 0.001,
-      'K' => 1024,
-      'Ki' => 1000,
-      'M' => 1024**2,
-      'Mi' => 1000**2,
-      'G' => 1024**3,
-      'Gi' => 1000**3
+      'K' => 1000,
+      'Ki' => 1024,
+      'M' => 1000**2,
+      'Mi' => 1024**2,
+      'G' => 1000**3,
+      'Gi' => 1024**3
     }.freeze
 
     self.table_name = 'kubernetes_roles'

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -256,8 +256,8 @@ module Kubernetes
 
     def set_resource_usage
       container[:resources] = {
-        requests: { cpu: @doc.requests_cpu.to_f, memory: "#{@doc.requests_memory}Mi" },
-        limits: { cpu: @doc.limits_cpu.to_f, memory: "#{@doc.limits_memory}Mi" }
+        requests: { cpu: @doc.requests_cpu.to_f, memory: "#{@doc.requests_memory}M" },
+        limits: { cpu: @doc.limits_cpu.to_f, memory: "#{@doc.limits_memory}M" }
       }
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
@@ -123,7 +123,7 @@ describe Kubernetes::DeployGroupRole do
       it "fills in missing roles" do
         seed!.must_equal []
         created_role.limits_cpu.must_equal 0.5
-        created_role.limits_memory.must_equal 95
+        created_role.limits_memory.must_equal 100
         created_role.replicas.must_equal 2
       end
 

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -28,7 +28,7 @@ describe Kubernetes::Role do
     {
       kind: 'Pod',
       metadata: {name: 'foo', labels: {role: 'migrate', project: 'bar'}},
-      spec: {containers: [{name: 'foo', resources: {limits: {cpu: '0.5', memory: '300Mi'}}}]}
+      spec: {containers: [{name: 'foo', resources: {limits: {cpu: '0.5', memory: '300M'}}}]}
     }
   end
   let(:config_content) do
@@ -286,9 +286,9 @@ describe Kubernetes::Role do
       role.defaults.must_equal(
         replicas: 2,
         requests_cpu: 0.25,
-        requests_memory: 48,
+        requests_memory: 50,
         limits_cpu: 0.5,
-        limits_memory: 95
+        limits_memory: 100
       )
     end
 
@@ -297,9 +297,9 @@ describe Kubernetes::Role do
       role.defaults.must_equal(
         replicas: 0,
         requests_cpu: 0.5,
-        requests_memory: 286,
+        requests_memory: 300,
         limits_cpu: 0.5,
-        limits_memory: 286
+        limits_memory: 300
       )
     end
 
@@ -324,9 +324,9 @@ describe Kubernetes::Role do
       role.defaults.must_equal(
         replicas: 2,
         requests_cpu: 0.25,
-        requests_memory: 48,
+        requests_memory: 50,
         limits_cpu: 0.5,
-        limits_memory: 95
+        limits_memory: 100
       )
     end
 
@@ -344,18 +344,18 @@ describe Kubernetes::Role do
       '10000Ki' => 10,
       '10M' => 10,
       '10Mi' => 10,
-      '10G' => 10 * 1024,
-      '10.5G' => 10.5 * 1024,
-      '10Gi' => 9537,
+      '10G' => 10 * 1000,
+      '10.5G' => 10.5 * 1000,
+      '10Gi' => 10737,
     }.each do |ram, expected|
       it "converts memory units #{ram}" do
-        assert config_content_yml.sub!('100Mi', ram)
+        assert config_content_yml.sub!('100M', ram)
         role.defaults.try(:[], :limits_memory).must_equal expected
       end
     end
 
     it "ignores unknown units" do
-      assert config_content_yml.sub!('100Mi', '200T')
+      assert config_content_yml.sub!('100M', '200T')
       role.defaults.must_be_nil
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -311,11 +311,11 @@ describe Kubernetes::TemplateFiller do
         container.fetch(:resources).must_equal(
           requests: {
             cpu: 0.5,
-            memory: "50Mi"
+            memory: "50M"
           },
           limits: {
             cpu: 1.0,
-            memory: "100Mi"
+            memory: "100M"
           }
         )
       end

--- a/plugins/kubernetes/test/samples/kubernetes_deployment.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_deployment.yml
@@ -25,10 +25,10 @@ spec:
         resources:
           requests:
             cpu: 250m
-            memory: 50Mi
+            memory: 50M
           limits:
             cpu: 500m
-            memory: 100Mi
+            memory: 100M
         ports:
         - name: some-role-port
           containerPort: 4242


### PR DESCRIPTION
The UI asks for memory in "MB", which means Megabytes (1000^2). The template filler would then take that value and apply it in "Mi" which means Mebibytes (1024^2). This means that each app was actually being given just a little more memory than it had asked for.

We should make the template filler consistent with the UI and reflect how people normally thing about units of digital memory. 

/cc @zendesk/samson

### Risks
- Level: Low. There will be a slight change to the k8s release docs.
