### PR TITLE
do not add bogus emails to integration users they will bite us later

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,11 +21,7 @@ class UsersController < ApplicationController
 
   def create
     name = params.require(:user).require(:name)
-    @user = User.new(
-      name: name,
-      email: 'noreply@example.com',
-      integration: true
-    )
+    @user = User.new(name: name, integration: true)
     if @user.save
       redirect_to @user, notice: "User created!"
     else

--- a/db/migrate/20171031110801_remove_noreply.rb
+++ b/db/migrate/20171031110801_remove_noreply.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class RemoveNoreply < ActiveRecord::Migration[5.1]
+  class User < ActiveRecord::Base
+  end
+
+  def up
+    User.where(User.arel_table[:email].matches("noreply%")).where(integration: true).update(email: nil)
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026135700) do
+ActiveRecord::Schema.define(version: 20171031110801) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -539,7 +539,7 @@ ActiveRecord::Schema.define(version: 20171026135700) do
     t.string "time_format", default: "relative", null: false
     t.datetime "last_login_at"
     t.datetime "last_seen_at"
-    t.index ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at"
+    t.index ["external_id", "deleted_at"], name: "index_users_on_external_id_and_deleted_at", unique: true
   end
 
   create_table "vault_servers", id: :integer, force: :cascade do |t|

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -139,7 +139,7 @@ describe UsersController do
         user = User.last
         assert_redirected_to "/users/#{user.id}"
         assert user.integration
-        user.email.must_equal 'noreply@example.com'
+        user.email.must_be_nil
         user.external_id.must_be_nil
       end
 


### PR DESCRIPTION
... this might cause a few bugs but then we should fix them and not hide them by making our mails go to noreply addresses.

@dragonfax 