### PR TITLE
use deploy-timeout for gcr builds to have same timeout as local builds

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -81,7 +81,7 @@ class DockerBuilderService
     if defined?(SamsonGcloud::ImageBuilder) && build.project.build_with_gcb
       # we do not push after this since GCR handles that
       build.docker_repo_digest = SamsonGcloud::ImageBuilder.build_image(
-        build, tmp_dir, @output, tag_as_latest: tag_as_latest, cache_from: cache
+        build, tmp_dir, @execution.executor, tag_as_latest: tag_as_latest, cache_from: cache
       )
     else
       build.docker_image = ImageBuilder.build_image(

--- a/test/models/docker_builder_service_test.rb
+++ b/test/models/docker_builder_service_test.rb
@@ -266,6 +266,7 @@ describe DockerBuilderService do
       it "stores docker_repo_digest directly" do
         with_env GCLOUD_PROJECT: 'p-123', GCLOUD_ACCOUNT: 'acc' do
           build.project.build_with_gcb = true
+          service.instance_variable_set(:@execution, stub("Ex", executor: TerminalExecutor.new(OutputBuffer.new)))
           assert service.send(:build_image, tmp_dir, tag_as_latest: false)
           refute build.docker_image_id
           build.docker_repo_digest.sub(/samson\/[^@]+/, "X").must_equal "gcr.io/p-123/X@sha-123:abc"

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -109,6 +109,12 @@ describe TerminalExecutor do
       output.string.must_equal("hello\r\nTimeout: execution took longer then 1s and was terminated\n")
     end
 
+    it "can timeout via argument" do
+      refute subject.execute('echo hello; sleep 10', timeout: 1)
+      `ps -ef | grep "[s]leep 10"`.wont_include "sleep 10" # process got killed
+      output.string.must_equal("hello\r\nTimeout: execution took longer then 1s and was terminated\n")
+    end
+
     it "does not log cursor movement ... special output coming from docker builds" do
       assert subject.execute("ruby -e 'puts %{Hello\\r\e[1B\\nWorld\\n}'")
       output.string.must_equal "Hello\rWorld\r\n"


### PR DESCRIPTION
 - makes the iamge-builder use the executor of the docker build,
so it will actually stop when the build is cancelled
 - uses shelljoin to avoid any kind of command injection or accidental bugs

@jonmoter @dragonfax 
/cc @zenhao 