### PR TITLE
do not fail on osx when changing directories for script execution

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -84,7 +84,8 @@ class TerminalExecutor
 
     # osx has a 4s startup delay for each new executable, so we keep the executable stable
     if RbConfig::CONFIG['host_os'].include?('darwin')
-      command = "export FILE=#{f.path.shellescape} && #{File.expand_path("bin/script-executor").shellescape}"
+      executor = File.expand_path("../../bin/script-executor", __dir__)
+      command = "export FILE=#{f.path.shellescape} && #{executor.shellescape}"
     end
 
     yield command

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -125,11 +125,20 @@ describe TerminalExecutor do
       output.string.must_equal "Hello\rWorld\r\n"
     end
 
-    it "uses script-executor to avoid slowness on osx" do
-      RbConfig::CONFIG.expects(:[]).with("host_os").returns("darwin-foo")
-      PTY.expects(:spawn).with { |_, command, _| command.must_include("script-executor") }
-      TerminalExecutor.any_instance.expects(:record_pid)
-      subject.execute('echo "hi"')
+    describe "with script-executor" do
+      before { RbConfig::CONFIG.expects(:[]).with("host_os").returns("darwin-foo") }
+
+      it "uses script-executor to avoid slowness on osx" do
+        PTY.expects(:spawn).with { |_, command, _| command.must_include("script-executor") }
+        TerminalExecutor.any_instance.expects(:record_pid)
+        subject.execute('echo "hi"')
+      end
+
+      it "works while switching directories" do
+        Dir.chdir "/tmp" do
+          assert subject.execute('echo "hi"')
+        end
+      end
     end
 
     it "uses regular executor on linux" do


### PR DESCRIPTION
Dir.chdir should never be used since it is not threadsafe, but we use it in testing

fixes https://github.com/zendesk/samson/issues/2727