### PR TITLE
Add JSON response to env groups controller#index

### DIFF
--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -4,7 +4,18 @@ class EnvironmentVariableGroupsController < ApplicationController
   before_action :group, only: [:show]
 
   def index
-    @groups = EnvironmentVariableGroup.all
+    @groups = EnvironmentVariableGroup.all.includes(:environment_variables)
+    respond_to do |format|
+      format.html
+      format.json do
+        groups = @groups.map do |group|
+          json = group.as_json
+          json['variables'] = group.environment_variables.sort_by(&:id).map(&:name).uniq
+          json
+        end
+        render json: {groups: groups}
+      end
+    end
   end
 
   def new

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -8,12 +8,7 @@ class EnvironmentVariableGroupsController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        groups = @groups.map do |group|
-          json = group.as_json
-          json['variables'] = group.environment_variables.sort_by(&:id).map(&:name).uniq
-          json
-        end
-        render json: {groups: groups}
+        render_as_json :environment_variable_groups, @groups
       end
     end
   end

--- a/plugins/env/app/models/environment_variable_group.rb
+++ b/plugins/env/app/models/environment_variable_group.rb
@@ -16,4 +16,12 @@ class EnvironmentVariableGroup < ActiveRecord::Base
   has_many :projects, through: :project_environment_variable_groups
 
   validates :name, presence: true
+
+  def variable_names
+    environment_variables.sort_by(&:id).map(&:name).uniq
+  end
+
+  def as_json
+    super(methods: [:variable_names])
+  end
 end

--- a/plugins/env/app/views/environment_variable_groups/index.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/index.html.erb
@@ -25,7 +25,7 @@
     </tr>
     </thead>
     <% @groups.each do |group| %>
-      <% sorted_vars = group.environment_variables.sort_by(&:id).map(&:name).uniq %>
+      <% sorted_vars = group.variable_names %>
       <tr>
         <td>
           <%= link_to group.name, group %>

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -77,26 +77,16 @@ describe EnvironmentVariableGroupsController do
         get :index
         assert_response :success
       end
-    end
 
-    describe "a json GET to #index" do
-      it "succeeds" do
+      it "renders json" do
         get :index, format: :json
         assert_response :success
         json_response = JSON.parse response.body
-        json_response.keys.must_include "groups"
-      end
-
-      it "contains variables in groups" do
-        # [{"id"=>27, "name"=>"G1", "comment"=>nil, "variables"=>["X", "Y"]}]
-        get :index, format: :json
-        assert_response :success
-        json_response = JSON.parse response.body
-        first_group = json_response['groups'].first
+        first_group = json_response['environment_variable_groups'].first
         first_group.keys.must_include "name"
-        first_group.keys.must_include "variables"
+        first_group.keys.must_include "variable_names"
         first_group['name'].must_equal "G1"
-        first_group['variables'].must_equal ["X", "Y"]
+        first_group['variable_names'].must_equal ["X", "Y"]
       end
     end
 

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -79,6 +79,27 @@ describe EnvironmentVariableGroupsController do
       end
     end
 
+    describe "a json GET to #index" do
+      it "succeeds" do
+        get :index, format: :json
+        assert_response :success
+        json_response = JSON.parse response.body
+        json_response.keys.must_include "groups"
+      end
+
+      it "contains variables in groups" do
+        # [{"id"=>27, "name"=>"G1", "comment"=>nil, "variables"=>["X", "Y"]}]
+        get :index, format: :json
+        assert_response :success
+        json_response = JSON.parse response.body
+        first_group = json_response['groups'].first
+        first_group.keys.must_include "name"
+        first_group.keys.must_include "variables"
+        first_group['name'].must_equal "G1"
+        first_group['variables'].must_equal ["X", "Y"]
+      end
+    end
+
     describe "#show" do
       def unauthorized_env_group
         ProjectEnvironmentVariableGroup.create!(environment_variable_group: env_group, project: other_project)

--- a/plugins/env/test/models/environment_variable_group_test.rb
+++ b/plugins/env/test/models/environment_variable_group_test.rb
@@ -38,5 +38,17 @@ describe EnvironmentVariableGroup do
         group.as_json.fetch("variable_names").must_equal ["A"]
       end
     end
+
+    describe "#variable_names" do
+      it "gives unique variable names" do
+        group.update_attributes!(
+          environment_variables_attributes: [
+            {name: "B", value: "B", scope_type_and_id: "Environment-#{environments(:production)}"},
+            {name: "C", value: "C", scope_type_and_id: "Environment-#{environments(:production)}"},
+          ]
+        )
+        group.variable_names.must_equal ["A", "B", "C"]
+      end
+    end
   end
 end

--- a/plugins/env/test/models/environment_variable_group_test.rb
+++ b/plugins/env/test/models/environment_variable_group_test.rb
@@ -32,5 +32,11 @@ describe EnvironmentVariableGroup do
         ]
       )
     end
+
+    describe "#as_json" do
+      it "includes variable names" do
+        group.as_json.fetch("variable_names").must_equal ["A"]
+      end
+    end
   end
 end


### PR DESCRIPTION
This gives a quick overview of what keys any group might contain, which
is useful for figuring out exactly what environment variables need to be
present in a given environment.