### PR TITLE
Make a deploy's env var state reflect precedence rules

### DIFF
--- a/app/models/concerns/group_scope.rb
+++ b/app/models/concerns/group_scope.rb
@@ -30,8 +30,6 @@ module GroupScope
     end
   end
 
-  private
-
   def priority
     [
       (project? ? 0 : 1),

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -20,7 +20,7 @@ class EnvironmentVariable < ActiveRecord::Base
     # also used by an external plugin
     def env(project, deploy_group, preview: false, resolve_secrets: true)
       variables = nested_variables(project)
-      variables.sort_by! { |ev| ev.send(:priority) }
+      variables.sort_by!(&:priority)
       env = variables.each_with_object({}) do |ev, all|
         all[ev.name] = ev.value if !all[ev.name] && ev.matches_scope?(deploy_group)
       end

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -12,17 +12,17 @@ module SamsonEnv
       write_dotenv("#{dir}/.env", groups)
     end
 
-    def env_groups(project, deploy_groups, preview: false)
+    def env_groups(project, deploy_groups, **kwargs)
       groups =
         if deploy_groups.any?
           deploy_groups.map do |deploy_group|
             [
               ".#{deploy_group.name.parameterize}",
-              EnvironmentVariable.env(project, deploy_group, preview: preview)
+              EnvironmentVariable.env(project, deploy_group, **kwargs)
             ]
           end
         else
-          [["", EnvironmentVariable.env(project, nil, preview: preview)]]
+          [["", EnvironmentVariable.env(project, nil, **kwargs)]]
         end
       return groups if groups.any? { |_, data| data.present? }
     end

--- a/plugins/kubernetes/app/models/kubernetes/usage_limit.rb
+++ b/plugins/kubernetes/app/models/kubernetes/usage_limit.rb
@@ -11,7 +11,7 @@ class Kubernetes::UsageLimit < ActiveRecord::Base
   validates :scope_id, uniqueness: {scope: [:scope_type, :project_id]}
 
   def self.most_specific(project, deploy_group)
-    all.sort_by { |l| l.send :priority }.detect { |l| l.send(:matches?, project, deploy_group) }
+    all.sort_by(&:priority).detect { |l| l.send(:matches?, project, deploy_group) }
   end
 
   private

--- a/test/models/concerns/group_scope_test.rb
+++ b/test/models/concerns/group_scope_test.rb
@@ -37,25 +37,25 @@ describe GroupScope do
   describe "#priority" do
     it "fails on bad references" do
       e = assert_raises RuntimeError do
-        EnvironmentVariable.new(scope_type: 'Foo', scope_id: 123).send(:priority)
+        EnvironmentVariable.new(scope_type: 'Foo', scope_id: 123).priority
       end
       e.message.must_equal "Unsupported scope Foo"
     end
 
     it "is higher with project" do
-      EnvironmentVariable.new(parent_type: 'Project').send(:priority).must_equal [0, 2]
+      EnvironmentVariable.new(parent_type: 'Project').priority.must_equal [0, 2]
     end
 
     it "is lower without project" do
-      EnvironmentVariable.new.send(:priority).must_equal [1, 2]
+      EnvironmentVariable.new.priority.must_equal [1, 2]
     end
 
     it "is higher with deploy group" do
-      EnvironmentVariable.new(scope_type: 'DeployGroup').send(:priority).must_equal [1, 0]
+      EnvironmentVariable.new(scope_type: 'DeployGroup').priority.must_equal [1, 0]
     end
 
     it "is lower with environment" do
-      EnvironmentVariable.new(scope_type: 'Environment').send(:priority).must_equal [1, 1]
+      EnvironmentVariable.new(scope_type: 'Environment').priority.must_equal [1, 1]
     end
   end
 


### PR DESCRIPTION
Deploy environment variable diffs were previously showing environment variable diffs that weren't going to be used for that deploy (e.g. `FOO=bar #All, FOO=bar #pod100`, though only the variable scoped to the `pod100` Deploy Group would be used in the deploy). This will update the diff to more accurately reflect which environment variables will be used, and so only show diffs that people care about. 

/cc @jonmoter 

### Tasks
 - [x] Rebase when #2743 is merged
 - [x] :+1: from team
 - [ ] Notify people that their env diffs will change once this is released? 

### References
 - [DEVEX-639](https://zendesk.atlassian.net/browse/DEVEX-639)
