### PR TITLE
job-queue should manage all threading

### DIFF
--- a/app/jobs/csv_export_job.rb
+++ b/app/jobs/csv_export_job.rb
@@ -2,13 +2,11 @@
 require 'csv'
 
 class CsvExportJob
-  attr_writer :thread # assigned by job_queue, but not used
-
   def initialize(csv_export)
     @csv_export = csv_export
   end
 
-  # used by job_queue
+  # used to identify in JobQueue
   def id
     "csv-export-#{@csv_export.id}"
   end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -269,7 +269,7 @@ describe Job do
       JobQueue.perform_later(job_execution)
       sleep 0.5
       job.pid.wont_be_nil
-      job_execution.wait
+      JobQueue.wait(job_execution.id)
       sleep 0.1
     end
 

--- a/test/support/job_queue_support.rb
+++ b/test/support/job_queue_support.rb
@@ -7,6 +7,7 @@ ActiveSupport::TestCase.class_eval do
     JobQueue.enabled = true
     yield
   ensure
+    puts $!
     JobQueue.enabled = false
     JobQueue.clear
   end


### PR DESCRIPTION
this allows us to kill/wait for any kind of job and jobs can be simpler

@dragonfax 
/cc @zendesk/samson 