### PR TITLE
Always show 'Dockerfiles' field

### DIFF
--- a/app/views/projects/_docker_fields.html.erb
+++ b/app/views/projects/_docker_fields.html.erb
@@ -4,7 +4,7 @@
   </legend>
   <% form_obj = form.object %>
   <% if form_obj.force_external_build? %>
-    <%= form.hidden_field :docker_build_method, value: "docker_image_building_disabled" if form_obj.new_record?%>
+    <%= form.hidden_field :docker_build_method, value: "docker_image_building_disabled" if form_obj.new_record? %>
     <span>
       Configured to use externally built docker images only, click
       <%= link_to "here", "https://zendesk.atlassian.net/wiki/spaces/TOOLS/pages/274488773/Building+Docker+Images+using+Google+Container+Builder", target: '_blank' %>
@@ -18,8 +18,7 @@
           class: "form-control"
       %>
     <% end %>
-
     <%= form.input :docker_release_branch, help: 'New commits on this branch will cause a docker image to be built when a webhook arrives.' %>
-    <%= form.input :dockerfiles, help: 'Space separated list of dockerfiles to build, default: Dockerfile' %>
   <% end %>
+  <%= form.input :dockerfiles, help: 'Space separated list of dockerfiles to build, default: Dockerfile' %>
 </fieldset>

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -172,16 +172,18 @@ describe ProjectsController do
       it "renders with docker fields" do
         with_env DOCKER_FORCE_EXTERNAL_BUILD: nil do
           get :edit, params: {id: project.to_param}
-          @response.body.must_include "Docker release branch"
-          @response.body.must_include "Dockerfiles"
+          assert_select 'select[id=project_docker_build_method]'
+          assert_select 'input[id=project_docker_release_branch]'
+          assert_select 'input[id=project_dockerfiles]'
         end
       end
 
       it "renders without docker fields" do
         with_env DOCKER_FORCE_EXTERNAL_BUILD: "1" do
           get :edit, params: {id: project.to_param}
-          @response.body.wont_include "Docker release branch"
-          @response.body.wont_include "Dockerfiles"
+          assert_select 'input[id=project_docker_release_branch]', count: 0
+          assert_select 'select[id=project_docker_build_method]', count: 0
+          assert_select 'input[id=project_dockerfiles]'
         end
       end
 


### PR DESCRIPTION
Always show Dockerfields input to allow `builds_in_environment` functionality. 
#2714