### PR TITLE
Only call function on objects with class

### DIFF
--- a/app/assets/javascripts/responsive_load.js.erb
+++ b/app/assets/javascripts/responsive_load.js.erb
@@ -1,6 +1,8 @@
 // show loading animation and errors inside the container that is being replaced
 $(document).ready(function () {
-  $('.lazy-load').responsiveLoad();
+  $('.lazy-load').each(function () {
+    $(this).responsiveLoad();
+  });
 });
 
 $.fn.responsiveLoad = function(url, callback){


### PR DESCRIPTION
The previous version causes a console error. It calls the function on the return value of `$()`, which is always an object, and the object that is returned when the selector doesn't match anything on the DOM doesn't have any of the necessary attributes. 