### PR TITLE
 ensure dockerfile is set when samson has to build the images

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -14,6 +14,7 @@ class Build < ActiveRecord::Base
 
   validates :project, presence: true
   validates :git_sha, allow_nil: true, format: SHA1_REGEX
+  validates :dockerfile, presence: true, unless: :external_id
   [:dockerfile, :image_name].each do |attribute|
     validates(
       :git_sha,

--- a/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
+++ b/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
@@ -34,8 +34,10 @@ describe SamsonAwsEcr::Engine do
   end
 
   describe :before_docker_repository_usage do
+    let(:build) { builds(:docker_build) }
+
     def fire
-      Samson::Hooks.fire(:before_docker_repository_usage, builds(:docker_build))
+      Samson::Hooks.fire(:before_docker_repository_usage, build)
     end
 
     run_inside_of_temp_directory
@@ -96,6 +98,12 @@ describe SamsonAwsEcr::Engine do
         ecr_client.
           expects(:create_repository).
           with(repository_name: 'foo')
+        fire
+      end
+
+      it 'derives repository from dockerfile' do
+        build.update_column :dockerfile, 'Dockerfile.foobar'
+        ecr_client.expects(:describe_repositories).with(repository_names: ['foo-foobar'])
         fire
       end
 


### PR DESCRIPTION
some error popped up from builds without dockerfile and without external_id ... idk how that happened but now they will show a validation error

https://zendesk.airbrake.io/projects/95346/groups/2068540302838673122/notices/2068576972005321027?tab=notice-detail
