### PR TITLE
Create task to report initial deployment wait times over time

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+namespace :reports do
+  desc "Average time initial deploys wait for their builds per week"
+  task deploy_build_wait_time: :environment do
+    result = []
+
+    52.times do |i|
+      start = 1.year.ago + i.weeks
+      range = start..(start + 1.week)
+
+      deploys = Deploy.where(created_at: range, kubernetes: true).successful.order(created_at: :asc).
+        uniq { |d| d.job.commit }
+      builds = Build.where(git_sha: deploys.map { |d| d.job.commit }).order(created_at: :asc).
+        group(:project_id, :git_sha)
+      wait_times = deploys.map do |deploy|
+        build = builds.detect { |b| b.git_sha == deploy.job.commit } || next
+        diff = build.updated_at - deploy.created_at
+        diff > 1.hour ? next : [diff, 0].max
+      end.compact
+
+      next if wait_times.empty?
+      average = (wait_times.sum / wait_times.count).round
+
+      result << average
+
+      puts "#{start.strftime('%b, Week %W %Y')}, " \
+        "wait time: #{average}, number of builds: #{wait_times.count}, number of deploys: #{deploys.count}"
+    end
+
+    puts result
+  end
+end


### PR DESCRIPTION
This task spits out all of the deployment 'wait times' per week for the past year. Wait time is defined as the time between when the deploy is first created to when the build is finished. The data can be put into Google Sheets to generate a graph showing the trend in wait times over time. This is one for the past year:

<img width="602" alt="screen shot 2018-03-06 at 1 31 49 pm" src="https://user-images.githubusercontent.com/15261525/37059622-ca548054-2142-11e8-9724-a28c02591e3a.png">

@grosser @JLandersZen 
