### PR TITLE
make sure test thread starts to avoid unlock-when-not-locked issue

### DIFF
--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -384,6 +384,7 @@ describe JobExecution do
   describe "#cancel" do
     def perform
       JobQueue.instance.instance_variable_get(:@threads)[execution.id] = Thread.new { execution.perform }
+      Thread.pass # make sure thread starts
     end
 
     with_job_cancel_timeout 0.1


### PR DESCRIPTION
```
JobExecution::#cancel#test_0001_stops the execution with interrupt:
ThreadError: Attempt to unlock a mutex which is not locked
    test/models/job_execution_test.rb:403:in `unlock'
    test/models/job_execution_test.rb:403:in `block (4 levels) in <top (required)>'
    app/models/job_execution.rb:63:in `cancel'
    test/models/job_execution_test.rb:407:in `block (3 levels) in <top (required)>'
bin/rails test test/models/job_execution_test.rb:400
```

@dragonfax 