### PR TITLE
catch mystery stop error

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -31,3 +31,14 @@ Puma::Runner.prepend(Module.new do
     super
   end
 end)
+
+# sometimes when puma tries to stop the @server is not even there and then things blow up
+# so we just pretend like we stopped it and hope that helps with our hanging restarts issue
+# https://github.com/puma/puma/issues/1523
+Puma::Single.prepend(Module.new do
+  def stop
+    super
+  rescue NoMethodError
+    nil
+  end
+end)


### PR DESCRIPTION
see https://github.com/puma/puma/issues/1523

hopefully fixes our restart-freeze error ...
which I saw a few months ago too, but never tracked down

https://zendesk.airbrake.io/projects/95346/groups/2160074558693386356

/cc @jonmoter @ragurney 