### PR TITLE
Shellescape secret values in terminal executor

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -133,7 +133,7 @@ class TerminalExecutor
       key = $1
       if expanded = resolver.expand('unused', key).first&.last
         key.replace(expanded)
-        Samson::Secrets::Manager.read(key, include_value: true).fetch(:value)
+        Samson::Secrets::Manager.read(key, include_value: true).fetch(:value).shellescape
       end
     end
 

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -221,6 +221,16 @@ describe TerminalExecutor do
         output.string.must_equal \
           "» export SECRET='secret://baz'; echo $SECRET\r\n#{secret.value}\r\n"
       end
+
+      it "escapes secret value with special characters" do
+        freeze_time
+
+        id = 'global/global/global/baz'
+        secret = create_secret(id, value: 'before; echo "after!"')
+        # author forgot to quote the export declaration to expose the raw content of the variable
+        subject.execute("export SECRET=secret://baz; echo $SECRET")
+        output.string.must_equal "#{secret.value}\r\n"
+      end
     end
   end
 


### PR DESCRIPTION
Escape secret values in terminal executor 

Feel free to suggest more test cases so I can update the PR. 
@grosser  @zendesk/devex 

### Reference
https://zendesk.atlassian.net/browse/DEVEX-364

### Risks
- Level: Low (tbc? @davidreuss)
