### PR TITLE
do not send errors to airbrake when messing around in the console

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -20,6 +20,7 @@ if defined?(Airbrake) && key = ENV['AIRBRAKE_API_KEY']
     # - add AIRBRAKE_API_KEY to ENV
     # - add AIRBRAKE_PROJECT_ID to ENV
     # - set consider_all_requests_local = false in development.rb
+    # - comment out Rails.application.console filter below
     # - uncomment
     # config.ignore_environments = [:test]
   end
@@ -33,6 +34,13 @@ if defined?(Airbrake) && key = ENV['AIRBRAKE_API_KEY']
   ]
   Airbrake.add_filter do |notice|
     notice.ignore! if notice[:errors].any? { |error| ignored.include?(error[:type]) }
+  end
+
+  Rails.application.console do
+    Airbrake.add_filter do |notice|
+      puts "Not sending errors to airbrake in console"
+      notice.ignore!
+    end
   end
 else
   module Airbrake


### PR DESCRIPTION
@dragonfax 

silencing some weird errors I got when booting the console

https://zendesk.airbrake.io/projects/95346/groups/2120509840735807649/notices/2120509838441715757?tab=overview

![screen shot 2018-01-04 at 4 05 00 pm](https://user-images.githubusercontent.com/11367/34590023-0f1d2862-f169-11e7-8276-83aa922a1d9d.png)

  