### PR TITLE
Added UI restriction for unauthorized command access

### DIFF
--- a/app/views/stages/_commands.html.erb
+++ b/app/views/stages/_commands.html.erb
@@ -34,6 +34,13 @@
   $(function() {
     var $localCommands = $('#commands pre.local:not(.no_access)');
 
+    function notify_warning(event, message){
+      var $warning = $('<div class="cannot-edit">' + message + '</div>')
+      $(event).after($warning);
+      $warning.fadeOut(3000);
+      return false;
+    }
+
     $('#commands').sortable();
     $.fn.editableform.buttons = <%= render('commands/buttons').inspect.html_safe %>;
 
@@ -62,17 +69,11 @@
     });
 
     $('#commands pre.global').dblclick(function(){
-      var $warning = $('<div class="cannot-edit">Global commands cannot be edited inline, use the Admin UI.</div>')
-      $(this).after($warning);
-      $warning.fadeOut(3000);
-      return false;
+      notify_warning(this, 'Global commands cannot be edited inline, use the Admin UI.');
     });
 
-    $('#commands pre.no_access').dblclick(function(){
-      var $warning = $('<div class="cannot-edit">Need admin access for the project, that owns this command.</div>')
-      $(this).after($warning);
-      $warning.fadeOut(3000);
-      return false;
+    $('#commands pre.no_access:not(.global)').dblclick(function(){
+      notify_warning(this, 'Need admin access for the project, that owns this command.');
     });
 
     $('#commands').on('click', '.editable-destroy', function(event) {

--- a/app/views/stages/_commands.html.erb
+++ b/app/views/stages/_commands.html.erb
@@ -34,9 +34,9 @@
   $(function() {
     var $localCommands = $('#commands pre.local:not(.no_access)');
 
-    function notify_warning(event, message){
+    function notify_warning(target, message){
       var $warning = $('<div class="cannot-edit">' + message + '</div>')
-      $(event).after($warning);
+      $(target).after($warning);
       $warning.fadeOut(3000);
       return false;
     }

--- a/app/views/stages/_commands.html.erb
+++ b/app/views/stages/_commands.html.erb
@@ -4,6 +4,7 @@
 
   <div id="commands">
     <% usage_ids = Command.usage_ids %>
+    <% administrated = current_user.administrated_projects.pluck(:id) %>
     <%= form.collection_check_boxes(:command_ids, Command.for_stage(form.object), :id, :command) do |b| %>
       <% command = b.object %>
       <% others = usage_ids.count(command.id) - (b.check_box.include?('checked') && form.object.persisted? ? 1 : 0) %>
@@ -14,7 +15,7 @@
           <%= b.check_box %>
         </div>
         <div class="col-lg-8">
-          <% klass = "pre-command pre-inline #{command.global? ? 'global' : 'local'} #{'others' if others_warning}" %>
+          <% klass = "pre-command pre-inline #{command.global? ? 'global' : 'local'} #{'others' if others_warning} #{'no_access' unless administrated.include?(command.project_id)}" %>
           <pre data-type="textarea" data-others-warning="<%= others_warning %>" data-url="<%= command_path(b.value) %>" class="<%= klass %>"><%= b.text %></pre>
         </div>
         <%= edit_command_link command %>
@@ -31,7 +32,7 @@
 
 <script>
   $(function() {
-    var $localCommands = $('#commands pre.local');
+    var $localCommands = $('#commands pre.local:not(.no_access)');
 
     $('#commands').sortable();
     $.fn.editableform.buttons = <%= render('commands/buttons').inspect.html_safe %>;
@@ -62,6 +63,13 @@
 
     $('#commands pre.global').dblclick(function(){
       var $warning = $('<div class="cannot-edit">Global commands cannot be edited inline, use the Admin UI.</div>')
+      $(this).after($warning);
+      $warning.fadeOut(3000);
+      return false;
+    });
+
+    $('#commands pre.no_access').dblclick(function(){
+      var $warning = $('<div class="cannot-edit">Need admin access for the project, that owns this command.</div>')
       $(this).after($warning);
       $warning.fadeOut(3000);
       return false;

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -248,6 +248,22 @@ describe StagesController do
         end
       end
 
+      describe "moving projects" do
+        let(:echo_command) { commands(:echo) }
+        before do
+          other_project = project.dup
+          other_project.update_attributes(name: 'duplicate', permalink: 'duplicate')
+
+          echo_command.project_id = other_project.id
+          echo_command.save!
+        end
+
+        it 'has no_access css class for commands when no admin for both' do
+          get :edit, params: {project_id: subject.project.to_param, id: subject.to_param}
+          assert_select '.no_access', echo_command.command
+        end
+      end
+
       it 'checks the appropriate next_stage_ids checkbox' do
         next_stage = Stage.create!(name: 'food', project: subject.project)
         subject.next_stage_ids = [next_stage.id]


### PR DESCRIPTION
Added simple UI restriction for unauthorized command access

Before:
<img width="802" alt="screen shot 2018-06-25 at 4 43 21 pm" src="https://user-images.githubusercontent.com/1404500/41881167-ee18d5e8-7896-11e8-9fb8-f1960e26c957.png">

After:
<img width="851" alt="screen shot 2018-06-25 at 4 42 02 pm" src="https://user-images.githubusercontent.com/1404500/41881185-febdc854-7896-11e8-91c6-f14d7605179a.png">


/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/BRE-759

### Risks
- Level: Low
