### PR TITLE
Accept Failure

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -32,7 +32,7 @@ module DeploysHelper
   end
 
   def deploy_notification
-    "Samson deploy finished:\n#{@project.name} / #{@deploy.stage.name} #{@deploy.status}"
+    "Samson deploy finished:\n#{@deploy.stage.unique_name} #{@deploy.status}"
   end
 
   def file_status_label(status)

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -196,6 +196,11 @@ class Stage < ActiveRecord::Base
     !confirm? && no_reference_selection? && !deploy_requires_approval?
   end
 
+  # A unique name to identify this stage in the whole system. useful for log files.
+  def unique_name
+    project.name + "::" + name
+  end
+
   private
 
   def audited_changes

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -198,7 +198,7 @@ class Stage < ActiveRecord::Base
 
   # A unique name to identify this stage in the whole system. useful for log files.
   def unique_name
-    project.name + "::" + name
+    "#{project.name} / #{name}"
   end
 
   private

--- a/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
+++ b/plugins/slack_webhooks/app/models/slack_webhook_notification.rb
@@ -26,7 +26,7 @@ class SlackWebhookNotification
     project = @deploy.project
     ":pray: <!here> _#{@deploy.user.name}_ is requesting approval to deploy " \
       "<#{Rails.application.routes.url_helpers.project_deploy_url(project, @deploy)}|" \
-      "#{project.name} *#{@deploy.reference}* to #{@deploy.stage.name}>."
+      "*#{@deploy.reference}* to #{@deploy.stage.unique_name}>."
   end
 
   private

--- a/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
+++ b/plugins/slack_webhooks/test/models/slack_webhook_notification_test.rb
@@ -89,7 +89,7 @@ describe SlackWebhookNotification do
       notification = stub_notification
       message = notification.default_buddy_request_message
       message.must_equal ":pray: <!here> _Super Admin_ is requesting approval to deploy " \
-        "<http://www.test-url.com/projects/foo/deploys/178003093|Foo *staging* to Staging>."
+        "<http://www.test-url.com/projects/foo/deploys/178003093|*staging* to Foo / Staging>."
     end
   end
 

--- a/test/controllers/mass_rollouts_controller_test.rb
+++ b/test/controllers/mass_rollouts_controller_test.rb
@@ -206,21 +206,21 @@ describe MassRolloutsController do
 
       describe "multiple stages" do
         let(:url) { "git://foo.com:hello/world.git" }
-        let(:project2) { 
+        let(:project2) do
           Project.any_instance.stubs(:valid_repository_url).returns(true)
           Project.create!(
-            name: 'blah', 
+            name: 'blah',
             repository_url: url,
             include_new_deploy_groups: true
           )
-        }
-        let(:template_stage2) { 
+        end
+        let(:template_stage2) do
           project2.stages.create!(
-            name: 'stage blah', 
-            deploy_groups: [ template_stage.deploy_groups.first ], 
+            name: 'stage blah',
+            deploy_groups: [template_stage.deploy_groups.first],
             is_template: true
-          ) 
-        }
+          )
+        end
 
         before do
           template_stage

--- a/test/controllers/mass_rollouts_controller_test.rb
+++ b/test/controllers/mass_rollouts_controller_test.rb
@@ -203,6 +203,56 @@ describe MassRolloutsController do
         ignore = ["id", "created_at", "updated_at", "deploy_group_id"]
         copied_dgr.attributes.except(*ignore).must_equal template_dgr.attributes.except(*ignore)
       end
+
+      describe "multiple stages" do
+        let(:url) { "git://foo.com:hello/world.git" }
+        let(:project2) { 
+          Project.any_instance.stubs(:valid_repository_url).returns(true)
+          Project.create!(
+            name: 'blah', 
+            repository_url: url,
+            include_new_deploy_groups: true
+          )
+        }
+        let(:template_stage2) { 
+          project2.stages.create!(
+            name: 'stage blah', 
+            deploy_groups: [ template_stage.deploy_groups.first ], 
+            is_template: true
+          ) 
+        }
+
+        before do
+          template_stage
+          template_stage2
+        end
+
+        it "creates multiple stages" do
+          assert_difference 'Stage.count', 2 do
+            post :create, params: {deploy_group_id: deploy_group}
+          end
+        end
+
+        it "reports number of stages created" do
+          post :create, params: {deploy_group_id: deploy_group}
+          assert_equal("Created 2 Stages", flash[:notice])
+        end
+
+        it "ignores errors" do
+          @controller.stubs(:create_stage_with_group).raises(StandardError)
+          assert_difference 'Stage.count', 0 do
+            post :create, params: {deploy_group_id: deploy_group}
+          end
+          assert_redirected_to deploy_group_path(deploy_group)
+        end
+
+        it "reports only the number of stages actually created" do
+          @controller.stubs(:create_stage_with_group).raises(StandardError).then.returns("something")
+
+          post :create, params: {deploy_group_id: deploy_group}
+          assert_equal("Created 1 Stages", flash[:notice])
+        end
+      end
     end
 
     describe "#merge" do

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -7,6 +7,10 @@ describe Stage do
   subject { stages(:test_staging) }
   let(:stage) { subject }
 
+  it "#unique_name" do
+    assert_equal "Foo / Staging", stage.unique_name
+  end
+
   describe "validations" do
     it "is valid" do
       assert_valid stage


### PR DESCRIPTION
When using mass rollout to create a number of stages, we should try to create each one, even if previous stages failed to create. This will allow the pod creation team to continue work even through various stage validations or other bugs.

This would have allowed the creation of non-kubernetes stages in pod 18 last week.

/cc @zendesk/samson

### References
 - Jira link: https://zendesk.atlassian.net/browse/DEVEX-83

### Risks
- Level: Low
