### PR TITLE
avoid having extra threads around to make testing/dev saner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ ruby File.read('.ruby-version').strip
 group :preload do
   gem 'rails', '5.1.4'
   gem 'dotenv'
-  gem 'sse-rails-engine'
   gem 'connection_pool'
   gem 'marco-polo'
 
@@ -50,6 +49,7 @@ gem 'diffy'
 gem 'validates_lengths_from_database'
 gem 'large_object_store'
 gem 'parallel'
+gem 'sse-rails-engine'
 
 # treat included plugins like gems
 Dir[File.join(Bundler.root, 'plugins/*/')].each { |f| gemspec path: f }

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ Bundler.require(:assets) if Rails.env.development? || ENV["PRECOMPILE"]
 
 ###
 # Railties need to be loaded before the application is defined
-if ['development', 'staging'].include?(Rails.env)
+if ['development', 'staging'].include?(Rails.env) && ENV["SERVER_MODE"]
   require 'rack-mini-profiler' # side effect: removes expires headers
 end
 
@@ -25,6 +25,10 @@ else
 
   # needed even in dev/test mode
   require 'new_relic/agent/method_tracer'
+end
+
+if ENV["SERVER_MODE"]
+  require 'sse-rails-engine'
 end
 # END Railties
 ###
@@ -128,7 +132,10 @@ module Samson
     config.samson.auth.bitbucket = Samson::EnvCheck.set?("AUTH_BITBUCKET")
 
     config.samson.uri = URI(ENV["DEFAULT_URL"] || 'http://localhost:3000')
-    config.sse_rails_engine.access_control_allow_origin = config.samson.uri.to_s
+
+    if ENV["SERVER_MODE"]
+      config.sse_rails_engine.access_control_allow_origin = config.samson.uri.to_s
+    end
 
     config.samson.stream_origin = ENV['STREAM_ORIGIN'].presence || config.samson.uri.to_s
     config.samson.deploy_origin = ENV['DEPLOY_ORIGIN'].presence || config.samson.uri.to_s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,7 @@ Samson::Application.routes.draw do
 
   resources :access_requests, only: [:new, :create]
 
-  mount SseRailsEngine::Engine, at: '/streaming'
+  mount SseRailsEngine::Engine, at: '/streaming' if ENV["SERVER_MODE"]
 
   use_doorkeeper # adds oauth/* routes
   resources :oauth_test, only: [:index, :show] if %w[development test].include?(Rails.env)

--- a/lib/samson/boot_check.rb
+++ b/lib/samson/boot_check.rb
@@ -18,7 +18,8 @@ module Samson
           [
             ActiveRecord::Base.send(:descendants).map(&:name) - ["Audited::Audit"],
             ActionController::Base.descendants.map(&:name),
-            (defined?(Mocha) && "mocha")
+            (defined?(Mocha) && "mocha"),
+            Thread.list.count == 1 || "Extra threads"
           ].compact.flatten.each { |c| raise "#{c} should not be loaded" }
         end
       end

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -224,7 +224,6 @@ describe DeployService do
     end
 
     before do
-      SseRailsEngine.expects(:send_event).with('deploys', type: 'finish').never
       stage.stubs(:create_deploy).returns(deploy)
       deploy.stubs(:persisted?).returns(true)
       job_execution.stubs(:execute)

--- a/test/support/default_stubs.rb
+++ b/test/support/default_stubs.rb
@@ -3,7 +3,6 @@ ActiveSupport::TestCase.class_eval do
   before { create_default_stubs }
 
   def create_default_stubs
-    SseRailsEngine.stubs(:send_event).returns(true)
     Project.any_instance.stubs(:clone_repository).returns(true)
     Project.any_instance.stubs(:clean_repository).returns(true)
   end
@@ -11,6 +10,5 @@ ActiveSupport::TestCase.class_eval do
   def undo_default_stubs
     Project.any_instance.unstub(:clone_repository)
     Project.any_instance.unstub(:clean_repository)
-    SseRailsEngine.unstub(:send_event)
   end
 end

--- a/test/support/sse_rails_engine.rb
+++ b/test/support/sse_rails_engine.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# not loaded for tests, but a few places need it
+module SseRailsEngine
+  def self.send_event(*)
+  end
+end


### PR DESCRIPTION
@ragurney 

was debugging some tests and it spit out unexpected thread errors from sse-rails-engine ...
we don't need this when running console or tests, so let's just not load it ...
(loading it's routes spawns a heartbeat thread)

/fyi @zendesk/devex might be nice for other rails projects too