### PR TITLE
No need for a github token during db:migrate

### DIFF
--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -30,7 +30,7 @@ Octokit.connection_options[:request] = { open_timeout: 2 }
 
 token = ENV['GITHUB_TOKEN']
 
-unless Rails.env.test? || ENV['PRECOMPILE']
+unless Rails.env.test? || ENV['PRECOMPILE'] || ( defined?(Rake) && Rake.application.top_level_tasks.include?("db:migrate") )
   raise "No GitHub token available" if token.blank?
 end
 


### PR DESCRIPTION
There should be no need to have github token set just to run `rake db:migrate`

I'm __certain__ there is a better way to write this.

@zendesk/samson 