### PR TITLE
bump doorkeeper to silence cvs ... we do not use the oauth part anyway

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
     dogstatsd-ruby (3.0.0)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (4.3.0)
+    doorkeeper (4.4.0)
       railties (>= 4.2)
     dotenv (2.2.1)
     encryptor (3.0.0)

--- a/db/migrate/20180719171414_add_confidential_to_doorkeeper_application.rb
+++ b/db/migrate/20180719171414_add_confidential_to_doorkeeper_application.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddConfidentialToDoorkeeperApplication < ActiveRecord::Migration[5.2]
+  def change
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: true # maintaining backwards compatibility: require secrets
+    )
+  end
+end


### PR DESCRIPTION
@ragurney 

```
Name: doorkeeper
Version: 4.3.0
Advisory: CVE-2018-1000211
Criticality: Unknown
URL: https://blog.justinbull.ca/cve-2018-1000211-public-apps-cant-revoke-tokens-in-doorkeeper/
Title: Doorkeeper gem does not revoke token for public clients
Solution: upgrade to >= 4.4.0, >= 5.0.0.rc2
```

```
  There is no breaking change in this release, however to take advantage of the security fix you must:

    1. Run `rails generate doorkeeper:add_client_confidentiality` for the migration
    2. Review your OAuth apps and determine which ones exclusively use public grant flows (eg implicit)
    3. Update their `confidential` column to `false` for those public apps

  This is a backported security release.

  For more information:

    * https://github.com/doorkeeper-gem/doorkeeper/pull/1119
    * https://github.com/doorkeeper-gem/doorkeeper/issues/891
```