### PR TITLE
Fix typo in deploy summary

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -48,7 +48,7 @@ class Deploy < ActiveRecord::Base
     deploy_details = "#{short_reference} to#{project_name} #{stage&.name}"
     if ["cancelled", "cancelling"].include?(status)
       canceller_name = job.canceller&.name || "Samson"
-      "#{canceller_name} #{summary_action} #{job.user.name}`s deploy#{deploy_buddy} of #{deploy_details}"
+      "#{canceller_name} #{summary_action} #{job.user.name}'s deploy#{deploy_buddy} of #{deploy_details}"
     else
       "#{job.user.name}#{deploy_buddy} #{summary_action} #{deploy_details}"
     end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -43,8 +43,8 @@ describe Deploy do
       "pending"    => "Deployer is about to deploy baz to Staging",
       "running"    => "Deployer is deploying baz to Staging",
       "succeeded"  => "Deployer deployed baz to Staging",
-      "cancelled"  => "Samson cancelled Deployer`s deploy of baz to Staging", # might not be done by the user
-      "cancelling" => "Samson is cancelling Deployer`s deploy of baz to Staging", # might not be done by the user
+      "cancelled"  => "Samson cancelled Deployer's deploy of baz to Staging", # might not be done by the user
+      "cancelling" => "Samson is cancelling Deployer's deploy of baz to Staging", # might not be done by the user
       "failed"     => "Deployer failed to deploy baz to Staging",
       "errored"    => "Deployer encountered an error deploying baz to Staging"
     }.each do |status, message|
@@ -57,7 +57,7 @@ describe Deploy do
     it "shows canceller when it was regularly cancelled" do
       deploy.job.status = "cancelled"
       deploy.job.canceller = users(:admin)
-      deploy.summary.must_equal "Admin cancelled Deployer`s deploy of baz to Staging"
+      deploy.summary.must_equal "Admin cancelled Deployer's deploy of baz to Staging"
     end
 
     describe "when buddy was required" do


### PR DESCRIPTION
### Description
Fix typo in deploy summary.

/cc @zendesk/samson @zendesk/aha-koalai 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: _enhancement_

### Risks
- Low: Just copy change
