### PR TITLE
allow reverting PodDisruptionBudget, they need to be created without …

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -106,7 +106,10 @@ module Kubernetes
 
       # TODO: remove the expire_cache and assign @resource but that breaks a bunch of deploy_executor tests
       def create
-        request(:create, @template)
+        restore_template do
+          @template[:metadata].delete(:resourceVersion)
+          request(:create, @template)
+        end
         expire_cache
       end
 


### PR DESCRIPTION
…resourceVersion

I was rolling back a failed deploy when I saw:

```
[17:01:31] Rolling back PodX role kube-stats
[17:01:35] FAILED: resourceVersion may not be set on objects to be created
```

which means the rollback failed and the resource stayed deleted (deploy is delete+create)
so need to fix that :)

/cc @zendesk/compute @ragurney 