### PR TITLE
TOOLS-2166 use docker cache from argument to speed up builds

### DIFF
--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -17,4 +17,19 @@ if !Rails.env.test? && !ENV['PRECOMPILE'] && ENV['DOCKER_FEATURE']
     warn "Unable to connect to docker!"
     Airbrake.notify($!)
   end
+
+  # ensure that --cache-from is supported (v13+)
+  min_version = 13
+  begin
+    Timeout.timeout(1) do
+      local = Integer(`docker -v`[/Docker version (\d+)/, 1])
+      server = Integer(Docker.version.fetch("Version")[/\d+/, 0])
+      if local < min_version || server < min_version
+        raise Docker::Error::VersionError, "Expected docker version to be >= #{min_version}"
+      end
+    end
+  rescue
+    warn "Unable to verify local docker!"
+    Airbrake.notify($!)
+  end
 end


### PR DESCRIPTION
needs docker v1.13+

seems to work:

```
[02:42:37] » docker build -f Dockerfile . --cache-from foobar.com/samson_non_prod/kube_service_watcher@sha256:e6a1e740f2b6af9fdc6442d744a75c6c7f717b50c4a184a34b1b43be2d195d78
```

@jonmoter 