### PR TITLE
Include deploy info in stages JSON responses

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -23,7 +23,9 @@ class StagesController < ApplicationController
         @deploys = @stage.deploys.page(page)
       end
       format.json do
-        render_as_json :stage, @stage do |reply|
+        render_as_json :stage, @stage, allowed_includes: [
+          :last_deploy, :last_successful_deploy, :active_deploy
+        ] do |reply|
           # deprecated way of inclusion, do not add more
           if params[:include] == "kubernetes_matrix"
             reply[:stage][:kubernetes_matrix] = Kubernetes::DeployGroupRole.matrix(@stage)

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -107,6 +107,18 @@ describe StagesController do
             '<iframe src="http://localhost/foo.txt"></iframe>alert("hi there");END_OF_TEXT'
           )
         end
+
+        it 'renders deploys mentioned in the include param' do
+          get :show, params: {
+            project_id: subject.project.to_param, id: subject.to_param,
+            includes: "last_deploy,last_successful_deploy,active_deploy"
+          }, format: :json
+          assert_response :success
+          json.keys.must_equal ["stage", "last_deploys", "last_successful_deploys", "active_deploys"]
+          json["stage"].keys.must_include 'last_deploy_id'
+          json["stage"].keys.must_include 'last_successful_deploy_id'
+          json["stage"].keys.must_include 'active_deploy_id'
+        end
       end
 
       it "fails with invalid project" do


### PR DESCRIPTION
We would like to include some information on what tags were deployed to various environment on our office dashboard. This is hard to come by programatically right now, so this PR includes the last successful deploy, the last deploy, and the active deploy into the JSON response for a stage.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
