### PR TITLE
show 'running on' on builds

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,8 +138,8 @@ module ApplicationHelper
     end
   end
 
-  def icon_tag(type)
-    content_tag :i, '', class: "glyphicon glyphicon-#{type}"
+  def icon_tag(type, options = {})
+    content_tag :i, '', options.merge(class: "glyphicon glyphicon-#{type}")
   end
 
   def link_to_delete(path, options = {})
@@ -295,5 +295,21 @@ module ApplicationHelper
     }
     url = "https://chart.googleapis.com/chart?#{params.to_query}"
     link_to icon_tag('signal'), url, target: :blank
+  end
+
+  # show which stages this reference is deploy(ed+ing) to
+  def deployed_or_running_list(stages, reference)
+    html = "".html_safe
+    stages.each do |stage|
+      next unless deploy = stage.deployed_or_running_deploy
+      next unless deploy.references?(reference)
+
+      text = "".html_safe
+      text << icon_tag("cloud-upload", title: deploy.status) << " " if deploy.active?
+      text << stage.name
+      html << content_tag(:span, text, class: "label label-success release-stage")
+      html << " "
+    end
+    html
   end
 end

--- a/app/helpers/stages_helper.rb
+++ b/app/helpers/stages_helper.rb
@@ -7,8 +7,6 @@ module StagesHelper
   end
 
   def stage_template_icon
-    content_tag :span, '',
-      class: "glyphicon glyphicon-duplicate",
-      title: "Template stage, this stage will be used when copying to new Deploy Groups"
+    icon_tag "duplicate", title: "Template stage, this stage will be used when copying to new Deploy Groups"
   end
 end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -66,8 +66,13 @@ class Deploy < ActiveRecord::Base
     end
   end
 
+  def references?(ref)
+    reference == ref || (ref =~ Build::SHA1_REGEX && job&.commit == ref)
+  end
+
+  # TODO: remove this an delegate to job directly, a commit is not a reference
   def commit
-    job.try(:commit).presence || reference
+    job&.commit.presence || reference
   end
 
   def short_reference

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -16,10 +16,6 @@ class Release < ActiveRecord::Base
   # This constant is here for convenience - the value that the database uses is in db/schema.rb.
   DEFAULT_RELEASE_NUMBER = "1"
 
-  def currently_deploying_stages
-    project.stages.where_reference_being_deployed(version)
-  end
-
   def changeset
     @changeset ||= Changeset.new(project.repository_path, previous_release.try(:commit), commit)
   end

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -83,9 +83,9 @@ class Stage < ActiveRecord::Base
     @last_successful_deploy = deploys.successful.first
   end
 
-  # comparing commits might be better ...
-  def current_release?(release)
-    last_successful_deploy&.reference == release.version
+  # last active or successful deploy
+  def deployed_or_running_deploy
+    deploys.joins(:job).where("jobs.status" => Job::ACTIVE_STATUSES + ["succeeded"]).first
   end
 
   def create_deploy(user, attributes = {})

--- a/app/views/builds/_build.html.erb
+++ b/app/views/builds/_build.html.erb
@@ -1,11 +1,12 @@
 <% job = build.docker_build_job %>
 <tr>
   <td><%= link_to build.nice_name, project_build_path(build.project, build) %></td>
-  <% unless @project %>
+  <% if @project %>
+    <td><%= deployed_or_running_list @project.stages, build.git_sha %></td>
+  <% else %>
     <td><%= link_to build.project.name, build.project %></td>
   <% end %>
   <td><%= relative_time(build.created_at) %></td>
-  <td><%= build.creator&.name || "Trigger" %></td>
   <td><%= duration_text job.duration if job %></td>
   <td><%= git_ref_and_sha_for(build) %></td>
   <td><%= build.image_name.presence || build.dockerfile %></td>

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -21,11 +21,12 @@
     <thead>
     <tr>
       <th>Name</th>
-      <% unless @project %>
+      <% if @project %>
+        <th>Deployed to</th>
+      <% else %>
         <th>Project</th>
       <% end %>
       <th>Created</th>
-      <th>Created By</th>
       <th>
         Duration
         <%= link_to_chart "Build duration", @builds.map { |b| b.docker_build_job&.duration }.compact %>

--- a/app/views/releases/_deployed_to.html.erb
+++ b/app/views/releases/_deployed_to.html.erb
@@ -1,9 +1,0 @@
-<%# this is n+1 ... we could fetch all deploys unique by stage instead %>
-<% if deployed_stages = @project.stages.select { |stage| stage.current_release?(release) }.presence %>
-  <p>
-    Deployed to:
-    <% deployed_stages.each do |stage| %>
-      <%= link_to stage.name, [@project, stage] %>
-    <% end %>
-  </p>
-<% end %>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -2,18 +2,7 @@
   <td>
     <%= release_label(@project, release) %>
   </td>
-  <td>
-    <% @stages.select {|stage| stage.current_release?(release) }.each do |stage| %>
-      <span class="label label-success release-stage" title="Currently deployed to <%= stage.name %>">
-        <%= stage.name %>
-      </span>
-    <% end %>
-    <% release.currently_deploying_stages.each do |stage| %>
-      <span class="label label-warning release-stage" title="Being deployed to <%= stage.name %>">
-        <span class="glyphicon glyphicon-cloud-upload"></span> <%= stage.name %>
-      </span>
-    <% end %>
-  </td>
+  <td><%= deployed_or_running_list @stages, release.version %></td>
   <td><%= relative_time(release.created_at) %></td>
   <td>
     <% if deployer_for_project? %>

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -19,7 +19,7 @@
         <thead>
           <tr>
             <th></th>
-            <th>Currently deployed to</th>
+            <th>Deployed to</th>
             <th>Created</th>
             <th></th>
           </tr>

--- a/app/views/releases/row_content.html.erb
+++ b/app/views/releases/row_content.html.erb
@@ -12,7 +12,6 @@
   <div class="tab-pane" id="info-<%= @release.version %>">
     Commit: <code><%= @release.commit %></code>
     <p>Author: <%= @release.author.name %>
-      <%= render 'deployed_to', release: @release %>
   </div>
 
   <div class="tab-pane" id="pulls-<%= @release.version %>">

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -9,7 +9,9 @@
     <%= render 'deploy_to_button', release: @release, stages: @project.stages %>
   </div>
 
-  <%= render 'deployed_to', release: @release %>
+  <% if list = deployed_or_running_list(@project.stages, @release.version).presence %>
+    <p>Deployed to: <%= list %></p>
+  <% end %>
 
   <label>Created</label>
   <%= relative_time(@release.created_at) %>

--- a/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
+++ b/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
@@ -25,7 +25,7 @@ describe SamsonAirbrake::Engine do
             "api_key" => "MY-SECRET",
             "deploy" => {
               "rails_env" => "staging",
-              "scm_revision" => "abcabc1",
+              "scm_revision" => "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1",
               "local_username" => "Super Admin",
               "scm_repository" => "https://example.com/bar/foo",
             }

--- a/plugins/github/test/models/github_deployment_test.rb
+++ b/plugins/github/test/models/github_deployment_test.rb
@@ -26,7 +26,7 @@ describe GithubDeployment do
         production_environment: false,
         auto_merge: false,
         required_contexts: [],
-        ref: "abcabc1"
+        ref: "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1"
       }
       create = stub_request(:post, endpoint).with(body: body.to_json)
       github_deployment.create

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -21,7 +21,7 @@ describe Samson::Jenkins do
   def stub_build_with_parameters(update_params)
     stub_request(:post, "http://www.test-url.com/job/test_job/buildWithParameters").
       with(
-        body: {"buildStartedBy": "Super Admin", "originatedFrom": "Foo_Staging_staging", "commit": "abcabc1", "deployUrl": "http://www.test-url.com/projects/foo/deploys/#{deploy.id}", "emails" => "super-admin@example.com", "tag" => nil}.merge(update_params),
+        body: {"buildStartedBy": "Super Admin", "originatedFrom": "Foo_Staging_staging", "commit": "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1", "deployUrl": "http://www.test-url.com/projects/foo/deploys/#{deploy.id}", "emails" => "super-admin@example.com", "tag" => nil}.merge(update_params),
         headers: {Authorization: 'Basic dXNlckB0ZXN0LmNvbTpqYXBpa2V5'}
       ).
       to_return(status: 200, body: "", headers: {}).to_timeout
@@ -30,7 +30,7 @@ describe Samson::Jenkins do
   def stub_build_with_parameters_when_autoconfig_is_enabled(update_params)
     stub_request(:post, "http://www.test-url.com/job/test_job/buildWithParameters").
       with(
-        body: {"SAMSON_buildStartedBy": "Super Admin", "SAMSON_commit": "abcabc1", "SAMSON_deployUrl": "http://www.test-url.com/projects/foo/deploys/178003093", "SAMSON_emails": "super-admin@example.com", "SAMSON_originatedFrom": "Foo_Staging_staging", "SAMSON_tag": nil}.merge(update_params),
+        body: {"SAMSON_buildStartedBy": "Super Admin", "SAMSON_commit": "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1", "SAMSON_deployUrl": "http://www.test-url.com/projects/foo/deploys/178003093", "SAMSON_emails": "super-admin@example.com", "SAMSON_originatedFrom": "Foo_Staging_staging", "SAMSON_tag": nil}.merge(update_params),
         headers: {
           Authorization: 'Basic dXNlckB0ZXN0LmNvbTpqYXBpa2V5'
         }

--- a/plugins/samson_ledger/test/lib/samson_ledger/client_test.rb
+++ b/plugins/samson_ledger/test/lib/samson_ledger/client_test.rb
@@ -30,8 +30,8 @@ describe 'SamsonLedger::Client' do
 
   describe ".post_deployment" do
     before do
-      stub_github_api("repos/bar/foo/compare/abcabc1...staging", "x" => "y")
-      GITHUB.stubs(:compare).with("bar/foo", "abcabc1", "staging").returns(comparison)
+      stub_github_api("repos/bar/foo/compare/abcabcaaabcabcaaabcabcaaabcabcaaabcabca1...staging", "x" => "y")
+      GITHUB.stubs(:compare).with("bar/foo", "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1", "staging").returns(comparison)
       Changeset::PullRequest.stubs(:find).with("bar/foo", 42).returns(pull_request)
 
       request_lambda = ->(request) do

--- a/test/fixtures/jobs.yml
+++ b/test/fixtures/jobs.yml
@@ -4,7 +4,7 @@ succeeded_test:
   project: test
   status: succeeded
   output: This worked!
-  commit: abcabc1
+  commit: abcabcaaabcabcaaabcabcaaabcabcaaabcabca1
 
 succeeded_production_test:
   command: cap production deploy
@@ -12,7 +12,7 @@ succeeded_production_test:
   project: test
   status: succeeded
   output: This worked!
-  commit: abcabc2
+  commit: abcabcaaabcabcaaabcabcaaabcabcaaabcabca2
 
 running_test:
   command: cap staging deploy
@@ -20,7 +20,7 @@ running_test:
   project: test
   status: running
   output: This worked!
-  commit: abcabc3
+  commit: abcabcaaabcabcaaabcabcaaabcabcaaabcabca3
 
 failed_test:
   command: cap staging deploy
@@ -28,4 +28,4 @@ failed_test:
   project: test
   status: failed
   output: Error
-  commit: staging
+  commit: staging # failed to resulve the reference so not a valid sha

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -634,4 +634,51 @@ describe ApplicationHelper do
       link_to_chart("Hello world", [1, 2]).must_equal nil
     end
   end
+
+  describe "#icon_tag" do
+    it "generates simple icons" do
+      html = icon_tag("foo")
+      html.must_equal "<i class=\"glyphicon glyphicon-foo\"></i>"
+      assert html.html_safe?
+    end
+
+    it "generates icons with titles" do
+      html = icon_tag("foo", title: "bar")
+      html.must_equal "<i title=\"bar\" class=\"glyphicon glyphicon-foo\"></i>"
+      assert html.html_safe?
+    end
+  end
+
+  describe "#deployed_or_running_list" do
+    let(:stage_list) { [stages(:test_staging)] }
+
+    it "produces safe output" do
+      html = deployed_or_running_list([], "foo")
+      html.must_equal ""
+      assert html.html_safe?
+    end
+
+    it "renders succeeded deploys" do
+      html = deployed_or_running_list(stage_list, "staging")
+      html.must_equal "<span class=\"label label-success release-stage\">Staging</span> "
+    end
+
+    it "ignores failed deploys" do
+      deploys(:succeeded_test).job.update_column(:status, 'failed')
+      html = deployed_or_running_list(stage_list, "staging")
+      html.must_equal ""
+    end
+
+    it "ignores non-matching deploys" do
+      deploys(:succeeded_test).update_column(:reference, 'nope')
+      html = deployed_or_running_list(stage_list, "staging")
+      html.must_equal ""
+    end
+
+    it "shows active deploys" do
+      deploys(:succeeded_test).job.update_column(:status, 'running')
+      html = deployed_or_running_list(stage_list, "staging")
+      html.must_equal "<span class=\"label label-success release-stage\"><i title=\"running\" class=\"glyphicon glyphicon-cloud-upload\"></i> Staging</span> "
+    end
+  end
 end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -128,55 +128,6 @@ describe Release do
     end
   end
 
-  describe "#currently_deploying_stages" do
-    let(:stage) { project.stages.create!(name: "One") }
-    before { release.update_column(:number, '42') }
-
-    it "returns stages where the release is pending deploy" do
-      create_deploy!(reference: "v42", status: "pending")
-      assert_equal [stage], release.currently_deploying_stages
-    end
-
-    it "returns stages where the release is currently being deployed" do
-      create_deploy!(reference: "v42", status: "running")
-      assert_equal [stage], release.currently_deploying_stages
-    end
-
-    it "returns stages where a deploy of the release is being cancelled" do
-      create_deploy!(reference: "v42", status: "cancelling")
-      assert_equal [stage], release.currently_deploying_stages
-    end
-
-    it "ignores stages where there are no current deploys" do
-      create_deploy!(reference: "v42", status: "succeeded")
-      assert_equal [], release.currently_deploying_stages
-    end
-
-    it "ignores stages where another release is being deployed" do
-      create_deploy!(reference: "v666", status: "running")
-      assert_equal [], release.currently_deploying_stages
-    end
-
-    it "handles deleted author" do
-      create_deploy!(reference: "v666", status: "succeeded")
-      author.soft_delete!
-      release.reload
-      assert_equal author.name, release.author.name
-    end
-
-    it "handles deleted author" do
-      create_deploy!(reference: "v666", status: "succeeded")
-      author.destroy!
-      release.reload
-      assert_equal NullUser.new(0).name, release.author.name
-    end
-
-    def create_deploy!(options)
-      job = project.jobs.create!(user: author, commit: "x", command: "yes", status: options.fetch(:status))
-      stage.deploys.create!(reference: options.fetch(:reference), job: job, project: project)
-    end
-  end
-
   describe "#changeset" do
     before do
       GitRepository.any_instance.stubs(:exact_tag_from_ref).returns("")


### PR DESCRIPTION
<img width="443" alt="screen shot 2017-12-14 at 7 47 28 pm" src="https://user-images.githubusercontent.com/11367/34026041-4340c660-e108-11e7-83db-f2e9e8d668d0.png">
<img width="258" alt="screen shot 2017-12-14 at 7 41 59 pm" src="https://user-images.githubusercontent.com/11367/34026042-435e8498-e108-11e7-8eae-73ed3d667372.png">
<img width="514" alt="screen shot 2017-12-14 at 8 23 26 pm" src="https://user-images.githubusercontent.com/11367/34026699-a92a3246-e10c-11e7-8b7e-b0282181fe16.png">
<img width="317" alt="screen shot 2017-12-14 at 8 22 29 pm" src="https://user-images.githubusercontent.com/11367/34026700-af6085ca-e10c-11e7-81be-b81d4a6b8548.png">

a lot of cleanup too ... and removing the duplicate show on releases/index when expanding a release

@jonmoter 