### PR TITLE
move automated deploys into regular namespace

### DIFF
--- a/app/controllers/automated_deploys_controller.rb
+++ b/app/controllers/automated_deploys_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # deploys that automatically get triggered when new hosts come up or are restarted
-class Api::AutomatedDeploysController < Api::BaseController
+class AutomatedDeploysController < ApplicationController
   before_action :find_or_create_stage
   before_action :find_deploy_group
   before_action :find_last_deploy
@@ -19,7 +19,7 @@ class Api::AutomatedDeploysController < Api::BaseController
     )
 
     if deploy.persisted?
-      render json: deploy.to_json, status: :created, location: api_deploys_path(deploy)
+      render json: deploy.as_json, status: :created, location: api_deploys_path(deploy)
     else
       failed! "Unable to start deploy: #{deploy.errors.full_messages}"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,6 @@ Samson::Application.routes.draw do
     end
 
     resources :projects, only: [] do
-      resources :automated_deploys, only: [:create]
       resources :deploys, only: [:index]
     end
 
@@ -131,6 +130,7 @@ Samson::Application.routes.draw do
   delete '/api/locks/:id', to: 'locks#destroy'
   delete '/locks', to: 'locks#destroy_via_resource'
   get '/api/projects', to: 'projects#index'
+  post '/api/projects/:project_id/automated_deploys', to: 'automated_deploys#create'
 
   get '/auth/github/callback', to: 'sessions#github'
   get '/auth/google/callback', to: 'sessions#google'

--- a/test/controllers/automated_deploys_controller_test.rb
+++ b/test/controllers/automated_deploys_controller_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require_relative '../../test_helper'
+require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe Api::AutomatedDeploysController do
+describe AutomatedDeploysController do
   def assert_created
     assert_difference 'Stage.count', +1 do
       assert_difference 'Deploy.count', +1 do


### PR DESCRIPTION
@dragonfax 
/cc @epssy 

route remains the same ... but access-tokens with api scope need to be updated to have `automated_deploys`