### PR TITLE
Prevent large screen jumps on load of Rollbar Dashboards

### DIFF
--- a/plugins/rollbar_dashboards/app/assets/stylesheets/rollbar_dashboards/application.css
+++ b/plugins/rollbar_dashboards/app/assets/stylesheets/rollbar_dashboards/application.css
@@ -1,0 +1,3 @@
+.dashboard-container {
+  margin-bottom: 20px;
+}

--- a/plugins/rollbar_dashboards/app/helpers/rollbar_dashboards/dashboards_helper.rb
+++ b/plugins/rollbar_dashboards/app/helpers/rollbar_dashboards/dashboards_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RollbarDashboards
+  module DashboardsHelper
+    DASHBOARD_HEIGHT = 22 # em
+
+    def rollbar_dashboard_placeholder_size(settings)
+      settings.size * DASHBOARD_HEIGHT
+    end
+
+    def rollbar_dashboard_container(item_path, settings)
+      content_tag(
+        :div,
+        '',
+        class: 'lazy-load dashboard-container',
+        style: "min-height: #{rollbar_dashboard_placeholder_size(settings)}em;",
+        data: {
+          url: item_path,
+          delay: 1000
+        }
+      )
+    end
+  end
+end

--- a/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_deploy.html.erb
+++ b/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_deploy.html.erb
@@ -1,13 +1,8 @@
-<% if deploy.project.rollbar_dashboards_settings.any? && deploy.succeeded? %>
+<% if (settings = deploy.project.rollbar_dashboards_settings.presence) && deploy.succeeded? %>
   <%# replaced by responsive_load.js.erb %>
-  <%= content_tag(
-      :span,
-      '',
-      class: 'lazy-load',
-      data: {
-          url: deploy_dashboard_deploy_rollbar_dashboards_dashboards_path(deploy),
-          delay: 1000
-      }
-    )
+  <%= rollbar_dashboard_container(
+        deploy_dashboard_deploy_rollbar_dashboards_dashboards_path(deploy),
+        settings
+      )
   %>
 <% end %>

--- a/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_project.html.erb
+++ b/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_project.html.erb
@@ -1,13 +1,8 @@
-<% if project.rollbar_dashboards_settings.any? %>
+<% if settings = project.rollbar_dashboards_settings.presence %>
   <%# replaced by responsive_load.js.erb %>
-  <%= content_tag(
-        :span,
-        '',
-        class: 'lazy-load',
-        data: {
-            url: project_dashboard_project_rollbar_dashboards_dashboards_path(project),
-            delay: 1000
-        }
+  <%= rollbar_dashboard_container(
+        project_dashboard_project_rollbar_dashboards_dashboards_path(project),
+        settings
       )
   %>
 <% end %>

--- a/plugins/rollbar_dashboards/test/helpers/rollbar_dashboards/dashboards_helper_test.rb
+++ b/plugins/rollbar_dashboards/test/helpers/rollbar_dashboards/dashboards_helper_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+SingleCov.covered!
+
+describe RollbarDashboards::DashboardsHelper do
+  describe '#rollbar_dashboard_placeholder_size' do
+    it 'reports correct size' do
+      settings = mock(size: 2)
+      rollbar_dashboard_placeholder_size(settings).must_equal 44
+    end
+  end
+
+  describe '#rollbar_dashboard_container' do
+    let(:path) { 'dummy/path' }
+    let(:settings) { mock('RollbarDashboards::Setting', size: 1) }
+
+    it 'renders containter div' do
+      rollbar_dashboard_container(path, settings).must_equal <<~HTML.delete("\n")
+        <div class="lazy-load dashboard-container" style="min-height: 22em;" data-url="dummy/path" data-delay="1000">
+        </div>
+      HTML
+    end
+  end
+end


### PR DESCRIPTION
Previously there were large screen jumps once the Rollbar Dashboard was loaded. This attempts to mitigate that by setting a min height for the dashboard container. 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15261525/39643057-5901cc3a-4f88-11e8-9003-a38312eab436.gif)
