### PR TITLE
Handle Stage deletes without pipeline plugin

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -238,7 +238,7 @@ class Stage < ActiveRecord::Base
 
   def destroy_stage_pipeline
     (project.stages - [self]).each do |s|
-      if s.next_stage_ids.delete(id)
+      if s.next_stage_ids&.delete(id)
         s.save(validate: false)
       end
     end

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -426,6 +426,12 @@ describe Stage do
       stage.soft_delete!(validate: false)
       refute other_stage.reload.next_stage_ids.include?(stage.id)
     end
+
+    it "removes the stage when other stages exist (issue #2719 regression)" do
+      Stage.any_instance.stubs(:next_stage_ids).returns(nil) # this happens when the pipeline plugin is disabled
+      other_stage = Stage.create!(project: stage.project, name: 'stage1')
+      stage.soft_delete!(validate: false)
+    end
   end
 
   describe '#script' do


### PR DESCRIPTION
When the pipeline plugin is disabled, the next_stage_ids is `nil`
rather than an empty array.
The test simulates it with a stub since we can't unload a plugin
modification of the model.

Closes #2719 

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
