### PR TITLE
Don't clone the pipeline

### DIFF
--- a/app/controllers/mass_rollouts_controller.rb
+++ b/app/controllers/mass_rollouts_controller.rb
@@ -134,6 +134,7 @@ class MassRolloutsController < ApplicationController
       is_template: false,
       next_stage_ids: []
     )
+
     stage.save!
 
     if template_stage.respond_to?(:next_stage_ids) # pipeline plugin was installed

--- a/app/controllers/mass_rollouts_controller.rb
+++ b/app/controllers/mass_rollouts_controller.rb
@@ -134,7 +134,6 @@ class MassRolloutsController < ApplicationController
       is_template: false,
       next_stage_ids: []
     )
-
     stage.save!
 
     if template_stage.respond_to?(:next_stage_ids) # pipeline plugin was installed

--- a/app/controllers/mass_rollouts_controller.rb
+++ b/app/controllers/mass_rollouts_controller.rb
@@ -131,7 +131,8 @@ class MassRolloutsController < ApplicationController
       template_stage,
       deploy_groups: [deploy_group],
       name: deploy_group.name,
-      is_template: false
+      is_template: false,
+      next_stage_ids: []
     )
 
     stage.save!

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -51,7 +51,7 @@ class Stage < ActiveRecord::Base
   end
 
   def self.build_clone(old_stage, attributes = {})
-    new(old_stage.attributes.except("id").merge(attributes)).tap do |new_stage|
+    new(old_stage.attributes.except("id", "next_stage_ids")).tap do |new_stage|
       Samson::Hooks.fire(:stage_clone, old_stage, new_stage)
       new_stage.command_ids = old_stage.command_ids
       new_stage.template_stage = old_stage

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -51,7 +51,7 @@ class Stage < ActiveRecord::Base
   end
 
   def self.build_clone(old_stage, attributes = {})
-    new(old_stage.attributes.except("id", "next_stage_ids")).tap do |new_stage|
+    new(old_stage.attributes.except("id", "next_stage_ids").merge(attributes)).tap do |new_stage|
       Samson::Hooks.fire(:stage_clone, old_stage, new_stage)
       new_stage.command_ids = old_stage.command_ids
       new_stage.template_stage = old_stage

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -280,6 +280,7 @@ describe Stage do
     before do
       subject.notify_email_address = "test@test.ttt"
       subject.flowdock_flows = [FlowdockFlow.new(name: "test", token: "abcxyz", stage_id: subject.id)]
+      subject.next_stage_ids = [1,2]
       subject.save
 
       @clone = Stage.build_clone(subject)
@@ -289,6 +290,10 @@ describe Stage do
       @clone.attributes.except("id").except("template_stage_id").
           must_equal subject.attributes.except("id").except("template_stage_id")
       @clone.id.wont_equal subject.id
+    end
+
+    it "doesn't clone the deploy pipeline" do
+      @clone.next_stage_ids.wont_equal subject.next_stage_ids
     end
   end
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -280,15 +280,15 @@ describe Stage do
     before do
       subject.notify_email_address = "test@test.ttt"
       subject.flowdock_flows = [FlowdockFlow.new(name: "test", token: "abcxyz", stage_id: subject.id)]
-      subject.next_stage_ids = [1,2]
+      subject.next_stage_ids = [1, 2]
       subject.save
 
       @clone = Stage.build_clone(subject)
     end
 
     it "returns an unsaved copy of the given stage with exactly the same everything except id" do
-      @clone.attributes.except("id").except("template_stage_id").
-          must_equal subject.attributes.except("id").except("template_stage_id")
+      @clone.attributes.except("id", "next_stage_ids", "template_stage_id").
+          must_equal subject.attributes.except("id", "next_stage_ids", "template_stage_id")
       @clone.id.wont_equal subject.id
     end
 


### PR DESCRIPTION
Otherwise, we get duplicate builds.

I.e. after the clone, Production(stage) finish and starts up Pod 15(stage) and Pod17(stage). But then after Pod17 (stage) is done, it starts up Pod 15 (stage) __again__.

/cc @zendesk/samson


@grosser  I'm thinking maybe this should go deeper, i.e. inside `build_clone`. So that other cloned stages don't get the pipeline clones either. What do you think?

### References
 - Jira link: https://zendesk.atlassian.net/browse/DEVEX-82

### Risks
- Level: Low
