### PR TITLE
Feature: Use LDAP_UID as user.external_id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,3 +173,14 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 
 ## Feature: Only admins can (un)lock stages which affect production.
 # PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN=1
+
+## Feature: Use LDAP_UID as user.external_id.
+# The default is to use the Distinguished Name for users.external_id.  If your organization changes
+# any part of the DNs for any reason, this could cause any configured users to loose their current
+# configuration since it will be assumed to be a new user with a new external_id.  This feature
+# forces the value of LDAP_UID (set above), which is used to query the user in the LDAP, which
+# almost certainly is unique per user), to also be used for the external_id.  Note, this name must
+# also exist in the "extra" raw info:
+# https://github.com/omniauth/omniauth-ldap/blob/master/README.md
+# https://github.com/omniauth/omniauth-ldap/blob/master/lib/omniauth/strategies/ldap.rb#L17
+# USE_LDAP_UID_AS_EXTERNAL_ID=1

--- a/.env.example
+++ b/.env.example
@@ -179,7 +179,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # any part of the DNs for any reason, this could cause any configured users to loose their current
 # configuration since it will be assumed to be a new user with a new external_id.  This feature
 # forces the value of LDAP_UID (set above), which is used to query the user in the LDAP, which
-# almost certainly is unique per user), to also be used for the external_id.  Note, this name must
+# almost certainly is unique per user, to also be used for the external_id.  Note, this name must
 # also exist in the "extra" raw info:
 # https://github.com/omniauth/omniauth-ldap/blob/master/README.md
 # https://github.com/omniauth/omniauth-ldap/blob/master/lib/omniauth/strategies/ldap.rb#L17

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -90,11 +90,12 @@ class SessionsController < ApplicationController
   end
 
   def login(options = {})
-    uid = auth_hash.uid
-    if ENV['AUTH_LDAP'] && ENV['USE_LDAP_UID_AS_EXTERNAL_ID']
+    if auth_hash.provider == 'ldap' && ENV['AUTH_LDAP'] && ENV['USE_LDAP_UID_AS_EXTERNAL_ID']
       uid_field = Rails.application.config.samson.ldap.uid
       uid = auth_hash.extra.raw_info.send(uid_field).presence || raise
       uid = Array(uid).first
+    else
+      uid = auth_hash.uid
     end
 
     user = User.create_or_update_from_hash(options.merge(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -91,7 +91,7 @@ class SessionsController < ApplicationController
 
   def login(options = {})
     uid = auth_hash.uid
-    if ENV['USE_LDAP_UID_AS_EXTERNAL_ID']
+    if ENV['AUTH_LDAP'] && ENV['USE_LDAP_UID_AS_EXTERNAL_ID']
       uid_field = Rails.application.config.samson.ldap.uid
       uid = auth_hash.extra.raw_info.send(uid_field).presence || auth_hash.uid
       uid = uid.is_a?(Array) ? uid.first : uid

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -93,8 +93,8 @@ class SessionsController < ApplicationController
     uid = auth_hash.uid
     if ENV['AUTH_LDAP'] && ENV['USE_LDAP_UID_AS_EXTERNAL_ID']
       uid_field = Rails.application.config.samson.ldap.uid
-      uid = auth_hash.extra.raw_info.send(uid_field).presence || auth_hash.uid
-      uid = uid.is_a?(Array) ? uid.first : uid
+      uid = auth_hash.extra.raw_info.send(uid_field).presence || raise
+      uid = Array(uid).first
     end
 
     user = User.create_or_update_from_hash(options.merge(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -90,8 +90,15 @@ class SessionsController < ApplicationController
   end
 
   def login(options = {})
+    uid = auth_hash.uid
+    if ENV['USE_LDAP_UID_AS_EXTERNAL_ID']
+      uid_field = Rails.application.config.samson.ldap.uid
+      uid = auth_hash.extra.raw_info.send(uid_field).presence || auth_hash.uid
+      uid = uid.is_a?(Array) ? uid.first : uid
+    end
+
     user = User.create_or_update_from_hash(options.merge(
-      external_id: "#{strategy.name}-#{auth_hash.uid}",
+      external_id: "#{strategy.name}-#{uid}",
       name: auth_hash.info.name,
       email: auth_hash.info.email
     ))

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -232,6 +232,7 @@ describe SessionsController do
     let(:strategy) { stub(name: 'ldap') }
     let(:auth_hash) do
       Hashie::Mash.new(
+        provider: 'ldap',
         uid: '4',
         info: Hashie::Mash.new(
           name: user.name,
@@ -297,13 +298,11 @@ describe SessionsController do
     describe 'with LDAP_UID as external_id' do
       it 'logs the user in' do
         Rails.application.config.samson.ldap.stub(:uid, 'sAMAccountName') do
-          with_env 'AUTH_LDAP': 'true' do
-            with_env 'USE_LDAP_UID_AS_EXTERNAL_ID': 'true' do
-              post :ldap
-              @controller.send(:current_user).external_id.must_equal(
-                "#{strategy.name}-#{auth_hash.extra.raw_info.sAMAccountName.first}"
-              )
-            end
+          with_env AUTH_LDAP: 'true', USE_LDAP_UID_AS_EXTERNAL_ID: 'true' do
+            post :ldap
+            @controller.send(:current_user).external_id.must_equal(
+              "#{strategy.name}-#{auth_hash.extra.raw_info.sAMAccountName.first}"
+            )
           end
         end
       end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -236,6 +236,11 @@ describe SessionsController do
         info: Hashie::Mash.new(
           name: user.name,
           email: user.email
+        ),
+        extra: Hashie::Mash.new(
+          raw_info: Hashie::Mash.new(
+            sAMAccountName: [user.name]
+          )
         )
       )
     end
@@ -255,6 +260,15 @@ describe SessionsController do
 
       it 'logs the user in' do
         @controller.send(:current_user).must_equal(user)
+      end
+
+      it 'logs the user in with USE_LDAP_UID_AS_EXTERNAL_ID' do
+        Rails.application.config.samson.ldap.stub(:uid, 'sAMAccountName') do
+          with_env 'USE_LDAP_UID_AS_EXTERNAL_ID' => 'true' do
+            post :ldap
+            @controller.send(:current_user).must_equal(user)
+          end
+        end
       end
 
       it 'redirects to the root path' do


### PR DESCRIPTION
- Use the value of the LDAP_UID not just for the query but also as the user's
  external_id when using LDAP.

* Add description here
* Add any screenshots if you are touching the UI
* Remember to add unit tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
