### PR TITLE
prefer previous builds when flag is used

### DIFF
--- a/test/lib/samson/build_finder_test.rb
+++ b/test/lib/samson/build_finder_test.rb
@@ -189,6 +189,17 @@ describe Samson::BuildFinder do
         setup_using_previous_builds
         execute.must_equal [build]
       end
+
+      it "prefers previous builds since that is what the user selected" do
+        setup_using_previous_builds
+        current = builds(:staging)
+        current.update_columns(
+          docker_repo_digest: 'ababababab',
+          git_sha: job.commit,
+          image_name: build.image_name
+        )
+        execute.must_equal [build]
+      end
     end
 
     describe "when using external builds" do


### PR DESCRIPTION
currently what often happens is that I deploy with reuse, but a new active build for the current sha is already building ... but I still want the old build so I can deploy right now and not wait for the new build to finish

@ragurney 