### PR TITLE
use cheaper usage_ids for validations and build-commands

### DIFF
--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -42,6 +42,10 @@ class Command < ActiveRecord::Base
     stages + projects
   end
 
+  def usage_ids
+    self.class.usage_ids.select { |id| id == self.id }
+  end
+
   def self.usage_ids
     StageCommand.pluck(:command_id) +
     Project.pluck(:build_command_id)
@@ -50,7 +54,7 @@ class Command < ActiveRecord::Base
   private
 
   def ensure_unused
-    if usages.any?
+    if usage_ids.any?
       errors.add(:base, 'Can only delete when unused.')
       throw(:abort)
     end

--- a/app/views/build_commands/show.html.erb
+++ b/app/views/build_commands/show.html.erb
@@ -1,5 +1,5 @@
 <%= page_title "#{@project.name} Build Command" %>
-<% reused = @command.usages.count > 1 %>
+<% reused = @command.usage_ids.count > 1 %>
 <%= breadcrumb @project, "Pre Build Command" %>
 
 <section>


### PR DESCRIPTION
we don't need to load the full objects ... which can be a lot for heavily resued commands
