### PR TITLE
Show expanded path for secrets when previewing

### DIFF
--- a/lib/samson/secrets/key_resolver.rb
+++ b/lib/samson/secrets/key_resolver.rb
@@ -39,8 +39,13 @@ module Samson
         found
       end
 
+      # expand a single key and return full path if present
+      def expand_key(key)
+        expand('unused-param', key).first&.last
+      end
+
       def read(key)
-        return unless full_key = expand('unused-param', key).first&.last
+        return unless full_key = expand_key(key)
         SecretStorage.read_multi([full_key], include_value: true).values.first&.fetch(:value) # read key without raising
       end
 

--- a/lib/samson/secrets/key_resolver.rb
+++ b/lib/samson/secrets/key_resolver.rb
@@ -17,22 +17,16 @@ module Samson
         env_name = env_name.to_s
         return [] unless validate_wildcard(env_name, secret_key)
 
-        # build a list of all possible ids
-        possible_ids = possible_secret_id_parts.map do |id_parts|
-          id_parts = id_parts.merge(key: secret_key)
-          id = SecretStorage.generate_id(id_parts)
-          id if key_granted?(id_parts) && !deprecated?(id)
-        end.compact
-
+        possible_id_list = possible_ids(secret_key)
         found =
           if secret_key.end_with?(WILDCARD)
-            expand_wildcard_keys(env_name, secret_key, possible_ids)
+            expand_wildcard_keys(env_name, secret_key, possible_id_list)
           else
-            expand_simple_key(env_name, possible_ids)
+            expand_simple_key(env_name, possible_id_list)
           end
 
         if found.empty?
-          @errors << "#{secret_key} (tried: #{possible_ids.join(', ')})"
+          @errors << "#{secret_key} (tried: #{possible_id_list.join(', ')})"
           return []
         end
 
@@ -60,6 +54,15 @@ module Samson
       end
 
       private
+
+      # get a list of all possible ids for a given secret
+      def possible_ids(secret_key)
+        possible_secret_id_parts.map do |id_parts|
+          id_parts = id_parts.merge(key: secret_key)
+          id = SecretStorage.generate_id(id_parts)
+          id if key_granted?(id_parts) && !deprecated?(id)
+        end.compact
+      end
 
       # local cache so we do not have to re-fetch cache on every resolve
       def deprecated?(id)

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -50,6 +50,11 @@ class EnvironmentVariableGroupsController < ApplicationController
         @project = Project.find(params[:project_id])
         SamsonEnv.env_groups(@project, DeployGroup.all, preview: true)
       end
+
+    respond_to do |format|
+      format.html
+      format.json { render json: { groups: @groups} }
+    end
   end
 
   private

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -53,7 +53,7 @@ class EnvironmentVariableGroupsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render json: { groups: @groups} }
+      format.json { render json: { groups: @groups || [] } }
     end
   end
 

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -57,8 +57,8 @@ class EnvironmentVariable < ActiveRecord::Base
           resolved =
             if preview
               path = resolver.expand_key(secret_key)
-              expanded_path = !path.nil? ? path : "n/a"
-              found ? "#{TerminalExecutor::SECRET_PREFIX}#{expanded_path} ✓" : "#{value} X"
+              expanded_path = !path.nil? ? path : ""
+              "#{TerminalExecutor::SECRET_PREFIX}#{expanded_path}"
             else
               found.to_s
             end

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -56,9 +56,8 @@ class EnvironmentVariable < ActiveRecord::Base
           found = resolver.read(secret_key)
           resolved =
             if preview
-              expanded_secrets = {}
-              resolver.expand(secret_key, secret_key).each { |k, v| expanded_secrets[k] = v }
-              expanded_path = expanded_secrets.key?(secret_key) ? expanded_secrets[secret_key] : "n/a"
+              path = resolver.expand_key(secret_key)
+              expanded_path = !path.nil? ? path : "n/a"
               found ? "#{TerminalExecutor::SECRET_PREFIX}#{expanded_path} ✓" : "#{value} X"
             else
               found.to_s

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -57,8 +57,7 @@ class EnvironmentVariable < ActiveRecord::Base
           resolved =
             if preview
               path = resolver.expand_key(secret_key)
-              expanded_path = !path.nil? ? path : ""
-              "#{TerminalExecutor::SECRET_PREFIX}#{expanded_path}"
+              path ? "#{TerminalExecutor::SECRET_PREFIX}#{path}" : "#{value} X"
             else
               found.to_s
             end

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -56,7 +56,10 @@ class EnvironmentVariable < ActiveRecord::Base
           found = resolver.read(secret_key)
           resolved =
             if preview
-              found ? "#{value} ✓" : "#{value} X"
+              expanded_secrets = {}
+              resolver.expand(secret_key, secret_key).each { |k, v| expanded_secrets[k] = v }
+              expanded_path = expanded_secrets.key?(secret_key) ? expanded_secrets[secret_key] : "n/a"
+              found ? "#{TerminalExecutor::SECRET_PREFIX}#{expanded_path} ✓" : "#{value} X"
             else
               found.to_s
             end

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -55,15 +55,22 @@ describe EnvironmentVariableGroupsController do
   end
 
   as_a_viewer do
-    before do
-      env_group
-      env_group.update_column :id, 1 # need static id
-    end
-
     unauthorized :get, :new
     unauthorized :post, :create
-    unauthorized :patch, :update, id: 1
-    unauthorized :delete, :destroy, id: 1
+
+    describe "#update" do
+      it "is unauthorized" do
+        patch :update, params: {id: env_group.id}
+        assert_response :unauthorized
+      end
+    end
+
+    describe "#destroy" do
+      it "is unauthorized" do
+        delete :destroy, params: {id: env_group.id}
+        assert_response :unauthorized
+      end
+    end
 
     describe "#index" do
       it "renders" do
@@ -99,10 +106,14 @@ describe EnvironmentVariableGroupsController do
 
     describe "a json GET to #preview" do
       it "succeeds" do
-        get :preview, params: {format: :json, group_id: env_group.id, project_id: project.id }
+        get :preview, params: {group_id: env_group.id, project_id: project.id }, format: :json
         assert_response :success
         json_response = JSON.parse response.body
-        assert_nil json_response['groups']
+        json_response['groups'].sort.must_equal [
+          [".pod-100", {"X" => "Y", "Y" => "Z"}],
+          [".pod1", {"X" => "Y", "Y" => "Z"}],
+          [".pod2", {"X" => "Y", "Y" => "Z"}]
+        ]
       end
     end
   end

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -96,6 +96,15 @@ describe EnvironmentVariableGroupsController do
         assert_response :success
       end
     end
+
+    describe "a json GET to #preview" do
+      it "succeeds" do
+        get :preview, params: {format: :json, group_id: env_group.id, project_id: project.id }
+        assert_response :success
+        json_response = JSON.parse response.body
+        assert_nil json_response['groups']
+      end
+    end
   end
 
   as_a_project_admin do

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -116,7 +116,7 @@ describe EnvironmentVariable do
         it "does not show secret values in preview mode" do
           create_secret 'global/global/global/foobar'
           EnvironmentVariable.env(project, nil, preview: true).must_equal(
-            "PROJECT" => "secret://foobar ✓", "X" => "Y", "Y" => "Z"
+            "PROJECT" => "secret://global/global/global/foobar ✓", "X" => "Y", "Y" => "Z"
           )
         end
 
@@ -128,8 +128,8 @@ describe EnvironmentVariable do
           all.sort_by { |x| x["PROJECT"] }.must_equal(
             [
               {"PROJECT" => "DEPLOY", "Z" => "A", "X" => "Y", "Y" => "Z"},
-              {"PROJECT" => "secret://foobar ✓", "X" => "Y", "Y" => "Z"},
-              {"PROJECT" => "secret://foobar ✓", "X" => "Y", "Y" => "Z"}
+              {"PROJECT" => "secret://global/global/global/foobar ✓", "X" => "Y", "Y" => "Z"},
+              {"PROJECT" => "secret://global/global/global/foobar ✓", "X" => "Y", "Y" => "Z"}
             ]
           )
         end

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -116,7 +116,7 @@ describe EnvironmentVariable do
         it "does not show secret values in preview mode" do
           create_secret 'global/global/global/foobar'
           EnvironmentVariable.env(project, nil, preview: true).must_equal(
-            "PROJECT" => "secret://global/global/global/foobar ✓", "X" => "Y", "Y" => "Z"
+            "PROJECT" => "secret://global/global/global/foobar", "X" => "Y", "Y" => "Z"
           )
         end
 
@@ -128,8 +128,8 @@ describe EnvironmentVariable do
           all.sort_by { |x| x["PROJECT"] }.must_equal(
             [
               {"PROJECT" => "DEPLOY", "Z" => "A", "X" => "Y", "Y" => "Z"},
-              {"PROJECT" => "secret://global/global/global/foobar ✓", "X" => "Y", "Y" => "Z"},
-              {"PROJECT" => "secret://global/global/global/foobar ✓", "X" => "Y", "Y" => "Z"}
+              {"PROJECT" => "secret://global/global/global/foobar", "X" => "Y", "Y" => "Z"},
+              {"PROJECT" => "secret://global/global/global/foobar", "X" => "Y", "Y" => "Z"}
             ]
           )
         end


### PR DESCRIPTION
Allows easy grok'ing where secrets are actually found for a deployment.

Also, added JSON formatting.