### PR TITLE
Use the Ruby time not SQL one

### DIFF
--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -54,7 +54,7 @@ class Lock < ActiveRecord::Base
   end
 
   def self.remove_expired_locks
-    Lock.where("delete_at IS NOT NULL and delete_at < CURRENT_TIMESTAMP").find_each(&:soft_delete!)
+    Lock.where("delete_at IS NOT NULL and delete_at < ?", Time.now).find_each(&:soft_delete!)
   end
 
   def delete_in=(seconds)


### PR DESCRIPTION
CURRENT_TIMESTAMP is local while Rails may be configured to use another
timezone. These shouldn't be mixed in one place.

Fixes #2699 

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
