### PR TITLE
dont fail a deploy when a hpa warns about metrics or failed scales

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -305,6 +305,24 @@ describe Kubernetes::Api::Pod do
         assert events_indicate_failure?
       end
     end
+
+    describe "HorizontalPodAutoscaler with failures we don't care about" do
+      before do
+        event.merge!(kind: 'HorizontalPodAutoscaler', type: 'Warning')
+      end
+
+      it "ignores failing to get metrics" do
+        event.merge!(reason: 'FailedGetMetrics')
+
+        refute events_indicate_failure?, 'FailedGetMetrics must not be recognized as failures'
+      end
+
+      it "ingores failures to scale" do
+        event.merge!(reason: 'FailedRescale')
+
+        refute events_indicate_failure?, 'FailedRescale must not be recognized as failures'
+      end
+    end
   end
 
   describe "#init_containers" do

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -312,15 +312,21 @@ describe Kubernetes::Api::Pod do
       end
 
       it "ignores failing to get metrics" do
-        event.merge!(reason: 'FailedGetMetrics')
+        event[:reason] = 'FailedGetMetrics'
 
         refute events_indicate_failure?, 'FailedGetMetrics must not be recognized as failures'
       end
 
       it "ingores failures to scale" do
-        event.merge!(reason: 'FailedRescale')
+        event[:reason] = 'FailedRescale'
 
         refute events_indicate_failure?, 'FailedRescale must not be recognized as failures'
+      end
+
+      it "does not ignore an unknown HPA event" do
+        event[:reason] = 'SomeOtherFailure'
+
+        assert events_indicate_failure?, 'Events we dont explicitly ignore must be recognized as failures'
       end
     end
   end


### PR DESCRIPTION
Deploys can be marked as failure if a pod event includes warnings from a horizontal pod autoscaler. 

Example:
```
FailedRescale: New size: 1; reason: All metrics below target; error: Operation cannot be fulfilled on deployments.extensions "some-app-server": the object has been modified; please apply your changes to the latest version and try again x3
```

This isn't a hard failure, just a warning, so lets not fail a deploy because of it. 

/cc @zendesk/samson

### Risks
- Level: Low. Deploys will succeed even if HPA might fail due to warnings that we ignore.
