### PR TITLE
Revert "Fix a race-condition with streams being requested after the job is finished"

### DIFF
--- a/app/models/event_streamer.rb
+++ b/app/models/event_streamer.rb
@@ -19,10 +19,9 @@
 #   # `stream` is e.g. the response.stream object in a Rails controller.
 #   streamer = EventStreamer.new(stream)
 #
-#   # `output` is anything that responds to `#each` or if a String is passed
-#   # in, the object will emulate an append-only stream consisting of each
-#   # line. The block will be called with each chunk of data that is about to
-#   # be streamed - its return value will be sent instead.
+#   # `output` is anything that responds to `#each`. The block will be called
+#   # with each chunk of data that is about to be streamed - its return value
+#   # will be sent instead.
 #   streamer.start(output) {|chunk| chunk.html_safe }
 #
 class EventStreamer
@@ -38,15 +37,8 @@ class EventStreamer
   end
 
   def start(output)
-    if output.is_a?(String)
-      output.split("\n").each do |line|
-        emit_event(:append, @handler.call(:append, line))
-      end
-      emit_event(:finished, @handler.call(:finished, nil))
-    else
-      @scanner = TerminalOutputScanner.new(output)
-      @scanner.each { |event, data| emit_event(event, @handler.call(event, data)) }
-    end
+    @scanner = TerminalOutputScanner.new(output)
+    @scanner.each { |event, data| emit_event(event, @handler.call(event, data)) }
   rescue IOError, ActionController::Live::ClientDisconnected
     # Raised on stream close
     nil

--- a/test/models/event_streamer_test.rb
+++ b/test/models/event_streamer_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered! uncovered: 2
 
 describe EventStreamer do
   class FakeStream
@@ -63,14 +63,6 @@ describe EventStreamer do
 
   it "closes the stream when there is no more output" do
     streamer.start(output)
-    assert stream.closed?
-  end
-
-  it "converts a string into a newline separated stream" do
-    output = "hello\nworld\n"
-    streamer.start(output)
-    stream.lines.must_include %(event: append\ndata: {"msg":"hello"}\n\n)
-    stream.lines.must_include %(event: append\ndata: {"msg":"world"}\n\n)
     assert stream.closed?
   end
 end


### PR DESCRIPTION
Reverts zendesk/samson#2798

can reproduce on a local production stage ... needs some js fixes, but not straight forward