### PR TITLE
Allow a deploy triggered by a GitHub webhook to be skipped

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -31,7 +31,11 @@ class Integrations::GithubController < Integrations::BaseController
   end
 
   def deploy?
-    webhook_handler&.valid_webhook?(payload)
+    webhook_handler&.valid_webhook?(payload) && !skip?
+  end
+
+  def skip?
+    contains_skip_token?(message)
   end
 
   # https://developer.github.com/webhooks/securing/
@@ -52,6 +56,10 @@ class Integrations::GithubController < Integrations::BaseController
 
   def branch
     webhook_event.branch
+  end
+
+  def message
+    webhook_event.message
   end
 
   private

--- a/app/models/changeset/code_push.rb
+++ b/app/models/changeset/code_push.rb
@@ -23,6 +23,10 @@ class Changeset::CodePush
     data['ref'][/\Arefs\/heads\/(\S+)\z/, 1]
   end
 
+  def message
+    data['head_commit']['message']
+  end
+
   def service_type
     'code' # Samson webhook category
   end

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -31,6 +31,10 @@ class Changeset::IssueComment
     'pull_request' # Samson webhook category
   end
 
+  def message
+    ''
+  end
+
   private
 
   def pull_request

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -123,6 +123,10 @@ class Changeset::PullRequest
     'pull_request' # Samson webhook category
   end
 
+  def message
+    ''
+  end
+
   private
 
   def parse_risks(body)

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -7,11 +7,15 @@ describe Integrations::GithubController do
   extend IntegrationsControllerTestHelper
 
   let(:commit) { "dc395381e650f3bac18457909880829fc20e34ba" }
+  let(:commit_message) { "hi" }
   let(:project) { projects(:test) }
   let(:payload) do
     {
       ref: 'refs/heads/dev',
-      after: commit
+      after: commit,
+      head_commit: {
+        message: commit_message
+      }
     }.with_indifferent_access
   end
   let(:user_name) { 'Github' }
@@ -23,6 +27,8 @@ describe Integrations::GithubController do
   end
 
   test_regular_commit "Github", no_mapping: { ref: 'refs/heads/foobar' }, failed: false
+
+  it_ignores_skipped_commits
 
   it_does_not_deploy 'when the event is invalid' do
     request.headers['X-Github-Event'] = 'event'

--- a/test/models/changeset/code_push_test.rb
+++ b/test/models/changeset/code_push_test.rb
@@ -7,7 +7,10 @@ describe Changeset::CodePush do
   let(:data) do
     {
       "ref" => "refs/heads/master",
-      "after" => "abc-sha"
+      "after" => "abc-sha",
+      "head_commit" => {
+        "message" => "hi!"
+      }
     }
   end
   let(:push) { Changeset::CodePush.new('foo/bar', data) }
@@ -33,6 +36,12 @@ describe Changeset::CodePush do
   describe "#service_type" do
     it "is code" do
       push.service_type.must_equal "code"
+    end
+  end
+
+  describe "#message" do
+    it "finds" do
+      push.message.must_equal "hi!"
     end
   end
 

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -76,4 +76,10 @@ describe Changeset::IssueComment do
       Changeset::IssueComment.new('foo/bar', {}).service_type.must_equal 'pull_request'
     end
   end
+
+  describe "#message" do
+    it "is empty" do
+      Changeset::IssueComment.new('foo/bar', {}).message.must_equal ''
+    end
+  end
 end

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -366,6 +366,12 @@ describe Changeset::PullRequest do
     end
   end
 
+  describe "#message" do
+    it "is empty" do
+      pr.message.must_equal ""
+    end
+  end
+
   describe "#risks" do
     before { add_risks }
 


### PR DESCRIPTION
* Allow a deploy triggered by a GitHub webhook to be skipped

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
