### PR TITLE
move api/deploys/:id to regular controller

### DIFF
--- a/app/controllers/api/deploys_controller.rb
+++ b/app/controllers/api/deploys_controller.rb
@@ -6,10 +6,6 @@ class Api::DeploysController < Api::BaseController
     render json: paginate(deploy_scope)
   end
 
-  def show
-    render json: Deploy.find(params.require(:id))
-  end
-
   protected
 
   def job_filter

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -77,7 +77,7 @@ class ProjectsController < ApplicationController
   def deploy_group_versions
     before = params[:before] ? Time.parse(params[:before]) : Time.now
     deploy_group_versions = @project.last_deploy_by_group(before).each_with_object({}) do |(id, deploy), hash|
-      hash[id] = deploy.as_json(methods: :url)
+      hash[id] = deploy.as_json
     end
     render json: deploy_group_versions
   end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -14,9 +14,12 @@ class Deploy < ActiveRecord::Base
   validate :validate_stage_is_unlocked, on: :create
   validate :validate_stage_uses_deploy_groups_properly, on: :create
 
-  delegate :started_by?, :can_be_cancelled_by?, :cancel, :status, :user, :output, to: :job
-  delegate :active?, :pending?, :running?, :cancelling?, :cancelled?, :succeeded?, to: :job
-  delegate :finished?, :errored?, :failed?, to: :job
+  delegate(
+    :started_by?, :can_be_cancelled_by?, :cancel, :status, :user, :output,
+    :active?, :pending?, :running?, :cancelling?, :cancelled?, :succeeded?,
+    :finished?, :errored?, :failed?,
+    to: :job
+  )
   delegate :production?, to: :stage
 
   before_validation :trim_reference
@@ -199,6 +202,12 @@ class Deploy < ActiveRecord::Base
       buddy_name, buddy_email, stage.name, stage.production?, !stage.no_code_deployed, project.deleted_at,
       stage.deploy_group_names.join('|')
     ]
+  end
+
+  def as_json
+    hash = super(methods: [:status, :url, :production])
+    hash["summary"] = summary_for_timeline
+    hash
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,6 @@
 Samson::Application.routes.draw do
   root to: 'projects#index'
 
-  get '/api/deploys/active_count', to: 'deploys#active_count' # can be moved down once show is moved
-
   namespace :api do
     resources :deploys, only: [:index, :show]
 
@@ -130,6 +128,8 @@ Samson::Application.routes.draw do
   delete '/locks', to: 'locks#destroy_via_resource'
   get '/api/projects', to: 'projects#index'
   post '/api/projects/:project_id/automated_deploys', to: 'automated_deploys#create'
+  get '/api/deploys/active_count', to: 'deploys#active_count'
+  get '/api/deploys/:id', to: 'deploys#show'
 
   get '/auth/github/callback', to: 'sessions#github'
   get '/auth/google/callback', to: 'sessions#google'

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -118,11 +118,4 @@ describe Api::DeploysController do
       end
     end
   end
-
-  describe '#show' do
-    it 'renders' do
-      get :show, params: {id: deploys(:succeeded_test).id}, format: :json
-      assert_response :success
-    end
-  end
 end

--- a/test/controllers/concerns/json_renderer_test.rb
+++ b/test/controllers/concerns/json_renderer_test.rb
@@ -46,7 +46,7 @@ describe "JsonRenderer Integration" do
       get '/users.json', params: {includes: "user_project_roles"}
       assert_response :success
       json.keys.must_equal ['users', 'user_project_roles']
-      json['users'].first.keys.must_include 'user_project_roles_ids'
+      json['users'].first.keys.must_include 'user_project_role_ids'
       ids = json['user_project_roles'].map { |upr| upr['id'] }
       ids.size.must_equal ids.uniq.size
     end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -614,6 +614,18 @@ describe Deploy do
     end
   end
 
+  describe "#as_json" do
+    it "includes simple methods status" do
+      deploy.as_json.fetch("status").must_equal "succeeded"
+      deploy.as_json.must_include "url"
+      deploy.as_json.must_include "production"
+    end
+
+    it "includes the summary" do
+      deploy.as_json.fetch("summary").must_equal deploy.summary_for_timeline
+    end
+  end
+
   def create_deploy!(attrs = {})
     default_attrs = {
       reference: "baz",


### PR DESCRIPTION
this will change the api to no longer automatically nest user/project/stage
they have to be requested via `?includes=` now

@dragonfax 
/cc @zendesk/samson 