### PR TITLE
make external build wait timeout configureable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # KUBERNETES_LOG_LINES=50 # how many lines of logs to show when a deploy fails
 # KUBERNETES_ALLOWED_VOLUME_HOST_PATHS=/data/ # prevent containers from mounting dangerous directories
 # KUBERNETES_USAGE_LIMIT_WARNING="If you need more, ask Steve!" # help message to display when user reaches usage limit
+# KUBERNETES_EXTERNAL_BUILD_WAIT=60 # home long to wait for external builds to arrive when deploying (checking every 5s)
 
 ## Jenkins, optional, for triggering Jenkins builds after deployment
 # JENKINS_URL= # server_url of jenkins


### PR DESCRIPTION
we saw a 40s wait is needed for GCR builds to arrive ... so need to increase that


### Risks
 - low: builds hanging forever
 - low: builds never finding external builds