### PR TITLE
fix branch pushes failing in integration controller since they do not…

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -80,7 +80,7 @@ class Integrations::BaseController < ApplicationController
 
   def contains_skip_token?(message)
     ["[deploy skip]", "[skip deploy]"].any? do |token|
-      message.include?(token)
+      message&.include?(token)
     end
   end
 

--- a/app/models/changeset/code_push.rb
+++ b/app/models/changeset/code_push.rb
@@ -24,7 +24,7 @@ class Changeset::CodePush
   end
 
   def message
-    data['head_commit']['message']
+    data['head_commit']&.[]('message')
   end
 
   def service_type

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -32,7 +32,7 @@ class Changeset::IssueComment
   end
 
   def message
-    ''
+    nil
   end
 
   private

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -124,7 +124,7 @@ class Changeset::PullRequest
   end
 
   def message
-    ''
+    nil
   end
 
   private

--- a/test/models/changeset/code_push_test.rb
+++ b/test/models/changeset/code_push_test.rb
@@ -43,6 +43,11 @@ describe Changeset::CodePush do
     it "finds" do
       push.message.must_equal "hi!"
     end
+
+    it "is empty when push is for a branch and does not have a head commit" do
+      data.delete('head_commit')
+      push.message.must_equal nil
+    end
   end
 
   describe ".valid_webhook?" do

--- a/test/models/changeset/issue_comment_test.rb
+++ b/test/models/changeset/issue_comment_test.rb
@@ -79,7 +79,7 @@ describe Changeset::IssueComment do
 
   describe "#message" do
     it "is empty" do
-      Changeset::IssueComment.new('foo/bar', {}).message.must_equal ''
+      Changeset::IssueComment.new('foo/bar', {}).message.must_equal nil
     end
   end
 end

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -368,7 +368,7 @@ describe Changeset::PullRequest do
 
   describe "#message" do
     it "is empty" do
-      pr.message.must_equal ""
+      pr.message.must_equal nil
     end
   end
 


### PR DESCRIPTION
… have head_commit

https://zendesk.airbrake.io/projects/95346/groups/2067341449019993699/notices/2067344219670196701?tab=notice-detail

```
NoMethodError: undefined method `[]' for nil:NilClass
```

caused by: https://github.com/zendesk/samson/pull/2300

TODO:
 - rebase on https://github.com/zendesk/samson/pull/2309