### PR TITLE
override project labels in budgets too

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -126,7 +126,8 @@ module Kubernetes
         metadata: {
           name: kubernetes_role.resource_name,
           namespace: resource.dig(:metadata, :namespace),
-          labels: resource.dig_fetch(:metadata, :labels).dup
+          labels: resource.dig_fetch(:metadata, :labels).dup,
+          annotations: (resource.dig(:metadata, :annotations) || {}).dup
         },
         spec: {
           minAvailable: target,

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -92,15 +92,13 @@ module Kubernetes
     end
 
     def set_project_labels
-      project_label = project.permalink
-      template.dig_set([:metadata, :labels, :project], project_label)
-
-      kind = template.fetch(:kind)
-      if kind == "Service"
-        template.dig_set([:spec, :selector, :project], project_label)
-      elsif kind != "Pod"
-        template.dig_set([:spec, :selector, :matchLabels, :project], project_label)
-        template.dig_set([:spec, :template, :metadata, :labels, :project], project_label)
+      [
+        [:metadata, :labels],
+        [:spec, :selector],
+        [:spec, :selector, :matchLabels],
+        [:spec, :template, :metadata, :labels]
+      ].each do |path|
+        template.dig(*path)[:project] = project.permalink if template.dig(*path, :project)
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -139,6 +139,13 @@ describe Kubernetes::ReleaseDoc do
         create!.resource_template[2][:metadata][:namespace].must_equal 'default'
       end
 
+      it "supports multiproject" do
+        metadata = template.dig(0, :metadata)
+        metadata[:annotations] = {"samson/minAvailable": '30%', "samson/override_project_label": "true"}
+        metadata[:labels][:project] = 'change-me'
+        create!.resource_template[2][:metadata][:labels][:project].must_equal 'foo'
+      end
+
       it "deletes when set to 0" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '0'}
         create!.resource_template[2][:delete].must_equal true

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -145,13 +145,14 @@ describe Kubernetes::TemplateFiller do
 
       it "overrides project label in pod" do
         raw_template.replace(raw_template.dig(:spec, :template).merge(raw_template.slice(:metadata)))
-        raw_template[:kind] = "Pod"
+        raw_template[:spec].delete(:template)
+        raw_template[:spec].delete(:selector)
         labels.must_equal ["foo", nil, nil, nil]
       end
 
       it "overrides project label in service" do
-        raw_template[:kind] = "Service"
-        labels.must_equal ["foo", "foo", "some-project", "some-project"]
+        raw_template[:spec][:selector][:project] = "bar"
+        labels.must_equal ["foo", "foo", "foo", "foo"]
       end
     end
 


### PR DESCRIPTION
currently resources that use project-overrides get budgets created that do not match their labels since the "multi-project" setting is in an annotation

@zendesk/compute 