### PR TITLE
do not auto-add pod disruption budgets when replica size is unknown

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -92,7 +92,7 @@ module Kubernetes
       end
       return if min_available == "disabled"
 
-      if !min_available && replica_target > 1
+      if !min_available && replica_target > 1 && !kubernetes_role.autoscaled?
         min_available = ENV["KUBERNETES_AUTO_MIN_AVAILABLE"]
       end
       return unless min_available

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -110,8 +110,13 @@ describe Kubernetes::ReleaseDoc do
           create!.resource_template[2][:spec][:minAvailable].must_equal 1
         end
 
-        it "does not add for things that are not highly available anyway" do
+        it "does not add when not highly available" do
           doc.replica_target = 1
+          refute create!.resource_template[2]
+        end
+
+        it "does not add when replicas are unknown" do
+          doc.kubernetes_role.update_column(:autoscaled, true)
           refute create!.resource_template[2]
         end
 


### PR DESCRIPTION
@jonmoter @adammw @bquorning 

/cc @zendesk/skyfox 
