### PR TITLE
do not fail stats reporting when using memory store

### DIFF
--- a/config/initializers/periodical.rb
+++ b/config/initializers/periodical.rb
@@ -19,7 +19,7 @@ end
 
 Samson::Periodical.register :report_system_stats, "Report system stats" do
   memcached_available =
-    if Rails.env.test?
+    if Rails.cache.class == ActiveSupport::Cache::MemoryStore
       1
     else
       Rails.cache.instance_variable_get(:@data).send(:ring).servers.count(&:alive?)


### PR DESCRIPTION
```
(2018-04-03 21:46:30 +0000)  with error undefined method `ring' for {}:Hash
```