### PR TITLE
pull cached image before using it since docker does not do that autom…

### DIFF
--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -225,12 +225,18 @@ describe DockerBuilderService do
     end
 
     describe "caching from the previous build" do
-      before { TerminalExecutor.any_instance.unstub(:execute) }
+      before do
+        TerminalExecutor.any_instance.unstub(:execute)
+        build.update_column(:docker_repo_digest, digest)
+      end
 
       it 'uses last build as cache' do
         TerminalExecutor.any_instance.expects(:execute).
-          with { |*args| args.join(" ").must_include " --cache-from #{build.docker_repo_digest}"; true }.
-          returns(true)
+          with do |*args|
+          args.join(" ").must_include " --cache-from #{build.docker_repo_digest}"
+          args.join(" ").must_include "docker pull #{build.docker_repo_digest}"
+          true
+        end.returns(true)
         service.send(:build_image, tmp_dir)
       end
 


### PR DESCRIPTION
…atically

idk why we'd still need to use `--cache-from` to tell docker to "consider this image" since that should happen automatically afaik ... but worth a try

https://semaphoreci.com/docs/docker/docker-layer-caching.html

@jacobat @jonmoter @davidreuss 

pull worked but not using cache :(
https://samsontest.zende.sk/projects/kube_service_watcher/builds/1190