### PR TITLE
do not pick up random digests from the build output

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -135,7 +135,8 @@ class DockerBuilderService
         end
 
         if primary
-          return nil unless sha = @output.to_s[DIGEST_SHA_REGEX, 1]
+          # cache-from also produced digest lines, so we need to be careful
+          return nil unless sha = @execution.executor.output.to_s.split("\n").last[DIGEST_SHA_REGEX, 1]
           digest = "#{repo}@#{sha}"
         end
       end

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -288,10 +288,10 @@ describe DockerBuilderService do
     let(:push_output) do
       [
         "pushing image to repo...",
+        "Ignore this Digest: #{repo_digest.tr("5", "F")}",
         "completed push.",
         "Frobinating...",
-        "Digest: #{repo_digest}",
-        "Done"
+        "Digest: #{repo_digest}"
       ]
     end
     let(:tag) { 'my-test' }


### PR DESCRIPTION
 - possibly picking up cache-from
 - possibly picking up digest from earlier build
 - possibly picking up random other output
 - introudced when converting from chunk reading to reading all output in https://github.com/zendesk/samson/pull/2403

@staugaard @dragonfax 