### PR TITLE
Use existing method to enable the buddy check

### DIFF
--- a/lib/buddy_check.rb
+++ b/lib/buddy_check.rb
@@ -2,7 +2,7 @@
 module BuddyCheck
   class << self
     def enabled?
-      ![nil, 'false'].include?(ENV["BUDDY_CHECK_FEATURE"])
+      Samson::EnvCheck.set?("BUDDY_CHECK_FEATURE")
     end
 
     # how long can the same commit be deployed ?


### PR DESCRIPTION
Previous method removed the previously-accepted "0" value. Now it
disables the check again.
To accomodate the buddy check which is default-enabled, add a parameter
to EnvCheck.

Closes #2707 

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
