### PR TITLE
[DEVEX-717] Fix duration display issue, and job/deploy updated_at behavior

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -156,7 +156,7 @@ class Job < ActiveRecord::Base
   end
 
   def status!(status)
-    success = update_column(:status, status)
+    success = update_attribute(:status, status)
     report_state if finished?
     success
   end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -397,6 +397,20 @@ describe Job do
 
       job.send(:status!, 'pending')
     end
+
+    it 'updates deploy updated_at' do
+      job = jobs(:succeeded_test)
+      deploy = job.deploy
+
+      freeze_time do
+        deploy.update_column(:updated_at, 1.day.ago)
+        deploy.updated_at.wont_equal Time.now
+
+        job.send(:status!, 'succeeded')
+
+        deploy.updated_at.must_equal Time.now
+      end
+    end
   end
 
   describe "#report_state" do


### PR DESCRIPTION
Fixes issue where duration time on deploy header [rendered via stream controller](https://github.com/zendesk/samson/blob/master/app/controllers/streams_controller.rb#L57) was incorrect, as the deploy `updated_at` was not being updated on `job.success!` but rather `job.update_output!` which is called after the header is rendered: 
https://github.com/zendesk/samson/blob/55c1a3250fd90018642e527fd310f59a9e1e2be3/app/models/job_execution.rb#L40-L43

Seems like we should be updating the deploy `updated_at` if the job's `updated_at` changes for statuses as well. 

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
[DEVEX-717](https://zendesk.atlassian.net/browse/DEVEX-717)
