### PR TITLE
[DEVEX-693] Add timestamp to GCR image tagging command

### DIFF
--- a/app/models/output_buffer.rb
+++ b/app/models/output_buffer.rb
@@ -104,7 +104,7 @@ class OutputBuffer
     @line_finished = lines.last.end_with?($/)
     stamped << lines.shift if append
     lines.each do |line|
-      stamped << "[#{Time.now.utc.strftime("%T")}] #{line}"
+      stamped << "#{Samson::OutputUtils.timestamp} #{line}"
     end
     stamped
   end

--- a/lib/samson/output_utils.rb
+++ b/lib/samson/output_utils.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Samson
+  module OutputUtils
+    def self.timestamp
+      "[#{Time.now.utc.strftime("%T")}]"
+    end
+  end
+end

--- a/plugins/gcloud/lib/samson_gcloud/image_tagger.rb
+++ b/plugins/gcloud/lib/samson_gcloud/image_tagger.rb
@@ -48,9 +48,12 @@ module SamsonGcloud
           "gcloud", "container", "images", "add-tag", digest, "#{base}:#{tag}", "--quiet", *SamsonGcloud.cli_options
         ]
         success, output = Samson::CommandExecutor.execute(*command, timeout: 10, whitelist_env: ["PATH"])
-        deploy.job.append_output!(
-          "Tagging GCR image:\n#{command.join(" ")}\n#{output.strip}\n#{success ? "SUCCESS" : "FAILED"}\n"
-        )
+        deploy.job.append_output!(<<~TEXT)
+          #{Samson::OutputUtils.timestamp} Tagging GCR image:
+          #{command.join(" ")}
+          #{output.strip}
+          #{success ? "SUCCESS" : "FAILED"}
+        TEXT
       end
     end
   end

--- a/plugins/gcloud/test/samson_gcloud/image_tagger_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/image_tagger_test.rb
@@ -37,6 +37,13 @@ describe SamsonGcloud::ImageTagger do
       deploy.job.output.must_include "\nOUT\nSUCCESS"
     end
 
+    it 'includes timestamp' do
+      freeze_time
+      assert_tagged_with 'stage-staging'
+      tag
+      deploy.job.output.must_include "[04:05:06] Tagging GCR image:\n"
+    end
+
     it 'does not tag with invalid stage permalink' do
       deploy.stage.update_column(:permalink, '%$!')
       tag

--- a/test/lib/samson/output_utils_test.rb
+++ b/test/lib/samson/output_utils_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::OutputUtils do
+  describe '.timestamp' do
+    it 'returns a formatted timestamp' do
+      freeze_time
+      Samson::OutputUtils.timestamp.must_equal '[04:05:06]'
+    end
+  end
+end


### PR DESCRIPTION
/cc @zendesk/samson @zendesk/devex

### References
 - Jira link: [DEVEX-693](https://zendesk.atlassian.net/browse/DEVEX-693)
