### PR TITLE
do not print cursor movements, it looks weird

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -90,7 +90,10 @@ class TerminalExecutor
   end
 
   def stream(from:, to:)
-    from.each(256) { |chunk| to.write chunk }
+    from.each(256) do |chunk|
+      chunk = chunk.gsub(/\r\e\[\d+[ABCD]\r\n/, "\r") # ignore cursor movement http://ascii-table.com/ansi-escape-sequences.php
+      to.write chunk
+    end
   rescue Errno::EIO
     nil # output was closed ... only happens on linux
   end

--- a/app/views/jobs/_log.html.erb
+++ b/app/views/jobs/_log.html.erb
@@ -1,7 +1,3 @@
 <pre id="messages" class="pre-scrollable log">
-  <% unless job.active? %>
-    <% job.output.split("\n").each do |line| %>
-<%= render_log(line) %>
-    <% end %>
-  <% end %>
+  <%= render_log(job.output) unless job.active? %>
 </pre>

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -109,6 +109,11 @@ describe TerminalExecutor do
       output.string.must_equal("hello\r\nTimeout: execution took longer then 1s and was terminated\n")
     end
 
+    it "does not log cursor movement ... special output coming from docker builds" do
+      assert subject.execute("ruby -e 'puts %{Hello\\r\e[1B\\nWorld\\n}'")
+      output.string.must_equal "Hello\rWorld\r\n"
+    end
+
     describe 'in verbose mode' do
       subject { TerminalExecutor.new(output, verbose: true) }
 


### PR DESCRIPTION
@jonmoter @dragonfax 

before:
![screen shot 2017-12-11 at 2 40 15 pm](https://user-images.githubusercontent.com/11367/33857948-c2b334b0-de82-11e7-857e-1f56d7bf916d.png)

after:
![screen shot 2017-12-11 at 2 46 27 pm](https://user-images.githubusercontent.com/11367/33857958-c9449616-de82-11e7-8359-e5823f277473.png)

http://ascii-table.com/ansi-escape-sequences.php
there is potential for more cleanup of cursor sequences, but this was the ugliest one we saw ...