### PR TITLE
ignore user errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,15 @@ class ApplicationController < ActionController::Base
   include JsonExceptions
   include JsonRenderer
 
+  # show error details to users and do not bother ExceptionNotifier
+  rescue_from Samson::Hooks::UserError do |exception|
+    if request.format.json?
+      render_json_error 400, exception.message
+    else
+      render status: 400, plain: exception.message
+    end
+  end
+
   protected
 
   def page

--- a/app/controllers/concerns/json_exceptions.rb
+++ b/app/controllers/concerns/json_exceptions.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+#
+# Rewrite unhelpful rails default errors
 module JsonExceptions
   def self.included(base)
     # default error has very little information

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -79,6 +79,26 @@ describe ApplicationController do
       request.env['requested_oauth_scopes'].must_equal ['default', 'application_test']
     end
   end
+
+  describe "Samson::Hooks::UserError" do
+    as_a_viewer do
+      before do
+        ApplicationTestController.any_instance.expects(:test_redirect_back).raises(Samson::Hooks::UserError, "Wut")
+      end
+
+      it "displays nice html message" do
+        get :test_redirect_back, params: {test_route: true}
+        assert_response :bad_request
+        response.body.must_equal "Wut"
+      end
+
+      it "displays nice json message" do
+        get :test_redirect_back, params: {test_route: true}, format: :json
+        assert_response :bad_request
+        response.body.must_equal "{\"status\":400,\"error\":\"Wut\"}"
+      end
+    end
+  end
 end
 
 describe "ApplicationController Integration" do


### PR DESCRIPTION
for things like https://zendesk.airbrake.io/projects/95346/groups/2155882956898903040
where a template was not filled out correctly and results in an error when trying to render it

@ragurney 