### PR TITLE
Add travis test with no plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - BUNDLE_WITHOUT=postgres:sqlite DATABASE_URL=mysql2://travis@127.0.0.1/samson_test USE_UTF8MB4=1 VERBOSE=0 TASK='db:create db:migrate default'
     - BUNDLE_WITHOUT=mysql:sqlite DATABASE_URL=postgresql://postgres@127.0.0.1/samson_test VERBOSE=0 TASK='db:create db:migrate default'
     - BUNDLE_WITHOUT=postgres:mysql DATABASE_URL=sqlite3://null$PWD/db/test.sqlite3 VERBOSE=0 TASK='db:create db:migrate default'
+    - BUNDLE_WITHOUT=postgres:mysql DATABASE_URL=sqlite3://null$PWD/db/test.sqlite3 VERBOSE=0 TASK='db:create db:migrate' PLUGINS=''
 script: bundle exec rake $TASK
 before_script:
   - mysql -u root -e 'set GLOBAL innodb_large_prefix = true'


### PR DESCRIPTION
This should help to catch issues where migrations with plugin-specific
tables[1][2] end up inside the main migrations folder.

[1] https://github.com/zendesk/samson/pull/2129
[2] https://github.com/zendesk/samson/issues/2321

/cc @zendesk/samson @zendesk/vulcan 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low