### PR TITLE
Only add the preview logic for env group

### DIFF
--- a/plugins/env/app/assets/javascripts/env/application.js
+++ b/plugins/env/app/assets/javascripts/env/application.js
@@ -80,15 +80,24 @@
     // add selectpicker to copied and original rows
     $.each(rows, function(idx, $row) {
       $row.find(".selectpicker").selectpicker();
-      setupEnvGroupPreview($row);
     });
+
+    return rows;
   }
 
   $(document).on("click", ".duplicate_previous_row", function(e){
     e.preventDefault();
     var $row = $(this).prev();
-    withoutSelectpicker($row, function(){
+    var rows = withoutSelectpicker($row, function(){
       return [copyRow($row)];
+    });
+
+    // Row duplication logic is reused in several places so only
+    // setup the preview link for the right target.
+    $.each(rows, function(idx, $row) {
+      if ($row.hasClass("env_group_inputs")) {
+        setupEnvGroupPreview($row);
+      }
     });
   });
 


### PR DESCRIPTION
Fix the UI bug where specific environment group logic was applied to all duplicated rows in the application.

Before
![bug](https://user-images.githubusercontent.com/1161962/41003492-c75792b2-68cb-11e8-877d-cd3924ce8ffd.png)

After
![screen shot 2018-06-05 at 2 15 40 pm](https://user-images.githubusercontent.com/1161962/41003454-aa5f62b6-68cb-11e8-818c-d6993f9a79b6.png)

### Tasks
 - [x] :+1: from team

### Risks
- Level: Low. UI fixes. 