### PR TITLE
do not start up a background thread for airbrake that breaks the boot…

### DIFF
--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -16,6 +16,6 @@ if !Rails.env.test? && !ENV['PRECOMPILE'] && ENV['DOCKER_FEATURE']
     end
   rescue
     warn "Unable to verify local docker!"
-    ErrorNotifier.notify($!)
+    ErrorNotifier.notify($!, sync: true) # sync to avoid background threads breaking boot_check.rb thread checker
   end
 end


### PR DESCRIPTION
… check in development

use sync error reporting which does not create a thread,
which then would trigger boot_check.rb to fail

reproduce by turning docker off and starting `rails c`

```
lib/samson/boot_check.rb:20:in `check': Extra threads: [#<Thread:0x00007f89abbab058@vendor/bundle/gems/airbrake-ruby-2.9.0/lib/airbrake-ruby/async_sender.rb:104 sleep_forever>] should not be loaded (RuntimeError)
```