### PR TITLE
make uniqueness migration not break when non-unique records exist by …

### DIFF
--- a/plugins/kubernetes/db/migrate/20180202000103_add_uniqueness_constraint_on_dgr.rb
+++ b/plugins/kubernetes/db/migrate/20180202000103_add_uniqueness_constraint_on_dgr.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 class AddUniquenessConstraintOnDgr < ActiveRecord::Migration[5.1]
+  class KubernetesDeployGroupRole < ActiveRecord::Base
+  end
+
   def change
+    bad = KubernetesDeployGroupRole.all.group_by { |f| [f.project_id, f.kubernetes_role_id, f.deploy_group_id] }.
+      select { |_, v| v.size > 1 }.
+      flat_map { |_, v| v[0..-1] }
+
+    write "deleting #{bad.size} duplicate DeployGroupRoles:"
+    write bad.map(&:attributes)
+
     remove_index :kubernetes_deploy_group_roles,
       column: ['project_id', 'deploy_group_id', 'kubernetes_role_id'],
       name: 'index_kubernetes_deploy_group_roles_on_project_id'


### PR DESCRIPTION
…deleting them

@ragurney 