### PR TITLE
avoid builds with nil projects

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/build_finder.rb
+++ b/plugins/kubernetes/app/models/kubernetes/build_finder.rb
@@ -131,7 +131,7 @@ module Kubernetes
           dockerfile: dockerfile,
           name: "Autobuild for Deploy ##{@job.deploy.id}"
         )
-        DockerBuilderService.new(build.clone).run(push: true) # clone to not update/reload the same object
+        DockerBuilderService.new(Build.find(build.id)).run(push: true) # .find to not update/reload the same object
         build
       elsif dockerfile == "Dockerfile"
         @output.puts("Not creating #{name} since is is not in the repository.")


### PR DESCRIPTION
saw a build triggered by a kubernetes deploy that had a nil project,
but when fetching it from DB it looked normal ... so the clone might be to blame

https://zendesk.airbrake.io/projects/95346/groups/2073278695669703679/notices/2103996377796181626?dur=90d%2F1d&tab=notice-detail

@dragonfax 
/cc @dongxiaohe 