### PR TITLE
Optional Feature: require admin for prod (un)lock.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,3 +173,6 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # GCLOUD_OPTIONS=--verbose    # optional, options
 # GCLOUD_PROJECT=foo-123
 # GCLOUD_ACCOUNT=my-account
+
+## Feature: Only admins can (un)lock stages which affect production.
+# PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN=1

--- a/app/controllers/concerns/current_stage.rb
+++ b/app/controllers/concerns/current_stage.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module CurrentStage
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_stage
+    helper_method :current_stage
+  end
+
+  def current_stage
+    @stage
+  end
+
+  protected
+
+  def require_stage
+    if current_project
+      query = Stage.where(project_id: current_project.id)
+      stage_param = params[:stage_id] || params[:id]
+      @stage = query.find_by_param!(stage_param) if stage_param
+    end
+  end
+end

--- a/app/controllers/concerns/current_stage.rb
+++ b/app/controllers/concerns/current_stage.rb
@@ -14,10 +14,8 @@ module CurrentStage
   protected
 
   def require_stage
-    if current_project
-      query = Stage.where(project_id: current_project.id)
-      stage_param = params[:stage_id] || params[:id]
-      @stage = query.find_by_param!(stage_param) if stage_param
-    end
+    return unless current_project
+    return unless stage_param = params[:stage_id] || params[:id]
+    @stage = Stage.where(project_id: current_project.id).find_by_param!(stage_param)
   end
 end

--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -66,7 +66,11 @@ module CurrentUser
   end
 
   def can?(action, resource_namespace, scope = nil)
-    scope ||= current_project if respond_to?(:current_project)
+    scope ||= if resource_namespace == :locks
+      try(:current_stage)
+    else
+      try(:current_project)
+    end
     AccessControl.can?(current_user, action, resource_namespace, scope)
   end
 end

--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -67,9 +67,9 @@ module CurrentUser
 
   def can?(action, resource_namespace, scope = nil)
     scope ||= if resource_namespace == :locks
-      try(:current_stage)
+      current_stage if respond_to?(:current_stage)
     else
-      try(:current_project)
+      current_project if respond_to?(:current_project)
     end
     AccessControl.can?(current_user, action, resource_namespace, scope)
   end

--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -66,10 +66,10 @@ module CurrentUser
   end
 
   def can?(action, resource_namespace, scope = nil)
-    scope ||= if resource_namespace == :locks
-      current_stage if respond_to?(:current_stage)
-    else
-      current_project if respond_to?(:current_project)
+    scope ||= if resource_namespace == :locks && respond_to?(:current_stage)
+      current_stage
+    elsif respond_to?(:current_project)
+      current_project
     end
     AccessControl.can?(current_user, action, resource_namespace, scope)
   end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 class LocksController < ApplicationController
   include CurrentProject
+  include CurrentStage
 
-  before_action :require_project, if: :for_stage_lock?
+  before_action :require_stage, if: :for_stage_lock?
   before_action :authorize_resource!
 
   def index
@@ -56,13 +57,13 @@ class LocksController < ApplicationController
     @lock ||= Lock.find(params[:id])
   end
 
-  # Overrides CurrentProject#require_project
-  def require_project
+  # Overrides CurrentStage#require_stage
+  def require_stage
     case action_name
     when 'create' then
-      @project = Stage.find(params[:lock][:resource_id]).project
+      @stage = Stage.find(params[:lock][:resource_id])
     when 'destroy' then
-      @project = lock.resource.project
+      @stage = lock.resource
     else
       raise 'Unsupported action'
     end

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -18,15 +18,12 @@ class AccessControl
         case action
         when :read then true
         when :write
-
-          if scope.nil? # global locks
+          if scope.is_a?(Stage) # stage locks
+              return user.admin_for?(scope.project) if ENV['PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN'] && scope.production
+              user.deployer_for?(scope.project)
+          else # global locks
             user.admin?
-          elsif ENV['PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN'] && scope.production
-            user.admin_for?(scope.project) # stage locks
-          else
-            user.deployer_for?(scope.project) # stage locks
           end
-
         else raise ArgumentError, "Unsupported action #{action}"
         end
       when :projects, :build_commands, :stages, :user_project_roles

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -18,11 +18,15 @@ class AccessControl
         case action
         when :read then true
         when :write
-          if scope
-            user.deployer_for?(scope) # stage locks
+
+          if scope.nil? # global locks
+            user.admin?
+          elsif ENV['PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN'] && scope.production
+            user.admin_for?(scope.project) # stage locks
           else
-            user.admin? # global locks
+            user.deployer_for?(scope.project) # stage locks
           end
+
         else raise ArgumentError, "Unsupported action #{action}"
         end
       when :projects, :build_commands, :stages, :user_project_roles

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -18,11 +18,12 @@ class AccessControl
         case action
         when :read then true
         when :write
-          if scope.is_a?(Stage) # stage locks
-              return user.admin_for?(scope.project) if ENV['PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN'] && scope.production
-              user.deployer_for?(scope.project)
-          else # global locks
-            user.admin?
+          return user.admin? if scope.nil? # global locks
+          return false unless scope.is_a?(Stage) # stage locks
+          if ENV['PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN'] && scope.production
+            user.admin_for?(scope.project)
+          else
+            user.deployer_for?(scope.project)
           end
         else raise ArgumentError, "Unsupported action #{action}"
         end

--- a/app/views/locks/_button.html.erb
+++ b/app/views/locks/_button.html.erb
@@ -1,4 +1,4 @@
-<% if can? :write, :locks, @project %>
+<% if can? :write, :locks, @stage %>
   <% prefix ||= "" %>
   <% warning = {resource: resource, warning: true, icon: warning_icon, text: "#{prefix}Warn", disabled: false} %>
   <% locking = {resource: resource, warning: false, icon: lock_icon, text: "#{prefix}Lock", disabled: false} %>

--- a/test/controllers/concerns/current_stage_test.rb
+++ b/test/controllers/concerns/current_stage_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+class CurrentStageConcernTest < ActionController::TestCase
+  class CurrentStageTestController < ApplicationController
+    include CurrentProject
+    include CurrentStage
+
+    def show
+      render inline: '<%= current_stage.class.name %>'
+    end
+  end
+
+  tests CurrentStageTestController
+  use_test_routes CurrentStageTestController
+
+  let(:project) { projects(:test) }
+  let(:stage) { stages(:test_staging) }
+
+  before { login_as(users(:viewer)) }
+
+  it "finds current stage" do
+    get :show, params: {project_id: project.id, id: stage.id, test_route: true}
+    response.body.must_equal 'Stage'
+  end
+
+  it "fails with invalid stage id" do
+    assert_raises ActiveRecord::RecordNotFound do
+      get :show, params: {project_id: project.id, id: 123456, test_route: true}
+    end
+  end
+
+  it "does not fail without stage" do
+    get :show, params: {test_route: true}
+    response.body.must_equal 'NilClass'
+  end
+end

--- a/test/controllers/concerns/current_user_test.rb
+++ b/test/controllers/concerns/current_user_test.rb
@@ -7,6 +7,7 @@ class CurrentUserConcernTest < ActionController::TestCase
   class CurrentUserTestController < ApplicationController
     include CurrentUser
     include CurrentProject
+    include CurrentStage
 
     def whodunnit
       render plain: Audited.store[:current_user].call.name
@@ -242,8 +243,11 @@ class CurrentUserConcernTest < ActionController::TestCase
         assert_response :unauthorized
       end
 
-      it "renders when authorized via the project" do
-        perform_get(project_id: projects(:test).id)
+      # This still authorizes based on Project, but for the lock controller, it needs a Stage object
+      # passed to access control since locks are per Stage.  See app/models/access_control.rb#can? when
+      # the resource_namespace is :locks
+      it "renders when authorized via the stage" do
+        perform_get(project_id: projects(:test).id, id: stages(:test_staging).id)
         assert_response :success
       end
 

--- a/test/controllers/locks_controller_test.rb
+++ b/test/controllers/locks_controller_test.rb
@@ -117,32 +117,28 @@ describe LocksController do
         assert_response :success
         JSON.parse(response.body).fetch("lock").fetch("id").must_equal Lock.last.id
       end
-    end
 
-    describe '#create with PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' do
-      with_env 'PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' => 'true'
-      before { travel_to Time.now }
-      after { travel_back }
+      describe 'with PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' do
+        with_env 'PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' => 'true'
 
-      it 'cannot create a stage lock for a production stage' do
-        create_lock prod_stage, delete_in: 3600
+        it 'cannot create a stage lock for a production stage' do
+          create_lock prod_stage
 
-        assert_response :unauthorized
-        stage.reload
-        assert_nil(stage.lock)
-      end
+          assert_response :unauthorized
+        end
 
-      it 'creates a stage lock' do
-        create_lock stage, delete_in: 3600
-        assert_redirected_to '/back'
-        assert flash[:notice]
+        it 'creates a stage lock' do
+          create_lock stage, delete_in: 3600
+          assert_redirected_to '/back'
+          assert flash[:notice]
 
-        stage.reload
+          stage.reload
 
-        lock = stage.lock
-        lock.warning?.must_equal(false)
-        lock.description.must_equal 'DESC'
-        lock.delete_at.must_equal(Time.now + 3600)
+          lock = stage.lock
+          lock.warning?.must_equal(false)
+          lock.description.must_equal 'DESC'
+          lock.delete_at.must_equal(Time.now + 3600)
+        end
       end
     end
 
@@ -178,15 +174,10 @@ describe LocksController do
       end
 
       it 'cannot destroy a stage production lock' do
-        stage.production = true
-        stage.save
+        stage.update_column(:production, true)
         delete :destroy, params: {id: lock.id}
 
         assert_response :unauthorized
-        stage.reload
-        Lock.count.must_equal 1
-        stage.production = false
-        stage.save
       end
     end
   end
@@ -212,62 +203,7 @@ describe LocksController do
       end
     end
 
-    describe '#create with PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' do
-      with_env 'PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' => 'true'
-      before { travel_to Time.now }
-      after { travel_back }
-
-      it 'creates a stage lock for a production stage' do
-        stage.production = true
-        stage.save
-        create_lock stage, delete_in: 3600
-
-        assert_redirected_to '/back'
-        assert flash[:notice]
-
-        stage.reload
-
-        lock = stage.lock
-        lock.warning?.must_equal(false)
-        lock.description.must_equal 'DESC'
-        lock.delete_at.must_equal(Time.now + 3600)
-        stage.production = false
-        stage.save
-      end
-
-      it 'creates a global lock' do
-        create_lock
-        assert_redirected_to '/back'
-        assert flash[:notice]
-
-        lock = Lock.global.first
-        lock.description.must_equal 'DESC'
-      end
-
-      it 'creates an environment lock' do
-        create_lock environment
-        assert_redirected_to '/back'
-        assert flash[:notice]
-
-        lock = environment.lock
-        lock.description.must_equal 'DESC'
-      end
-    end
-
     describe '#destroy' do
-      it 'destroys a global lock' do
-        delete :destroy, params: {id: global_lock.id}
-
-        assert_redirected_to '/back'
-        assert flash[:notice]
-
-        Lock.count.must_equal 0
-      end
-    end
-
-    describe '#destroy with PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' do
-      with_env 'PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' => 'true'
-
       it 'destroys a global lock' do
         delete :destroy, params: {id: global_lock.id}
 


### PR DESCRIPTION
- When set, will require admin role for (un)locking stages with production attribute set.
- All other locking is unchanged.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
