### PR TITLE
Scrub session from rollbar

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -194,11 +194,14 @@ module Samson
   RELEASE_NUMBER = '\d+(:?\.\d+)*'
 end
 
-# Configure sensitive parameters which will be filtered from the log file
+# Configure sensitive parameters which will be filtered from the log files + errors
 # Must be here instead of in an initializer because plugin initializers run before app initializers
-# Used in plugins/airbrake which does not support the 'foo.bar' syntax as rails does
+# Used in plugins/airbrake + rollbar which do not support the 'foo.bar' syntax as rails does
 # https://github.com/airbrake/airbrake-ruby/issues/137
-Rails.application.config.filter_parameters.concat [:password, :value, :value_hashed, :token, :access_token]
+Samson::Application.config.session_key = :"_samson_session_#{Rails.env}"
+Rails.application.config.filter_parameters.concat [
+  :password, :value, :value_hashed, :token, :access_token, Samson::Application.config.session_key, 'HTTP_AUTHORIZATION'
+]
 
 # Avoid starting up another background thread if we don't need it, see lib/samson/boot_check.rb
 if ["test", "development"].include?(Rails.env)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 # Restart your server when you modify this file.
 
-# enable multiple samson instances on the same base domain (samson-staging.foo.com + samson-production.foo.com)
-Samson::Application.config.session_store :cookie_store, key: "_samson_session_#{Rails.env}"
+Samson::Application.config.session_store :cookie_store, key: Samson::Application.config.session_key

--- a/plugins/airbrake/config/initializers/airbrake.rb
+++ b/plugins/airbrake/config/initializers/airbrake.rb
@@ -12,7 +12,7 @@ if key = ENV['AIRBRAKE_API_KEY']
 
     config.app_version = Rails.application.config.samson.version&.first(7)
     raise 'This must run after config/initializers/ ' if Rails.application.config.filter_parameters.empty?
-    config.blacklist_keys = Rails.application.config.filter_parameters + ['HTTP_AUTHORIZATION']
+    config.blacklist_keys = Rails.application.config.filter_parameters
 
     # send correct errors even when something blows up during initialization
     config.environment = Rails.env

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -14,7 +14,6 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
     config.code_version = Rails.application.config.samson.version&.first(7)
     config.populate_empty_backtraces = true
     config.logger = Rails.logger
-    config.scrub_fields |= Rails.application.config.filter_parameters + ['HTTP_AUTHORIZATION']
 
     # ignore errors we do not want to send to Rollbar
     config.before_process << proc do |options|


### PR DESCRIPTION
Scrub session from rollbar. Doesn't seem like something we need to be storing. 
(Haven't tested that this patch actually works, needs Rollbar to be set up for that)

/cc @zendesk/samson @grosser 

### Tasks
 - [ ] :+1: from team
