### PR TITLE
add rename_project secrets helper so I do not fat-finger it on the console

### DIFF
--- a/test/lib/samson/secrets/manager_test.rb
+++ b/test/lib/samson/secrets/manager_test.rb
@@ -158,6 +158,16 @@ describe Samson::Secrets::Manager do
     end
   end
 
+  describe ".rename_project" do
+    it "copies secrets and tells user how many were copied" do
+      create_secret "global/bar/global/bar" # create a bogus secret to make sure we filter
+      secret # trigger creation
+      Samson::Secrets::Manager.rename_project("foo", "baz").must_equal 1
+      assert Samson::Secrets::Manager.read('production/foo/pod2/hello')
+      assert Samson::Secrets::Manager.read('production/baz/pod2/hello')
+    end
+  end
+
   describe ".exist?" do
     it "is true when when it exists" do
       Samson::Secrets::Manager.exist?(secret.id).must_equal true


### PR DESCRIPTION
/cc @zendesk/samson @zendesk/compute 

we had to rename a few projects and it involved console sessions ... so would be nice to have a tested/reviewed helper for that