### PR TITLE
Add update timestamp so budget monitor can ignore recent deployments

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_26_154722) do
+ActiveRecord::Schema.define(version: 2018_07_19_171414) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -342,6 +342,7 @@ ActiveRecord::Schema.define(version: 2018_06_26_154722) do
     t.string "scopes", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "confidential", default: true, null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true, length: 191
   end
 

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -112,7 +112,8 @@ module Kubernetes
         [replica_target - 1, Integer(min_available)].min
       end
       target = 0 if target < 0
-
+      annotations = (resource.dig(:metadata, :annotations) || {}).dup
+      annotations[:"samson/updateTimestamp"] = Time.now.utc.iso8601
       budget = {
         apiVersion: "policy/v1beta1",
         kind: "PodDisruptionBudget",
@@ -120,7 +121,7 @@ module Kubernetes
           name: kubernetes_role.resource_name,
           namespace: resource.dig(:metadata, :namespace),
           labels: resource.dig_fetch(:metadata, :labels).dup,
-          annotations: (resource.dig(:metadata, :annotations) || {}).dup
+          annotations: annotations
         },
         spec: {
           minAvailable: target,

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -81,10 +81,12 @@ describe Kubernetes::ReleaseDoc do
 
     describe "PodDisruptionBudget" do
       it "adds relative PodDisruptionBudget when requested" do
+        Time.stubs(:now).returns(Time.parse("2018-01-01"))
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '30%'}
         budget = create!.resource_template[2]
         budget[:spec][:minAvailable].must_equal 1
         budget[:metadata][:namespace].must_equal 'pod1'
+        budget[:metadata][:annotations][:"samson/updateTimestamp"].must_equal "2018-01-01T00:00:00Z"
         refute budget.key?(:delete)
       end
 


### PR DESCRIPTION
@zendesk/compute 