### PR TITLE
Allow deploy scripts to know about docker builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,7 +108,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # DOCKER_HOST= # e.g. tcp://my-docker-registry.example.com:2375
 # DOCKER_KEEP_BUILT_IMGS # optional. Set to 1 to keep built images for cache. Fills the disk so some cleanup machanism is needed
 # DOCKER_READ_TIMEOUT=600 # optional. How long to wait on docker reads.
-# EXTERNAL_BUILD_WAIT=60 # home long to wait for external builds to arrive when deploying (checking every 5s)
+# EXTERNAL_BUILD_WAIT=60 # how long to wait for external builds to arrive when deploying (checking every 5s)
 
 # FLOWDOCK_API_TOKEN= # optional. only required for the flowdock integration user mention autocomplete in the buddy approval request form (when BUDDY_CHECK_FEATURE=1). Buddy approval notification would still work without this
 

--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # DOCKER_HOST= # e.g. tcp://my-docker-registry.example.com:2375
 # DOCKER_KEEP_BUILT_IMGS # optional. Set to 1 to keep built images for cache. Fills the disk so some cleanup machanism is needed
 # DOCKER_READ_TIMEOUT=600 # optional. How long to wait on docker reads.
+# EXTERNAL_BUILD_WAIT=60 # home long to wait for external builds to arrive when deploying (checking every 5s)
 
 # FLOWDOCK_API_TOKEN= # optional. only required for the flowdock integration user mention autocomplete in the buddy approval request form (when BUDDY_CHECK_FEATURE=1). Buddy approval notification would still work without this
 
@@ -156,7 +157,6 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # KUBERNETES_LOG_LINES=50 # how many lines of logs to show when a deploy fails
 # KUBERNETES_ALLOWED_VOLUME_HOST_PATHS=/data/ # prevent containers from mounting dangerous directories
 # KUBERNETES_USAGE_LIMIT_WARNING="If you need more, ask Steve!" # help message to display when user reaches usage limit
-# KUBERNETES_EXTERNAL_BUILD_WAIT=60 # home long to wait for external builds to arrive when deploying (checking every 5s)
 
 ## Jenkins, optional, for triggering Jenkins builds after deployment
 # JENKINS_URL= # server_url of jenkins

--- a/lib/samson/build_finder.rb
+++ b/lib/samson/build_finder.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-# makes sure all builds that are needed for a kubernetes release are successfully built
+# makes sure all builds that are needed for a deploy are successfully built
 # (needed builds are determined by projects `dockerfiles` column)
 #
-# Ideally it would come from what `template_filler.rb` needs, but it wants know about builds to render.
+# FIXME: Ideally it would come from what `template_filler.rb` needs, but it wants know about builds to render.
 #
 # Special cases:
 # - when no Dockerfile is in the repo and it is the only requested dockerfile (column default value), return no builds
@@ -10,7 +10,7 @@
 # - builds can be reused from the previous release if the deployer requested it
 # - if the deploy is cancelled we finish up asap
 # - we find builds accross all projects so multiple projects can share them
-module Kubernetes
+module Samson
   class BuildFinder
     TICK = 2.seconds
 
@@ -35,7 +35,7 @@ module Kubernetes
           # since samson and the image building can be triggered at the same time
           # we check if the image is there every 5 seconds up to a maximum of <max> seconds
           step = 5
-          max = Integer(ENV['KUBERNETES_EXTERNAL_BUILD_WAIT'] || '5')
+          max = Integer(ENV['KUBERNETES_EXTERNAL_BUILD_WAIT'] || ENV['EXTERNAL_BUILD_WAIT'] || '5')
           loop do
             builds = find_build_by_image_name(try: true)
             break builds if builds

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -27,7 +27,7 @@ module Kubernetes
       @output = output
       @job = job
       @reference = reference
-      @build_finder = BuildFinder.new(
+      @build_finder = Samson::BuildFinder.new(
         @output,
         @job,
         @reference,

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -285,7 +285,7 @@ module Kubernetes
       containers.each do |container|
         build =
           if project.docker_image_building_disabled?
-            Kubernetes::BuildFinder.detect_build_by_image_name!(builds, container.fetch(:image), try: false)
+            Samson::BuildFinder.detect_build_by_image_name!(builds, container.fetch(:image), try: false)
           elsif selected = container[:"samson/dockerfile"]
             builds.detect { |b| b.dockerfile == selected } ||
               raise(Samson::Hooks::UserError, "Build for dockerfile #{selected} not found")

--- a/test/lib/samson/build_finder_test.rb
+++ b/test/lib/samson/build_finder_test.rb
@@ -3,7 +3,7 @@ require_relative "../../test_helper"
 
 SingleCov.covered!
 
-describe Kubernetes::BuildFinder do
+describe Samson::BuildFinder do
   def setup_using_previous_builds
     previous = deploys(:failed_staging_test)
     previous.update_column(:id, job.deploy.id - 1) # make previous_deploy work
@@ -18,7 +18,7 @@ describe Kubernetes::BuildFinder do
   let(:build) { builds(:docker_build) }
   let(:job) { jobs(:succeeded_test) }
   let(:images) { nil }
-  let(:finder) { Kubernetes::BuildFinder.new(output, job, 'master', images: images) }
+  let(:finder) { Samson::BuildFinder.new(output, job, 'master', images: images) }
 
   before do
     build.update_column(:docker_repo_digest, nil) # build is needed

--- a/test/lib/samson/build_finder_test.rb
+++ b/test/lib/samson/build_finder_test.rb
@@ -13,6 +13,11 @@ describe Samson::BuildFinder do
     job.deploy.update_column(:kubernetes_reuse_build, true)
   end
 
+  def expect_sleep
+    finder.unstub(:sleep)
+    finder.expects(:sleep)
+  end
+
   let(:output) { StringIO.new }
   let(:out) { output.string }
   let(:build) { builds(:docker_build) }
@@ -21,13 +26,16 @@ describe Samson::BuildFinder do
   let(:finder) { Samson::BuildFinder.new(output, job, 'master', images: images) }
 
   before do
-    build.update_column(:docker_repo_digest, nil) # build is needed
+    expect_sleep.with { raise "Unexpected sleep" }.never
+    build.update_column(:docker_repo_digest, nil) # building needs to happen
     job.update_column(:commit, build.git_sha) # this is normally done by JobExecution
     GitRepository.any_instance.stubs(:file_content).with('Dockerfile', job.commit).returns "FROM all"
   end
 
   describe "#ensure_successful_builds" do
-    let(:execute) { finder.ensure_successful_builds.presence }
+    def execute
+      finder.ensure_successful_builds
+    end
 
     it "fails when the build is not built" do
       e = assert_raises(Samson::Hooks::UserError) { execute }
@@ -40,7 +48,7 @@ describe Samson::BuildFinder do
       GitRepository.any_instance.expects(:file_content).with('Dockerfile', job.commit).returns nil
 
       refute_difference 'Build.count' do
-        refute execute # no build found or created
+        execute.must_equal [] # no build found or created
         out.must_include "Not creating build"
       end
     end
@@ -57,13 +65,14 @@ describe Samson::BuildFinder do
     end
 
     it "waits when build is active" do
+      expect_sleep
       done = false
       build.class.any_instance.expects(:active?).times(2).with do
         build.class.any_instance.stubs(:docker_repo_digest).returns('some-digest') unless done
         done = true
       end.returns(true, false)
 
-      assert execute
+      assert execute.any?
 
       out.must_include "Waiting for Build #{build.url} to finish."
     end
@@ -86,12 +95,12 @@ describe Samson::BuildFinder do
 
       it "retries finding when build is created through parallel execution of build" do
         job.project.docker_release_branch = 'master' # indicates that there will be a build kicked off on merge
-        finder.expects(:wait_for_parallel_build_creation).with do
+        expect_sleep.with do
           build.update_column(:git_sha, job.commit)
           build.update_column(:docker_repo_digest, 'somet-digest') # a bit misleading since it should be running
         end
         DockerBuilderService.any_instance.expects(:run).never
-        assert execute
+        assert execute.any?
         out.must_include "Build #{build.url} is looking good!"
       end
 
@@ -102,7 +111,7 @@ describe Samson::BuildFinder do
           build.expects(:reload).never # instance is not shared with BuildFinder to avoid both modifying the same
           true
         end.returns(stub(run: true))
-        assert execute
+        assert execute.any?
         out.must_include "Creating build for Dockerfile."
         out.must_include "Build #{Build.last.url} is looking good"
       end
@@ -112,7 +121,7 @@ describe Samson::BuildFinder do
 
         DockerBuilderService.any_instance.expects(:run).never
 
-        assert execute
+        assert execute.any?
         out.must_include "Build #{build.url} is looking good"
       end
 
@@ -149,7 +158,7 @@ describe Samson::BuildFinder do
 
       it "does not find for different sha" do
         build.update_column(:git_sha, 'other')
-        finder.expects(:sleep) # waiting for external builds to arrive
+        expect_sleep # waiting for external builds to arrive
         e = assert_raises(Samson::Hooks::UserError) { execute }
         e.message.must_include("Did not find build")
       end
@@ -157,7 +166,7 @@ describe Samson::BuildFinder do
       it "can find build that arrives late" do
         matching_sha = build.git_sha
         build.update_column(:git_sha, 'other')
-        finder.expects(:sleep).with do
+        expect_sleep.with do
           build.update_column(:git_sha, matching_sha)
         end # waiting for external builds to arrive
         execute.must_equal [build]
@@ -174,17 +183,36 @@ describe Samson::BuildFinder do
         execute.must_equal [build]
       end
     end
-  end
 
-  describe "#wait_for_parallel_build_creation" do
-    it "sleeps ... test to get coverage" do
-      finder.expects(:sleep)
-      finder.send(:wait_for_parallel_build_creation)
-    end
+    describe "when using external builds" do
+      with_env EXTERNAL_BUILD_WAIT: '15'
+      let!(:matching_sha) { build.git_sha }
 
-    it "does not sleep when already executed" do
-      finder.expects(:sleep)
-      2.times { finder.send(:wait_for_parallel_build_creation) }
+      before do
+        job.project.update_column(:docker_image_building_disabled, true)
+        build.update_columns(git_sha: 'other')
+      end
+
+      it "waits for builds to arrive" do
+        expect_sleep.with do
+          build.update_columns(git_sha: matching_sha, docker_repo_digest: 'done')
+        end # waiting for external builds to arrive
+
+        execute.must_equal [build]
+      end
+
+      it "fails if a build does not arrive" do
+        expect_sleep.times(3)
+
+        execute.must_equal []
+      end
+
+      it "does not wait multiple times because builds start simultaneously" do
+        expect_sleep.times(3)
+
+        execute.must_equal []
+        execute.must_equal []
+      end
     end
   end
 end


### PR DESCRIPTION
Working towards a generic ability to offload work to an external build. This moves the build finder out of kubernetes into generic Samson so it can be used by any deploy, not just kubernetes.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Med