### PR TITLE
tell what builds we found so when the GCR scanner (or any other plugi…

### DIFF
--- a/lib/samson/build_finder.rb
+++ b/lib/samson/build_finder.rb
@@ -153,9 +153,13 @@ module Samson
     end
 
     def wait_for_build_completion(build)
-      return unless build.reload.active?
+      if build.reload.active?
+        @output.puts("Waiting for Build #{build.url} to finish.")
+      else
+        @output.puts("Build #{build.url} is finish.")
+        return
+      end
 
-      @output.puts("Waiting for Build #{build.url} to finish.")
       loop do
         break if @cancelled
         sleep TICK

--- a/test/lib/samson/build_finder_test.rb
+++ b/test/lib/samson/build_finder_test.rb
@@ -153,7 +153,7 @@ describe Samson::BuildFinder do
         finder.cancelled!
         DockerBuilderService.any_instance.expects(:run).returns(true)
         execute
-        out.scan(/.*build.*/).must_equal ["Creating build for Dockerfile."] # not waiting for build
+        out.scan(/.*build for.*/).must_equal(["Creating build for Dockerfile."])
       end
     end
 
@@ -186,9 +186,8 @@ describe Samson::BuildFinder do
         execute.must_equal [build]
       end
 
-      it "finds accross projects" do
-        Build.any_instance.expects(:url).returns("foo") # bogus project not found so url building fails
-        build.update_column(:project_id, 123)
+      it "finds across projects" do
+        build.update_column(:project_id, projects(:other).id)
         execute.must_equal [build]
       end
 


### PR DESCRIPTION
…n) waits it is obvious for what build

@ragurney 

before:

```
[22:20:44] # Deploy URL: /projects/kube_service_watcher/deploys/425946
[22:20:45] Waiting for GCR scan to finish...
```