### PR TITLE
dont fail a deploy when a autoscale down event happens during a deploy

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -218,7 +218,7 @@ module Kubernetes
       statuses = Array.new(release_doc.desired_pod_count).each_with_index.map do |_, i|
         pod = pods[i]
 
-        if !pod
+        s = if !pod
           {live: false, details: "Missing", pod: pod}
         elsif pod.restarted?
           {live: false, stop: true, details: "Restarted", pod: pod}
@@ -231,10 +231,27 @@ module Kubernetes
         else
           {live: false, details: "Waiting (#{pod.phase}, #{pod.reason})", pod: pod}
         end
+
+        s[:details] += " (autoscaled role, only showing one pod)" if role.autoscaled?
+        s
       end
+
+      # If a role is autoscaled, there is a chance pods can be deleted during a deployment.
+      # Sort them by "most alive" and use the first one, so we ensure at least one pods works.
+      statuses.sort_by!(&method(:pod_liveliness)).slice!(1..-1) if role.autoscaled?
 
       statuses.map do |status|
         ReleaseStatus.new(status.merge(role: role.name, group: group.name))
+      end
+    end
+
+    def pod_liveliness(status_hash)
+      if status_hash[:live]
+        -1
+      elsif status_hash[:stop]
+        1
+      else
+        0
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -218,7 +218,7 @@ module Kubernetes
       statuses = Array.new(release_doc.desired_pod_count).each_with_index.map do |_, i|
         pod = pods[i]
 
-        s = if !pod
+        status = if !pod
           {live: false, details: "Missing", pod: pod}
         elsif pod.restarted?
           {live: false, stop: true, details: "Restarted", pod: pod}
@@ -232,8 +232,8 @@ module Kubernetes
           {live: false, details: "Waiting (#{pod.phase}, #{pod.reason})", pod: pod}
         end
 
-        s[:details] += " (autoscaled role, only showing one pod)" if role.autoscaled?
-        s
+        status[:details] += " (autoscaled role, only showing one pod)" if role.autoscaled?
+        status
       end
 
       # If a role is autoscaled, there is a chance pods can be deleted during a deployment.


### PR DESCRIPTION
This adds a check to the deploy executor for an autoscaled role. If a role is autoscaled, sort the pods for that role by "liveliness". This will order pods following this order: live, pending, stopped. After sorting, only use the most alive pod to check status because there might be a scale event during a deploy which destroys pods. We don't want that scale down event to fail a deploy if there is still at least some valid pods running.

I also added a note to the deploy output when you are only going to see one pod when there might by many replicas.

```
Creating for Pod 100 role resque-worker
Creating for Pod 100 role app-server
Waiting for pods to be created
Deploy status after 0 seconds:
  Pod 100 resque-worker: Live (autoscaled role, only showing one pod)
  Pod 100 app-server: Live
READY, starting stability test
```

/cc @zendesk/samson

### Risks
- Level: Low. Kubernetes deploys might fail to properly display errors is a role is marked as autoscaled.