### PR TITLE
TOOLS-2043 support multiple external docker images

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -41,10 +41,11 @@ class BuildsController < ApplicationController
       @build = scope.new(new_build_params.merge(creator: current_user))
     end
 
+    new = @build.new_record?
     saved = @build.save
 
     start_docker_build if saved && EXTERNAL_BUILD_ATTRIBUTES.all? { |e| @build.public_send(e).blank? }
-    respond_to_save saved, :created, :new
+    respond_to_save saved, (new ? :created : :ok), :new
   end
 
   def show

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -4,7 +4,7 @@ class BuildsController < ApplicationController
   include CurrentProject
 
   before_action :authorize_resource!
-  before_action :rename_source_url, only: [:create, :update]
+  before_action :rename_deprecated_attributes, only: [:create, :update]
   before_action :enforce_disabled_docker_builds, only: [:new, :create, :build_docker_image]
   before_action :find_build, only: [:show, :build_docker_image, :edit, :update]
 
@@ -79,16 +79,15 @@ class BuildsController < ApplicationController
     @build = Build.find(params[:id])
   end
 
-  # previously the attribute was called source_url so some clients might still use that
-  def rename_source_url
-    if (build = params[:build]) && source_url = build.delete(:source_url)
-      build[:external_url] = source_url
-    end
+  def rename_deprecated_attributes
+    return unless build = params[:build]
+    return unless source_url = build.delete(:source_url)
+    build[:external_url] = source_url
   end
 
   def new_build_params
     params.require(:build).permit(
-      :git_ref, :name, :description, :dockerfile, :docker_repo_digest, :git_sha,
+      :git_ref, :name, :description, :dockerfile, :image_name, :docker_repo_digest, :git_sha,
       :external_id, :external_status, :external_url,
       *Samson::Hooks.fire(:build_permitted_params)
     )

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -34,9 +34,8 @@ class BuildsController < ApplicationController
   end
 
   def create
-    scope = scope()
     external_id = params.dig(:build, :external_id).presence
-    if external_id && @build = scope.where(external_id: external_id).first
+    if external_id && @build = Build.where(external_id: external_id).first
       @build.attributes = edit_build_params(validate: false)
     else
       @build = scope.new(new_build_params.merge(creator: current_user))

--- a/app/views/builds/_build.html.erb
+++ b/app/views/builds/_build.html.erb
@@ -8,6 +8,6 @@
   <td><%= build.creator&.name || "Trigger" %></td>
   <td><%= duration_text job.duration if job %></td>
   <td><%= git_ref_and_sha_for(build) %></td>
-  <td><%= build.dockerfile %></td>
+  <td><%= build.image_name.presence || build.dockerfile %></td>
   <td><%= job ? job_status_badge(job) : build.docker_status %></td>
 </tr>

--- a/app/views/builds/edit.html.erb
+++ b/app/views/builds/edit.html.erb
@@ -20,6 +20,9 @@
     <%= form.input :dockerfile do %>
       <p class="form-control-static"><%= @build.dockerfile %></p>
     <% end %>
+    <%= form.input :image_name do %>
+      <p class="form-control-static"><%= @build.image_name %></p>
+    <% end %>
     <%= form.input :docker_repo_digest, label: 'Docker Digest' do %>
       <p class="form-control-static"><%= @build.docker_repo_digest %></p>
     <% end %>

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -31,7 +31,7 @@
         <%= link_to_chart "Build duration", @builds.map { |b| b.docker_build_job&.duration }.compact %>
       </th>
       <th>Git Ref</th>
-      <th>Dockerfile</th>
+      <th></th>
       <th>Status</th>
     </tr>
     </thead>

--- a/app/views/builds/new.html.erb
+++ b/app/views/builds/new.html.erb
@@ -18,6 +18,7 @@
     <% end %>
 
     <%= form.input :dockerfile, input_html: {placeholder: 'Dockerfile'} %>
+    <%= form.input :image_name %>
     <%= form.input :name %>
     <%= form.input :description, input_html: {row: 3} %>
 

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -45,6 +45,9 @@
     <dt>Git Ref</dt>
     <dd><%= git_ref_and_sha_for(@build, make_link: true) %></dd>
 
+    <dt>Image Identifier</dt>
+    <dd><%= @build.image_name %></dd>
+
     <dt>Dockerfile</dt>
     <dd><%= @build.dockerfile %></dd>
 

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -45,7 +45,7 @@
     <dt>Git Ref</dt>
     <dd><%= git_ref_and_sha_for(@build, make_link: true) %></dd>
 
-    <dt>Image Identifier</dt>
+    <dt>Image Name</dt>
     <dd><%= @build.image_name %></dd>
 
     <dt>Dockerfile</dt>

--- a/db/migrate/20171012004814_make_build_dockerfile_universal.rb
+++ b/db/migrate/20171012004814_make_build_dockerfile_universal.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class MakeBuildDockerfileUniversal < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :builds, :dockerfile, true
+    add_column :builds, :image_name, :string
+    add_index :builds, [:git_sha, :image_name], unique: true, length: {git_sha: 80, image_name: 80}
+  end
+end

--- a/db/migrate/20171020184047_increase_build_external_id_index_size.rb
+++ b/db/migrate/20171020184047_increase_build_external_id_index_size.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class IncreaseBuildExternalIdIndexSize < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :builds, :external_id
+    add_index :builds, :external_id, unique: true, length: {external_id: 191}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170929181901) do
+ActiveRecord::Schema.define(version: 20171012004814) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -52,12 +52,14 @@ ActiveRecord::Schema.define(version: 20170929181901) do
     t.datetime "started_at"
     t.datetime "finished_at"
     t.string "external_url"
-    t.string "dockerfile", default: "Dockerfile", null: false
+    t.string "dockerfile", default: "Dockerfile"
     t.string "external_id"
     t.string "external_status"
+    t.string "image_name"
     t.index ["created_by"], name: "index_builds_on_created_by"
     t.index ["external_id"], name: "index_builds_on_external_id", unique: true, length: { external_id: 40 }
     t.index ["git_sha", "dockerfile"], name: "index_builds_on_git_sha_and_dockerfile", unique: true
+    t.index ["git_sha", "image_name"], name: "index_builds_on_git_sha_and_image_name", unique: true, length: { git_sha: 80, image_name: 80 }
     t.index ["project_id"], name: "index_builds_on_project_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171012004814) do
+ActiveRecord::Schema.define(version: 20171020184047) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20171012004814) do
     t.string "external_status"
     t.string "image_name"
     t.index ["created_by"], name: "index_builds_on_created_by"
-    t.index ["external_id"], name: "index_builds_on_external_id", unique: true, length: { external_id: 40 }
+    t.index ["external_id"], name: "index_builds_on_external_id", unique: true, length: { external_id: 191 }
     t.index ["git_sha", "dockerfile"], name: "index_builds_on_git_sha_and_dockerfile", unique: true
     t.index ["git_sha", "image_name"], name: "index_builds_on_git_sha_and_image_name", unique: true, length: { git_sha: 80, image_name: 80 }
     t.index ["project_id"], name: "index_builds_on_project_id"

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -162,6 +162,12 @@ samson will then override the `project` labels and keep deployments/services uni
 
  - Set the projects `dockerfiles` attribute to all the files that need to be built.
  - Add `samson/dockerfile: Dockerfile.foobar` to the container configuration (same level as `image`) to use a different Dockerfile
+ 
+### Using multiple external images
+
+ - Set the projects `docker image building disabled` 
+ - Create images via the `POST /builds.json` with a `image_name` that matches the `image` attribute of the containers
+ - All containers (including init containers) must have a matching build
 
 ### Clair security scans
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -65,6 +65,12 @@ module Kubernetes
       expand_secret_annotations
     end
 
+    def images
+      all = containers
+      modify_init_container { |containers| all += containers }
+      all.map { |c| c.fetch(:image) }.uniq
+    end
+
     private
 
     def set_project_labels

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -519,4 +519,15 @@ describe Kubernetes::TemplateFiller do
       end
     end
   end
+
+  describe "#images" do
+    it "finds images from containers" do
+      template.images.must_equal ["docker-registry.zende.sk/truth_service:latest"]
+    end
+
+    it "finds images from init-containers" do
+      add_init_container image: 'init-container'
+      template.images.must_equal ["docker-registry.zende.sk/truth_service:latest", "init-container"]
+    end
+  end
 end

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -173,6 +173,13 @@ describe BuildsController do
         Build.last.external_url.must_equal 'http://foo.com'
       end
 
+      it 'can set dockerfile and image_name' do
+        create dockerfile: 'bar', image_name: 'foo'
+        build = Build.last
+        build.dockerfile.must_equal 'bar'
+        build.image_name.must_equal 'foo'
+      end
+
       it 'updates a build via external_id' do
         build = Build.last
         build.update_columns(external_id: 'foo', external_status: 'running')

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -184,8 +184,8 @@ describe BuildsController do
         build = Build.last
         build.update_columns(external_id: 'foo', external_status: 'running')
 
-        create external_id: 'foo', external_status: 'succeeded'
-        assert_response :redirect
+        create external_id: 'foo', external_status: 'succeeded', format: :json
+        assert_response :success
 
         build.reload.external_status.must_equal 'succeeded'
       end


### PR DESCRIPTION
 - all containers must have a build
 - external builds must set `image_name`
 - `image_name` must match `image` attribute (`a.com/foo/bar -> bar`)

@jonmoter @irwaters @dndungu 

# TODO:
 - [ ] figure out how to wait for images to arrive for automated deploys to work <-> @dndungu 