### PR TITLE
update-many kubernetes resources

### DIFF
--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/edit_many.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/edit_many.html.erb
@@ -1,0 +1,41 @@
+<%= page_title "Edit #{@project.name} Kubernetes Resources" %>
+
+<section>
+  <%= form_tag update_many_project_kubernetes_deploy_group_roles_path(@project), method: :put, class: "form-horizontal" do %>
+    <% rows = [
+        [:replicas, "Replicas"],
+        [:requests_cpu, 'Requests CPU Cores'],
+        [:requests_memory, 'Requests Memory in MB'],
+        [:limits_cpu, 'Limits CPU Cores'],
+        [:limits_memory, 'Limits Memory in MB']
+    ] %>
+    <table class="table table-hover table-condensed">
+      <thead>
+        <tr>
+          <th>Deploy Group</th>
+          <th>Role</th>
+          <% rows.each do |_, label| %>
+            <th><%= label %></th>
+          <% end %>
+        </tr>
+      </thead>
+
+      <% @deploy_group_roles.each do |deploy_group_role| %>
+        <% if deploy_group_role.errors.any? %>
+          <tr>
+            <td colspan="<%= 2 + rows.size %>"><%= render 'shared/errors', object: deploy_group_role %></td>
+          </tr>
+        <% end %>
+        <tr>
+          <td><%= deploy_group_role.deploy_group.name %></td>
+          <td><%= deploy_group_role.kubernetes_role.name %></td>
+          <% rows.each do |attribute, _| %>
+            <td><%= text_field_tag "kubernetes_deploy_group_roles[#{deploy_group_role.id}][#{attribute}]", deploy_group_role.public_send(attribute), size: 10 %></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </table>
+
+    <%= submit_tag "Update all" %>
+  <% end %>
+</section>

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
@@ -54,7 +54,7 @@
         <td><%= @deploy_group_roles.sum { |d| d.requests_cpu * d.replicas } %> to <%= @deploy_group_roles.sum { |d| d.limits_cpu * d.replicas } %></td>
         <td><%= @deploy_group_roles.sum { |d| d.requests_memory * d.replicas } %> to <%= @deploy_group_roles.sum { |d| d.limits_memory * d.replicas } %></td>
         <td><%= @deploy_group_roles.sum(&:replicas) %></td>
-        <td></td>
+        <td><%= link_to "Edit all", edit_many_project_kubernetes_deploy_group_roles_path(@project) if @project && current_user.admin_for?(@project) %></td>
       </tr>
     </table>
   </div>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -15,6 +15,7 @@
         <% if missing %>
           <%= link_to 'Seed Missing', seed_kubernetes_deploy_group_roles_path(stage_id: @stage.id), data: {method: :post}, class: 'btn btn-default' %>
         <% end %>
+        <%= link_to "Edit all", edit_many_project_kubernetes_deploy_group_roles_path(@project) if current_user.admin_for?(@project) %>
       </th>
     </thead>
 

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -2,7 +2,12 @@
 Samson::Application.routes.draw do
   resources :projects do
     namespace :kubernetes do
-      resources :deploy_group_roles, only: [:index]
+      resources :deploy_group_roles, only: [:index] do
+        collection do
+          get :edit_many
+          put :update_many
+        end
+      end
       resources :roles, except: :edit do
         collection do
           post :seed


### PR DESCRIPTION
flow to update multiple deploy-group-roles

<img width="1164" alt="screen shot 2017-12-28 at 4 54 32 pm" src="https://user-images.githubusercontent.com/11367/34427115-439aedca-ebf3-11e7-887b-5de7c8ed9d45.png">

<img width="1146" alt="screen shot 2017-12-28 at 4 54 50 pm" src="https://user-images.githubusercontent.com/11367/34427112-37925fea-ebf3-11e7-8a81-3ada9eb76f44.png">


@jonmoter @dragonfax 

Alternatives:
 - add a "apply changes to all siblings" box ... that is less work/code, but displaying errors is harder ... 
 - make deploy-group-roles per environment so we don't have that much repetition