### PR TITLE
make path available to avoid python not found erors

### DIFF
--- a/plugins/gcloud/lib/samson_gcloud/image_tagger.rb
+++ b/plugins/gcloud/lib/samson_gcloud/image_tagger.rb
@@ -19,7 +19,7 @@ module SamsonGcloud
             "gcloud", *SamsonGcloud.container_in_beta, "container", "images", "add-tag", digest, "#{base}:#{tag}",
             "--quiet", *SamsonGcloud.cli_options
           ]
-          success, output = Samson::CommandExecutor.execute(*command, timeout: 10)
+          success, output = Samson::CommandExecutor.execute(*command, timeout: 10, whitelist_env: ["PATH"])
           deploy.job.append_output!(
             "Tagging GCR image:\n#{command.join(" ")}\n#{output.strip}\n#{success ? "SUCCESS" : "FAILED"}\n"
           )


### PR DESCRIPTION
```
  File "/opt/google-cloud-sdk/lib/googlecloudsdk/core/execution_utils.py", line 60, in GetPythonExecutable
    raise ValueError('Could not find Python executable.')
ValueError: Could not find Python executable.
```

https://github.com/GoogleCloudPlatform/gsutil/issues/402