### PR TITLE
revert deployment deletion simplification since it leaves replicasets…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -233,7 +233,25 @@ module Kubernetes
       private
 
       def request_delete
-        delete_pods { super }
+        # Make kubernetes kill all the pods by scaling down
+        restore_template do
+          @template.dig_set [:spec, :replicas], 0
+          update
+        end
+
+        # Wait for there to be zero pods
+        loop do
+          loop_sleep
+          # prevent cases when status.replicas are missing
+          # e.g. running locally on Minikube, after scale replicas to zero
+          # $ kubectl scale deployment {DEPLOYMENT_NAME} --replicas 0
+          # "replicas" key is actually removed from "status" map
+          # $ {"status":{"conditions":[...],"observedGeneration":2}}
+          break if fetch_resource.dig(:status, :replicas).to_i.zero?
+        end
+
+        # delete the actual deployment
+        super
       end
 
       def client

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -715,11 +715,11 @@ describe Kubernetes::DeployExecutor do
       assert_request(:put, "#{services_url}/some-project", to_return: {body: "{}"}) # update to point to blue
 
       # delete old deployment
-      Kubernetes::Resource::Deployment.any_instance.expects(:pods).returns([])
       assert_request(
         :get, "#{deployments_url}/test-app-server-green",
         to_return: [{body: "{}"}, {body: "{}"}, {status: 404}] # green did exist and gets deleted
       )
+      assert_request(:put, "#{deployments_url}/test-app-server-green", to_return: {body: "{}"}) # set green to 0
       assert_request(:delete, "#{deployments_url}/test-app-server-green", to_return: {body: "{}"}) # delete green
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
@@ -735,14 +735,14 @@ describe Kubernetes::DeployExecutor do
 
     it "reverts new resources when they fail" do
       # deployment
-      Kubernetes::Resource::Deployment.any_instance.expects(:pods).returns([])
       assert_request(
         :get, "#{deployments_url}/test-app-server-blue", to_return:
         [
-          {status: 404}, {body: "{}"}, {status: 404} # blue did not exist + 3 replies for deletion
+          {status: 404}, {body: "{}"}, {body: "{}"}, {status: 404} # blue did not exist + 3 replies for deletion
         ]
       )
       assert_request(:post, deployments_url, to_return: {body: "{}"}) # blue was created
+      assert_request(:put, "#{deployments_url}/test-app-server-blue", to_return: {body: "{}"}) # set blue to 0
       assert_request(:delete, "#{deployments_url}/test-app-server-blue", to_return: {body: "{}"}) # delete blue
 
       executor.expects(:wait_for_resources_to_complete).returns([])


### PR DESCRIPTION
… behind

... could make a nicer fix, but not worth the effort when 1.9 will handle all that

partially reverts https://github.com/zendesk/samson/pull/2565

@ragurney 