### PR TITLE
[DEVEX-643] Add commit status warning if deploying to production without first deploying to a non-production stage

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -181,6 +181,14 @@ class Project < ActiveRecord::Base
     Deploy.find(found.map(&:id)).select(&:stage).sort_by { |d| d.stage.order }.presence
   end
 
+  def deployed_reference_to_non_production_stage?(reference)
+    return false unless commit = repository.commit_from_ref(reference)
+
+    stages.joins(deploys: :job).where(
+      jobs: {status: 'succeeded', commit: commit}
+    ).distinct.any? { |stage| !stage.production? }
+  end
+
   def url
     Rails.application.routes.url_helpers.project_url(self)
   end

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -53,7 +53,7 @@ describe DeploysHelper do
       end
 
       it "renders buddy check when waiting for buddy" do
-        stub_github_api "repos/bar/foo/commits/staging/status", state: "success", statuses: {}
+        stub_github_api "repos/bar/foo/commits/staging/status", state: "success", statuses: []
         deploy.expects(:waiting_for_buddy?).returns(true)
         result.wont_include output
         result.must_include 'This deploy requires a buddy.'


### PR DESCRIPTION
/cc @zendesk/samson

Three different versions of this query on classic's data which has a ton of deploys: 
```Ruby
    # V3
    non_production_stages = stages.reject(&:production?).map(&:id)
    Deploy.where(stage_id: non_production_stages).joins(:job).where(jobs: {commit: commit, status: 'succeeded'}).any?

    # V2
    jobs_with_commit = Job.where(commit: commit, status: 'succeeded').pluck(:id)
    stages_with_commit_depoyed = Deploy.where(job_id: jobs_with_commit).pluck(:stage_id).uniq
    Stage.where(id: stages_with_commit_depoyed).any? { |stage| !stage.production? }

    # V1
    stages.joins(deploys: :job).where(
      jobs: {status: 'succeeded', commit: commit}
    ).distinct.any? { |stage| !stage.production? }
```

Results: 
```
Deploy with commit does not exist
   user     system      total        real        # queries
V3 .023371   0.013249   0.036620 (  0.119199)        21
V2 0.002848   0.000849   0.003697 (  1.752046)        3
V1 0.002021   0.000603   0.002624 (  0.131441)        1

Deploy with commit exists
   user     system      total        real        # queries
V3 0.027942   0.009176   0.037118 (  0.094476)       21
V2 0.013067   0.005522   0.018589 (  1.444021)       12
V1 0.017112   0.000404   0.017516 (  0.142118)       10
```

Looks like V1 is the winner here

### References
 - Jira link: [DEVEX-643](https://zendesk.atlassian.net/browse/DEVEX-643)
