### PR TITLE
set DEPLOY_ID env var for deploys

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -194,6 +194,7 @@ class JobExecution
 
   def commands(dir)
     env = {
+      DEPLOY_ID: @job.deploy&.id || @job.id,
       DEPLOY_URL: @job.url,
       DEPLOYER: @job.user.email,
       DEPLOYER_EMAIL: @job.user.email,

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -150,6 +150,7 @@ describe JobExecution do
     job.update(command: 'env | sort')
     execute_job 'master', env: {FOO: 'bar'}
     lines = job.output.split "\n"
+    lines.must_include "[04:05:06] DEPLOY_ID=#{deploy.id}"
     lines.must_include "[04:05:06] DEPLOY_URL=#{deploy.url}"
     lines.must_include "[04:05:06] DEPLOYER=jdoe@test.com"
     lines.must_include "[04:05:06] DEPLOYER_EMAIL=jdoe@test.com"


### PR DESCRIPTION
@tscoville2012 asked for this so he could give a temporary docker container a unique name based on the deploy.

/cc @grosser 
