### PR TITLE
make cache_key for deploy not need job, prepare for rails 5.2

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Deploy < ActiveRecord::Base
+  include Samson::BumpTouch
   has_soft_deletion default_scope: true
 
   belongs_to :stage, touch: true
@@ -35,10 +36,6 @@ class Deploy < ActiveRecord::Base
     "failed"     => "failed to deploy",
     "errored"    => "encountered an error deploying"
   }.freeze
-
-  def cache_key
-    [super, commit]
-  end
 
   # queue deploys on stages that cannot execute in parallel
   def job_execution_queue_name

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -127,6 +127,7 @@ class Job < ActiveRecord::Base
 
   def update_git_references!(commit:, tag:)
     update_columns(commit: commit, tag: tag)
+    deploy&.bump_touch
   end
 
   def url

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -190,6 +190,7 @@ class JobExecution
     tag = @repository.fuzzy_tag_from_ref(@reference)
     if commit
       @job.update_git_references!(commit: commit, tag: tag)
+
       @output.puts("Commit: #{commit}")
       true
     else

--- a/lib/samson/bump_touch.rb
+++ b/lib/samson/bump_touch.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Samson
+  module BumpTouch
+    def bump_touch
+      new = Time.now
+      new += 1 if new.to_i == updated_at.to_i
+      update_column(:updated_at, new)
+    end
+  end
+end

--- a/test/lib/samson/bump_touch_test.rb
+++ b/test/lib/samson/bump_touch_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::BumpTouch do
+  describe "#bump_touch" do
+    let(:deploy) { deploys(:succeeded_test) }
+
+    before { freeze_time }
+
+    it "touches when not in conflict" do
+      deploy.updated_at = 1.minute.ago
+      deploy.bump_touch
+      deploy.reload.updated_at.must_equal Time.now
+    end
+
+    it "bumps when new time would not be a change and cache would not expire" do
+      deploy.updated_at = Time.now
+      deploy.bump_touch
+      deploy.reload.updated_at.must_equal Time.now + 1
+    end
+  end
+end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -554,13 +554,6 @@ describe Deploy do
     end
   end
 
-  describe "#cache_key" do
-    it "includes self and commit" do
-      deploys(:succeeded_test).cache_key.
-        must_equal ["deploys/178003093-20140101201000000000", "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1"]
-    end
-  end
-
   describe ".csv_header" do
     it "has as many elements as csv_line does" do
       Deploy.csv_header.size.must_equal deploy.csv_line.size

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -192,6 +192,13 @@ describe Job do
       job.commit.must_equal "foo"
       job.tag.must_equal "bar"
     end
+
+    it "expires the deploy" do
+      job.deploy = deploys(:succeeded_test)
+      Rails.cache.fetch(job.deploy) { 1 }
+      job.update_git_references!(commit: "foo", tag: "bar")
+      Rails.cache.fetch(job.deploy) { 2 }.must_equal 2
+    end
   end
 
   describe "#url" do

--- a/test/support/query_counter.rb
+++ b/test/support/query_counter.rb
@@ -4,7 +4,7 @@ class ActiveSupport::TestCase
   # not on rails 5.1 payload[:name] could be used for finding schema queries, maybe fixed on 5.2/6.0
   SCHEMA_QUERIES = [
     "RELEASE SAVEPOINT", "SAVEPOINT", "SELECT column_name", "SHOW FULL FIELDS FROM", "SELECT a.attname",
-    "PRAGMA table_info", "SELECT sql FROM", "SHOW search_path"
+    "PRAGMA table_info", "SELECT sql FROM", "SHOW search_path", "SHOW max_identifier_length"
   ].freeze
 
   def sql_queries(&block)


### PR DESCRIPTION
saw the cache_key test failing on rails 5.2 and looked into why it was even there ...