### PR TITLE
[BRE-826] Do not show Rollbar dashboard item links when setting is empty string

### DIFF
--- a/plugins/rollbar_dashboards/app/helpers/rollbar_dashboards/dashboards_helper.rb
+++ b/plugins/rollbar_dashboards/app/helpers/rollbar_dashboards/dashboards_helper.rb
@@ -22,7 +22,7 @@ module RollbarDashboards
     end
 
     def item_link(item_title, item_id, dashboard_setting)
-      if account_and_project_name = dashboard_setting.account_and_project_name
+      if account_and_project_name = dashboard_setting.account_and_project_name.presence
         # Removes path and handles https://api.rollbar.com cases
         domain = URI.join(dashboard_setting.base_url, '/').to_s.sub('://api.', '://')
 

--- a/plugins/rollbar_dashboards/test/helpers/rollbar_dashboards/dashboards_helper_test.rb
+++ b/plugins/rollbar_dashboards/test/helpers/rollbar_dashboards/dashboards_helper_test.rb
@@ -39,6 +39,10 @@ describe RollbarDashboards::DashboardsHelper do
       item_link('title', '123', setting(account_and_project_name: nil)).must_equal 'title'
     end
 
+    it 'returns item title if account_and_project_name is empty string' do
+      item_link('title', '123', setting(account_and_project_name: '')).must_equal 'title'
+    end
+
     it 'handles api subdomain' do
       setting(account_and_project_name: 'Account/Cool-Project', base_url: 'https://api.rollbar.com')
       item_link('title', '123', setting).must_equal <<~HTML.delete("\n")


### PR DESCRIPTION
/cc @zendesk/samson

### References
 - Jira link: [BRE-826](https://zendesk.atlassian.net/browse/BRE-826)
