### PR TITLE
fix DockerBuilderService and BuildFinder#wait_for_build both modifyin…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/build_finder.rb
+++ b/plugins/kubernetes/app/models/kubernetes/build_finder.rb
@@ -123,7 +123,7 @@ module Kubernetes
           dockerfile: dockerfile,
           name: "Autobuild for Deploy ##{@job.deploy.id}"
         )
-        DockerBuilderService.new(build).run(push: true)
+        DockerBuilderService.new(build.clone).run(push: true) # clone to not update/reload the same object
         build
       elsif dockerfile == "Dockerfile"
         @output.puts("Not creating #{name} since is is not in the repository.")

--- a/plugins/kubernetes/test/models/kubernetes/build_finder_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/build_finder_test.rb
@@ -96,11 +96,12 @@ describe Kubernetes::BuildFinder do
       end
 
       it "succeeds when the build works" do
-        DockerBuilderService.any_instance.expects(:run).with do
-          Build.last.create_docker_job.update_column(:status, 'succeeded')
-          Build.last.update_column(:docker_repo_digest, 'some-sha')
+        DockerBuilderService.expects(:new).with do |build|
+          build.create_docker_job.update_column(:status, 'succeeded')
+          build.update_column(:docker_repo_digest, 'some-sha')
+          build.expects(:reload).never # instance is not shared with BuildFinder to avoid both modifying the same
           true
-        end
+        end.returns(stub(run: true))
         assert execute
         out.must_include "Creating build for Dockerfile."
         out.must_include "Build #{Build.last.url} is looking good"


### PR DESCRIPTION
…g the same Build instance

caused by https://github.com/zendesk/samson/pull/2330

alternative to https://github.com/zendesk/samson/pull/2351 to completely avoid any concurrent access

https://zendesk.airbrake.io/projects/95346/groups/2073278695669703679/notices/2073278694427718853?tab=comments

@jonmoter 