### PR TITLE
unbreak heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: bundle exec rails s
+# TODO: using 'bundle exec rails c' fails to boot a server on heroku because of a LOAD_PATH issue
+web: bundle exec puma -C config/puma.rb

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails s -p $PORT
+web: bundle exec rails s


### PR DESCRIPTION
`bin/rails:6:in '<main>': No options supported, use puma directly (RuntimeError)`