### PR TITLE
move stages json api to base controller

### DIFF
--- a/app/controllers/api/stages_controller.rb
+++ b/app/controllers/api/stages_controller.rb
@@ -4,10 +4,6 @@ class Api::StagesController < Api::BaseController
 
   before_action :require_project
 
-  def index
-    render json: @project.stages
-  end
-
   def clone
     new_stage = Stage.build_clone(stage_to_clone)
     new_stage.name = stage_name

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -13,6 +13,7 @@ class StagesController < ApplicationController
 
     respond_to do |format|
       format.html
+      format.json { render json: {stages: @stages} }
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Samson::Application.routes.draw do
     resources :projects, only: [:index] do
       resources :automated_deploys, only: [:create]
       resources :deploys, only: [:index]
-      resources :stages, only: [:index]
     end
 
     resources :stages, only: [] do

--- a/test/controllers/api/stages_controller_test.rb
+++ b/test/controllers/api/stages_controller_test.rb
@@ -8,23 +8,6 @@ describe Api::StagesController do
   let(:project) { projects(:test) }
   let(:stages) { project.stages }
 
-  describe 'get #index' do
-    before do
-      get :index, params: {project_id: project.id}, format: :json
-    end
-
-    subject { JSON.parse(response.body) }
-
-    it 'succeeds' do
-      assert_response :success
-      response.content_type.must_equal 'application/json'
-    end
-
-    it 'contains a stage' do
-      subject.size.must_equal 1
-    end
-  end
-
   describe 'post #clone' do
     describe '#stage_name' do
       before do

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -6,6 +6,7 @@ SingleCov.covered!
 describe StagesController do
   subject { stages(:test_staging) }
   let(:project) { subject.project }
+  let(:json) { JSON.parse(response.body) }
 
   unauthorized :get, :show, project_id: :foo, id: 1, token: Rails.application.config.samson.badge_token
   unauthorized :get, :index, project_id: :foo, token: Rails.application.config.samson.badge_token, format: :svg
@@ -107,6 +108,13 @@ describe StagesController do
       it "renders html" do
         get :index, params: {project_id: project}
         assert_template 'index'
+      end
+
+      it "renders json" do
+        get :index, params: {project_id: project}, format: :json
+        assert_response :success
+        json.keys.must_equal ['stages']
+        json['stages'][0].keys.must_include 'name'
       end
     end
   end


### PR DESCRIPTION
 - old api uses project id as `params[:project_id]` instead of permalink so they are not compatible
 - now returns all stage attributes

@dragonfax 
/cc @jonmoter 