### PR TITLE
fix error during deploy due to incomplete release-doc

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -171,7 +171,7 @@ describe Kubernetes::DeployExecutor do
         e = assert_raises Samson::Hooks::UserError do
           refute execute
         end
-        e.message.must_include "Error found when parsing kubernetes/"
+        e.message.must_include "Error parsing kubernetes/" # order is random so we check prefix
       end
 
       it "fails before building when roles as a group are invalid" do


### PR DESCRIPTION
reading the raw_template was stubbed out so nobody ran into these issues
unless docker_image_building_disabled was set
unifying the temp docs to avoid any 1-off errors in the future
and moving basic validations up so they fail faster and nicer

https://zendesk.airbrake.io/projects/95346/groups/2069899841173399203/notices/2069917241354891382?tab=notice-detail

@dndungu @dragonfax 