### PR TITLE
Allow users who can deploy to a project to cancel deploys

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -108,12 +108,7 @@ class DeploysController < ApplicationController
   end
 
   def destroy
-    if @deploy.can_be_cancelled_by?(current_user)
-      @deploy.cancel(current_user)
-    else
-      flash[:error] = "You do not have privileges to cancel this deploy."
-    end
-
+    @deploy.cancel(current_user)
     redirect_to [current_project, @deploy]
   end
 

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -38,13 +38,8 @@ class JobsController < ApplicationController
   end
 
   def destroy
-    if @job.can_be_cancelled_by?(current_user)
-      @job.cancel(current_user)
-      flash[:notice] = "Cancelled!"
-    else
-      flash[:error] = "You are not allowed to cancel this job."
-    end
-
+    @job.cancel(current_user)
+    flash[:notice] = "Cancelled!"
     redirect_back fallback_location: [@project, @job]
   end
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -19,7 +19,7 @@ class Deploy < ActiveRecord::Base
   validate :validate_stage_uses_deploy_groups_properly, on: :create
 
   delegate(
-    :started_by?, :can_be_cancelled_by?, :cancel, :status, :user, :output,
+    :started_by?, :cancel, :status, :user, :output,
     :active?, :pending?, :running?, :cancelling?, :cancelled?, :succeeded?,
     :finished?, :errored?, :failed?,
     to: :job

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -60,10 +60,6 @@ class Job < ActiveRecord::Base
     updated_at - created_at
   end
 
-  def can_be_cancelled_by?(user)
-    started_by?(user) || user.admin? || user.admin_for?(project)
-  end
-
   def commands
     commands = []
     raw = command.split(/\r?\n|\r/)

--- a/app/views/deploys/_buddy_check.html.erb
+++ b/app/views/deploys/_buddy_check.html.erb
@@ -27,10 +27,8 @@
     <p>This deploy requires a buddy.</p>
     <div class="buddy-approval">
       <%= link_to "Approve", buddy_check_project_deploy_path(@project, @deploy), method: :post, class: "btn btn-primary btn-xl" %>
-      <% if @deploy.can_be_cancelled_by?(current_user) %>
-        or
-        <%= cancel_button deploy: @deploy, project: @project %>
-      <% end %>
+      or
+      <%= cancel_button deploy: @deploy, project: @project %>
     </div>
   <% else %>
     <p>This deploy requires a buddy since it is going to production. (Someone with deploy rights or greater.)</p>

--- a/app/views/shared/_output.html.erb
+++ b/app/views/shared/_output.html.erb
@@ -10,9 +10,7 @@
       <button class="btn btn-default only-finished" id="output-expand-toggle">Expand</button>
       <%= link_to "Download log", [@project, deployable, {format: :text}], class: "btn btn-primary only-finished" %>
 
-      <% if deployable.can_be_cancelled_by?(current_user) %>
-        <%= cancel_button deploy: deployable, project: @project, class: "btn btn-danger only-active" %>
-      <% end %>
+      <%= cancel_button deploy: deployable, project: @project, class: "btn btn-danger only-active" %>
     </div>
   </div>
 

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -502,22 +502,8 @@ describe DeploysController do
           delete :destroy, params: {project_id: project.to_param, id: deploy.to_param}
         end
 
-        it "cancels a deploy" do
-          flash[:error].must_be_nil
-        end
-      end
-
-      describe "with a deploy not owned by the user" do
-        before do
-          deploy_service.expects(:cancel).never
-          Deploy.any_instance.stubs(:started_by?).returns(false)
-          User.any_instance.stubs(:admin?).returns(false)
-
-          delete :destroy, params: {project_id: project.to_param, id: deploy.to_param}
-        end
-
-        it "doesn't cancel the deloy" do
-          flash[:error].wont_be_nil
+        it "redirects to project page" do
+          assert_redirected_to "/projects/foo/deploys/#{deploy.id}"
         end
       end
     end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -82,13 +82,6 @@ describe JobsController do
         flash[:notice].must_equal 'Cancelled!'
       end
 
-      it "is unauthorized when not allowed" do
-        job.update_column(:user_id, users(:admin).id)
-        delete :destroy, params: {project_id: project.to_param, id: job}
-        assert_redirected_to [project, job]
-        flash[:error].must_equal "You are not allowed to cancel this job."
-      end
-
       it "redirects to passed path" do
         delete :destroy, params: {project_id: project.to_param, id: job, redirect_to: '/ping'}
         assert_redirected_to '/ping'

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -53,24 +53,6 @@ describe Job do
     end
   end
 
-  describe "#can_be_cancelled_by?" do
-    it "can be cancelled by user that started the job" do
-      job.can_be_cancelled_by?(job.user).must_equal true
-    end
-
-    it "can be cancelled by admin " do
-      job.can_be_cancelled_by?(user).must_equal true
-    end
-
-    it "can be cancelled by admin of this project" do
-      job.can_be_cancelled_by?(users(:project_admin)).must_equal true
-    end
-
-    it "cannot be cancelled by other users" do
-      job.can_be_cancelled_by?(users(:viewer)).must_equal false
-    end
-  end
-
   describe "#commands" do
     it "splits the commands" do
       job.command = "a\rb\r\nc\nd"


### PR DESCRIPTION
* This change will give any user with deploy permissions to a project the permission to cancel any deploy on that project

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: n/a

### Risks
- Level: Low - Issues cancelling deploys
