### PR TITLE
resolve git-sha before checking uniqueness

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -12,6 +12,8 @@ class Build < ActiveRecord::Base
   before_validation :nil_out_blanks
   before_validation :make_default_dockerfile_and_image_name_not_collide, on: :create
 
+  validate :validate_docker_repo_digest_matches_git_sha, on: :create
+  validate :validate_git_reference, on: :create
   validates :project, presence: true
   validates :git_sha, allow_nil: true, format: SHA1_REGEX
   validates :dockerfile, presence: true, unless: :external_id
@@ -26,9 +28,6 @@ class Build < ActiveRecord::Base
   validates :docker_image_id, format: SHA256_REGEX, allow_nil: true
   validates :docker_repo_digest, format: DIGEST_REGEX, allow_nil: true
   validates :external_url, format: /\Ahttps?:\/\/\S+\z/, allow_nil: true
-
-  validate :validate_docker_repo_digest_matches_git_sha, on: :create
-  validate :validate_git_reference, on: :create
 
   before_create :assign_number
 

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -47,6 +47,7 @@ describe Build do
       Dir.chdir(repo_temp_dir) do
         build.update_column(:git_sha, current_commit)
         refute_valid(valid_build(git_ref: nil, git_sha: current_commit)) # not unique
+        refute_valid(valid_build) # not unique since ref resolves to sha
         assert_valid(valid_build(git_ref: nil, git_sha: current_commit, dockerfile: 'Other'))
         assert_valid(valid_build(git_ref: nil, git_sha: current_commit, dockerfile: nil, external_id: '123'))
       end


### PR DESCRIPTION
users were getting mysql errors since the validations did not catch the duplication because the git_sha would be nil until validate_git_reference

https://zendesk.airbrake.io/projects/95346/groups/2051047488865381110/notices/2069665228147090112

<img width="542" alt="screen shot 2017-10-26 at 4 54 04 pm" src="https://user-images.githubusercontent.com/11367/32060341-be5e30e6-ba6e-11e7-97f9-cd7b9f9d2e65.png">


@bastien @dragonfax 