### PR TITLE
Allow triggering deploys to be destroyed

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -8,6 +8,7 @@ class Deploy < ActiveRecord::Base
   belongs_to :project
   belongs_to :job
   belongs_to :buddy, -> { unscope(where: "deleted_at") }, class_name: 'User', optional: true
+  has_many :triggered_deploys, class_name: 'Deploy', foreign_key: 'triggering_deploy_id', dependent: :destroy
 
   default_scope { order(id: :desc) }
 

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -677,6 +677,17 @@ describe Deploy do
     end
   end
 
+  describe "#triggered_deploys" do
+    it 'can destroy triggered deploys' do
+      triggered_deploy = create_deploy!(triggering_deploy_id: deploy.id)
+      deploy.triggered_deploys.must_equal [triggered_deploy]
+
+      assert_difference 'Deploy.count', -2 do
+        deploy.destroy!
+      end
+    end
+  end
+
   def create_deploy!(attrs = {})
     default_attrs = {
       reference: "baz",


### PR DESCRIPTION
Ran across debugging another issue. Allows `Deploy.destroy_all` again, which was being prevented by the `triggering_deploy_id` fk. 

/cc @zendesk/samson
