### PR TITLE
make deleted deploy group roles more obvious

### DIFF
--- a/plugins/kubernetes/app/helpers/deploy_group_roles_helper.rb
+++ b/plugins/kubernetes/app/helpers/deploy_group_roles_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# NOTE: using kubernetes namespace resulted in a strange error on every page
+module DeployGroupRolesHelper
+  def kubernetes_deploy_group_role_replica(role, dgr)
+    if dgr.delete_resource?
+      icon_tag :remove, title: "Marked for deletion"
+    else
+      html = "".html_safe
+      html << dgr.replicas.to_s
+      if role.autoscaled?
+        html << icon_tag(:scale, title: "Replicas managed externally, actual count might not match this")
+      end
+      html
+    end
+  end
+end

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
@@ -40,7 +40,7 @@
           <td><%= link_to deploy_group_role.kubernetes_role.name, [deploy_group_role.project, deploy_group_role.kubernetes_role] %></td>
           <td><%= deploy_group_role.requests_cpu %> to <%= deploy_group_role.limits_cpu %></td>
           <td><%= deploy_group_role.requests_memory %> to <%= deploy_group_role.limits_memory %></td>
-          <td><%= deploy_group_role.replicas %></td>
+          <td><%= kubernetes_deploy_group_role_replica deploy_group_role.kubernetes_role, deploy_group_role %></td>
           <td>
             <% if current_user.admin_for?(deploy_group_role.project) %>
               <%= link_to 'Edit', edit_kubernetes_deploy_group_role_path(deploy_group_role) %>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -27,10 +27,7 @@
         <tr>
           <td><%= link_to role.name, [@project, role] %></td>
           <% if dg_role %>
-            <td>
-              <%= dg_role.replicas %>
-              <%= icon_tag :scale, title: "Replicas managed externally, actual count might not match this" if role.autoscaled? %>
-            </td>
+            <td><%= kubernetes_deploy_group_role_replica role, dg_role %></td>
             <td>
               <%= dg_role.requests_cpu %> to <%= dg_role.limits_cpu %>
               <%= "(Not enforced)" if dg_role.no_cpu_limit?  %>

--- a/plugins/kubernetes/test/helpers/deploy_group_roles_helper_test.rb
+++ b/plugins/kubernetes/test/helpers/deploy_group_roles_helper_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require_relative "../test_helper"
+
+SingleCov.covered!
+
+describe DeployGroupRolesHelper do
+  include ApplicationHelper
+
+  let(:dgr) { kubernetes_deploy_group_roles(:test_pod1_app_server) }
+  let(:role) { dgr.kubernetes_role }
+
+  describe "#kubernetes_deploy_group_role_replica" do
+    it "shows a simple count" do
+      kubernetes_deploy_group_role_replica(role, dgr).must_equal "3"
+    end
+
+    it "shows autoscaled" do
+      role.autoscaled = true
+      kubernetes_deploy_group_role_replica(role, dgr).must_include "3<i title=\"Replicas managed"
+    end
+
+    it "shows deleted" do
+      dgr.delete_resource = true
+      kubernetes_deploy_group_role_replica(role, dgr).must_include "<i title=\"Marked"
+    end
+  end
+end


### PR DESCRIPTION
@ragurney 
/cc @zendesk/compute 

<img width="1020" alt="screen shot 2018-07-18 at 11 06 15 am" src="https://user-images.githubusercontent.com/11367/42900352-8f3ef6c6-8a7d-11e8-91e5-e27ad78b2452.png">
<img width="1057" alt="screen shot 2018-07-18 at 11 06 07 am" src="https://user-images.githubusercontent.com/11367/42900353-8f66f482-8a7d-11e8-8f20-3b533852efc4.png">
