### PR TITLE
Limit depth while git fetch to reduce traffic

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -131,7 +131,7 @@ class GitRepository
   add_method_tracer :create_workspace
 
   def update!
-    executor.execute("cd #{repo_cache_dir}", 'git fetch -p')
+    executor.execute("cd #{repo_cache_dir}", 'git fetch -p --depth=50')
   end
   add_method_tracer :update!
 


### PR DESCRIPTION
Everytime we fetch git repo, we get the full history while we need only recent commits, that PR helps to reduce traffic and speed up deployments.

Idea has taken from Travis, every Travis build is limiting git history by 50.

/cc @zendesk/samson @DinoRosic 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: High - can break deployment
