### PR TITLE
Fixing typo in Kubernetes error message.

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -310,7 +310,7 @@ module Kubernetes
             raise(
               Samson::Hooks::UserError,
               "Role #{roles} for #{group.name} is not configured, but in repo at #{@job.commit}. " \
-              "Remove it from the repo or configure via it the stage page."
+              "Remove it from the repo or configure it via the stage page."
             )
           end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -235,7 +235,7 @@ describe Kubernetes::DeployExecutor do
         e = assert_raises(Samson::Hooks::UserError) { execute }
         e.message.must_equal(
           "Role resque-worker for Pod 100 is not configured, but in repo at #{commit}. " \
-          "Remove it from the repo or configure via it the stage page."
+          "Remove it from the repo or configure it via the stage page."
         )
       end
 


### PR DESCRIPTION
/cc @zendesk/other

### Description

Corrects a typo that appears in Kubernetes error messages. The error was a prompt to configure stage (See screenshot).

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team


### Steps to reproduce
This should include pulling related branches of different repos, editing Gemfiles, adding arturo bits etc

### Risks
* Low

<img width="1208" alt="samson-failure_message_typo-2" src="https://user-images.githubusercontent.com/12619/33921933-117f47d8-df7c-11e7-9e70-2d1ff5b4cfd1.png">