### PR TITLE
run dev in pura puma so we can reproduce restart issues better

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,14 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+# we don't want rails overhead when booting the server and behave like the real app server
+if ["s", "server"].include?(ARGV[0])
+  raise "No options supported, use puma directly" unless ARGV.size == 1
+  ENV.replace(Bundler::ORIGINAL_ENV) if defined?(Bundler) # fix bundle exec rails s
+  ENV["RAILS_LOG_TO_STDOUT"] ||= "1"
+  ENV["PORT"] ||= "3000"
+  exec *File.read("Dockerfile")[/^CMD \[(.*)\]/, 1].delete('",').split(" ")
+end
+
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,13 +4,7 @@ require_relative "boot"
 threads ENV.fetch('RAILS_MIN_THREADS', 8), ENV.fetch('RAILS_MAX_THREADS', 250)
 preload_app!
 
-port = 9080
-
-# make dev puma boot on port 3000
-# remove once https://github.com/puma/puma/pull/1277 is released
-port = 3000 if (ENV["RAILS_ENV"] || "development") == "development" && File.basename($0) == "rails"
-
-bind "tcp://0.0.0.0:#{port}"
+bind "tcp://0.0.0.0:#{ENV.fetch("PORT", 9080)}"
 
 # make puma restart reset modified ENV vars and BUNDLE_GEMFILE/RUBYLIB which are set via `bundle exec puma`
 # Bundler.original_env will not do since it already has a hardcoded BUNDLE_GEMFILE

--- a/lib/samson/initializer_logging.rb
+++ b/lib/samson/initializer_logging.rb
@@ -2,7 +2,7 @@
 
 # We saw initializers hanging boot so we are logging before every initializer is called to easily debug
 # Test: boot up rails and look at the logs
-if ENV['SERVER_MODE']
+if ENV['SERVER_MODE'] && !Rails.env.development?
   Rails::Engine.prepend(Module.new do
     def load(file, *)
       Rails.logger.info "Loading initializer #{file.sub("#{Rails.root}/", "")}"


### PR DESCRIPTION
without this sending signals to puma process does not reach RestartSignalHandler but goes straight to puma itself

checked that dev reload still works ... we'll see if we run into more issues ...

@jonmoter @ragurney 