### PR TITLE
make kubernetes default page useful/fast and paginate releases

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/releases_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/releases_controller.rb
@@ -5,7 +5,7 @@ class Kubernetes::ReleasesController < ApplicationController
   before_action :authorize_project_deployer!
 
   def index
-    @kubernetes_releases = current_project.kubernetes_releases.order('id desc')
+    @pagy, @kubernetes_releases = pagy(current_project.kubernetes_releases.order('id desc'), items: 25)
   end
 
   def show

--- a/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/releases/index.html.erb
@@ -49,4 +49,8 @@
       <% end %>
     </tbody>
   </table>
+
+  <div class="admin-actions">
+    <%= paginate @pagy %>
+  </div>
 </section>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_project_tab.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_project_tab.html.erb
@@ -1,5 +1,5 @@
 <li class="<%= 'active' if active == 'kubernetes' %>">
-  <%= link_to project_kubernetes_releases_path(project), style: 'padding-top: 10px; padding-bottom: 10px' do %>
+  <%= link_to project_kubernetes_roles_path(project), style: 'padding-top: 10px; padding-bottom: 10px' do %>
     <%= image_tag('kubernetes/icon.png', height: '30px') %>
   <% end %>
 </li>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_role_navigation.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_role_navigation.html.erb
@@ -1,6 +1,6 @@
 <% links = [
-  ["Releases", project_kubernetes_releases_path],
   ["Roles", project_kubernetes_roles_path],
+  ["Releases", project_kubernetes_releases_path],
   ["Resources", project_kubernetes_deploy_group_roles_path(@project)],
   ["Limits", project_kubernetes_usage_limits_path(@project)],
 ] %>


### PR DESCRIPTION
I never want to look at the releases page, which is also slow to load,
so switching that and making it faster

![screen shot 2018-06-08 at 3 01 25 pm](https://user-images.githubusercontent.com/11367/41183013-2e2ddeca-6b2d-11e8-8b63-fcae88051569.png)
![screen shot 2018-06-08 at 3 02 42 pm](https://user-images.githubusercontent.com/11367/41183014-2e4498b8-6b2d-11e8-9c52-88b0c7269dd7.png)
