### PR TITLE
help text as popover not just html title

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,3 +29,8 @@
 //= require underscore_mixins
 //= require jstimezonedetect
 //= require_tree .
+
+// initialize popovers after all of our other javascript is done
+$(function () {
+  $('[data-toggle="popover"]').popover()
+})

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,8 +29,3 @@
 //= require underscore_mixins
 //= require jstimezonedetect
 //= require_tree .
-
-// initialize popovers after all of our other javascript is done
-$(function () {
-  $('[data-toggle="popover"]').popover()
-})

--- a/app/assets/javascripts/popover.js
+++ b/app/assets/javascripts/popover.js
@@ -1,0 +1,3 @@
+$(function () {
+  $('[data-toggle="popover"]').popover();
+});

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,7 @@ require 'github/markdown'
 
 module ApplicationHelper
   BOOTSTRAP_FLASH_MAPPINGS = { notice: :info, error: :danger, authorization_error: :danger, success: :success }.freeze
+  BOOTSTRAP_TOOLTIP_PROPS = { 'data-toggle': 'popover', 'data-placement': 'right', 'data-trigger': 'hover' }.freeze
 
   include Ansible
   include DateTimeHelper
@@ -216,7 +217,13 @@ module ApplicationHelper
   end
 
   def additional_info(text)
-    content_tag :i, '', class: "glyphicon glyphicon-info-sign", title: text
+    html_attrs = if text.html_safe?
+      { 'data-content': h(h(text).to_str), 'data-html': true }
+    else
+      { 'data-content': text }
+    end.merge(BOOTSTRAP_TOOLTIP_PROPS)
+
+    content_tag :i, '', class: "glyphicon glyphicon-info-sign", **html_attrs
   end
 
   def page_title(content = nil, in_tab: false, &block)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ require 'github/markdown'
 
 module ApplicationHelper
   BOOTSTRAP_FLASH_MAPPINGS = { notice: :info, error: :danger, authorization_error: :danger, success: :success }.freeze
-  BOOTSTRAP_TOOLTIP_PROPS = { 'data-toggle': 'popover', 'data-placement': 'right', 'data-trigger': 'hover' }.freeze
+  BOOTSTRAP_TOOLTIP_PROPS = { toggle: 'popover', placement: 'right', trigger: 'hover' }.freeze
 
   include Ansible
   include DateTimeHelper
@@ -217,13 +217,13 @@ module ApplicationHelper
   end
 
   def additional_info(text)
-    html_attrs = if text.html_safe?
-      { 'data-content': h(h(text).to_str), 'data-html': true }
+    data_attrs = if text.html_safe?
+      { content: h(h(text).to_str), html: true }
     else
-      { 'data-content': text }
+      { content: text }
     end.merge(BOOTSTRAP_TOOLTIP_PROPS)
 
-    content_tag :i, '', class: "glyphicon glyphicon-info-sign", **html_attrs
+    content_tag :i, '', class: "glyphicon glyphicon-info-sign", data: data_attrs
   end
 
   def page_title(content = nil, in_tab: false, &block)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -7,6 +7,7 @@ SingleCov.covered!
 describe ApplicationHelper do
   include LocksHelper
   include StatusHelper
+  include ERB::Util
 
   describe "#render_log" do
     it "removes translates ascii escapes to html colors" do
@@ -400,8 +401,32 @@ describe ApplicationHelper do
   end
 
   describe "#additional_info" do
+    let(:always_attributes) { 'data-toggle="popover" data-placement="right" data-trigger="hover"' }
+
     it "builds a help text" do
-      additional_info("foo").must_equal "<i class=\"glyphicon glyphicon-info-sign\" title=\"foo\"></i>"
+      additional_info("foo").must_equal(
+        %(<i class="glyphicon glyphicon-info-sign" data-content="foo" #{always_attributes}></i>)
+      )
+    end
+
+    it "escapes html in the help text" do
+      additional_info("<em>foo</em>").must_equal(
+        %(<i class="glyphicon glyphicon-info-sign" data-content="&lt;em&gt;foo&lt;/em&gt;" #{always_attributes}></i>)
+      )
+    end
+
+    it "escapes html html_safe strings and sets the 'data-html' attribute" do
+      additional_info("<em>foo</em>".html_safe).must_equal(
+        %(<i class="glyphicon glyphicon-info-sign" data-content="&lt;em&gt;foo&lt;/em&gt;" data-html="true" #{always_attributes}></i>)
+      )
+    end
+
+    it "double escapes html_safe string with appened non-safe html and sets the 'data-html' attribute" do
+      string = "".html_safe << "<em>foo</em>"
+
+      additional_info(string).must_equal(
+        %(<i class="glyphicon glyphicon-info-sign" data-content="&amp;lt;em&amp;gt;foo&amp;lt;/em&amp;gt;" data-html="true" #{always_attributes}></i>)
+      )
     end
   end
 

--- a/test/lib/samson/form_builder_test.rb
+++ b/test/lib/samson/form_builder_test.rb
@@ -42,11 +42,13 @@ describe Samson::FormBuilder do
     end
 
     it "can show help" do
-      builder.input(:name, help: "Hello!").must_include "title=\"Hello!\"></i>"
+      builder.input(:name, help: "Hello!").must_include "data-content=\"Hello!\""
+      builder.input(:name, help: "Hello!").must_include "</i>"
     end
 
     it "can show help for check box" do
-      builder.input(:name, as: :check_box, help: "Hello!").must_include "title=\"Hello!\"></i>"
+      builder.input(:name, as: :check_box, help: "Hello!").must_include "data-content=\"Hello!\""
+      builder.input(:name, as: :check_box, help: "Hello!").must_include "</i>"
     end
 
     it "can show size" do


### PR DESCRIPTION
This changes how the `additional_info` renders help text. Instead of just adding the html `title` attribute, we add a bootstrap popover for two reasons:

1. The help text now shows immediately on hover instead of waiting
1. We can render actual HTML in the helper for a nicer display or examples

**before**
![](https://content.screencast.com/users/CDay.zendesk/folders/Jing/media/cf2323eb-255a-4035-85f8-2aff75705d2e/00000521.png)

**after**
![](https://content.screencast.com/users/CDay.zendesk/folders/Jing/media/c6a4b159-c3c5-45db-a096-57ac13afcb45/00000522.png)

/cc @zendesk/samson

### Risks
- Level: Low. The help icon may fail to show if there is a javascript problem.
