### PR TITLE
add optional GCLOUD_IMG_TAGGER_OPTS env var to set extra params 

### DIFF
--- a/plugins/gcloud_image_tagger/README.md
+++ b/plugins/gcloud_image_tagger/README.md
@@ -9,3 +9,7 @@ Tag gcloud images with the stage permalink they deployed to, so developers can p
  - download credentials for that account
  - run `gcloud auth activate-service-account --key-file <YOUR-KEY>` on the samson host
  - run `gcloud config set account $(jq -r .client_email < <YOUR-KEY>)` on the samson host
+
+## ENV Vars
+
+  - `GCLOUD_IMG_TAGGER_OPTS` - options ENV var to specify options that are passed to the `gcloud` command

--- a/plugins/gcloud_image_tagger/lib/gcloud_image_tagger/samson_plugin.rb
+++ b/plugins/gcloud_image_tagger/lib/gcloud_image_tagger/samson_plugin.rb
@@ -20,7 +20,8 @@ module SamsonGcloudImageTagger
           base = digest.split('@').first
           tag = deploy.stage.permalink
           beta = container_in_beta
-          command = ["gcloud", *beta, "container", "images", "add-tag", digest, "#{base}:#{tag}", "--quiet", *gcloud_options]
+          command = ["gcloud", *beta, "container", "images", "add-tag", digest, "#{base}:#{tag}",
+                     "--quiet", *gcloud_options]
           success, output = Samson::CommandExecutor.execute(*command, timeout: 10)
           deploy.job.append_output!(
             "Tagging GCR image:\n#{command.join(" ")}\n#{output.strip}\n#{success ? "SUCCESS" : "FAILED"}\n"

--- a/plugins/gcloud_image_tagger/lib/gcloud_image_tagger/samson_plugin.rb
+++ b/plugins/gcloud_image_tagger/lib/gcloud_image_tagger/samson_plugin.rb
@@ -22,7 +22,7 @@ module SamsonGcloudImageTagger
           tag = deploy.stage.permalink
           beta = container_in_beta
           command = ["gcloud", *beta, "container", "images", "add-tag", digest, "#{base}:#{tag}",
-            "--quiet", *gcloud_options]
+                     "--quiet", *gcloud_options]
           success, output = Samson::CommandExecutor.execute(*command, timeout: 10)
           deploy.job.append_output!(
             "Tagging GCR image:\n#{command.join(" ")}\n#{output.strip}\n#{success ? "SUCCESS" : "FAILED"}\n"

--- a/plugins/gcloud_image_tagger/test/gcloud_image_tagger/samson_plugin_test.rb
+++ b/plugins/gcloud_image_tagger/test/gcloud_image_tagger/samson_plugin_test.rb
@@ -71,10 +71,10 @@ describe SamsonGcloudImageTagger::Engine do
 
     it "includes options from ENV var" do
       expect_version_check("")
-      with_env('GCLOUD_IMG_TAGGER_OPTS' => '--verbose debug') do
+      with_env(GCLOUD_IMG_TAGGER_OPTS: '--foo "bar baz"') do
         Samson::CommandExecutor.expects(:execute).with(
           'gcloud', 'container', 'images', 'add-tag', 'gcr.io/sdfsfsdf@some-sha', 'gcr.io/sdfsfsdf:staging',
-          '--quiet', '--verbose', 'debug', anything
+          '--quiet', '--foo', 'bar baz', anything
         ).returns([true, "OUT"])
         tag
       end

--- a/plugins/gcloud_image_tagger/test/gcloud_image_tagger/samson_plugin_test.rb
+++ b/plugins/gcloud_image_tagger/test/gcloud_image_tagger/samson_plugin_test.rb
@@ -74,7 +74,7 @@ describe SamsonGcloudImageTagger::Engine do
       with_env('GCLOUD_IMG_TAGGER_OPTS' => '--verbose debug') do
         Samson::CommandExecutor.expects(:execute).with(
           'gcloud', 'container', 'images', 'add-tag', 'gcr.io/sdfsfsdf@some-sha', 'gcr.io/sdfsfsdf:staging',
-          '--quiet', '--verbose', 'debug'
+          '--quiet', '--verbose', 'debug', anything
         ).returns([true, "OUT"])
         tag
       end

--- a/plugins/gcloud_image_tagger/test/gcloud_image_tagger/samson_plugin_test.rb
+++ b/plugins/gcloud_image_tagger/test/gcloud_image_tagger/samson_plugin_test.rb
@@ -68,6 +68,17 @@ describe SamsonGcloudImageTagger::Engine do
       ).returns([true, "OUT"])
       tag
     end
+
+    it "includes options from ENV var" do
+      expect_version_check("")
+      with_env('GCLOUD_IMG_TAGGER_OPTS' => '--verbose debug') do
+        Samson::CommandExecutor.expects(:execute).with(
+          'gcloud', 'container', 'images', 'add-tag', 'gcr.io/sdfsfsdf@some-sha', 'gcr.io/sdfsfsdf:staging',
+          '--quiet', '--verbose', 'debug'
+        ).returns([true, "OUT"])
+        tag
+      end
+    end
   end
 
   describe :after_deploy do


### PR DESCRIPTION
When doing GCR image tagging, it could be useful to add `--verbosity=debug` or `--account=account_name`.  This adds a `GCLOUD_IMG_TAGGER_OPTS` ENV var where you can define extra options to get passed along.

/cc @zendesk/samson, @grosser, @yizhang-zen 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
