### PR TITLE
[DEVEX-137] Implement expected duration for a stage's deploys

### DIFF
--- a/app/views/deploys/_deploy.html.erb
+++ b/app/views/deploys/_deploy.html.erb
@@ -4,7 +4,12 @@
       <td><%= link_to deploy.project.name, deploy.project %></td>
     <% end %>
     <td><%= render_time(deploy.start_time) %></td>
-    <td><%= duration_text deploy.duration %></td>
+    <td>
+      <%= duration_text deploy.duration %>
+      <% if deploy.active? && (eta = duration_text(deploy.stage.average_deploy_time).presence) %>
+        <%= " (#{eta})" %>
+      <% end %>
+    </td>
     <td>
       <%= link_to deploy.summary, [@project || deploy.project, deploy] %>
     </td>

--- a/db/migrate/20180611172637_add_average_deploy_time_to_stages.rb
+++ b/db/migrate/20180611172637_add_average_deploy_time_to_stages.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class AddAverageDeployTimeToStages < ActiveRecord::Migration[5.2]
+  def up
+    add_column :stages, :average_deploy_time, :float
+
+    ActiveRecord::Base.transaction do
+      # Grab data
+      deploy_data = execute(<<~SQL).to_a
+        SELECT stage_id,
+               updated_at,
+               started_at,
+               created_at
+        FROM deploys
+        WHERE deploys.deleted_at IS NULL
+      SQL
+
+      stage_groups = deploy_data.group_by(&:first)
+
+      stage_insert_values = stage_groups.map do |stage_id, deploys|
+        average = deploys.reduce(0) do |sum, (_stage_id, updated_at, started_at, created_at)|
+          sum + (updated_at - (started_at || created_at))
+        end / deploys.size
+
+        "(#{stage_id},#{average})"
+      end
+
+      if stage_insert_values.any?
+        # Create temporary table
+        execute(<<~SQL)
+          CREATE TEMPORARY TABLE averages (
+            id int,
+            average float
+          );
+        SQL
+
+        execute(<<~SQL)
+          INSERT INTO averages (id, average)
+          VALUES #{stage_insert_values.join(',')};
+        SQL
+
+        # Backfill averages (sqlite doesn't support join in update)
+        execute(<<~SQL)
+          UPDATE stages
+          SET average_deploy_time =
+            (SELECT average
+             FROM averages
+             WHERE id = stages.id)
+        SQL
+
+        # Remove temporary table (sqlite doesn't support DROP TEMPORARY TABLE)
+        execute(<<~SQL)
+          DROP TABLE averages;
+        SQL
+      end
+    end
+  end
+
+  def down
+    remove_column :stages, :average_deploy_time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_07_172824) do
+ActiveRecord::Schema.define(version: 2018_06_11_172637) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -525,6 +525,7 @@ ActiveRecord::Schema.define(version: 2018_06_07_172824) do
     t.boolean "block_on_gcr_vulnerabilities", default: false, null: false
     t.boolean "notify_assertible", default: false, null: false
     t.string "notify_email_address"
+    t.float "average_deploy_time"
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -69,6 +69,16 @@ describe DeploysController do
           response.body.must_include queued.id.to_s # renders as job
         end
       end
+
+      it 'renders active deploy expected time' do
+        Deploy.expects(:active).twice.returns([deploy])
+        deploy.expects(:active?).returns(true)
+        deploy.stage.expects(:average_deploy_time).returns(4.123)
+
+        get :active
+
+        response.body.must_include "(00:00:04)"
+      end
     end
 
     describe '#active_count' do

--- a/test/helpers/status_helper_test.rb
+++ b/test/helpers/status_helper_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered!
 
 describe StatusHelper do
   include ERB::Util
@@ -10,12 +10,27 @@ describe StatusHelper do
   let(:current_user) { users(:viewer) }
 
   describe "#status_panel" do
+    let(:deploy) { deploys(:succeeded_production_test) }
+    let(:job) { jobs(:running_test) }
     it "accepts a deploy" do
-      refute_nil status_panel(deploys(:succeeded_production_test))
+      refute_nil status_panel(deploy)
     end
 
     it "accepts a job" do
-      refute_nil status_panel(jobs(:running_test))
+      refute_nil status_panel(job)
+    end
+
+    it 'shows duration text for deploys' do
+      deploy.stage.update_column(:average_deploy_time, 3)
+      deploy.expects(:active?).returns(true)
+
+      status_panel(deploy).must_include 'ETA: 00:00:03.'
+    end
+
+    it 'does not show duration text for jobs' do
+      job.expects(:active?).returns(true)
+
+      status_panel(job).wont_include 'ETA: 00:00:03.'
     end
   end
 
@@ -34,6 +49,10 @@ describe StatusHelper do
   describe "#duration_text" do
     it "shows duration" do
       duration_text(5 * 60 * 60 + 59 * 60 + 4).must_equal "05:59:04"
+    end
+
+    it "shows nothing if duration is nil" do
+      duration_text(nil).must_equal ''
     end
   end
 end


### PR DESCRIPTION
Adds an `average_deploy_time` field to `Stage`, backfilling any existing stage averages. This allows tracking of overall deployment time for a particular stage, and estimates on a new deploy's duration.

/cc @zendesk/devex 

Status of active deploy:
<img width="342" alt="screen shot 2018-06-11 at 4 30 27 pm" src="https://user-images.githubusercontent.com/15261525/41263996-2911c32e-6d9f-11e8-85c6-791e733e86e2.png">

Status of active deploy - no previous average: 
<img width="325" alt="screen shot 2018-06-11 at 4 30 55 pm" src="https://user-images.githubusercontent.com/15261525/41263994-24449af6-6d9f-11e8-8b5b-3049bd9fa2b2.png">

Deploying page:
<img width="160" alt="screen shot 2018-06-11 at 5 11 55 pm" src="https://user-images.githubusercontent.com/15261525/41263991-2139163e-6d9f-11e8-9560-f2c1b28872b4.png">

### References
 - Jira link: [DEVEX-137](https://zendesk.atlassian.net/browse/DEVEX-137)
 - [Formula for running average calculation](https://math.stackexchange.com/questions/22348/how-to-add-and-subtract-values-from-an-average)