### PR TITLE
ensure users do not abuse limits

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
@@ -63,6 +63,7 @@ class Kubernetes::DeployGroupRolesController < ApplicationController
     if @deploy_group_role.save
       redirect_back fallback_location: @deploy_group_role
     else
+      puts @deploy_group_role.errors.full_messages
       render :edit, status: 422
     end
   end

--- a/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
@@ -144,11 +144,11 @@ describe Kubernetes::DeployGroupRolesController do
     end
 
     describe "#update" do
-      let(:valid_params) { {id: deploy_group_role.id, kubernetes_deploy_group_role: {limits_cpu: 3.1}} }
+      let(:valid_params) { {id: deploy_group_role.id, kubernetes_deploy_group_role: {limits_cpu: 0.7}} }
 
       it "updates" do
         put :update, params: valid_params
-        deploy_group_role.reload.limits_cpu.must_equal 3.1
+        deploy_group_role.reload.limits_cpu.must_equal 0.7
         assert_redirected_to deploy_group_role
       end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
@@ -187,6 +187,30 @@ describe Kubernetes::DeployGroupRole do
     end
   end
 
+  describe "#limits_close_to_requests" do
+    it "shows no error when limits are ok" do
+      assert_valid deploy_group_role
+    end
+
+    it "allows 0 with up to 1 cpu" do
+      deploy_group_role.requests_cpu = 0
+      deploy_group_role.limits_cpu = 1.0
+      assert_valid deploy_group_role
+    end
+
+    it "shows an error if the limits are more than 10x the requests" do
+      deploy_group_role.limits_cpu = 2.0
+      deploy_group_role.limits_memory = 2048
+      refute_valid deploy_group_role
+      deploy_group_role.errors.full_messages.must_equal(
+        [
+          "Limits cpu must be less than 10x requested cpu",
+          "Limits memory must be less than 10x requested memory"
+        ]
+      )
+    end
+  end
+
   describe "#requests_below_usage_limits" do
     before { usage_limit }
 


### PR DESCRIPTION
setting a max 10x difference for now, to prevent users requesing silly things like
0.1 cpu and 99 cpu limit

<img width="513" alt="screen shot 2017-12-21 at 10 15 45 am" src="https://user-images.githubusercontent.com/11367/34269191-46875296-e638-11e7-9862-7f75b468304b.png">


@aliciacatalina @jonmoter @dragonfax 