### PR TITLE
only prepend permalink when we actually replace dockerfile for more i…

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -92,11 +92,15 @@ class Project < ActiveRecord::Base
   end
 
   def docker_image(dockerfile)
-    name = permalink_base
-    if suffix = dockerfile.gsub(/^Dockerfile\.?|\/Dockerfile\.?/, '').presence
-      name << "-#{suffix.parameterize}"
+    if suffix = dockerfile.dup.gsub!(/(^|\/)Dockerfile\.?/, '')
+      if suffix.present?
+        "#{permalink_base}-#{suffix.parameterize}"
+      else
+        permalink_base
+      end
+    else
+      dockerfile
     end
-    name
   end
 
   def dockerfile_list

--- a/test/lib/samson/build_finder_test.rb
+++ b/test/lib/samson/build_finder_test.rb
@@ -226,7 +226,7 @@ describe Samson::BuildFinder do
 
         e = assert_raises(Samson::Hooks::UserError) { execute }
         e.message.must_equal(
-          "Did not find build for dockerfile \"foobar\" or image_name \"foo-foobar\".\nFound builds: []."
+          "Did not find build for dockerfile \"foobar\" or image_name \"foobar\".\nFound builds: []."
         )
       end
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -422,6 +422,18 @@ describe Project do
     it "builds nonstandard" do
       project.docker_image("Dockerfile.baz").must_equal "foo-baz"
     end
+
+    it "builds folders" do
+      project.docker_image("baz/Dockerfile").must_equal "foo-baz"
+    end
+
+    it "builds standard" do
+      project.docker_image("Dockerfile").must_equal "foo"
+    end
+
+    it "builds 1-off to allow flexibility" do
+      project.docker_image("wut").must_equal "wut"
+    end
   end
 
   describe '#soft_delete' do


### PR DESCRIPTION
…mage flexibility

```
[10:19:29] JobExecution failed: Did not find build for dockerfile "foo" or image_name "bar-foo".
[10:19:29] Found builds: [[nil, "foo"]].
```
