### PR TITLE
do not fail seeding with an exception when too many roles have errors

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
@@ -89,7 +89,10 @@ class Kubernetes::DeployGroupRolesController < ApplicationController
         errors.concat(created.map do |dgr|
           "#{dgr.kubernetes_role.name} for #{dgr.deploy_group.name}: #{dgr.errors.full_messages.to_sentence}"
         end)
-        {alert: view_context.simple_format(errors.join("\n"))}
+        max = 4 # header + 3
+        message = errors.first(max).join("\n")
+        message << " ..." if errors.size > max
+        {alert: view_context.simple_format(message)}
       end
     redirect_to [@stage.project, @stage], options
   end


### PR DESCRIPTION
@ragurney 
/cc @zendesk/compute 

previously would result in a cookieoverflow since the limit message is quiet long ... there seems to be no generic way to cut down alerts to not overflow cookies, so using this until it happens again ...