### PR TITLE
hide cluttered mass-rollout UI

### DIFF
--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -71,54 +71,55 @@
   <%= Samson::Hooks.render_views(:deploy_group_show, self) %>
 
   <div class="form-group">
-    <div class="col-lg-offset-2 col-lg-10">
-      <%= link_to "Edit", edit_deploy_group_path(@deploy_group), class: "btn btn-primary" %>
-      <% if DeployGroup.enabled? %>
+    <% if DeployGroup.enabled? %>
+      <div class="col-lg-offset-2 col-lg-10" style="display: none" id="mass_rollout">
         <%= link_to "Create Stages ...",
-                    create_all_stages_preview_deploy_group_path(@deploy_group),
-                    class: "btn btn-default"
+            create_all_stages_preview_deploy_group_path(@deploy_group),
+            class: "btn btn-default"
         %>
         <%= link_to "Deploy All Projects",
-                    deploy_all_deploy_group_path(@deploy_group),
-                    class: "btn btn-default",
-                    data: {
-                        method: "post",
-                        confirm: "Deploys will be started for all stages."
-                    }
+            deploy_all_deploy_group_path(@deploy_group),
+            class: "btn btn-default",
+            data: {
+              method: "post",
+              confirm: "Deploys will be started for all stages."
+            }
         %>
         <%= link_to "Deploy Missing Projects",
-                    deploy_all_deploy_group_path(@deploy_group, missing_only: "true"),
-                    class: "btn btn-default",
-                    data: {
-                        method: "post",
-                        confirm: "Deploys will be started for any stages that haven't yet been deployed or have failed all their deploys."
-                    }
+            deploy_all_deploy_group_path(@deploy_group, missing_only: "true"),
+            class: "btn btn-default",
+            data: {
+              method: "post",
+              confirm: "Deploys will be started for any stages that haven't yet been deployed or have failed all their deploys."
+            }
         %>
         <% cloned_stage_count = @deploy_group.stages.cloned.count %>
         <%= link_to "Merge #{cloned_stage_count} Cloned Stages",
-                    merge_all_stages_deploy_group_path(@deploy_group),
-                    class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
-                    data: {
-                      method: "post",
-                      confirm: "Stages will be deleted. Before deleting, each stage will have its Deploy Group added to the stage it was copied from. Stages affected are those cloned from a template stage, have exactly this deploy group, and are on a project that uses include_new_deploy_groups.\n\n" +
-                               "Merge #{@deploy_group.stages.cloned.count} cloned stages now?"
-                    }
+            merge_all_stages_deploy_group_path(@deploy_group),
+            class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
+            data: {
+              method: "post",
+              confirm: "Stages will be deleted. Before deleting, each stage will have its Deploy Group added to the stage it was copied from. Stages affected are those cloned from a template stage, have exactly this deploy group, and are on a project that uses include_new_deploy_groups.\n\n" \
+                "Merge #{@deploy_group.stages.cloned.count} cloned stages now?"
+            }
         %>
         <%= link_to "Delete #{cloned_stage_count} Cloned Stages",
-                    delete_all_stages_deploy_group_path(@deploy_group),
-                    class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
-                    data: {
-                        method: "post",
-                        confirm: "Cloned stages will be deleted. No stages will be merged into their templates. You will need to create a new stage to deploy the project to this deploy group."
-                    }
+            delete_all_stages_deploy_group_path(@deploy_group),
+            class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
+            data: {
+              method: "post",
+              confirm: "Cloned stages will be deleted. No stages will be merged into their templates. You will need to create a new stage to deploy the project to this deploy group."
+            }
         %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
     <br>
     <div class="col-lg-offset-2 col-lg-10" style="margin-top: 10px;">
+      <%= link_to "Edit", edit_deploy_group_path(@deploy_group), class: "btn btn-primary" %>
       <%= link_to "Back", deploy_groups_path, class: "btn btn-default" %>
       | <%= link_to_history @deploy_group %>
       | <%= link_to "Deploys", deploys_path(search: {group: "DeployGroup-#{@deploy_group.id}"}) %>
+      | <%= link_to "Mass rollout", "#", data: {target: "#mass_rollout"}, class: 'toggle' if DeployGroup.enabled? %>
     </div>
   </div>
 </section>

--- a/app/views/vault_servers/show.html.erb
+++ b/app/views/vault_servers/show.html.erb
@@ -32,7 +32,7 @@
   <% end %>
 
   <% if sync_targets %>
-    <div style="display: none;" id="sync_dialog">
+    <div style="display: none" id="sync_dialog">
       <%= form_tag sync_vault_server_path(@vault_server) do %>
         <fieldset>
           Copy eligible secrets from


### PR DESCRIPTION
very few people use this, so better hide it ...

before:
![screen shot 2018-01-19 at 1 37 25 pm](https://user-images.githubusercontent.com/11367/35172786-e6b00438-fd1d-11e7-9aee-f32a05eb3cff.png)


after:

![screen shot 2018-01-19 at 1 36 59 pm](https://user-images.githubusercontent.com/11367/35172779-db8ea42e-fd1d-11e7-8145-41c5f5fd08f7.png)

![screen shot 2018-01-19 at 1 37 04 pm](https://user-images.githubusercontent.com/11367/35172778-db77a3be-fd1d-11e7-9e88-a264f7c8aabe.png)
