### PR TITLE
[PAAS-1939] always set spec.initContainers regardless of k8s version

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -237,8 +237,11 @@ module Kubernetes
       # Kubernetes will ignore it, but having it present makes cluster upgrades a lot easier.
       pod_template.dig_set([:spec, :initContainers], init_containers)
 
+      key = Kubernetes::Api::Pod::INIT_CONTAINER_KEY
       if init_containers_need_annotation?
-        annotations[Kubernetes::Api::Pod::INIT_CONTAINER_KEY] = JSON.pretty_generate(init_containers)
+        annotations[key] = JSON.pretty_generate(init_containers)
+      else
+        annotations.delete(key)
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -405,15 +405,17 @@ describe Kubernetes::TemplateFiller do
 
         let(:spec_init_containers) { result.dig(:spec, :template, :spec, :initContainers) || [] }
 
-        it 'sets init containers in annotations if using < 1.6.0 k8s server version' do
+        it 'sets init containers both formats if using < 1.6.0 k8s server version' do
           add_init_container("samson/dockerfile": 'Dockerfile')
+
+          spec_init_containers[0].must_equal('samson/dockerfile': "Dockerfile", image: image)
           spec_annotation_containers[0].must_equal("samson/dockerfile" => "Dockerfile", "image" => image)
         end
 
-        it 'sets init containers using updated syntax to old syntax if using < 1.6.0 k8s server version' do
+        it 'sets init containers using updated syntax to both formats if using < 1.6.0 k8s server version' do
           add_init_contnainer_new_syntax('samson/dockerfile': 'Dockerfile')
 
-          spec_init_containers.must_equal([])
+          spec_init_containers[0].must_equal('samson/dockerfile': "Dockerfile", image: image)
           spec_annotation_containers[0].must_equal("samson/dockerfile" => "Dockerfile", "image" => image)
         end
 


### PR DESCRIPTION
We're upgrading our K8S clusters from 1.5.7 to 1.10, and this is causing problems when Deployments that only have the annotations get new pods scheduled on Nodes running 1.10. The end result is no init containers at all.

I'll test to confirm it's safe to have `.spec.initContainers` set for earlier versions of Kubernetes.

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-1938

### Risks
- Level: Low

/cc @zendesk/samson, @zendesk/compute 
