### PR TITLE
Replace tooltip that has passive aggressive tone

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -66,11 +66,6 @@ module DeploysHelper
     html_options = {method: :post}
     if @deploy.succeeded?
       html_options[:class] = 'btn btn-default'
-      html_options[:data] = {
-        toggle: 'tooltip',
-        placement: 'auto bottom'
-      }
-      html_options[:title] = 'Why? This deploy succeeded.'
     else
       html_options[:class] = 'btn btn-danger'
     end

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -66,6 +66,11 @@ module DeploysHelper
     html_options = {method: :post}
     if @deploy.succeeded?
       html_options[:class] = 'btn btn-default'
+      html_options[:data] = {
+        toggle: 'tooltip',
+        placement: 'auto bottom'
+      }
+      html_options[:title] = 'Previous deploy succeeded.'
     else
       html_options[:class] = 'btn btn-danger'
     end

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -144,7 +144,7 @@ describe DeploysHelper do
   end
 
   describe "#redeploy_button" do
-    let(:redeploy_warning) { "Previous deploy succeeded" }
+    let(:redeploy_warning) { "Previous deploy succeeded." }
 
     before do
       @deploy = deploy

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -144,7 +144,7 @@ describe DeploysHelper do
   end
 
   describe "#redeploy_button" do
-    let(:redeploy_warning) { "Why? This deploy succeeded." }
+    let(:redeploy_warning) { "Previous deploy succeeded" }
 
     before do
       @deploy = deploy


### PR DESCRIPTION
/cc @zendesk/samson

### Description 

The tooltip that appears below the `Redeploy` button has a passive aggressive tone. There are many reasons why a successful deploy might need to be redeployed. For instance, if the deploy was based off a branch, maybe the branch has new commits and a redeploy would deploy those changes. 

This pull request changes the tooltip to have a neutral tone but still provide the same value (warn against redeploying a successful deploy).  

### Screenshots

<img width="194" alt="why" src="https://user-images.githubusercontent.com/3042264/40085506-ff7e42d8-58dd-11e8-90f2-08f7cffd1c94.png">

![screen shot 2018-05-16 at 7 55 46 am](https://user-images.githubusercontent.com/3042264/40085694-b7d6ddea-58de-11e8-92c0-e1ce05832001.png)

### Tasks
 - [x] :+1: from team

### References
 - Jira link: N/A

### Risks
- Level: Low, changes the display value of a tooltip
