### PR TITLE
do not blow up the release index page when a deploy group was removed

### DIFF
--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
@@ -36,7 +36,7 @@
           <% unless @project %>
             <td><%= link_to deploy_group_role.project.name, deploy_group_role.project %></td>
           <% end %>
-          <td><%= link_to deploy_group_role.deploy_group.name, deploy_group_role.deploy_group %></td>
+          <td><%= DeployGroup.with_deleted { link_to deploy_group_role.deploy_group.name, deploy_group_role.deploy_group } %></td>
           <td><%= link_to deploy_group_role.kubernetes_role.name, [deploy_group_role.project, deploy_group_role.kubernetes_role] %></td>
           <td><%= deploy_group_role.requests_cpu %> to <%= deploy_group_role.limits_cpu %></td>
           <td><%= deploy_group_role.requests_memory %> to <%= deploy_group_role.limits_memory %></td>

--- a/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
@@ -38,7 +38,7 @@
               <%= link_to "Build", project_builds_path(@project, search: {git_sha: kubernetes_release.git_sha}) %>
             </td>
             <td>
-              <% kubernetes_release.release_docs.map(&:deploy_group).uniq.sort_by(&:natural_order).each do |deploy_group| %>
+              <% DeployGroup.with_deleted { kubernetes_release.release_docs.map(&:deploy_group) }.uniq.sort_by(&:natural_order).each do |deploy_group| %>
                  <span class="label label-info"><%= deploy_group.name %></span>
               <% end %>
             </td>

--- a/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
@@ -27,6 +27,12 @@ describe Kubernetes::DeployGroupRolesController do
         assigns[:deploy_group_roles].must_include deploy_group_role
       end
 
+      it "renders when deploy group got deleted" do
+        kubernetes_release_docs(:test_release_pod_1).deploy_group.update_column(:deleted_at, Time.now)
+        get :index
+        assert_template :index
+      end
+
       it "renders as project tab" do
         get :index, params: {project_id: project}
         assert_template :index

--- a/plugins/kubernetes/test/controllers/kubernetes/releases_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/releases_controller_test.rb
@@ -15,6 +15,12 @@ describe Kubernetes::ReleasesController do
         get :index, params: {project_id: :foo}
         assert_response :success
       end
+
+      it "does not blow up when a deploy group was removed" do
+        kubernetes_release_docs(:test_release_pod_1).deploy_group.update_column(:deleted_at, Time.now)
+        get :index, params: {project_id: :foo}
+        assert_response :success
+      end
     end
 
     describe '#show' do


### PR DESCRIPTION
@ragurney @jonmoter 

https://rollbar-us.zendesk.com/Zendesk/Samson/items/146/occurrences/783863930/
https://rollbar-us.zendesk.com/Zendesk/Samson/items/147/occurrences/784082700/