### PR TITLE
Improve Rollbar plugin behaviour and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,3 +197,9 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # https://github.com/omniauth/omniauth-ldap/blob/master/README.md
 # https://github.com/omniauth/omniauth-ldap/blob/master/lib/omniauth/strategies/ldap.rb#L17
 # USE_LDAP_UID_AS_EXTERNAL_ID=1
+
+## Feature: Rollbar error reporting
+# Report Samson's internal failures to Rollbar service
+# ROLLBAR_ACCESS_TOKEN= # API token, required
+# ROLLBAR_URL=https://api.rollbar.com # optional, needed only for custom/test deployments
+# ROLLBAR_WEB_BASE=https://rollbar.com # optional, needed only for custom/test deployments

--- a/.env.example
+++ b/.env.example
@@ -201,5 +201,5 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 ## Feature: Rollbar error reporting
 # Report Samson's internal failures to Rollbar service
 # ROLLBAR_ACCESS_TOKEN= # API token, required
-# ROLLBAR_URL=https://api.rollbar.com # optional, needed only for custom/test deployments
-# ROLLBAR_WEB_BASE=https://rollbar.com # optional, needed only for custom/test deployments
+# ROLLBAR_URL=https://api.rollbar.com # optional
+# ROLLBAR_WEB_BASE=https://rollbar.com # optional

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -4,8 +4,8 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
   Rollbar.configure do |config|
     config.access_token = token
     config.environment = Rails.env
-    config.endpoint = ENV.fetch('ROLLBAR_URL') + '/api/1/item/' if ENV.has_key?('ROLLBAR_URL')
-    config.web_base = ENV.fetch('ROLLBAR_WEB_BASE') if ENV.has_key?('ROLLBAR_WEB_BASE')
+    config.endpoint = ENV.fetch('ROLLBAR_URL') + '/api/1/item/' if ENV.key?('ROLLBAR_URL')
+    config.web_base = ENV.fetch('ROLLBAR_WEB_BASE') if ENV.key?('ROLLBAR_WEB_BASE')
     config.use_thread # use threads for async notifications (waits for them at_exit)
     config.code_version = Rails.application.config.samson.version&.first(7)
     config.populate_empty_backtraces = true

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -4,8 +4,12 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
   Rollbar.configure do |config|
     config.access_token = token
     config.environment = Rails.env
-    config.endpoint = ENV.fetch('ROLLBAR_URL') + '/api/1/item/' if ENV.key?('ROLLBAR_URL')
-    config.web_base = ENV.fetch('ROLLBAR_WEB_BASE') if ENV.key?('ROLLBAR_WEB_BASE')
+    if url = ENV['ROLLBAR_URL']
+      config.endpoint = url + '/api/1/item/'
+    end
+    if web_base = ENV['ROLLBAR_WEB_BASE']
+      config.web_base = web_base
+    end
     config.use_thread # use threads for async notifications (waits for them at_exit)
     config.code_version = Rails.application.config.samson.version&.first(7)
     config.populate_empty_backtraces = true

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -4,8 +4,8 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
   Rollbar.configure do |config|
     config.access_token = token
     config.environment = Rails.env
-    config.endpoint = ENV.fetch('ROLLBAR_URL') + '/api/1/item/' if ENV.fetch('ROLLBAR_URL')
-    config.web_base = ENV.fetch('ROLLBAR_WEB_BASE') if ENV.fetch('ROLLBAR_WEB_BASE')
+    config.endpoint = ENV.fetch('ROLLBAR_URL') + '/api/1/item/' if ENV.has_key?('ROLLBAR_URL')
+    config.web_base = ENV.fetch('ROLLBAR_WEB_BASE') if ENV.has_key?('ROLLBAR_WEB_BASE')
     config.use_thread # use threads for async notifications (waits for them at_exit)
     config.code_version = Rails.application.config.samson.version&.first(7)
     config.populate_empty_backtraces = true

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -4,8 +4,8 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
   Rollbar.configure do |config|
     config.access_token = token
     config.environment = Rails.env
-    config.endpoint = ENV.fetch('ROLLBAR_URL') + '/api/1/item/'
-    config.web_base = ENV.fetch('ROLLBAR_URL')
+    config.endpoint = ENV.fetch('ROLLBAR_URL') + '/api/1/item/' if ENV.fetch('ROLLBAR_URL')
+    config.web_base = ENV.fetch('ROLLBAR_WEB_BASE') if ENV.fetch('ROLLBAR_WEB_BASE')
     config.use_thread # use threads for async notifications (waits for them at_exit)
     config.code_version = Rails.application.config.samson.version&.first(7)
     config.populate_empty_backtraces = true

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -15,7 +15,6 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
     config.populate_empty_backtraces = true
     config.logger = Rails.logger
     config.scrub_fields |= Rails.application.config.filter_parameters + ['HTTP_AUTHORIZATION']
-    config.enabled = true
 
     # ignore errors we do not want to send to Rollbar
     config.before_process << proc do |options|


### PR DESCRIPTION
Parameter ROLLBAR_URL is not required - the default urls are already
configured by the gem. Additionally it was incorrectly used for
the web_base parameter, which may not be the same url.

Make both optional, separate, and document all the parameters used.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
