### PR TITLE
builds can fail with timeout too

### DIFF
--- a/plugins/gcloud/app/controllers/gcloud_controller.rb
+++ b/plugins/gcloud/app/controllers/gcloud_controller.rb
@@ -6,6 +6,7 @@ class GcloudController < ApplicationController
     "WORKING" => "running",
     "FAILURE" => "failed",
     "ERRORED" => "failed",
+    "TIMEOUT" => "failed",
     "CANCELLED" => "cancelled"
   }.freeze
 


### PR DESCRIPTION
@ragurney 

`KeyError: key not found: "TIMEOUT"`

https://zendesk.airbrake.io/projects/95346/groups/2155173804119632237