### PR TITLE
enforce read-only root filesystem or make users opt-out

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180202000103) do
+ActiveRecord::Schema.define(version: 20180207013051) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -380,6 +380,7 @@ ActiveRecord::Schema.define(version: 20180202000103) do
     t.string "dockerfiles"
     t.boolean "build_with_gcb", default: false, null: false
     t.boolean "show_gcr_vulnerabilities", default: false, null: false
+    t.boolean "kubernetes_allow_writing_to_root_filesystem", default: false, null: false
     t.index ["build_command_id"], name: "index_projects_on_build_command_id"
     t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: { permalink: 191 }
     t.index ["token"], name: "index_projects_on_token", unique: true, length: { token: 191 }

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -97,7 +97,11 @@ module Kubernetes
       @raw_template ||= begin
         file = kubernetes_role.config_file
         content = kubernetes_release.project.repository.file_content(file, kubernetes_release.git_sha)
-        RoleConfigFile.new(content, file).elements
+        elements = RoleConfigFile.new(content, file).elements
+        if errors = Kubernetes::RoleVerifier.new(elements, kubernetes_release.project).verify
+          raise Samson::Hooks::UserError, "Error found when parsing #{file}\n#{errors.join("\n")}"
+        end
+        elements
       end
     end
   end

--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -24,10 +24,6 @@ module Kubernetes
       rescue
         raise Samson::Hooks::UserError, "Error found when parsing #{path}\n#{$!.message}"
       end
-
-      if errors = Kubernetes::RoleVerifier.new(@elements).verify
-        raise Samson::Hooks::UserError, "Error found when parsing #{path}\n#{errors.join("\n")}"
-      end
     end
 
     def primary

--- a/plugins/kubernetes/app/views/samson_kubernetes/_project_form_checkbox.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_project_form_checkbox.html.erb
@@ -1,0 +1,1 @@
+<%= form.input :kubernetes_allow_writing_to_root_filesystem, help: "Ensure `securityContext: readOnlyRootFilesystem: true` is set when this is disabled.", as: :check_box %>

--- a/plugins/kubernetes/db/migrate/20180207013051_add_allow_writing_to_root_filesystem.rb
+++ b/plugins/kubernetes/db/migrate/20180207013051_add_allow_writing_to_root_filesystem.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddAllowWritingToRootFilesystem < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :kubernetes_allow_writing_to_root_filesystem, :boolean, default: false, null: false
+  end
+end


### PR DESCRIPTION
@jonmoter 

a draft of what that could look like:
fail deploys that try to write to root file system without opting in to that in the project settings

