### PR TITLE
reuse parallel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'logstash-event'
 gem 'diffy'
 gem 'validates_lengths_from_database'
 gem 'large_object_store'
+gem 'parallel'
 
 # treat included plugins like gems
 Dir[File.join(Bundler.root, 'plugins/*/')].each { |f| gemspec path: f }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,6 +535,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-ldap
   omniauth-oauth2
+  parallel
   parallel_tests
   pg
   pry

--- a/lib/samson/parallelizer.rb
+++ b/lib/samson/parallelizer.rb
@@ -1,47 +1,16 @@
 # frozen_string_literal: true
+require 'parallel'
+
 module Samson
   class Parallelizer
     class << self
       def map(elements, db: false)
-        raise ArgumentError, "argument must be arrayish" unless elements.respond_to?(:[])
-
-        max = elements.size
-        return [] if max.zero?
-        return [yield(elements[0])] if max == 1
-
-        mutex = Mutex.new
-        current = -1
-        results = Array.new(max)
-        exception = nil
-
-        Array.new([max, 10].min).map do
-          Thread.new do
-            begin
-              with_db_connection(db) do
-                loop do
-                  working_index = mutex.synchronize { current += 1 }
-                  break if working_index >= max || exception
-                  results[working_index] = yield elements[working_index]
-                end
-              end
-            rescue
-              exception = $!
-            end
+        Parallel.map(elements, in_threads: 10) do |e|
+          if db
+            ActiveRecord::Base.connection_pool.with_connection { yield e }
+          else
+            yield e
           end
-        end.map(&:join)
-
-        raise exception if exception
-
-        results
-      end
-
-      private
-
-      def with_db_connection(needed, &block)
-        if needed
-          ActiveRecord::Base.connection_pool.with_connection(&block)
-        else
-          yield
         end
       end
     end

--- a/test/lib/samson/parallelizer_test.rb
+++ b/test/lib/samson/parallelizer_test.rb
@@ -10,20 +10,8 @@ describe Samson::Parallelizer do
       Samson::Parallelizer.map([]).must_equal []
     end
 
-    it "does not produce threads when serial work is equally fast" do
-      Thread.expects(:new).never
-      Samson::Parallelizer.map([1]) { 2 }.must_equal [2]
-    end
-
-    it "fails fast when non-array is given" do
-      assert_raises ArgumentError do
-        Samson::Parallelizer.map([1].each_slice(2)) { 2 }
-      end
-    end
-
-    it "produces maximum amount of threads" do
-      Thread.expects(:new).times(10).returns([])
-      Samson::Parallelizer.map(Array.new(20)) { 1 }.must_equal(Array.new(20))
+    it "can handle non-arrays" do
+      Samson::Parallelizer.map([1].each_slice(2)) { |x| x }.must_equal [[1]]
     end
 
     it "works in reused threads" do


### PR DESCRIPTION
already a dependency of rubocop, so we might as well use it
