### PR TITLE
allow modifying reply before sending it to users to add more custom f…

### DIFF
--- a/app/controllers/concerns/json_renderer.rb
+++ b/app/controllers/concerns/json_renderer.rb
@@ -58,6 +58,8 @@ module JsonRenderer
     json = {namespace => resource_json}
     JsonRenderer.add_includes(json, resource_list, requested_includes)
 
+    yield json if block_given?
+
     render status: status, json: json
   rescue ActiveRecord::AssociationNotFoundError, JsonRenderer::ForbiddenIncludesError
     render status: 400, json: {status: 400, error: $!.message}

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -23,11 +23,12 @@ class StagesController < ApplicationController
         @deploys = @stage.deploys.page(page)
       end
       format.json do
-        stage = @stage.as_json
-        if params[:include].to_s.split(',').include?("kubernetes_matrix")
-          stage[:kubernetes_matrix] = Kubernetes::DeployGroupRole.matrix(@stage)
+        render_as_json :stage, @stage do |reply|
+          # deprecated way of inclusion, do not add more
+          if params[:include] == "kubernetes_matrix"
+            reply[:stage][:kubernetes_matrix] = Kubernetes::DeployGroupRole.matrix(@stage)
+          end
         end
-        render json: { stage: stage }
       end
       format.svg do
         badge =

--- a/test/controllers/concerns/json_renderer_test.rb
+++ b/test/controllers/concerns/json_renderer_test.rb
@@ -57,6 +57,14 @@ describe "JsonRenderer Integration" do
       json['deploy_groups'].first.keys.must_include "kubernetes_cluster_id"
     end
 
+    it "can add custom things via yield" do
+      project = projects(:test)
+      stage = stages(:test_staging)
+      get "/projects/#{project.to_param}/stages/#{stage.to_param}.json?include=kubernetes_matrix"
+      json.keys.must_equal ['stage']
+      assert json['stage'].key?('kubernetes_matrix')
+    end
+
     it "shows a descriptive error to users that use unsupported includes" do
       get '/deploys.json', params: {includes: "nope"}
       assert_response :bad_request


### PR DESCRIPTION
…oobar

to make https://github.com/zendesk/samson/pull/2584 not a mess we need to enable render_as_json to work with the wicked kubernetes_matrix include ... so adding a bit of hackery around it.
After that we can simply say `render_as_json :stage, @stage, allowed_includes: [:last_deploy, :last_successful_deploy, :active_deploy]` and everything should work automagically

@ragurney @st33n 