### PR TITLE
delete orphaned pods when we delete statefulset

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -322,6 +322,12 @@ module Kubernetes
         wait_for_pods_to_restart
       end
 
+      def delete
+        old_pods = pods
+        super
+        delete_pods(old_pods)
+      end
+
       private
 
       def wait_for_pods_to_restart


### PR DESCRIPTION
not only do they keep hanging around, they also break future deploys
this caused memcached deploy foobar on Friday

@dragonfax @jonmoter 
/cc @libo 