### PR TITLE
make external_id truly unique to avoid any kind of issues or hacks

### DIFF
--- a/db/migrate/20171031104602_make_external_id_unique.rb
+++ b/db/migrate/20171031104602_make_external_id_unique.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class MakeExternalIdUnique < ActiveRecord::Migration[5.1]
+  class User < ActiveRecord::Base
+  end
+
+  def up
+    # update the external_id of all uses that would violate the new uniqueness
+    scope = User.where(deleted_at: nil)
+    bad = scope.group(:external_id).count.select { |_, count| count.size >= 2 }
+    bad.each do |id, _|
+      duplicates = scope.where(external_id: id)
+      duplicates[1..-1].each_with_index do |u, i|
+        write "Updating user #{u.id} external_id"
+        u.update_column :external_id, "#{id}-#{i}"
+      end
+    end
+
+    remove_index :users, [:external_id, :deleted_at]
+    add_index :users, [:external_id, :deleted_at], unique: true
+  end
+
+  def down
+    remove_index :users, [:external_id, :deleted_at]
+    add_index :users, [:external_id, :deleted_at]
+  end
+end


### PR DESCRIPTION
we use it for auth so better be carful ...

```
== 20171031104602 MakeExternalIdUnique: migrating =============================
Updating user 3 external_id
-- remove_index(:users, [:external_id, :deleted_at])
   -> 0.0507s
-- add_index(:users, [:external_id, :deleted_at], {:unique=>true})
   -> 0.0297s
== 20171031104602 MakeExternalIdUnique: migrated (0.1576s) ====================
```

@dragonfax 