### PR TITLE
Add styles for additions/deletions in files/PRs

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -180,6 +180,24 @@ h3 {
 .label {
   padding: .3em 0.65em .35em;
   border-radius: .2em;
+
+  &.additions {
+    color: green;
+
+    &::before {
+      content: "+";
+      padding: 0 2px;
+    }
+  }
+
+  &.deletions {
+    color: red;
+
+    &::before {
+      content: "-";
+      padding: 0 2px;
+    }
+  }
 }
 
 .label-success {

--- a/app/views/changeset/_files.html.erb
+++ b/app/views/changeset/_files.html.erb
@@ -14,8 +14,8 @@
           <%= file.filename %>
         </td>
         <td align="right">
-          <%= file_changes_label file.additions, "success" %>
-          <%= file_changes_label file.deletions, "danger" %>
+          <%= file_changes_label file.additions, "additions" %>
+          <%= file_changes_label file.deletions, "deletions" %>
         </td>
       </tr>
       <tr class="file-diff" style="display:none">


### PR DESCRIPTION
Right now, the number of additions and deletions in every pull request
is invisible, as it has the same color as the background, white.
This change makes those numbers visible again.

Result:

![screen shot 2018-02-12 at 12 56 33](https://user-images.githubusercontent.com/1541959/36095876-3f3012fe-0ff4-11e8-9f32-bbecf58fbf93.png)


/cc @zendesk/samson @zendesk/sustaining 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: None
