### PR TITLE
do not allow limits in schema that blow up on postgres

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20170929181901) do
     t.string "user_type"
     t.string "username"
     t.string "action", null: false
-    t.text "audited_changes", limit: 4294967295
+    t.text "audited_changes", limit: 1073741823
     t.integer "version", default: 0, null: false
     t.string "comment"
     t.string "remote_address"

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -25,6 +25,14 @@ describe "cleanliness" do
     File.read("db/schema.rb").wont_match /\st\.boolean.*limit: 1/
   end
 
+  it "does not have limits too big for postgres in schema" do
+    File.readlines("db/schema.rb").each do |line|
+      if line[/limit: (\d+)/, 1].to_i > 1073741823
+        raise "Line >#{line}< has a too big limit ... use 1073741823 or lower"
+      end
+    end
+  end
+
   it "does not have string index without limit since that breaks our mysql migrations" do
     table_definitions = File.read("db/schema.rb").scan(/  create_table "(\S+)"(.*?)\n  end/m)
     table_definitions.size.must_be :>, 10


### PR DESCRIPTION
previously failed:

```
rake db:test:prepare
rake aborted!
ActiveRecord::ActiveRecordError: The limit on text can be at most 1GB - 1byte.
```

test will fail as:

```
RuntimeError: Line >    t.text "audited_changes", limit: 4294967295
< has a too big limit ... use 1073741823 or lower
```
