### PR TITLE
wait for a few seconds for external builds to arrive

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -282,7 +282,7 @@ module Kubernetes
       containers.each do |container|
         build =
           if project.docker_image_building_disabled?
-            Kubernetes::BuildFinder.detect_build_by_image_name!(builds, container.fetch(:image))
+            Kubernetes::BuildFinder.detect_build_by_image_name!(builds, container.fetch(:image), try: false)
           elsif selected = container[:"samson/dockerfile"]
             builds.detect { |b| b.dockerfile == selected } ||
               raise(Samson::Hooks::UserError, "Build for dockerfile #{selected} not found")


### PR DESCRIPTION
when a project can only use external builds the samson deploy might be triggered
simultanously with the build stage, so we should wait a bit for the builds to arrive before
declaring that they do not exist ... at least with GCB we get the initial "started" callback
pretty fast so this might just work

followup to #2296

@dndungu 
/cc @jonmoter @irwaters 