### PR TITLE
make osx command execution fast again

### DIFF
--- a/bin/script-executor
+++ b/bin/script-executor
@@ -1,0 +1,2 @@
+# used by app/models/terminal_executor.rb to avoid osx command startup slowness
+eval "$(cat $FILE)"

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -120,6 +120,13 @@ describe TerminalExecutor do
       output.string.must_equal "Hello\rWorld\r\n"
     end
 
+    it "uses script-executor to avoid slowness on osx" do
+      RbConfig::CONFIG.expects(:[]).with("host_os").returns("darwin-foo")
+      PTY.expects(:spawn).with { |_, command, _| command.must_include("script-executor") }
+      TerminalExecutor.any_instance.expects(:record_pid)
+      subject.execute('echo "hi"')
+    end
+
     describe 'in verbose mode' do
       subject { TerminalExecutor.new(output, verbose: true) }
 


### PR DESCRIPTION
osx has a fun startup delay for unknown executables ... we tried a bunch of things but could not track it down, so avoiding it now by having a static executable.

This makes local testing faster and stops breaking any testcase that uses a command.

caused by https://github.com/zendesk/samson/pull/2411

@dragonfax @jonmoter 

/cc @zendesk/samson @craig-day @jcheatham 


before:

```
Benchmark.realtime { TerminalExecutor.new(STDOUT).execute "echo #{rand}" }
=> 3.752056999997876
```

```
Benchmark.realtime { TerminalExecutor.new(STDOUT).execute "echo #{rand}" }
=> 0.012225999998918269
```