### PR TITLE
use the same api since vulnzsummary seems to be constantly 404

### DIFF
--- a/plugins/gcloud/lib/samson_gcloud/image_scanner.rb
+++ b/plugins/gcloud/lib/samson_gcloud/image_scanner.rb
@@ -16,7 +16,7 @@ module SamsonGcloud
       def scan(build)
         return ERROR unless result = request(build, "occurrences", "kind=\"DISCOVERY\"")
         return WAITING unless result.dig("occurrences", 0, "discovered", "operation", "done")
-        return ERROR unless result = request(build, "vulnzsummary")
+        return ERROR unless result = request(build, "occurrences", "kind=\"PACKAGE_VULNERABILITY\"")
         result.empty? ? SUCCESS : FOUND
       end
 
@@ -52,7 +52,7 @@ module SamsonGcloud
           begin
             response = Faraday.get(
               "https://containeranalysis.googleapis.com/v1alpha1/projects/#{SamsonGcloud.project}/#{path}",
-              {filter: filter},
+              {filter: filter, pageSize: 1},
               authorization: "Bearer #{token}"
             )
           rescue

--- a/plugins/gcloud/test/samson_gcloud/image_scanner_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/image_scanner_test.rb
@@ -11,7 +11,7 @@ describe SamsonGcloud::ImageScanner do
   describe ".scan" do
     def assert_done(done: true)
       assert_request(
-        :get, /occurrences/,
+        :get, /DISCOVERY/,
         to_return: {body: {occurrences: [{discovered: {operation: {done: done}}}]}.to_json}
       )
     end
@@ -25,25 +25,25 @@ describe SamsonGcloud::ImageScanner do
 
     it "returns success" do
       assert_done
-      assert_request(:get, /vulnzsummary/, to_return: { body: "[]" })
+      assert_request(:get, /PACKAGE_VULNERABILITY/, to_return: { body: "[]" })
       SamsonGcloud::ImageScanner.scan(build).must_equal SamsonGcloud::ImageScanner::SUCCESS
     end
 
     it "returns found" do
       assert_done
-      assert_request(:get, /vulnzsummary/, to_return: { body: "[111]" })
+      assert_request(:get, /PACKAGE_VULNERABILITY/, to_return: { body: "[111]" })
       SamsonGcloud::ImageScanner.scan(build).must_equal SamsonGcloud::ImageScanner::FOUND
     end
 
     it "returns error when not found" do
       assert_done
-      assert_request(:get, /vulnzsummary/, to_return: { status: 400, body: "[]" })
+      assert_request(:get, /PACKAGE_VULNERABILITY/, to_return: { status: 400, body: "[]" })
       SamsonGcloud::ImageScanner.scan(build).must_equal SamsonGcloud::ImageScanner::ERROR
     end
 
     it "returns error when it blows up" do
       assert_done
-      assert_request(:get, /vulnzsummary/, to_timeout: [])
+      assert_request(:get, /PACKAGE_VULNERABILITY/, to_timeout: [])
       SamsonGcloud::ImageScanner.scan(build).must_equal SamsonGcloud::ImageScanner::ERROR
     end
 
@@ -53,12 +53,12 @@ describe SamsonGcloud::ImageScanner do
     end
 
     it "returns waiting if we are unable to determine the status" do
-      assert_request(:get, /occurrences/, to_return: { body: "{}" })
+      assert_request(:get, /DISCOVERY/, to_return: { body: "{}" })
       SamsonGcloud::ImageScanner.scan(build).must_equal SamsonGcloud::ImageScanner::WAITING
     end
 
     it "retries request if error code >= 500" do
-      assert_request(:get, /occurrences/, to_return: { status: 500 }, times: 3)
+      assert_request(:get, /DISCOVERY/, to_return: { status: 500 }, times: 3)
       SamsonGcloud::ImageScanner.scan(build).must_equal SamsonGcloud::ImageScanner::ERROR
     end
   end


### PR DESCRIPTION
this is broken now ... so use a different api
`gcloud alpha container images list-tags XXX --show-occurrences --log-http`

@ragurney 
/cc @jonmoter 