### PR TITLE
Have branch input when generating changelog

### DIFF
--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -11,6 +11,10 @@ class ChangelogsController < ApplicationController
     @branch = params[:branch] || 'master'
     @start_date = Date.strptime(params[:start_date], '%Y-%m-%d')
     @end_date = Date.strptime(params[:end_date], '%Y-%m-%d')
-    @changeset = Changeset.new(current_project.repository_path, "#{@branch}@{#{@start_date}}", "#{@branch}@{#{@end_date}}")
+    @changeset = Changeset.new(
+      current_project.repository_path,
+      "#{@branch}@{#{@start_date}}",
+      "#{@branch}@{#{@end_date}}"
+    )
   end
 end

--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -4,13 +4,13 @@ class ChangelogsController < ApplicationController
 
   def show
     if params[:start_date].blank? || params[:end_date].blank?
-      params[:start_date] = (Date.today.beginning_of_week - 3.days).to_s
+      params[:start_date] = (Date.today.beginning_of_week - 7.days).to_s
       params[:end_date] = Date.today.to_s
     end
 
+    @branch = params[:branch] || 'master'
     @start_date = Date.strptime(params[:start_date], '%Y-%m-%d')
     @end_date = Date.strptime(params[:end_date], '%Y-%m-%d')
-
-    @changeset = Changeset.new(current_project.repository_path, "master@{#{@start_date}}", "master@{#{@end_date}}")
+    @changeset = Changeset.new(current_project.repository_path, "#{@branch}@{#{@start_date}}", "#{@branch}@{#{@end_date}}")
   end
 end

--- a/app/views/changelogs/show.html.erb
+++ b/app/views/changelogs/show.html.erb
@@ -5,6 +5,8 @@
 <section class="tabs table-responsive">
   <form id="date-chooser">
     <p class="form-inline">
+      Branch:
+      <input type="text" class="form-control" value="<%= @branch.to_s %>" name="branch" id="branch">
       Changes made between
       <input type="text" class="form-control" value="<%= @start_date.to_s %>"  name="start_date" id="start-date"> and
       <input type="text" class="form-control" value="<%= @end_date.to_s %>" name="end_date" id="end-date">

--- a/test/controllers/changelogs_controller_test.rb
+++ b/test/controllers/changelogs_controller_test.rb
@@ -13,7 +13,7 @@ describe ChangelogsController do
         Date.stubs(:today).returns(today)
         Changeset.expects(:new).with(
           'bar/foo',
-          'master@{2016-02-26}',
+          'master@{2016-02-22}',
           'master@{2016-03-01}'
         ).returns(stub(pull_requests: []))
         get :show, params: {project_id: project}
@@ -27,6 +27,18 @@ describe ChangelogsController do
           'master@{2016-02-01}'
         ).returns(stub(pull_requests: []))
         get :show, params: {project_id: project, start_date: '2016-01-01', end_date: '2016-02-01'}
+        assert_template :show
+      end
+
+      it "renders requested branch" do
+        today = Date.parse('2016-03-01')
+        Date.stubs(:today).returns(today)
+        Changeset.expects(:new).with(
+          'bar/foo',
+          'production@{2016-02-22}',
+          'production@{2016-03-01}'
+        ).returns(stub(pull_requests: []))
+        get :show, params: {project_id: project, branch: 'production'}
         assert_template :show
       end
     end


### PR DESCRIPTION
Have branch as an input when generating the changelog. Now teams can get a list of changes on their production branch for internal/external release notes. 

I've also set the default date range to be a week as most teams with scheduled deploys release on a weekly schedule.


<img width="932" alt="screen shot 2017-10-31 at 10 21 37 am" src="https://user-images.githubusercontent.com/1566114/32238559-5b6e6662-be25-11e7-9742-3bc2b488e76e.png">



/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
