### PR TITLE
Show pipeline results

### DIFF
--- a/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
@@ -19,7 +19,10 @@
     <div>
       After this stage finishes deploying it will deploy to:
       <%= unordered_list next_stages do |stage| %>
-        <%= link_to stage.name, [@project, stage] %>
+        <%= link_to stage.name, [@project, stage] %>  
+        <% if last_deploy = stage.last_deploy %> 
+          Last Deploy: <%= render_time last_deploy.start_time %> <%= status_badge last_deploy.status %>
+        <% end %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
When doing a multi stage deploy, it may not be easy to see when the entire pipeline is completed, e.g. you'd have to click on each of the linked stages to see whether or not they have finished/failed.

This PR will show the last deploy status for the individual stages so that you can get a quick summary of the overall deploy. 

<img width="1162" alt="screen shot 2018-08-08 at 2 45 06 pm" src="https://user-images.githubusercontent.com/8293149/43816753-bb90246e-9b19-11e8-8b0b-9cc5ab78ba6d.png">

### Risks
- Level: Low, updates UI.

