### PR TITLE
Fix a race-condition with streams being requested after the job is finished

### DIFF
--- a/test/controllers/streams_controller_test.rb
+++ b/test/controllers/streams_controller_test.rb
@@ -8,46 +8,70 @@ describe StreamsController do
 
   let(:project) { projects(:test) }
   let(:stage) { stages(:test_staging) }
-  let(:job) { jobs(:running_test) }
 
   after { maxitest_kill_extra_threads } # SSE heartbeat never finishes
 
   as_a_viewer do
     describe "#show" do
-      it "has an initial :started SSE and a :finished SSE" do
-        # Override the job retrieval in the streams controller. This way we don't have
-        # to stub out all the rest of the JobExecution setup/execute/... flow.
-        fake_execution = JobExecution.new("foo", job)
-        JobQueue.expects(:find_by_id).returns(fake_execution)
+      context "with a running job" do
+        let(:job) { jobs(:running_test) }
 
-        # make sure that the JobExecution object responds to the pid method
-        assert fake_execution.respond_to?(:pid)
+        it "has an initial :started SSE and a :finished SSE" do
+          # Override the job retrieval in the streams controller. This way we don't have
+          # to stub out all the rest of the JobExecution setup/execute/... flow.
+          fake_execution = JobExecution.new("foo", job)
+          JobQueue.expects(:find_by_id).returns(fake_execution)
 
-        # wait a bit for stream to open, then generate events
-        t = Thread.new do
-          sleep 0.2
-          wait_for_listeners(fake_execution.output)
+          # make sure that the JobExecution object responds to the pid method
+          assert fake_execution.respond_to?(:pid)
 
-          # Write some msgs to our fake TerminalExecutor stream
-          fake_execution.output.write("Hello there!\n")
-          # Close the stream to denote the job finishing, which will trigger sending the :finished SSE
-          fake_execution.output.close
+          # wait a bit for stream to open, then generate events
+          lines = String.new
+          t = Thread.new do
+            sleep 0.1
+            wait_for_listeners(fake_execution.output)
 
-          # Collect the output from the ActiveController::Live::Buffer stream
-          lines = []
-          response.stream.each { |l| lines << l }
+            # Write some msgs to our fake TerminalExecutor stream
+            fake_execution.output.write("Hello there!\n")
+            # Close the stream to denote the job finishing, which will trigger sending the :finished SSE
+            fake_execution.output.close
+
+            # Collect the output from the ActiveController::Live::Buffer stream
+            response.stream.each { |l| lines << l }
+          end
+
+          # Get the :show page to open the SSE stream
+          get :show, params: {id: job.id}
+
+          response.status.must_equal(200)
+          t.join
 
           # Ensure we have at least the :started and :finished SSE msgs
-          assert lines.grep(/event: started\ndata:/)
-          assert lines.grep(/event: append\ndata:.*Hello there!/)
-          assert lines.grep(/event: finished\ndata/)
+          lines.must_match(/event: started\ndata:/)
+          lines.must_match(/event: append\ndata:.*Hello there!/)
+          lines.must_match(/event: finished\ndata/)
         end
+      end
 
-        # Get the :show page to open the SSE stream
-        get :show, params: {id: job.id}
+      context "with a finished job" do
+        let(:job) { jobs(:succeeded_test) }
+        it "has some :append SSEs and a :finished SSE" do
+          # Collect the output from the ActiveController::Live::Buffer stream
+          lines = String.new
+          t = Thread.new do
+            sleep 0.1
+            response.stream.each { |l| lines << l }
+          end
 
-        response.status.must_equal(200)
-        t.join
+          get :show, params: {id: job.id}
+
+          response.status.must_equal(200)
+          t.join
+
+          # Ensure we have at least the :started and :finished SSE msgs
+          lines.must_match(/event: append\ndata:.*#{Regexp.escape(job.output.split("\n").first)}/)
+          lines.must_match(/event: finished\ndata/)
+        end
       end
     end
   end

--- a/test/controllers/streams_controller_test.rb
+++ b/test/controllers/streams_controller_test.rb
@@ -27,7 +27,7 @@ describe StreamsController do
           assert fake_execution.respond_to?(:pid)
 
           # wait a bit for stream to open, then generate events
-          lines = String.new
+          lines = +''
           t = Thread.new do
             sleep 0.1
             wait_for_listeners(fake_execution.output)
@@ -60,7 +60,7 @@ describe StreamsController do
         let(:job) { jobs(:succeeded_test) }
         it "has some :append SSEs and a :finished SSE" do
           # Collect the output from the ActiveController::Live::Buffer stream
-          lines = String.new
+          lines = +''
           t = Thread.new do
             sleep 0.1
             response.stream.each { |l| lines << l }

--- a/test/models/event_streamer_test.rb
+++ b/test/models/event_streamer_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 2
+SingleCov.covered! uncovered: 1
 
 describe EventStreamer do
   class FakeStream
@@ -63,6 +63,14 @@ describe EventStreamer do
 
   it "closes the stream when there is no more output" do
     streamer.start(output)
+    assert stream.closed?
+  end
+
+  it "converts a string into a newline separated stream" do
+    output = "hello\nworld\n"
+    streamer.start(output)
+    stream.lines.must_include %(event: append\ndata: {"msg":"hello"}\n\n)
+    stream.lines.must_include %(event: append\ndata: {"msg":"world"}\n\n)
     assert stream.closed?
   end
 end


### PR DESCRIPTION
Occasionally you can get a job finishing before the request to the stream has been made, at which point it infinitely retries (especially if the error is within the first step of cloning the repo). This change enables the stream to update the page and log the final output. Also fixes the tests which weren't asserting correctly.

/cc @zendesk/samson

### Risks
- Level: Low - affects job output streaming only
