### PR TITLE
make service update work like any other resource but allow persistent…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # KUBERNETES_LOG_LINES=50 # how many lines of logs to show when a deploy fails
 # KUBERNETES_ALLOWED_VOLUME_HOST_PATHS=/data/ # prevent containers from mounting dangerous directories
 # KUBERNETES_USAGE_LIMIT_WARNING="If you need more, ask Steve!" # help message to display when user reaches usage limit
+# KUBERNETES_SERVICE_PERSISTENT_FIELDS="metadata.labels.proxy,spec.foo" # fields to not override when updating services unless they are not set, does not support fields with . in their name like metadata.annotations.gcr.io/foo/bar
 
 ## Jenkins, optional, for triggering Jenkins builds after deployment
 # JENKINS_URL= # server_url of jenkins

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -168,3 +168,7 @@ samson will then override the `project` labels and keep deployments/services uni
  - Set the projects `docker image building disabled` 
  - Create images via the `POST /builds.json` with a `image_name` that matches the `image` attribute of the containers
  - All containers (including init containers) must have a matching build
+
+### Service updates
+
+Too keep fields/labels that are manually managed persistent during updates, use `KUBERNETES_SERVICE_PERSISTENT_FIELDS`, see .env.example

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -448,7 +448,13 @@ describe Kubernetes::DeployExecutor do
       before { worker_is_unstable }
 
       it "rolls back when previous resource existed" do
-        stub_request(:get, service_url).to_return(body: {metadata: {uid: '123'}}.to_json)
+        old = {
+          kind: 'Service',
+          metadata: {uid: '123', name: 'some-project', namespace: 'staging', resourceVersion: 'X'},
+          spec: {clusterIP: "Y"}
+        }
+        stub_request(:get, service_url).to_return(body: old.to_json)
+        stub_request(:put, service_url)
 
         refute execute
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -100,8 +100,8 @@ describe Kubernetes::ReleaseDoc do
 
     it "remembers the previous deploy in case we have to revert" do
       # check service ... do nothing
-      stub_request(:get, service_url).
-        to_return(body: '{"SER":"VICE"}')
+      stub_request(:get, service_url).to_return(body: '{"SER":"VICE"}')
+      stub_request(:put, service_url)
 
       # check and update deployment
       client.expects(:get_deployment).returns({DE: "PLOY"}.to_json)


### PR DESCRIPTION
without these hacks we get:

```
Service "truth-service" is invalid: [metadata.resourceVersion: Invalid value: "": must be specified for an update, spec.clusterIP: Invalid value: "": field is immutable]
```

for example `metadata.labels.proxy,metadata.labels.proxyEnabled`

confirmed working on staging

@jonmoter @dragonfax 