### PR TITLE
Fix inline deletion of deselected stage command

### DIFF
--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -54,7 +54,7 @@ class CommandsController < ApplicationController
 
   def destroy
     # Destroy specific stage command usage if `stage_id` is passed in to allow for inline deletion
-    remove_stage_usage if params[:stage_id]
+    remove_stage_usage_if_exists
 
     if @command.destroy
       successful_response('Command removed.')
@@ -107,7 +107,8 @@ class CommandsController < ApplicationController
     end
   end
 
-  def remove_stage_usage
-    StageCommand.find_by!(stage_id: params[:stage_id], command_id: @command.id).destroy
+  def remove_stage_usage_if_exists
+    return if params[:stage_id].nil?
+    StageCommand.find_by(stage_id: params[:stage_id], command_id: @command.id)&.destroy
   end
 end

--- a/test/controllers/commands_controller_test.rb
+++ b/test/controllers/commands_controller_test.rb
@@ -204,33 +204,43 @@ describe CommandsController do
             Command.exists?(command.id).must_equal(false)
           end
 
-          it 'removes stage command and command if stage is passed' do
-            stage = stages(:test_staging)
-            stage_command = stage_commands(:test_staging_echo)
+          describe 'delete from stage edit' do
+            it 'removes stage command and command if stage is passed' do
+              stage = stages(:test_staging)
+              stage_command = stage_commands(:test_staging_echo)
 
-            command.stage_commands = [stage_command]
+              command.stage_commands = [stage_command]
 
-            assert_difference 'StageCommand.count', -1 do
-              assert_difference 'Command.count', -1 do
-                delete_command(stage_id: stage.id)
+              assert_difference 'StageCommand.count', -1 do
+                assert_difference 'Command.count', -1 do
+                  delete_command(stage_id: stage.id)
+                end
               end
+
+              StageCommand.exists?(stage_command.id).must_equal false
+              Command.exists?(command.id).must_equal false
             end
 
-            StageCommand.exists?(stage_command.id).must_equal false
-            Command.exists?(command.id).must_equal false
-          end
+            it 'removes stage command but not command if stage is passed but command is still in use elsewhere' do
+              stage_command_id = stage_commands(:test_staging_echo).id
 
-          it 'removes stage command but not command if stage is passed but command is still in use elsewhere' do
-            stage_command_id = stage_commands(:test_staging_echo).id
-
-            assert_difference 'StageCommand.count', -1 do
-              assert_no_difference 'Command.count' do
-                delete_command(stage_id: stages(:test_staging).id)
+              assert_difference 'StageCommand.count', -1 do
+                assert_no_difference 'Command.count' do
+                  delete_command(stage_id: stages(:test_staging).id)
+                end
               end
+
+              StageCommand.exists?(stage_command_id).must_equal false
+              Command.exists?(command.id).must_equal true
             end
 
-            StageCommand.exists?(stage_command_id).must_equal false
-            Command.exists?(command.id).must_equal true
+            it 'removes command without stage command (command deselected)' do
+              StageCommand.delete_all
+
+              delete_command(stage_id: stages(:test_staging).id)
+
+              Command.exists?(command.id).must_equal(false)
+            end
           end
         end
 


### PR DESCRIPTION
#2867 fixed inline deletion of selected stage commands but broke inline deletion of deselected commands :/ This is because deselected stage commands to not have an accompanying `StageCommand`, so we delete the `StageCommand` if it exists and don't blow up if it doesn't.

/cc @zendesk/samson