### PR TITLE
fix misuse of `pluck` which caused ENV var group writes to fail

### DIFF
--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -8,7 +8,7 @@ class EnvironmentVariableGroupsController < ApplicationController
     return true if user.admin?
 
     administrated = user.administrated_projects.pluck(:id)
-    return true if administrated.any? && group.projects.pluck(&:id).all? { |id| administrated.include?(id) }
+    return true if administrated.any? && group.projects.pluck(:id).all? { |id| administrated.include?(id) }
 
     false
   end

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -151,7 +151,7 @@ describe EnvironmentVariableGroupsController do
 
       it_updates
 
-      it "destoys variables" do
+      it "destroys variables" do
         variable = env_group.environment_variables.first
         assert_difference "EnvironmentVariable.count", -1 do
           put :update, params: {
@@ -164,6 +164,13 @@ describe EnvironmentVariableGroupsController do
         end
 
         assert_redirected_to "/environment_variable_groups"
+      end
+
+      it 'updates when the group is used by a project where the user is an admin' do
+        ProjectEnvironmentVariableGroup.create!(environment_variable_group: env_group, project: project)
+        assert_difference "EnvironmentVariable.count", +1 do
+          put :update, params: params
+        end
       end
 
       it "cannot update when not an admin for any used projects" do


### PR DESCRIPTION
Discovered this talking to @ombhatt, who was unable to update a Env Var group, even though he was a project admin for both of the projects that used that group.  I traced it down to this one-character bug.

```
samson(prod)> group = EnvironmentVariableGroup.find 43
=> #<EnvironmentVariableGroup id: 43, name: "BILLING", comment: "Billing variables used by Classic (maybe more apps...">

samson(prod)> group.projects.pluck(&:id)
=> [[79, "Billing App", "git@github.com:zendesk/billing", nil, Tue, 03 Mar 2015 22:30:57 UTC +00:00, Tue, 31 Oct 2017 17:47:11 UTC +00:00, "...", "master", "billing", "Zendesk's Billing and Payments platform", "narwhals@zendesk.com", true, "", "any", nil, "", false, ""], [5, "Zendesk Classic", "git@github.com:zendesk/zendesk.git", nil, Mon, 13 Jan 2014 08:48:05 UTC +00:00, Tue, 31 Oct 2017 17:54:03 UTC +00:00, "...", "staging", "zendesk", "", "", true, "staging", "travis", nil, "Check out <a href=\"...\">Classic Production Patch Process</a> for deployment process guidelines.", false, ""]]

samson(prod)> group.projects.pluck(:id)
=> [79, 5]
```

The thing is, I have no idea why the tests didn't catch this bug. 'Cause it should have failed to update any Env Var Group where the user was a project admin.

/cc @zendesk/samson, @grosser 

### Risks
- Level: Low
