### PR TITLE
announce when no pods got created to make empty deploys easier to spot

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -79,7 +79,10 @@ module Kubernetes
 
       loop do
         statuses = pod_statuses(release_docs)
-        return success if statuses.none?
+        if statuses.none?
+          @output.puts "No pods were created"
+          return success
+        end
         not_ready = statuses.reject(&:live)
 
         if @testing_for_stability


### PR DESCRIPTION
@zendesk/compute 