### PR TITLE
Make SMTP configurable by environment vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,11 @@ GITHUB_TOKEN=
 # BITBUCKET_KEY=
 # BITBUCKET_SECRET=
 
+## SMTP settings
+# SMTP_URL='smtp://localhost'
+# SMTP_USER=
+# SMTP_PASSWORD=
+
 ## Periodical tasks (cron substitute, see lib/samson/periodical.rb)
 # stop_expired_deploys:60
 # remove_expired_locks:10

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
+require 'uri'
+
+smtp_url = URI.parse(ENV["SMTP_URL"] || "smtp://localhost")
+smtp_url.port ||= 25
+smtp_url.user ||= ENV["SMTP_USER"]
+smtp_url.password ||= ENV["SMTP_PASSWORD"]
+
 ActionMailer::Base.smtp_settings = {
+  port:                 smtp_url.port,
+  address:              smtp_url.host,
+  user_name:            smtp_url.user,
+  password:             smtp_url.password,
   authentication:       'plain',
   enable_starttls_auto: false,
   openssl_verify_mode:  'none'


### PR DESCRIPTION
Closes #2327.

* Adds an `SMTP_URL` with a default of `smtp://localhost:25`
* Credentials can be specified in URL or via `SMTP_USER` & `SMTP_PASSWORD` to enable populating from secret storage.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
