### PR TITLE
improve desired pod checking

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -388,8 +388,8 @@ describe Kubernetes::Resource do
       end
 
       it "blows up when desired count cannot be found (bad state or no nodes are available)" do
-        assert_request(:get, url, to_return: {body: {status: {desiredNumberScheduled: 0}}.to_json}, times: 2) do
-          resource.expects(:loop_sleep).once
+        assert_request(:get, url, to_return: {body: {status: {desiredNumberScheduled: 0}}.to_json}, times: 3) do
+          resource.expects(:loop_sleep).times(2)
           assert_raises Samson::Hooks::UserError do
             resource.desired_pod_count
           end


### PR DESCRIPTION
 - say which deploy group failed
 - try 1 more time
 - dry up lookup logic

@zendesk/compute 