### PR TITLE
simplify pod cleanup after deletion

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -708,11 +708,11 @@ describe Kubernetes::DeployExecutor do
       assert_request(:put, "#{services_url}/some-project", to_return: {body: "{}"}) # update to point to blue
 
       # delete old deployment
+      Kubernetes::Resource::Deployment.any_instance.expects(:pods).returns([])
       assert_request(
         :get, "#{deployments_url}/test-app-server-green",
         to_return: [{body: "{}"}, {body: "{}"}, {status: 404}] # green did exist and gets deleted
       )
-      assert_request(:put, "#{deployments_url}/test-app-server-green", to_return: {body: "{}"}) # set green to 0
       assert_request(:delete, "#{deployments_url}/test-app-server-green", to_return: {body: "{}"}) # delete green
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
@@ -728,14 +728,14 @@ describe Kubernetes::DeployExecutor do
 
     it "reverts new resources when they fail" do
       # deployment
+      Kubernetes::Resource::Deployment.any_instance.expects(:pods).returns([])
       assert_request(
         :get, "#{deployments_url}/test-app-server-blue", to_return:
         [
-          {status: 404}, {body: "{}"}, {body: "{}"}, {status: 404} # blue did not exist + 3 replies for deletion
+          {status: 404}, {body: "{}"}, {status: 404} # blue did not exist + 3 replies for deletion
         ]
       )
       assert_request(:post, deployments_url, to_return: {body: "{}"}) # blue was created
-      assert_request(:put, "#{deployments_url}/test-app-server-blue", to_return: {body: "{}"}) # set blue to 0
       assert_request(:delete, "#{deployments_url}/test-app-server-blue", to_return: {body: "{}"}) # delete blue
 
       executor.expects(:wait_for_resources_to_complete).returns([])

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -47,7 +47,7 @@ describe Kubernetes::Resource do
   let(:url) { "#{origin}/api/v1/namespaces/pod1/services/some-project" }
   let(:base_url) { File.dirname(url) }
 
-  before { Kubernetes::Resource::Base.any_instance.expects(:sleep).never }
+  before { Kubernetes::Resource::Base.any_instance.expects(:sleep).with { raise }.never }
 
   it "does modify passed in template" do
     content = File.read(File.expand_path("../../../app/models/kubernetes/resource.rb", __dir__))
@@ -378,13 +378,6 @@ describe Kubernetes::Resource do
   end
 
   describe Kubernetes::Resource::Deployment do
-    def deployment_stub(replica_count)
-      {
-        spec: {},
-        status: {replicas: replica_count}
-      }.to_json
-    end
-
     let(:kind) { 'Deployment' }
     let(:url) { "#{origin}/apis/extensions/v1beta1/namespaces/pod1/deployments/some-project" }
 
@@ -401,28 +394,17 @@ describe Kubernetes::Resource do
         end
       end
 
-      it "waits for pods to terminate before deleting" do
-        client = resource.send(:client)
-        client.expects(:update_deployment).with do |template|
-          template[:spec][:replicas].must_equal 0
+      it "deletes pods too" do
+        deployment = {spec: {template: {metadata: {labels: {release_id: 123, deploy_group_id: 234}}}}}
+        assert_request(:get, url, to_return: [{body: deployment.to_json}, {status: 404}]) do
+          assert_pods_lookup do
+            assert_pod_deletion do
+              assert_request(:delete, url, to_return: {body: '{}'}) do
+                resource.delete
+              end
+            end
+          end
         end
-        client.expects(:get_deployment).raises(KubeException.new(404, 'Not Found', {}))
-        client.expects(:get_deployment).times(3).returns(
-          deployment_stub(3),
-          deployment_stub(3),
-          deployment_stub(0)
-        )
-        client.expects(:delete_deployment)
-        resource.delete
-      end
-
-      it "does not fail on unset replicas" do
-        client = resource.send(:client)
-        client.expects(:update_deployment)
-        client.expects(:get_deployment).raises(KubeException.new(404, 'Not Found', {}))
-        client.expects(:get_deployment).times(2).returns(deployment_stub(nil))
-        client.expects(:delete_deployment)
-        resource.delete
       end
     end
 


### PR DESCRIPTION
had lots of issues deleting leftover deployments manually ... should use a single way of deleting things...
once we are on 1.9 pod deletion will be handled automatically, but until then this should be nice/consistent ...

@ragurney 
/cc @jonmoter 