### PR TITLE
Alter bin/setup to conditionally load custom config and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # Ignore config
 /config/database.yml
 
+# Ignore custom setup files (see bin/setup)
+/custom
+
 /node_modules
 
 /public/assets

--- a/bin/setup
+++ b/bin/setup
@@ -47,9 +47,9 @@ try "Bundling" "bundle check > /dev/null || bundle --local --quiet "
 
 echo
 bold "Copying example files"
-try "Creating .env" "test -e .env || cp .env.bootstrap .env"
-try "Creating config/database.yml" "test -e config/database.yml || cp config/database.mysql.yml.example config/database.yml"
-try "Creating databases" "bundle exec rake db:setup > /dev/null"
+try "Creating .env" "test -e .env || (test -e custom/.env.bootstrap && cp custom/.env.bootstrap .env) || cp .env.bootstrap .env"
+try "Creating config/database.yml" "test -e config/database.yml || (test -e custom/database.yml && cp custom/database.yml config/database.yml) || cp config/database.mysql.yml.example config/database.yml"
+try "Creating databases" "(test -e custom/seeds.rb && cp -f custom/seeds.rb db/seeds.rb) && false || bundle exec rake db:setup > /dev/null"
 
 echo
 bold "Success!"


### PR DESCRIPTION
The goal of this commit is to make it so we can spin up from scratch using external configuration  and data files using only bin/setup.

Files modified:
.gitignore
bin/setup
db/seeds.rb


/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
