### PR TITLE
cloning a template should not make the other a template

### DIFF
--- a/app/controllers/mass_rollouts_controller.rb
+++ b/app/controllers/mass_rollouts_controller.rb
@@ -135,9 +135,7 @@ class MassRolloutsController < ApplicationController
     stage = Stage.build_clone(
       template_stage,
       deploy_groups: [deploy_group],
-      name: deploy_group.name,
-      is_template: false,
-      next_stage_ids: []
+      name: deploy_group.name
     )
 
     stage.save!

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -51,7 +51,7 @@ class Stage < ActiveRecord::Base
   end
 
   def self.build_clone(old_stage, attributes = {})
-    new(old_stage.attributes.except("id", "next_stage_ids").merge(attributes)).tap do |new_stage|
+    new(old_stage.attributes.except("id", "next_stage_ids", "is_template").merge(attributes)).tap do |new_stage|
       Samson::Hooks.fire(:stage_clone, old_stage, new_stage)
       new_stage.command_ids = old_stage.command_ids
       new_stage.template_stage = old_stage


### PR DESCRIPTION
 - leads to confusion since there are multiple templates
 - leads to bugs if someone clones and then modifies a stage
 - rewriting tests to make them helpful when things break

@dragonfax @ragurney 