### PR TITLE
a build with failed external status is not active

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -60,7 +60,11 @@ class Build < ActiveRecord::Base
   end
 
   def active?
-    external_status? ? !docker_repo_digest? : docker_build_job&.active?
+    if external?
+      !docker_repo_digest? && (!external_status || Job::ACTIVE_STATUSES.include?(external_status))
+    else
+      docker_build_job&.active?
+    end
   end
 
   private

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -220,6 +220,11 @@ describe Build do
         build.docker_repo_digest = 'some-digest'
         refute build.active?
       end
+
+      it "is not active when finished by status" do
+        build.external_status = 'failed'
+        refute build.active?
+      end
     end
   end
 
@@ -229,8 +234,6 @@ describe Build do
     end
 
     it 'cancels builds that have been running for too long' do
-      puts build.created_at
-
       Build.cancel_stalled_builds
 
       build.reload.external_status.must_equal 'cancelled'


### PR DESCRIPTION
had a deploy hanging forever even after we killed unresponsive builds ...