### PR TITLE
show on which cluster ssl errors happened since only http errors are …

### DIFF
--- a/plugins/kubernetes/config/initializers/kubeclient.rb
+++ b/plugins/kubernetes/config/initializers/kubeclient.rb
@@ -19,3 +19,13 @@ Kubeclient::Client.class_eval do
     end
   end
 end
+
+# we want know what cluster had ssl errors
+Kubeclient::Client.prepend(Module.new do
+  def handle_exception
+    super
+  rescue OpenSSL::SSL::SSLError
+    $!.message << " (#{@api_endpoint})" unless $!.message.frozen?
+    raise
+  end
+end)


### PR DESCRIPTION
…instrumented

atm we get unhelpful errors like
```
[17:31:57] JobExecution failed: SSL_connect SYSCALL returned=5 errno=0 state=unknown state
```
that do not tell us which server/deploy-group failed
... this will add the host the request was going too and make debugging easier

@jonmoter @ragurney 