### PR TITLE
bump wait time since 5 minutes seems to not be enough

### DIFF
--- a/plugins/gcloud/lib/samson_gcloud/samson_plugin.rb
+++ b/plugins/gcloud/lib/samson_gcloud/samson_plugin.rb
@@ -5,7 +5,7 @@ require 'samson_gcloud/image_builder'
 require 'samson_gcloud/image_scanner'
 
 module SamsonGcloud
-  SCAN_WAIT_PERIOD = 5.minutes
+  SCAN_WAIT_PERIOD = 10.minutes
   SCAN_SLEEP_PERIOD = 5.seconds
 
   class Engine < Rails::Engine

--- a/plugins/gcloud/test/samson_gcloud/samson_plugin_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/samson_plugin_test.rb
@@ -105,8 +105,8 @@ describe SamsonGcloud do
         end
 
         it "fails if waiting did not help" do
-          SamsonGcloud::ImageScanner.expects(:scan).times(60).returns(SamsonGcloud::ImageScanner::WAITING)
-          expects_sleep 60
+          SamsonGcloud::ImageScanner.expects(:scan).times(120).returns(SamsonGcloud::ImageScanner::WAITING)
+          expects_sleep 120
           fire.must_equal [false]
         end
 


### PR DESCRIPTION
@ragurney 

just saw this deploy fail, so maybe bump it a little ...
```
[22:38:37] Waiting for GCR scan to finish ...
[22:43:47] Waiting for Vulnerability scan, see 
```
