### PR TITLE
show active stages in different color as before

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -303,11 +303,11 @@ module ApplicationHelper
     stages.each do |stage|
       next unless deploy = stage.deployed_or_running_deploy
       next unless deploy.references?(reference)
+      label = (deploy.active? ? "label-warning" : "label-success")
 
       text = "".html_safe
-      text << icon_tag("cloud-upload", title: deploy.status) << " " if deploy.active?
       text << stage.name
-      html << content_tag(:span, text, class: "label label-success release-stage")
+      html << content_tag(:span, text, class: "label #{label} release-stage")
       html << " "
     end
     html

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -656,7 +656,7 @@ describe ApplicationHelper do
     it "shows active deploys" do
       deploys(:succeeded_test).job.update_column(:status, 'running')
       html = deployed_or_running_list(stage_list, "staging")
-      html.must_equal "<span class=\"label label-success release-stage\"><i title=\"running\" class=\"glyphicon glyphicon-cloud-upload\"></i> Staging</span> "
+      html.must_equal "<span class=\"label label-warning release-stage\">Staging</span> "
     end
   end
 end


### PR DESCRIPTION
broken in https://github.com/zendesk/samson/pull/2433
... removing cloud-icon since color is enough

@dragonfax @bquorning 
  
<img width="524" alt="screen shot 2018-01-05 at 9 45 36 am" src="https://user-images.githubusercontent.com/11367/34621247-3c0a9dde-f1fd-11e7-8fd7-72f2ec97a391.png">
