### PR TITLE
Use secret annotations instead of env vars when secrets are used in e…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 ## Secret storage
 # SECRET_STORAGE_BACKEND= # optional, should be one of: Samson::Secrets::DbBackend (default) or Samson::Secrets::HashicorpVaultBackend
 # SECRET_STORAGE_SHARING_GRANTS=true # optional, instead of sharing global secrets by default, access has to be granted
+# SECRET_ENV_AS_ANNOTATIONS=true # optional, convert env vars that include secrets to annotations
 # VAULT_PREFIX= # optional, what to prefix vault keys with if using Samson::Secrets::HashicorpVaultBackend
 
 ## Kubernetes

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -68,8 +68,8 @@ Samson::Hooks.callback :before_docker_build do |tmp_dir, build, _|
   SamsonEnv.write_env_files(tmp_dir, build.project, [])
 end
 
-Samson::Hooks.callback :deploy_group_env do |project, deploy_group|
-  EnvironmentVariable.env(project, deploy_group)
+Samson::Hooks.callback :deploy_group_env do |*args|
+  EnvironmentVariable.env(*args)
 end
 
 # TODO: make a edit page and link to that


### PR DESCRIPTION
…nv vars

@ragurney @jonmoter @davidreuss @KJTsanaktsidis 

failure scenarios:
 - unable to resolve secrets -> shows it as unresolved `secret://`
 - annotation already exists -> blow up

FYI related approach to auto-create secrets [commit](https://github.com/zendesk/samson/commit/504a0891be4fec5b5006d464c40c2ba54ac0f851)