### PR TITLE
render Unauthorized when no authentication was provided during POST r…

### DIFF
--- a/app/controllers/concerns/json_exceptions.rb
+++ b/app/controllers/concerns/json_exceptions.rb
@@ -22,6 +22,12 @@ module JsonExceptions
       details = exception.params.each_with_object({}) { |p, h| h[p] = ["is not permitted"] }
       render_json_error 400, details
     end
+
+    # renders as {} 422 otherwise which is super unhelpful
+    base.rescue_from ActionController::InvalidAuthenticityToken do
+      raise unless request.format.json?
+      render_json_error 401, "Unauthorized"
+    end
   end
 
   private

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -8,17 +8,11 @@ describe Api::BaseController do
     def test_render
       head :ok
     end
-
-    private
-
-    # turned off in test ... but we want to simulate it
-    def allow_forgery_protection
-      true
-    end
   end
 
   tests ApiBaseTestController
   use_test_routes ApiBaseTestController
+  with_forgery_protection
 
   before { @controller.stubs(:store_requested_oauth_scope) }
 

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -116,16 +116,14 @@ describe "ApplicationController Integration" do
       end
 
       it 'cannot POST without authenticity_token' do
-        assert_raises ActionController::InvalidAuthenticityToken do
-          post '/api/locks', params: post_params
-        end
+        post '/api/locks', params: post_params
+        assert_response :unauthorized
       end
     end
 
     it 'cannot POST without authenticity_token when not logged in' do
-      assert_raises ActionController::InvalidAuthenticityToken do
-        post '/api/locks', params: post_params
-      end
+      post '/api/locks', params: post_params
+      assert_response :unauthorized
     end
   end
 end

--- a/test/controllers/concerns/json_exceptions_test.rb
+++ b/test/controllers/concerns/json_exceptions_test.rb
@@ -57,5 +57,12 @@ describe "Api::BaseController Integration" do
       delete '/api/locks/1.json', params: {id: 1}, headers: headers
       assert_json 500, "Internal Server Error"
     end
+
+    it "presents csrf errors" do
+      with_forgery_protection do
+        delete '/api/locks/1.json', params: {id: 1}
+        assert_json 401, "Unauthorized"
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -159,15 +159,15 @@ class ActiveSupport::TestCase
   end
 
   def self.with_forgery_protection
-    around do |test|
-      begin
-        old = ActionController::Base.allow_forgery_protection
-        ActionController::Base.allow_forgery_protection = true
-        test.call
-      ensure
-        ActionController::Base.allow_forgery_protection = old
-      end
-    end
+    around { |test| with_forgery_protection(&test) }
+  end
+
+  def with_forgery_protection
+    old = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    yield
+  ensure
+    ActionController::Base.allow_forgery_protection = old
   end
 
   def self.with_registries(registries)


### PR DESCRIPTION
…equests

currently just renders `{}` which is useless for debugging

@dndungu 