### PR TITLE
keep namespaces of resources and poddisruptionbudget in sync

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -108,6 +108,7 @@ module Kubernetes
         kind: "PodDisruptionBudget",
         metadata: {
           name: kubernetes_role.resource_name,
+          namespace: raw_template.first.dig(:metadata, :namespace),
           labels: raw_template.first.dig_fetch(:metadata, :labels).dup
         },
         spec: {

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -83,6 +83,7 @@ describe Kubernetes::ReleaseDoc do
       it "adds relative PodDisruptionBudget when requested" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '30%'}
         create!.resource_template[2][:spec][:minAvailable].must_equal 1
+        create!.resource_template[2][:metadata][:namespace].must_equal 'pod1'
       end
 
       it "adds valid relative PodDisruptionBudget when sometimes invalid is requested" do
@@ -98,6 +99,14 @@ describe Kubernetes::ReleaseDoc do
       it "adds absolute PodDisruptionBudget when requested" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '1'}
         create!.resource_template[2][:spec][:minAvailable].must_equal 1
+      end
+
+      it "uses the same namespace as the resource" do
+        metadata = template.dig(0, :metadata)
+        metadata[:annotations] = {"samson/minAvailable": '30%'}
+        metadata[:namespace] = "default"
+        metadata[:labels][:'kubernetes.io/cluster-service'] = 'true'
+        create!.resource_template[2][:metadata][:namespace].must_equal 'default'
       end
     end
   end


### PR DESCRIPTION
... deploying them to 2 different namespaces is a bug / makes them useless