### PR TITLE
[BRE-525] Differentiate between failure and error reporter URL

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -106,8 +106,9 @@ class JobExecution
   end
 
   def error!(exception)
-    puts_if_present report_error(exception)
     puts_if_present "JobExecution failed: #{exception.message}"
+    error_url = report_error(exception)
+    @output.puts "Error URL: #{error_url}" if error_url
     puts_if_present render_backtrace(exception)
     @job.errored! if @job.active?
   end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -385,6 +385,7 @@ describe JobExecution do
         ErrorNotifier.expects(:notify).with { |_e, o| assert o.key?(:sync) }.returns('foo')
         job.expects(:running!).raises("Oh boy")
         perform
+        execution.output.to_s.must_include "Error URL: foo"
       end
     end
   end


### PR DESCRIPTION
There was some confusion around the error messaging when a `JobExecution` fails during a deploy. Previously we were printing the exception's error message, followed by the error reporter's URL for the exception:
```
[10:05:23] https://rollbar-us.zendesk.com/instance/uuid?uuid=d9a7ffdb-fc08-40e0-a6f0-4b9da087fb2b
[10:05:23] JobExecution failed: Timed out connecting to server
``` 
Which was causing some confusion, as it kind of looked like it was an error with Rollbar itself. This makes it more clear that the url printed is tied to the failure of the `JobExecution`
```
[10:05:23] JobExecution failed: Timed out connecting to server
[10:05:23] Error URL: https://rollbar-us.zendesk.com/instance/uuid?uuid=d9a7ffdb-fc08-40e0-a6f0-4b9da087fb2b
```

/cc @zendesk/samson

### References
 - Jira link: [BRE-525](https://zendesk.atlassian.net/browse/BRE-525)

### Risks
- Level: Low
