### PR TITLE
show more details when backoff wait fails so we can debug better

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -92,7 +92,7 @@ module Kubernetes
           yield
           sleep wait
         end
-        raise "Unable to #{reason}"
+        raise "Unable to #{reason} (#{name} #{namespace})"
       end
 
       def request_delete

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -191,7 +191,7 @@ describe Kubernetes::Resource do
         resource.expects(:sleep).times(tries)
 
         e = assert_raises(RuntimeError) { resource.delete }
-        e.message.must_equal "Unable to delete resource"
+        e.message.must_equal "Unable to delete resource (some-project pod1)"
       end
     end
   end


### PR DESCRIPTION
atm all we see in airbrake is "RuntimeError: Unable to delete resource" ... which is not helpful

@ragurney 