### PR TITLE
Add link back to triggering deploy

### DIFF
--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -1,5 +1,5 @@
 <h1>
-  <%= @project.name %>
+  <%= "#{@project.name} - Deploy ##{@deploy.id}" %>
 
   <div class="pull-right">
     <% if deployer_for_project? %>
@@ -23,5 +23,5 @@
   <%= render 'jobs/restarting' %>
 <% else %>
   <%= status_panel @deploy %>
-  <%= Samson::Hooks.render_views(:deploys_header, self) %>
+  <%= Samson::Hooks.render_views(:deploys_header, self, deploy: @deploy) %>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180329204838) do
+ActiveRecord::Schema.define(version: 20180510172630) do
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id", null: false
@@ -119,11 +119,13 @@ ActiveRecord::Schema.define(version: 20180329204838) do
     t.boolean "kubernetes_rollback", default: true, null: false
     t.boolean "kubernetes_reuse_build", default: false, null: false
     t.text "env_state"
+    t.integer "triggering_deploy_id"
     t.index ["build_id"], name: "index_deploys_on_build_id"
     t.index ["deleted_at"], name: "index_deploys_on_deleted_at"
     t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
     t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at"
     t.index ["stage_id", "deleted_at"], name: "index_deploys_on_stage_id_and_deleted_at"
+    t.index ["triggering_deploy_id"], name: "index_deploys_on_triggering_deploy_id"
   end
 
   create_table "environment_variable_groups", id: :integer, force: :cascade do |t|
@@ -598,6 +600,7 @@ ActiveRecord::Schema.define(version: 20180329204838) do
   end
 
   add_foreign_key "deploy_groups", "environments"
+  add_foreign_key "deploys", "deploys", column: "triggering_deploy_id"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
 end

--- a/plugins/jenkins/app/views/samson_jenkins/_deploys_header.html.erb
+++ b/plugins/jenkins/app/views/samson_jenkins/_deploys_header.html.erb
@@ -1,9 +1,9 @@
-<% if @deploy.stage.jenkins_job_names? && @deploy.jenkins_jobs.none? && @deploy.active? %>
-  <% @deploy.stage.jenkins_job_names.to_s.split(/, ?/).map do |jenkins_job_name| %>
-    <div class="alert alert-info">Jenkins build <%= jenkins_job_name %> for <%= @deploy.stage.name %> will start after successful deploy. Reload this page after deploy is finished to get latest status.</div>
+<% if deploy.stage.jenkins_job_names? && deploy.jenkins_jobs.none? && deploy.active? %>
+  <% deploy.stage.jenkins_job_names.to_s.split(/, ?/).map do |jenkins_job_name| %>
+    <div class="alert alert-info">Jenkins build <%= jenkins_job_name %> for <%= deploy.stage.name %> will start after successful deploy. Reload this page after deploy is finished to get latest status.</div>
   <% end %>
 <% end %>
 
-<% @deploy.jenkins_jobs.each do |jenkins_job| %>
-  <%= jenkins_status_panel @deploy, jenkins_job %>
+<% deploy.jenkins_jobs.each do |jenkins_job| %>
+  <%= jenkins_status_panel deploy, jenkins_job %>
 <% end %>

--- a/plugins/pipelines/app/decorators/deploy_decorator.rb
+++ b/plugins/pipelines/app/decorators/deploy_decorator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Deploy.class_eval do
+  belongs_to :triggering_deploy, class_name: 'Deploy', foreign_key: 'triggering_deploy_id', optional: true
+end

--- a/plugins/pipelines/app/views/samson_pipelines/_deploy_header.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_deploy_header.html.erb
@@ -1,0 +1,5 @@
+<% if triggering_deploy = deploy.triggering_deploy %>
+  <div class="alert alert-info">
+    Triggered via <%= link_to "Deploy ##{triggering_deploy.id}", project_deploy_path(deploy.project, triggering_deploy) %>
+  </div>
+<% end %>

--- a/plugins/pipelines/db/migrate/20180510172630_add_pipelined_to_deploys.rb
+++ b/plugins/pipelines/db/migrate/20180510172630_add_pipelined_to_deploys.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPipelinedToDeploys < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :deploys, :triggering_deploy, foreign_key: {to_table: :deploys}, type: :integer
+  end
+end

--- a/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
+++ b/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
@@ -14,12 +14,13 @@ module SamsonPipelines
 
     private
 
-    def deploy_to_stage(stage, template_deploy, output)
-      deploy_service = DeployService.new(template_deploy.user)
+    def deploy_to_stage(stage, previous_deploy, output)
+      deploy_service = DeployService.new(previous_deploy.user)
       deploy = deploy_service.deploy(
         stage,
-        reference: template_deploy.reference,
-        buddy: template_deploy.buddy
+        reference: previous_deploy.reference,
+        buddy: previous_deploy.buddy,
+        triggering_deploy: previous_deploy
       )
       raise deploy.errors.full_messages.join(", ") unless deploy.persisted?
 
@@ -32,6 +33,7 @@ end
 
 Samson::Hooks.view :stage_form, "samson_pipelines/stage_form"
 Samson::Hooks.view :stage_show, "samson_pipelines/stage_show"
+Samson::Hooks.view :deploys_header, "samson_pipelines/deploy_header"
 
 Samson::Hooks.callback :stage_permitted_params do
   {next_stage_ids: []}

--- a/plugins/pipelines/test/decorators/deploy_decorator_test.rb
+++ b/plugins/pipelines/test/decorators/deploy_decorator_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe Deploy do
+  describe '#triggering_deploy' do
+    let(:deploy) { deploys(:succeeded_test) }
+
+    it 'references triggering deploy' do
+      other_deploy = deploys(:succeeded_production_test)
+
+      deploy.update_column(:triggering_deploy_id, other_deploy.id)
+      deploy.triggering_deploy.must_equal other_deploy
+    end
+
+    it 'can have a null triggering deploy' do
+      new_deploy = Deploy.new(deploy.attributes.except('id', 'created_at', 'updated_at'))
+      new_deploy.triggering_deploy_id.must_equal nil
+
+      assert_predicate new_deploy, :valid?
+    end
+  end
+end

--- a/plugins/pipelines/test/samson_pipelines/samson_plugin_test.rb
+++ b/plugins/pipelines/test/samson_pipelines/samson_plugin_test.rb
@@ -24,9 +24,9 @@ describe SamsonPipelines do
 
     it 'kicks off the next stages in the deploy' do
       DeployService.any_instance.expects(:deploy).
-        with(stages(:test_production), reference: 'staging', buddy: nil).returns(deploy)
+        with(stages(:test_production), reference: 'staging', buddy: nil, triggering_deploy: deploy).returns(deploy)
       DeployService.any_instance.expects(:deploy).
-        with(stages(:test_production_pod), reference: 'staging', buddy: nil).returns(deploy)
+        with(stages(:test_production_pod), reference: 'staging', buddy: nil, triggering_deploy: deploy).returns(deploy)
       Samson::Hooks.fire(:after_job_execution, job, true, output)
       output.string.must_equal "# Pipeline: Started stage: 'Production' - #{deploy.url}\n" \
         "# Pipeline: Started stage: 'Production Pod' - #{deploy.url}\n"
@@ -91,6 +91,39 @@ describe SamsonPipelines do
   describe :stage_permitted_params do
     it "lists extra keys" do
       Samson::Hooks.fire(:stage_permitted_params).must_include next_stage_ids: []
+    end
+  end
+
+  describe 'view callbacks' do
+    let(:view_context) do
+      view_context = ActionView::Base.new(ActionController::Base.view_paths)
+
+      class << view_context
+        include Rails.application.routes.url_helpers
+      end
+
+      view_context
+    end
+
+    describe 'deploys_header callback' do
+      def render_view
+        Samson::Hooks.render_views(:deploys_header, view_context, deploy: deploy)
+      end
+
+      let(:deploy) { deploys(:succeeded_test) }
+
+      it 'renders alert if there is a triggering deploy' do
+        other_deploy = deploys(:succeeded_production_test)
+        deploy.update_column(:triggering_deploy_id, other_deploy.id)
+
+        html = render_view
+        html.must_match 'alert-info'
+        html.must_match "<a href=\"/projects/foo/deploys/#{other_deploy.id}"
+      end
+
+      it 'renders nothing if there is no triggering deploy' do
+        render_view.must_equal "\n"
+      end
     end
   end
 end


### PR DESCRIPTION
There have been a couple of cases where people don't know if a stage was triggered manually or via pipeline. This adds a nice convenience message that tells people the stage was triggered via a pipelined stage and links to the deploy that kicked it off.

<img width="1267" alt="screen shot 2018-05-10 at 12 09 58 pm" src="https://user-images.githubusercontent.com/15261525/39889580-3109170a-544d-11e8-914b-43b23a07a18c.png">

