### PR TITLE
Nullify Vault server dependency after destroy

### DIFF
--- a/lib/samson/secrets/vault_server.rb
+++ b/lib/samson/secrets/vault_server.rb
@@ -36,7 +36,7 @@ module Samson
         read_timeout: 2
       }.freeze
 
-      has_many :deploy_groups
+      has_many :deploy_groups, dependent: :nullify
 
       attribute :token
       attr_encrypted :token

--- a/test/lib/samson/secrets/vault_server_test.rb
+++ b/test/lib/samson/secrets/vault_server_test.rb
@@ -50,10 +50,10 @@ describe Samson::Secrets::VaultServer do
       ) { refute_valid server }
     end
 
-    it "nullifies the association on destroy" do
+    it "removes valut servers from associated deploy group" do
       deploy_group = deploy_groups(:pod100)
       server.deploy_groups = [deploy_group]
-      server.save
+      server.save!
       deploy_group.vault_server.must_equal server
       server.destroy!
       refute deploy_group.reload.vault_server_id

--- a/test/lib/samson/secrets/vault_server_test.rb
+++ b/test/lib/samson/secrets/vault_server_test.rb
@@ -49,6 +49,15 @@ describe Samson::Secrets::VaultServer do
         to_raise: Vault::HTTPError.new("address", stub(code: '200'))
       ) { refute_valid server }
     end
+
+    it "nullifies the association on destroy" do
+      deploy_group = deploy_groups(:pod100)
+      server.deploy_groups = [deploy_group]
+      server.save
+      deploy_group.vault_server.must_equal server
+      server.destroy!
+      refute deploy_group.reload.vault_server_id
+    end
   end
 
   describe "#sync!" do


### PR DESCRIPTION
Removes the Vault server foreign_key after destroying.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/DEVEX-691

### Risks
- Level: Low
