### PR TITLE
Tag Production Images as 'Production'

### DIFF
--- a/plugins/gcloud/README.md
+++ b/plugins/gcloud/README.md
@@ -2,7 +2,8 @@
 
 ## Image tagging
 
-Tag gcloud images with the stage permalink they deployed to, so developers can pull down the "production" image.
+Tag gcloud images with the stage permalink they deployed to, so developers can pull down the a specific stage's image.
+If the stage is a production stage, the image is also tagged with 'production'.
 
 ## Image building
 

--- a/plugins/gcloud/test/samson_gcloud/image_tagger_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/image_tagger_test.rb
@@ -33,6 +33,26 @@ describe SamsonGcloud::ImageTagger do
       deploy.job.output.must_include "\nOUT\nSUCCESS"
     end
 
+    it 'tags with production if stage is production' do
+      deploy.stage.expects(:production?).returns(true)
+
+      Samson::CommandExecutor.expects(:execute).with(
+        'gcloud', 'container', 'images', 'add-tag', 'gcr.io/sdfsfsdf@some-sha', 'gcr.io/sdfsfsdf:production',
+        '--quiet', *auth_options, anything
+      ).returns([true, "OUT"])
+
+      Samson::CommandExecutor.expects(:execute).with(
+        'gcloud', 'container', 'images', 'add-tag', 'gcr.io/sdfsfsdf@some-sha', 'gcr.io/sdfsfsdf:staging',
+        '--quiet', *auth_options, anything
+      ).returns([true, "OUT"])
+
+      deploy.stage.permalink.wont_equal 'production'
+
+      tag
+
+      deploy.job.output.must_include "\nOUT\nSUCCESS"
+    end
+
     it "tags other regions" do
       build.update_column(:docker_repo_digest, 'asia.gcr.io/sdfsfsdf@some-sha')
       Samson::CommandExecutor.expects(:execute).returns([true, "OUT"])


### PR DESCRIPTION
Tag images considered to be production as 'production', otherwise us the stage permalink.