### PR TITLE
try to fix random error

### DIFF
--- a/test/models/restart_signal_handler_test.rb
+++ b/test/models/restart_signal_handler_test.rb
@@ -74,6 +74,7 @@ describe RestartSignalHandler do
       silence_thread_exceptions do
         assert_raises(RuntimeError) { handle }.message.must_equal "Whoops"
       end
+      maxitest_wait_for_extra_threads # lets signal thread finish
     end
 
     it 'performs a hard restart if puma takes too long to call exec' do


### PR DESCRIPTION
```
Error:
RestartSignalHandler::.listen#test_0006_notifies error notifier when an exception happens and keeps samson running:
RuntimeError: Test left 1 extra threads ([#<Thread:0x0000000008c016f8@/home/travis/build/zendesk/samson/test/models/restart_signal_handler_test.rb:15 sleep>])

bin/rails test test/models/restart_signal_handler_test.rb:71
```
