### PR TITLE
[BRE-749] Improve regexp to capture section content

### DIFF
--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -8,4 +8,9 @@ $(function () {
   $('.nav-tabs a[href^="#"]').click(function(){
     window.location.hash = this.hash;
   });
+
+  // Initialize popover tooltips in tab when tab is shown
+  $('a[data-toggle="tab"]').on('shown.bs.tab', function() {
+    $('.tab-content i[data-toggle="popover"]').popover();
+  });
 });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,14 +222,16 @@ module ApplicationHelper
     link_to "History#{count}", audits_path(search: {auditable_id: resource.id, auditable_type: resource.class.name})
   end
 
-  def additional_info(text)
+  def additional_info(text, overrides = {})
     data_attrs = if text.html_safe?
       {content: h(h(text).to_str), html: true}
     else
       {content: text}
     end.merge(BOOTSTRAP_TOOLTIP_PROPS)
 
-    content_tag :i, '', class: "glyphicon glyphicon-info-sign", data: data_attrs
+    options = {class: 'glyphicon glyphicon-info-sign'}.merge(overrides)
+
+    content_tag :i, '', **options, data: data_attrs
   end
 
   def page_title(content = nil, in_tab: false, &block)

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -6,12 +6,6 @@ class Changeset::PullRequest
 
   WEBHOOK_FILTER = /(^|\s)\[samson review\]($|\s)/i
 
-  # Matches a markdown section heading named "Risks".
-  RISKS_SECTION = /^\s*#*\s*Risks?\s*#*\s*\n(?:\s*[-=]*\s*\n)?/i
-
-  # Matches a markdown section heading
-  SECTION_HEADING = /^\s*#*\s*\w+.*\n(?:\s*[-=]*\s*\n)?/i
-
   # Matches URLs to JIRA issues.
   JIRA_ISSUE_URL = %r[https?:\/\/[\da-z\.\-]+\.[a-z\.]{2,6}\/browse\/#{CODE_ONLY}(?=#{PUNCT}|$)]
 
@@ -129,9 +123,17 @@ class Changeset::PullRequest
 
   private
 
+  def section_content(section_title, text)
+    desired_header_regexp = "^(?:\\s*#+\\s*#{section_title}.*|\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
+    content_regexp = '([\W\w]*?)'
+    next_header_regexp = '(?=^(?:\s*#+|.*\n\s*(?:-{2,}|={2,}\s*\n))|\z)'
+
+    text[/#{desired_header_regexp}#{content_regexp}#{next_header_regexp}/i, 1]
+  end
+
   def parse_risks(body)
     body_stripped = ActionController::Base.helpers.strip_tags(body)
-    body_stripped.to_s.split(RISKS_SECTION, 2)[1].to_s.strip.split(SECTION_HEADING).first.to_s.strip.presence
+    section_content('Risks', body_stripped).to_s.strip.presence
   end
 
   def parse_jira_issues

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -105,8 +105,14 @@ class Changeset::PullRequest
   def risks
     return @risks if defined?(@risks)
     @risks = parse_risks(@data.body.to_s)
+    @missing_risks = @risks.nil?
     @risks = nil if @risks&.match?(/\A\s*\-?\s*None\Z/i)
     @risks
+  end
+
+  def missing_risks?
+    risks
+    @missing_risks
   end
 
   def jira_issues
@@ -125,7 +131,7 @@ class Changeset::PullRequest
 
   def section_content(section_title, text)
     desired_header_regexp = "^(?:\\s*#+\\s*#{section_title}.*|\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
-    content_regexp = '([\W\w]*?)'
+    content_regexp = '([\W\w]*?)' # capture all section content, including new lines
     next_header_regexp = '(?=^(?:\s*#+|.*\n\s*(?:-{2,}|={2,}\s*\n))|\z)'
 
     text[/#{desired_header_regexp}#{content_regexp}#{next_header_regexp}/i, 1]

--- a/app/views/changeset/_risks.html.erb
+++ b/app/views/changeset/_risks.html.erb
@@ -6,5 +6,5 @@
 <% else %>
   <p>There are no risks described in any pull request in this <%= type %>. If you want Samson to pick up and display
   any risks associated with your pull request, add a heading called "Risks" in your pull request description. Anything
-  following that heading will be considered part of the risks section.</p>
+  in that section will be listed here as a risk.</p>
 <% end %>

--- a/app/views/changeset/_risks.html.erb
+++ b/app/views/changeset/_risks.html.erb
@@ -1,10 +1,20 @@
-<% if risky_prs = changeset.risky_pull_requests.presence %>
-  <% risky_prs.each do |pr| %>
+<div class="alert alert-info">
+  If you want Samson to pick up and display any risks associated with your pull request, add a heading called "Risks"
+  in your pull request description. Anything in that section will be listed here as a risk.
+</div>
+
+<% changeset.pull_requests.each do |pr| %>
+  <% if pr.risky? %>
     <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %></h5>
     <%= markdown pr.risks %>
+  <% elsif pr.missing_risks? %>
+    <div>
+      <% help_icon = additional_info(
+            "Missing 'Risks' section or failed to parse risks",
+            class: 'glyphicon glyphicon-alert deployment-alert'
+          )
+      %>
+      <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %><%= help_icon %></h5>
+    </div>
   <% end %>
-<% else %>
-  <p>There are no risks described in any pull request in this <%= type %>. If you want Samson to pick up and display
-  any risks associated with your pull request, add a heading called "Risks" in your pull request description. Anything
-  in that section will be listed here as a risk.</p>
 <% end %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -439,6 +439,11 @@ describe ApplicationHelper do
         %(<i class="glyphicon glyphicon-info-sign" data-content="&amp;lt;em&amp;gt;foo&amp;lt;/em&amp;gt;" data-html="true" #{always_attributes}></i>)
       )
     end
+
+    it 'allows option overrides' do
+      expected_html = %(<i class="glyphicon glyphicon-alert barfoo" data-content="foo" #{always_attributes}></i>)
+      additional_info('foo', class: 'glyphicon glyphicon-alert barfoo').must_equal expected_html
+    end
   end
 
   describe "#link_to_history" do

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -487,4 +487,16 @@ describe Changeset::PullRequest do
       end
     end
   end
+
+  describe '#missing_risks?' do
+    it 'returns true if pr has no risks' do
+      pr.risks.must_be_nil
+      pr.missing_risks?.must_equal true
+    end
+
+    it 'returns false if pr has risks' do
+      add_risks
+      pr.missing_risks?.must_equal false
+    end
+  end
 end

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -401,6 +401,28 @@ describe Changeset::PullRequest do
       pr.risks.must_be_nil
     end
 
+    it "finds risks ignoring case" do
+      body.replace(+<<~BODY)
+        # risks
+          - Planes
+      BODY
+      pr.risks.must_equal "- Planes"
+    end
+
+    it "finds risks with new lines" do
+      body.replace(+<<~BODY)
+        # Risks
+
+        None
+
+        But wait!
+
+        Just kidding, none.
+      BODY
+
+      pr.risks.must_equal "None\n\nBut wait!\n\nJust kidding, none."
+    end
+
     it "finds risks with underline style markdown headers" do
       body.replace(+<<~BODY)
         Risks


### PR DESCRIPTION
* Fixes regex used to get risk content from PRs to make it more robust and enable it to handle edge cases.
* Now shows all PRs under 'Risks' and alerts if there was no risk section found (either it was not defined or not able to be parsed)

<img width="1122" alt="screen shot 2018-06-20 at 1 21 32 pm" src="https://user-images.githubusercontent.com/15261525/41682774-81eb3f62-748d-11e8-8a3c-3b9bf088c524.png">
<img width="1112" alt="screen shot 2018-06-20 at 1 21 42 pm" src="https://user-images.githubusercontent.com/15261525/41682779-83950258-748d-11e8-868a-1406d667fc97.png">


/cc @zendesk/samson

### References
 - Jira link: [BRE-749](https://zendesk.atlassian.net/browse/BRE-749)
