### PR TITLE
cleanup stubs so later requests cannot use them by accident

### DIFF
--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -20,6 +20,7 @@ ActiveSupport::TestCase.class_eval do
     if block_given?
       yield
       assert_requested(*assert_args)
+      remove_request_stub(request)
     else
       raise "use assert_requests in the describe block" unless @assert_requests
       @assert_requests << assert_args


### PR DESCRIPTION
@oliakremmyda  

as per discussion in https://github.com/zendesk/samson/pull/2458#issuecomment-362844675

before this would pass:
```
assert_request(:get, url) do
  Faraday.get(url)
end
  Faraday.get(url)
```

now it fails:

```
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://foobar.server
```