### PR TITLE
Add mass rollout for k8s stages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ group :development, :test do
   gem 'byebug'
   gem 'bootsnap'
   gem 'pry-rails'
+  gem 'pry-byebug'
   gem 'pry'
   gem 'awesome_print'
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (3.11.3)
@@ -584,6 +587,7 @@ DEPENDENCIES
   parallel_tests
   pg
   pry
+  pry-byebug
   pry-rails
   puma
   rack-mini-profiler

--- a/app/controllers/mass_rollouts_controller.rb
+++ b/app/controllers/mass_rollouts_controller.rb
@@ -38,7 +38,7 @@ class MassRolloutsController < ApplicationController
     end
 
     if deploys.empty?
-      flash[:error] = "There were no stages that matched the mass rollout deploy criteria."
+      flash[:error] = "No deployable stages found."
       redirect_to deploys_path
     else
       redirect_to deploys_path(ids: deploys.map(&:id))

--- a/app/views/deploy_groups/_mass_rollout_form.html.erb
+++ b/app/views/deploy_groups/_mass_rollout_form.html.erb
@@ -1,0 +1,61 @@
+<label class="col-lg-2 control-label">Mass Rollout</label>
+<div class="col-lg-10">
+  <%= form_tag deploy_deploy_group_mass_rollouts_path(@deploy_group) do %>
+
+    <% if defined?(SamsonKubernetes::Engine) %>
+      <div class="form-group">
+        <div class="col-lg-10">
+          <label>Kubernetes</label>
+          <div class="form-group">
+            <div class="col-lg-4 radio">
+              <%= label_tag do %>
+                <%= radio_button_tag :kubernetes, '', :checked %>
+                All
+              <% end %>
+            </div>
+            <div class="col-lg-4 radio">
+              <%= label_tag do %>
+                <%= radio_button_tag :kubernetes, 'true' %>
+                Only Kubernetes
+              <% end %>
+            </div>
+
+            <div class="col-lg-4 radio">
+              <%= label_tag do %>
+                <%= radio_button_tag :kubernetes, 'false' %>
+                Only Non-Kubernetes
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="form-group">
+      <div class="col-lg-10">
+        <label>Stage Status Filter</label>
+        <div class="form-group">
+          <div class="col-lg-4 radio">
+            <%= label_tag do %>
+              <%= radio_button_tag :status, '', :checked %>
+              All
+            <% end %>
+          </div>
+          <div class="col-lg-4 radio">
+            <%= label_tag do %>
+              <%= radio_button_tag :status, 'successful' %>
+              Previously successful
+            <% end %>
+          </div>
+          <div class="col-lg-4 radio">
+            <%= label_tag do %>
+              <%= radio_button_tag :status, 'missing' %>
+              <abbr title="Any stages that haven't yet been deployed or have failed all their deploys">Missing</abbr>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <%= submit_tag "Start Deploys", class: "btn btn-default", data: { confirm: "Deploys will be started for all matching stages", disable_with: "Deploying..." } %>
+  <% end %>
+</div>

--- a/app/views/deploy_groups/_mass_stage_creation_form.html.erb
+++ b/app/views/deploy_groups/_mass_stage_creation_form.html.erb
@@ -1,0 +1,25 @@
+<label class="col-lg-2 control-label">Mass Stage Creation</label>
+<div class="col-lg-10">
+  <%= link_to "Create Stages ...",
+      new_deploy_group_mass_rollouts_path(@deploy_group),
+      class: "btn btn-default"
+  %>
+  <% cloned_stage_count = @deploy_group.stages.cloned.count %>
+  <%= link_to "Merge #{cloned_stage_count} Cloned Stages",
+      merge_deploy_group_mass_rollouts_path(@deploy_group),
+      class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
+      data: {
+          method: "post",
+          confirm: "Stages will be deleted. Before deleting, each stage will have its Deploy Group added to the stage it was copied from. Stages affected are those cloned from a template stage, have exactly this deploy group, and are on a project that uses include_new_deploy_groups.\n\n" \
+                "Merge #{@deploy_group.stages.cloned.count} cloned stages now?"
+      }
+  %>
+  <%= link_to "Delete #{cloned_stage_count} Cloned Stages",
+      deploy_group_mass_rollouts_path(@deploy_group),
+      class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
+      data: {
+          method: "delete",
+          confirm: "Cloned stages will be deleted. No stages will be merged into their templates. You will need to create a new stage to deploy the project to this deploy group."
+      }
+  %>
+</div>

--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -72,28 +72,13 @@
 
   <%= Samson::Hooks.render_views(:deploy_group_show, self) %>
 
-  <div class="form-group">
-    <% if DeployGroup.enabled? %>
-      <div class="col-lg-offset-2 col-lg-10" style="display: none" id="mass_rollout">
+  <% if DeployGroup.enabled? %>
+    <div class="form-group" id="mass_stage_creation" style="display: none">
+      <label class="col-lg-2 control-label">Mass Stage Creation</label>
+      <div class="col-lg-10">
         <%= link_to "Create Stages ...",
             new_deploy_group_mass_rollouts_path(@deploy_group),
             class: "btn btn-default"
-        %>
-        <%= link_to "Deploy All Projects",
-            deploy_deploy_group_mass_rollouts_path(@deploy_group),
-            class: "btn btn-default",
-            data: {
-              method: "post",
-              confirm: "Deploys will be started for all stages."
-            }
-        %>
-        <%= link_to "Deploy Missing Projects",
-            deploy_deploy_group_mass_rollouts_path(@deploy_group, missing_only: "true"),
-            class: "btn btn-default",
-            data: {
-              method: "post",
-              confirm: "Deploys will be started for any stages that haven't yet been deployed or have failed all their deploys."
-            }
         %>
         <% cloned_stage_count = @deploy_group.stages.cloned.count %>
         <%= link_to "Merge #{cloned_stage_count} Cloned Stages",
@@ -114,13 +99,68 @@
             }
         %>
       </div>
-    <% end %>
-    <br>
+    </div>
+    <div class="form-group" id="mass_rollout" style="display: none">
+      <label class="col-lg-2 control-label">Mass Rollout</label>
+      <div class="col-lg-10">
+        <%= form_tag deploy_deploy_group_mass_rollouts_path(@deploy_group) do %>
+
+          <% if defined?(SamsonKubernetes::Engine) %>
+          <div class="form-group">
+            <div class="col-lg-8">
+              <label>Stage Type</label>
+
+              <div class="form-group">
+                <div class="col-lg-5 checkbox">
+                  <%= label_tag do %>
+                    <%= check_box_tag :kubernetes, true, :checked %>
+                    Kubernetes stages
+                  <% end %>
+                </div>
+
+                <div class="col-lg-5 checkbox">
+                  <%= label_tag do %>
+                    <%= check_box_tag :non_kubernetes, true, :checked%>
+                    Non-Kubernetes stages
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <% end %>
+
+          <div class="form-group">
+            <div class="col-lg-8">
+              <label>Stage Filter</label>
+              <div class="form-group">
+                <div class="col-lg-5 checkbox">
+                  <%= label_tag do %>
+                    <%= check_box_tag :successful, true, :checked %>
+                    Previously successful stages
+                  <% end %>
+                </div>
+                <div class="col-lg-5 checkbox">
+                  <%= label_tag do %>
+                    <%= check_box_tag :missing, true, :checked %>
+                    <abbr title="Any stages that haven't yet been deployed or have failed all their deploys">Missing</abbr> stages
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <%= submit_tag "Start Deploys", class: "btn btn-default", data: { confirm: "Deploys will be started for all stages matching the checkboxes selected", disable_with: "Deploying..." } %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="form-group">
     <div class="col-lg-offset-2 col-lg-10" style="margin-top: 10px;">
       <%= link_to "Edit", edit_deploy_group_path(@deploy_group), class: "btn btn-primary" %>
       <%= render "locks/button", lock: @deploy_group.lock, resource: @deploy_group %>
       | <%= link_to_history @deploy_group %>
       | <%= link_to "Deploys", deploys_path(search: {group: "DeployGroup-#{@deploy_group.id}"}) %>
+      | <%= link_to "Mass stage creation", "#", data: {target: "#mass_stage_creation"}, class: 'toggle' if DeployGroup.enabled? %>
       | <%= link_to "Mass rollout", "#", data: {target: "#mass_rollout"}, class: 'toggle' if DeployGroup.enabled? %>
       | <%= link_to "Missing config", missing_config_deploy_group_path(@deploy_group) %>
     </div>

--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -74,95 +74,10 @@
 
   <% if DeployGroup.enabled? %>
     <div class="form-group" id="mass_stage_creation" style="display: none">
-      <label class="col-lg-2 control-label">Mass Stage Creation</label>
-      <div class="col-lg-10">
-        <%= link_to "Create Stages ...",
-            new_deploy_group_mass_rollouts_path(@deploy_group),
-            class: "btn btn-default"
-        %>
-        <% cloned_stage_count = @deploy_group.stages.cloned.count %>
-        <%= link_to "Merge #{cloned_stage_count} Cloned Stages",
-            merge_deploy_group_mass_rollouts_path(@deploy_group),
-            class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
-            data: {
-              method: "post",
-              confirm: "Stages will be deleted. Before deleting, each stage will have its Deploy Group added to the stage it was copied from. Stages affected are those cloned from a template stage, have exactly this deploy group, and are on a project that uses include_new_deploy_groups.\n\n" \
-                "Merge #{@deploy_group.stages.cloned.count} cloned stages now?"
-            }
-        %>
-        <%= link_to "Delete #{cloned_stage_count} Cloned Stages",
-            deploy_group_mass_rollouts_path(@deploy_group),
-            class: "btn btn-default #{ 'disabled' if cloned_stage_count.zero? }",
-            data: {
-              method: "delete",
-              confirm: "Cloned stages will be deleted. No stages will be merged into their templates. You will need to create a new stage to deploy the project to this deploy group."
-            }
-        %>
-      </div>
+      <%= render 'mass_stage_creation_form' %>
     </div>
     <div class="form-group" id="mass_rollout" style="display: none">
-      <label class="col-lg-2 control-label">Mass Rollout</label>
-      <div class="col-lg-10">
-        <%= form_tag deploy_deploy_group_mass_rollouts_path(@deploy_group) do %>
-
-          <% if defined?(SamsonKubernetes::Engine) %>
-            <div class="form-group">
-              <div class="col-lg-10">
-                <label>Stage Type</label>
-
-                <div class="form-group">
-                  <div class="col-lg-4 radio">
-                    <%= label_tag do %>
-                      <%= radio_button_tag :type, '', :checked %>
-                      All
-                    <% end %>
-                  </div>
-                  <div class="col-lg-4 radio">
-                    <%= label_tag do %>
-                      <%= radio_button_tag :type, 'kubernetes' %>
-                      Kubernetes stages only
-                    <% end %>
-                  </div>
-
-                  <div class="col-lg-4 radio">
-                    <%= label_tag do %>
-                      <%= radio_button_tag :type, 'non_kubernetes' %>
-                      Non-Kubernetes stages only
-                    <% end %>
-                  </div>
-                </div>
-              </div>
-            </div>
-          <% end %>
-
-          <div class="form-group">
-            <div class="col-lg-10">
-              <label>Stage Status Filter</label>
-              <div class="form-group">
-                <div class="col-lg-4 radio">
-                  <%= label_tag do %>
-                    <%= radio_button_tag :status, '', :checked %>
-                    All
-                  <% end %>
-                </div>
-                <div class="col-lg-4 radio">
-                  <%= label_tag do %>
-                    <%= radio_button_tag :status, 'successful' %>
-                    Previously successful stages only
-                  <% end %>
-                </div>
-                <div class="col-lg-4 radio">
-                  <%= label_tag do %>
-                    <%= radio_button_tag :status, 'missing' %>
-                    <abbr title="Any stages that haven't yet been deployed or have failed all their deploys">Missing</abbr> stages only
-                  <% end %>
-                </div>
-              </div>
-            </div>
-          </div>
-          <%= submit_tag "Start Deploys", class: "btn btn-default", data: { confirm: "Deploys will be started for all matching stages", disable_with: "Deploying..." } %>
-        <% end %>
-      </div>
+      <%= render 'mass_rollout_form' %>
     </div>
   <% end %>
 

--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -106,49 +106,61 @@
         <%= form_tag deploy_deploy_group_mass_rollouts_path(@deploy_group) do %>
 
           <% if defined?(SamsonKubernetes::Engine) %>
-          <div class="form-group">
-            <div class="col-lg-8">
-              <label>Stage Type</label>
+            <div class="form-group">
+              <div class="col-lg-10">
+                <label>Stage Type</label>
 
-              <div class="form-group">
-                <div class="col-lg-5 checkbox">
-                  <%= label_tag do %>
-                    <%= check_box_tag :kubernetes, true, :checked %>
-                    Kubernetes stages
-                  <% end %>
-                </div>
+                <div class="form-group">
+                  <div class="col-lg-4 radio">
+                    <%= label_tag do %>
+                      <%= radio_button_tag :type, '', :checked %>
+                      All
+                    <% end %>
+                  </div>
+                  <div class="col-lg-4 radio">
+                    <%= label_tag do %>
+                      <%= radio_button_tag :type, 'kubernetes' %>
+                      Kubernetes stages only
+                    <% end %>
+                  </div>
 
-                <div class="col-lg-5 checkbox">
-                  <%= label_tag do %>
-                    <%= check_box_tag :non_kubernetes, true, :checked%>
-                    Non-Kubernetes stages
-                  <% end %>
+                  <div class="col-lg-4 radio">
+                    <%= label_tag do %>
+                      <%= radio_button_tag :type, 'non_kubernetes' %>
+                      Non-Kubernetes stages only
+                    <% end %>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
           <% end %>
 
           <div class="form-group">
-            <div class="col-lg-8">
-              <label>Stage Filter</label>
+            <div class="col-lg-10">
+              <label>Stage Status Filter</label>
               <div class="form-group">
-                <div class="col-lg-5 checkbox">
+                <div class="col-lg-4 radio">
                   <%= label_tag do %>
-                    <%= check_box_tag :successful, true, :checked %>
-                    Previously successful stages
+                    <%= radio_button_tag :status, '', :checked %>
+                    All
                   <% end %>
                 </div>
-                <div class="col-lg-5 checkbox">
+                <div class="col-lg-4 radio">
                   <%= label_tag do %>
-                    <%= check_box_tag :missing, true, :checked %>
-                    <abbr title="Any stages that haven't yet been deployed or have failed all their deploys">Missing</abbr> stages
+                    <%= radio_button_tag :status, 'successful' %>
+                    Previously successful stages only
+                  <% end %>
+                </div>
+                <div class="col-lg-4 radio">
+                  <%= label_tag do %>
+                    <%= radio_button_tag :status, 'missing' %>
+                    <abbr title="Any stages that haven't yet been deployed or have failed all their deploys">Missing</abbr> stages only
                   <% end %>
                 </div>
               </div>
             </div>
           </div>
-          <%= submit_tag "Start Deploys", class: "btn btn-default", data: { confirm: "Deploys will be started for all stages matching the checkboxes selected", disable_with: "Deploying..." } %>
+          <%= submit_tag "Start Deploys", class: "btn btn-default", data: { confirm: "Deploys will be started for all matching stages", disable_with: "Deploying..." } %>
         <% end %>
       </div>
     </div>

--- a/test/controllers/mass_rollouts_controller_test.rb
+++ b/test/controllers/mass_rollouts_controller_test.rb
@@ -51,8 +51,12 @@ describe MassRolloutsController do
         let(:env) { environments(:staging) }
         let(:pod100) { DeployGroup.create!(name: 'Pod 100', environment: env) }
         let(:pod101) { DeployGroup.create!(name: 'Pod 101', environment: env) }
-        let(:stage100) { Stage.create!(name: 'Staging 100', project: Project.first, deploy_groups: [pod100], is_template: true) }
-        let(:stage101) { Stage.create!(name: 'Staging 101', project: Project.first, deploy_groups: [pod101], template_stage: stage100) }
+        let(:stage100) do
+          Stage.create!(name: 'Staging 100', project: Project.first, deploy_groups: [pod100], is_template: true)
+        end
+        let(:stage101) do
+          Stage.create!(name: 'Staging 101', project: Project.first, deploy_groups: [pod101], template_stage: stage100)
+        end
 
         before do
           DeployGroup.delete_all
@@ -195,7 +199,7 @@ describe MassRolloutsController do
         deploy_group.stages.first.deploys.delete_all
 
         assert_difference 'Deploy.count', 1 do
-          post :deploy, params: {deploy_group_id: deploy_group, missing: true, non_kubernetes: true }
+          post :deploy, params: {deploy_group_id: deploy_group, missing: true, non_kubernetes: true}
         end
       end
 

--- a/test/controllers/mass_rollouts_controller_test.rb
+++ b/test/controllers/mass_rollouts_controller_test.rb
@@ -1,12 +1,25 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 8
+SingleCov.covered! uncovered: 7
 
 describe MassRolloutsController do
   def create_stages
     @controller.instance_variable_set(:@deploy_group, deploy_group)
     @controller.send(:create_all_stages)
+  end
+
+  def create_deploy(stage, reference, status)
+    stage.deploys.create!(
+      reference: reference,
+      project: stage.project,
+      job: Job.create!(
+        project: stage.project,
+        user: User.first,
+        status: status,
+        command: 'blah'
+      )
+    )
   end
 
   let(:deploy_group) { deploy_groups(:pod100) }
@@ -47,7 +60,29 @@ describe MassRolloutsController do
     end
 
     describe "#deploy" do
-      describe "deploy for successful deploys" do
+      def deploy(deploy_group)
+        post :deploy, params: {deploy_group_id: deploy_group, status: status}
+      end
+
+      let(:status) { nil }
+
+      it "deploys all" do
+        assert_difference('Deploy.count', 1) do
+          post :deploy, params: {deploy_group_id: deploy_groups(:pod100)}
+          assert_response :redirect
+        end
+      end
+
+      it "complains about unknown status" do
+        post :deploy, params: {deploy_group_id: deploy_groups(:pod100), status: "wut"}
+        assert_response :bad_request
+      end
+
+      describe "successful deploys filtering" do
+        def deploy(deploy_group)
+          post :deploy, params: {deploy_group_id: deploy_group, status: 'successful'}
+        end
+
         let(:env) { environments(:staging) }
         let(:pod100) { DeployGroup.create!(name: 'Pod 100', environment: env) }
         let(:pod101) { DeployGroup.create!(name: 'Pod 101', environment: env) }
@@ -57,88 +92,38 @@ describe MassRolloutsController do
         let(:stage101) do
           Stage.create!(name: 'Staging 101', project: Project.first, deploy_groups: [pod101], template_stage: stage100)
         end
+        let(:status) { "successful" }
 
         before do
           DeployGroup.delete_all
           Deploy.delete_all
-
-          stage100.deploys.create!(
-            reference: 'v121',
-            project: stage100.project,
-            job: Job.create!(
-              project: stage100.project,
-              user: User.first,
-              status: "succeeded",
-              command: 'blah'
-            )
-          )
-
-          stage100.deploys.create!(
-            reference: 'v123',
-            project: stage101.project,
-            job: Job.create!(
-              project: stage101.project,
-              user: User.first,
-              status: "failed",
-              command: 'blah'
-            )
-          )
-
-          stage101.deploys.create!(
-            reference: 'master',
-            project: stage101.project,
-            job: Job.create!(
-              project: stage101.project,
-              user: User.first,
-              status: "succeeded",
-              command: 'blah'
-            )
-          )
-
-          stage101.deploys.create!(
-            reference: 'v123',
-            project: stage101.project,
-            job: Job.create!(
-              project: stage101.project,
-              user: User.first,
-              status: "failed",
-              command: 'blah'
-            )
-          )
+          create_deploy stage100, "v121", "succeeded"
+          create_deploy stage100, "v123", "failed"
+          create_deploy stage101, "master", "succeeded"
+          create_deploy stage101, "v123", "failed"
         end
 
         it 'deploys all stages with successful deploys for this deploy_group' do
-          assert_difference 'Deploy.count', 1 do
-            post :deploy, params: {deploy_group_id: pod100, status: 'successful', type: 'non_kubernetes'}
-          end
-
+          assert_difference('Deploy.count', 1) { deploy pod100 }
           deploy = stage100.deploys.order('created_at desc').first
           assert_redirected_to "/deploys?ids%5B%5D=#{deploy.id}"
         end
 
         it "redeploys the same reference as the template stage's last successful deploy" do
-          assert_difference 'Deploy.count', 1 do
-            post :deploy, params: {deploy_group_id: pod101, status: 'successful', type: 'non_kubernetes'}
-          end
+          assert_difference('Deploy.count', 1) { deploy pod101 }
           deploy = Deploy.order('created_at desc').first
           assert_equal 'v121', deploy.reference
         end
 
         it 'ignores stages that have not been deployed yet' do
           stage100.deploys.delete_all
-
-          refute_difference 'Deploy.count' do
-            post :deploy, params: {deploy_group_id: pod100, status: 'successful', type: 'non_kubernetes'}
-          end
+          refute_difference('Deploy.count') { deploy pod100 }
           assert_redirected_to "/deploys" # with no ids present.
         end
 
         it 'ignores stages with only a failed deploy' do
           Job.where(id: stage100.deploys.pluck(:job_id)).update_all(status: :failed)
-
-          refute_difference 'Deploy.count' do
-            post :deploy, params: {deploy_group_id: pod100, status: 'successful', type: 'non_kubernetes'}
-          end
+          refute_difference('Deploy.count') { deploy pod100 }
           assert_redirected_to "/deploys" # with no ids present.
         end
 
@@ -147,106 +132,85 @@ describe MassRolloutsController do
           assert stage100.last_deploy.failed?
           assert stage100.last_successful_deploy
 
-          assert_difference 'Deploy.count', 1 do
-            post :deploy, params: {deploy_group_id: pod101, status: 'successful', type: 'non_kubernetes'}
-          end
+          assert_difference('Deploy.count', 1) { deploy pod101 }
+
           deploy = stage101.deploys.order('created_at desc').first
           assert_equal stage100.last_successful_deploy.reference, deploy.reference
         end
 
         it 'ignores stages with no deploy groups' do
           DeployGroupsStage.delete_all
-
-          post :deploy, params: {deploy_group_id: pod100, status: 'successful', type: 'non_kubernetes'}
+          refute_difference('Deploy.count') { deploy pod100 }
           assert_redirected_to "/deploys" # with no ids  present.
         end
 
         it 'ignores stages that include only other deploy groups' do
-          env = environments(:staging)
-          new_dp = DeployGroup.create!(name: "foo", environment: env)
+          new_dp = DeployGroup.create!(name: "foo", environment: pod100.environment)
           DeployGroupsStage.update_all(deploy_group_id: new_dp.id)
 
-          refute_difference 'Deploy.count' do
-            post :deploy, params: {deploy_group_id: pod100, status: 'successful', type: 'non_kubernetes'}
-          end
+          refute_difference('Deploy.count') { deploy pod100 }
           assert_redirected_to "/deploys" # with no ids  present.
         end
       end
-    end
 
-    describe "deploy for missing deploys" do
-      let(:env) { environments(:staging) }
-      let(:deploy_group) { DeployGroup.create!(name: 'pod102', environment: env) }
+      describe "missing deploys filtering" do
+        let(:env) { environments(:staging) }
+        let(:deploy_group) { DeployGroup.create!(name: 'pod102', environment: env) }
+        let(:status) { "missing" }
 
-      before do
-        create_stages
+        before do
+          create_stages
 
-        # Give it a successful deploy
-        new_stage = deploy_group.reload.stages.first
-        new_stage.deploys.create!(
-          reference: 'master',
-          project: stage.project,
-          job: Job.create!(
-            project: stage.project,
-            user: User.first,
-            status: "succeeded",
-            command: 'blah'
-          )
-        )
-      end
+          # Give it a successful deploy
+          new_stage = deploy_group.reload.stages.first
+          create_deploy new_stage, "master", "succeeded"
+        end
 
-      it "deploys undeployed stage" do
-        deploy_group.stages.first.deploys.delete_all
+        it "deploys undeployed stage" do
+          deploy_group.stages.first.deploys.delete_all
+          assert_difference('Deploy.count', 1) { deploy deploy_group }
+        end
 
-        assert_difference 'Deploy.count', 1 do
-          post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'non_kubernetes'}
+        it "ignores 'successfully deployed' stage" do
+          refute_difference('Deploy.count') { deploy deploy_group }
+        end
+
+        it "deploys 'failed deploy' stage with the template_stage reference" do
+          deploy_group.stages.first.deploys.last.job.update_column(:status, "failed")
+          refute_nil Stage.find(deploy_group.stages.first.template_stage_id).last_successful_deploy
+          assert_difference('Deploy.count', 1) { deploy deploy_group }
+        end
+
+        it 'ignores template_stages that have not been deployed yet' do
+          Deploy.delete_all
+          refute_difference('Deploy.count') { deploy deploy_group }
+          assert_redirected_to "/deploys" # with no ids  present.
+        end
+
+        it 'ignores template_stages with only a failed deploy' do
+          Job.update_all(status: :failed)
+          refute_difference('Deploy.count') { deploy deploy_group }
+          assert_redirected_to "/deploys" # with no ids  present.
+        end
+
+        it 'ignores template_stages not marked as template stages' do
+          deploy_group.environment.template_stages.update_all(is_template: false)
+          refute_difference('Deploy.count') { deploy deploy_group }
+          assert_redirected_to "/deploys" # with no ids  present.
+        end
+
+        it 'ignores projects with no template stage for this environment' do
+          Stage.update_all(template_stage_id: nil)
+          refute_difference('Deploy.count') { deploy deploy_group }
+          assert_redirected_to "/deploys" # with no ids  present.
         end
       end
 
-      it "deploys 'failed deploy' stage with the template_stage reference" do
-        deploy_group.stages.first.deploys.last.job.update_column(:status, "failed")
-        refute_nil Stage.find(deploy_group.stages.first.template_stage_id).last_successful_deploy
-
-        assert_difference 'Deploy.count', 1 do
-          post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'non_kubernetes'}
+      describe 'kubernetes filtering' do
+        def deploy(kubernetes)
+          post :deploy, params: {deploy_group_id: deploy_group, kubernetes: kubernetes}
         end
-      end
 
-      it 'ignores template_stages that have not been deployed yet' do
-        Deploy.delete_all
-
-        post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'non_kubernetes'}
-        assert_redirected_to "/deploys" # with no ids  present.
-      end
-
-      it 'ignores template_stages with only a failed deploy' do
-        Job.update_all(status: :failed)
-
-        post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'non_kubernetes'}
-        assert_redirected_to "/deploys" # with no ids  present.
-      end
-
-      it 'ignores template_stages not marked as template stages' do
-        deploy_group.environment.template_stages.update_all(is_template: false)
-
-        post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'non_kubernetes'}
-        assert_redirected_to "/deploys" # with no ids  present.
-      end
-
-      it 'ignores projects with no template stage for this environment' do
-        Stage.update_all(template_stage_id: nil)
-
-        post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'non_kubernetes'}
-        assert_redirected_to "/deploys" # with no ids  present.
-      end
-
-      it "ignores 'successfully deployed' stage" do
-        refute_difference 'Deploy.count' do
-          post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'non_kubernetes'}
-        end
-      end
-
-      describe 'deploy for kubernetes stages' do
         let(:cluster) { kubernetes_clusters(:test_cluster) }
         let(:template_stage) { deploy_group.environment.template_stages.first }
         let(:k8s_stage) do
@@ -262,44 +226,25 @@ describe MassRolloutsController do
         before do
           Kubernetes::Cluster.any_instance.stubs(connection_valid?: true, namespaces: ['staging'])
           Kubernetes::ClusterDeployGroup.create!(cluster: cluster, deploy_group: deploy_group, namespace: 'staging')
-
           k8s_stage.save!
         end
 
-        it 'deploys already deployed k8s stages' do
-          k8s_stage.deploys.create!(
-            reference: 'v123',
-            project: stage.project,
-            job: Job.create!(
-              project: stage.project,
-              user: User.first,
-              status: "succeeded",
-              command: 'blah'
-            )
-          )
-
-          assert_difference 'Deploy.count', 1 do
-            post :deploy, params: {deploy_group_id: deploy_group, status: 'successful', type: 'kubernetes'}
-          end
-
-          deploy = k8s_stage.deploys.order('created_at desc').first
-          assert_redirected_to "/deploys?ids%5B%5D=#{deploy.id}"
+        it "complains about unknown kubernetes" do
+          deploy "wut"
+          assert_response :bad_request
         end
 
-        it 'deploys missing k8s stages' do
-          assert_difference 'Deploy.count', 1 do
-            post :deploy, params: {deploy_group_id: deploy_group, status: 'missing', type: 'kubernetes'}
-          end
-
+        it 'deploys k8s stages' do
+          assert_difference('Deploy.count', 1) { deploy "true" }
           deploy = k8s_stage.deploys.order('created_at desc').first
           assert_redirected_to "/deploys?ids%5B%5D=#{deploy.id}"
-          assert_equal template_stage.last_successful_deploy.reference, deploy.reference
+          deploy.reference.must_equal template_stage.last_successful_deploy.reference
         end
 
         it 'ignores non-kubernetes stages' do
-          refute_difference 'Deploy.count' do
-            post :deploy, params: {deploy_group_id: deploy_group, status: 'successful', type: 'kubernetes'}
-          end
+          assert_difference('Deploy.count', 1) { deploy "false" }
+          deploy = stages(:test_staging).deploys.order('created_at desc').first
+          assert_redirected_to "/deploys?ids%5B%5D=#{deploy.id}"
         end
       end
     end


### PR DESCRIPTION
Refactor mass rollout to include k8s stage options.

![screen shot 2018-09-10 at 1 20 11 pm](https://user-images.githubusercontent.com/153219/45322212-760b2400-b4fc-11e8-974d-0fae5458003f.png)

/cc @zendesk/samson @zendesk/compute

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-1970

### Risks
- Level: Medium
- While shouldn't break any existing functionality, the new functionality has the potential to create many K8s deploys so should be rigorously reviewed/tested.
