### PR TITLE
Display the Github status of a release on the overview page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,10 +146,13 @@ module ApplicationHelper
   end
 
   def icon_tag(type, options = {})
-    # Prepend the CSS classes to the existing `css` option if present.
-    css_class = ["glyphicon glyphicon-#{type}", options.fetch(:class, "")].join(" ")
+    css_classes = "glyphicon glyphicon-#{type}"
 
-    content_tag :i, '', options.merge(class: css_class)
+    if klass = options[:class]
+      css_classes += " #{klass}"
+    end
+
+    content_tag :i, '', options.merge(class: css_classes)
   end
 
   def link_to_delete(path, options = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,7 +146,10 @@ module ApplicationHelper
   end
 
   def icon_tag(type, options = {})
-    content_tag :i, '', options.merge(class: "glyphicon glyphicon-#{type}")
+    # Prepend the CSS classes to the existing `css` option if present.
+    css_class = ["glyphicon glyphicon-#{type}", options.fetch(:class, "")].join(" ")
+
+    content_tag :i, '', options.merge(class: css_class)
   end
 
   def link_to_delete(path, options = {})

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -8,6 +8,17 @@ module ReleasesHelper
     )
   end
 
+  def status_glyphicon(status_state)
+    icon, text = case status_state
+           when "success" then ["ok", "success"]
+           when "failure" then ["remove", "danger"]
+           when "missing" then ["minus", "muted"]
+           when "pending" then ["hourglass", "primary"]
+           end
+
+    %(<span class="glyphicon glyphicon-#{icon} text-#{text}" aria-hidden="true"></span>).html_safe
+  end
+
   def link_to_deploy_stage(stage, release)
     deploy_params = {reference: release.version}
 

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -26,7 +26,7 @@ module ReleasesHelper
     icon = STATUS_ICONS.fetch(status_state)
     text = STATUS_TEXT_LABELS.fetch(status_state)
 
-    %(<span class="glyphicon glyphicon-#{icon} text-#{text}" aria-hidden="true"></span>).html_safe
+    icon_tag icon, class: "text-#{text}"
   end
 
   def link_to_deploy_stage(stage, release)

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -22,7 +22,7 @@ module ReleasesHelper
     )
   end
 
-  def status_glyphicon(status_state)
+  def github_commit_status_icon(status_state)
     icon = STATUS_ICONS.fetch(status_state)
     text = STATUS_TEXT_LABELS.fetch(status_state)
     title = "Github status: #{status_state}"

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 module ReleasesHelper
+  STATUS_ICONS = {
+    "success" => "ok",
+    "failure" => "remove",
+    "missing" => "minus",
+    "pending" => "hourglass"
+  }
+
+  STATUS_TEXT_LABELS = {
+    "success" => "success",
+    "failure" => "danger",
+    "missing" => "muted",
+    "pending" => "primary"
+  }
+
   def release_label(project, release)
     link_to(
       release.version,
@@ -9,12 +23,8 @@ module ReleasesHelper
   end
 
   def status_glyphicon(status_state)
-    icon, text = case status_state
-           when "success" then ["ok", "success"]
-           when "failure" then ["remove", "danger"]
-           when "missing" then ["minus", "muted"]
-           when "pending" then ["hourglass", "primary"]
-           end
+    icon = STATUS_ICONS.fetch(status_state)
+    text = STATUS_TEXT_LABELS.fetch(status_state)
 
     %(<span class="glyphicon glyphicon-#{icon} text-#{text}" aria-hidden="true"></span>).html_safe
   end

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -5,14 +5,14 @@ module ReleasesHelper
     "failure" => "remove",
     "missing" => "minus",
     "pending" => "hourglass"
-  }
+  }.freeze
 
   STATUS_TEXT_LABELS = {
     "success" => "success",
     "failure" => "danger",
     "missing" => "muted",
     "pending" => "primary"
-  }
+  }.freeze
 
   def release_label(project, release)
     link_to(

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -25,8 +25,9 @@ module ReleasesHelper
   def status_glyphicon(status_state)
     icon = STATUS_ICONS.fetch(status_state)
     text = STATUS_TEXT_LABELS.fetch(status_state)
+    title = "Github status: #{status_state}"
 
-    icon_tag icon, class: "text-#{text}"
+    icon_tag icon, class: "text-#{text}", 'data-toggle': "tooltip", 'data-placement': "right", title: title
   end
 
   def link_to_deploy_stage(stage, release)

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 module ReleasesHelper
-  STATUS_ICONS = {
+  GITHUB_STATUS_ICONS = {
     "success" => "ok",
     "failure" => "remove",
     "missing" => "minus",
     "pending" => "hourglass"
   }.freeze
 
-  STATUS_TEXT_LABELS = {
+  GITHUB_STATUS_TEXT_LABELS = {
     "success" => "success",
     "failure" => "danger",
     "missing" => "muted",
@@ -23,8 +23,8 @@ module ReleasesHelper
   end
 
   def github_commit_status_icon(status_state)
-    icon = STATUS_ICONS.fetch(status_state)
-    text = STATUS_TEXT_LABELS.fetch(status_state)
+    icon = GITHUB_STATUS_ICONS.fetch(status_state)
+    text = GITHUB_STATUS_TEXT_LABELS.fetch(status_state)
     title = "Github status: #{status_state}"
 
     icon_tag icon, class: "text-#{text}", 'data-toggle': "tooltip", 'data-placement': "right", title: title

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -3,6 +3,14 @@ class GithubStatus
     def success?
       latest_status.state == "success"
     end
+
+    def failure?
+      latest_status.state == "failure"
+    end
+
+    def pending?
+      latest_status.state == "pending"
+    end
   end
 
   def initialize(repo, ref, github: GITHUB)
@@ -12,7 +20,19 @@ class GithubStatus
   end
 
   def success?
-    statuses.all?(&:success?)
+    !missing? && statuses.all?(&:success?)
+  end
+
+  def failure?
+    statuses.any?(&:failure?)
+  end
+
+  def pending?
+    statuses.any?(&:pending?)
+  end
+
+  def missing?
+    statuses.none?
   end
 
   def statuses

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -1,0 +1,33 @@
+class GithubStatus
+  class Status < Struct.new(:context, :latest_status)
+    def success?
+      latest_status.state == "success"
+    end
+  end
+
+  def initialize(repo, ref, github: GITHUB)
+    @github = github
+    @repo = repo
+    @ref = ref
+  end
+
+  def success?
+    statuses.all?(&:success?)
+  end
+
+  def statuses
+    response = @github.combined_status(@repo, @ref)
+
+    statuses = response.statuses
+
+    return [] if statuses.nil?
+
+    statuses.group_by {|status| status.context }
+      .map {|context, statuses|
+        Status.new(context, statuses.max_by {|status| status.created_at.to_i })
+      }
+  rescue Octokit::Error
+    # In case of error, fall back to not listing the statuses.
+    []
+  end
+end

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -1,15 +1,27 @@
 class GithubStatus
   class Status < Struct.new(:context, :latest_status)
+    def state
+      latest_status.state
+    end
+
+    def description
+      latest_status.description
+    end
+
+    def url
+      latest_status.target_url
+    end
+
     def success?
-      latest_status.state == "success"
+      state == "success"
     end
 
     def failure?
-      latest_status.state == "failure"
+      state == "failure"
     end
 
     def pending?
-      latest_status.state == "pending"
+      state == "pending"
     end
   end
 

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -49,7 +49,7 @@ class GithubStatus
     return new("missing", []) if response.nil?
 
     # Don't cache pending statuses, since we expect updates soon.
-    unless response&.state == "pending"
+    unless response.state == "pending"
       Rails.cache.write(cache_key, response, expires_in: 1.hour)
     end
 

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -81,7 +81,7 @@ class GithubStatus
     end
 
     # Don't cache pending statuses, since we expect updates soon.
-    unless @status_response.nil? || @status_response.state == "pending"
+    unless @status_response&.state == "pending"
       @cache.write(cache_key, @status_response, expires_in: 1.hour)
     end
 

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -66,8 +66,10 @@ class GithubStatus
   private
 
   def status_response
-    @status_response ||= @github.combined_status(@repo, @ref)
-  rescue Octokit::Error
-    nil
+    @status_response ||= begin
+      @github.combined_status(@repo, @ref)
+    rescue Octokit::Error
+      nil
+    end
   end
 end

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 class GithubStatus
-  class Status < Struct.new(:context, :latest_status)
+  Status = Struct.new(:context, :latest_status) do
     def state
       latest_status.state
     end
@@ -57,7 +58,7 @@ class GithubStatus
       return [] if status_response.nil?
 
       status_response.statuses.group_by(&:context).map do |context, statuses|
-        Status.new(context, statuses.max_by {|status| status.created_at.to_i })
+        Status.new(context, statuses.max_by { |status| status.created_at.to_i })
       end
     end
   end

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -48,9 +48,7 @@ class GithubStatus
   end
 
   def statuses
-    response = @github.combined_status(@repo, @ref)
-
-    statuses = response.statuses
+    statuses = @github.combined_status(@repo, @ref).statuses
 
     return [] if statuses.nil?
 

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -38,19 +38,19 @@ class GithubStatus
   end
 
   def success?
-    !missing? && statuses.all?(&:success?)
+    state == "success"
   end
 
   def failure?
-    statuses.any?(&:failure?)
+    state == "failure"
   end
 
   def pending?
-    statuses.any?(&:pending?)
+    state == "pending"
   end
 
   def missing?
-    statuses.none?
+    state == "missing"
   end
 
   def statuses

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -48,12 +48,14 @@ class GithubStatus
   end
 
   def statuses
-    statuses = @github.combined_status(@repo, @ref).statuses
+    @statuses ||= begin
+      statuses = @github.combined_status(@repo, @ref).statuses
 
-    return [] if statuses.nil?
+      return [] if statuses.nil?
 
-    statuses.group_by(&:context).map do |context, statuses|
-      Status.new(context, statuses.max_by {|status| status.created_at.to_i })
+      statuses.group_by(&:context).map do |context, statuses|
+        Status.new(context, statuses.max_by {|status| status.created_at.to_i })
+      end
     end
   rescue Octokit::Error
     # In case of error, fall back to not listing the statuses.

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -80,7 +80,10 @@ class GithubStatus
       nil
     end
 
-    @cache.write(cache_key, @status_response)
+    # Don't cache pending statuses, since we expect updates soon.
+    unless @status_response.state == "pending"
+      @cache.write(cache_key, @status_response, expires_in: 1.hour)
+    end
 
     @status_response
   end

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -52,10 +52,9 @@ class GithubStatus
 
     return [] if statuses.nil?
 
-    statuses.group_by {|status| status.context }
-      .map {|context, statuses|
-        Status.new(context, statuses.max_by {|status| status.created_at.to_i })
-      }
+    statuses.group_by(&:context).map do |context, statuses|
+      Status.new(context, statuses.max_by {|status| status.created_at.to_i })
+    end
   rescue Octokit::Error
     # In case of error, fall back to not listing the statuses.
     []

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -26,16 +26,38 @@ class GithubStatus
     end
   end
 
-  def initialize(repo, ref, github: GITHUB, cache: Rails.cache)
-    @github = github
-    @cache = cache
-    @repo = repo
-    @ref = ref
-    @state = nil
+  attr_reader :state, :statuses
+
+  def initialize(state, statuses)
+    @state = state
+    @statuses = statuses
   end
 
-  def state
-    status_response ? status_response.state : "missing"
+  def self.fetch(repo, ref)
+    cache_key = [name, repo, ref]
+
+    response = Rails.cache.read(cache_key)
+
+    # Fetch the data if the cache returned nil.
+    response ||= begin
+      GITHUB.combined_status(repo, ref)
+    rescue Octokit::Error
+      nil
+    end
+
+    # Fall back to a "missing" status.
+    return new("missing", []) if response.nil?
+
+    # Don't cache pending statuses, since we expect updates soon.
+    unless response&.state == "pending"
+      Rails.cache.write(cache_key, response, expires_in: 1.hour)
+    end
+
+    statuses = response.statuses.group_by(&:context).map do |context, statuses|
+      Status.new(context, statuses.max_by { |status| status.created_at.to_i })
+    end
+
+    new(response.state, statuses)
   end
 
   def success?
@@ -52,39 +74,5 @@ class GithubStatus
 
   def missing?
     state == "missing"
-  end
-
-  def statuses
-    @statuses ||= begin
-      return [] if status_response.nil?
-
-      status_response.statuses.group_by(&:context).map do |context, statuses|
-        Status.new(context, statuses.max_by { |status| status.created_at.to_i })
-      end
-    end
-  end
-
-  private
-
-  def status_response
-    return @status_response if defined?(@status_response)
-
-    cache_key = [self.class.to_s, @repo, @ref]
-
-    @status_response = @cache.read(cache_key)
-
-    # Fetch the data if the cache returned nil.
-    @status_response ||= begin
-      @github.combined_status(@repo, @ref)
-    rescue Octokit::Error
-      nil
-    end
-
-    # Don't cache pending statuses, since we expect updates soon.
-    unless @status_response&.state == "pending"
-      @cache.write(cache_key, @status_response, expires_in: 1.hour)
-    end
-
-    @status_response
   end
 end

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -66,7 +66,9 @@ class GithubStatus
   private
 
   def status_response
-    @status_response ||= begin
+    return @status_response if defined?(@status_response)
+
+    @status_response = begin
       @github.combined_status(@repo, @ref)
     rescue Octokit::Error
       nil

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -81,7 +81,7 @@ class GithubStatus
     end
 
     # Don't cache pending statuses, since we expect updates soon.
-    unless @status_response.state == "pending"
+    unless @status_response.nil? || @status_response.state == "pending"
       @cache.write(cache_key, @status_response, expires_in: 1.hour)
     end
 

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -32,6 +32,10 @@ class Release < ActiveRecord::Base
     version
   end
 
+  def github_status
+    @github_status ||= GithubStatus.new(project.repository_path, commit)
+  end
+
   def self.find_by_param!(version)
     if number = version[VERSION_REGEX, 1]
       find_by_number!(number)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -33,7 +33,7 @@ class Release < ActiveRecord::Base
   end
 
   def github_status
-    @github_status ||= GithubStatus.new(project.repository_path, commit)
+    @github_status ||= GithubStatus.fetch(project.repository_path, commit)
   end
 
   def self.find_by_param!(version)

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -3,15 +3,7 @@
     <%= release_label(@project, release) %>
   </td>
   <td>
-    <% if release.github_status.success? %>
-      <span class="glyphicon glyphicon-ok text-success" aria-hidden="true"></span>
-    <% elsif release.github_status.pending? %>
-      <span class="glyphicon glyphicon-hourglass text-primary" aria-hidden="true"></span>
-    <% elsif release.github_status.missing? %>
-      <span class="glyphicon glyphicon-minus text-muted" aria-hidden="true"></span>
-    <% elsif release.github_status.failure? %>
-      <span class="glyphicon glyphicon-remove text-danger" aria-hidden="true"></span>
-    <% end %>
+    <%= render partial: "release_status", locals: { status: release.github_status } %>
   </td>
   <td><%= deployed_or_running_list @stages, release.version %></td>
   <td><%= relative_time(release.created_at) %></td>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -2,6 +2,13 @@
   <td>
     <%= release_label(@project, release) %>
   </td>
+  <td>
+    <% if release.github_status.success? %>
+      <span class="glyphicon glyphicon-ok text-success" aria-hidden="true"></span>
+    <% else %>
+      <span class="glyphicon glyphicon-remove text-danger" aria-hidden="true"></span>
+    <% end %>
+  </td>
   <td><%= deployed_or_running_list @stages, release.version %></td>
   <td><%= relative_time(release.created_at) %></td>
   <td>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -5,7 +5,11 @@
   <td>
     <% if release.github_status.success? %>
       <span class="glyphicon glyphicon-ok text-success" aria-hidden="true"></span>
-    <% else %>
+    <% elsif release.github_status.pending? %>
+      <span class="glyphicon glyphicon-hourglass text-primary" aria-hidden="true"></span>
+    <% elsif release.github_status.missing? %>
+      <span class="glyphicon glyphicon-minus text-muted" aria-hidden="true"></span>
+    <% elsif release.github_status.failure? %>
       <span class="glyphicon glyphicon-remove text-danger" aria-hidden="true"></span>
     <% end %>
   </td>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -3,7 +3,7 @@
     <%= release_label(@project, release) %>
   </td>
   <td>
-    <%= render partial: "release_status", locals: { status: release.github_status } %>
+    <%= status_glyphicon release.github_status.state %>
   </td>
   <td><%= deployed_or_running_list @stages, release.version %></td>
   <td><%= relative_time(release.created_at) %></td>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -4,9 +4,9 @@
   </td>
   <td>
     <% if github_ok? %>
-      <%= status_glyphicon release.github_status.state %>
+      <%= github_commit_status_icon release.github_status.state %>
     <% else %>
-      <%= status_glyphicon "missing" %>
+      <%= github_commit_status_icon "missing" %>
     <% end %>
   </td>
   <td width="100%"><%= deployed_or_running_list @stages, release.version %></td>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -3,7 +3,11 @@
     <%= release_label(@project, release) %>
   </td>
   <td>
-    <%= status_glyphicon release.github_status.state %>
+    <% if github_ok? %>
+      <%= status_glyphicon release.github_status.state %>
+    <% else %>
+      <%= status_glyphicon "missing" %>
+    <% end %>
   </td>
   <td><%= deployed_or_running_list @stages, release.version %></td>
   <td><%= relative_time(release.created_at) %></td>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -9,7 +9,7 @@
       <%= status_glyphicon "missing" %>
     <% end %>
   </td>
-  <td><%= deployed_or_running_list @stages, release.version %></td>
+  <td width="100%"><%= deployed_or_running_list @stages, release.version %></td>
   <td><%= relative_time(release.created_at) %></td>
   <td>
     <% if deployer_for_project? %>

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -14,5 +14,5 @@
   </td>
 </tr>
 <tr class="release-info collapse" data-url="<%= url_for [@project, release] %>">
-  <td colspan="4"></td>
+  <td colspan="5"></td>
 </tr>

--- a/app/views/releases/_release_status.html.erb
+++ b/app/views/releases/_release_status.html.erb
@@ -1,0 +1,9 @@
+<% if status.success? %>
+  <span class="glyphicon glyphicon-ok text-success" aria-hidden="true"></span>
+<% elsif status.pending? %>
+  <span class="glyphicon glyphicon-hourglass text-primary" aria-hidden="true"></span>
+<% elsif status.missing? %>
+  <span class="glyphicon glyphicon-minus text-muted" aria-hidden="true"></span>
+<% elsif status.failure? %>
+  <span class="glyphicon glyphicon-remove text-danger" aria-hidden="true"></span>
+<% end %>

--- a/app/views/releases/_release_status.html.erb
+++ b/app/views/releases/_release_status.html.erb
@@ -1,9 +1,0 @@
-<% if status.success? %>
-  <span class="glyphicon glyphicon-ok text-success" aria-hidden="true"></span>
-<% elsif status.pending? %>
-  <span class="glyphicon glyphicon-hourglass text-primary" aria-hidden="true"></span>
-<% elsif status.missing? %>
-  <span class="glyphicon glyphicon-minus text-muted" aria-hidden="true"></span>
-<% elsif status.failure? %>
-  <span class="glyphicon glyphicon-remove text-danger" aria-hidden="true"></span>
-<% end %>

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -19,6 +19,7 @@
         <thead>
           <tr>
             <th></th>
+            <th>Status</th>
             <th>Deployed to</th>
             <th>Created</th>
             <th></th>

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -19,7 +19,7 @@
         <thead>
           <tr>
             <th></th>
-            <th>Status</th>
+            <th></th>
             <th>Deployed to</th>
             <th>Created</th>
             <th></th>

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -16,6 +16,13 @@
   <label>Created</label>
   <%= relative_time(@release.created_at) %>
 
+  <legend>Github Status</legend>
+  <p>
+    <% @release.github_status.statuses.each do |status| %>
+      <%= status_glyphicon(status.state) %> <b><%= status.context %>:</b> <%= link_to status.description, status.url %><br/>
+    <% end %>
+  </p>
+
   <% if @changeset.empty? %>
     <p>This release contains no changes.</p>
   <% else %>

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -19,7 +19,7 @@
   <legend>Commit Status</legend>
   <p>
     <% @release.github_status.statuses.each do |status| %>
-      <%= status_glyphicon(status.state) %> <b><%= status.context %>:</b> <%= link_to status.description, status.url %><br/>
+      <%= github_commit_status_icon(status.state) %> <b><%= status.context %>:</b> <%= link_to status.description, status.url %><br/>
     <% end %>
   </p>
 

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -16,7 +16,7 @@
   <label>Created</label>
   <%= relative_time(@release.created_at) %>
 
-  <legend>Github Status</legend>
+  <legend>Commit Status</legend>
   <p>
     <% @release.github_status.statuses.each do |status| %>
       <%= status_glyphicon(status.state) %> <b><%= status.context %>:</b> <%= link_to status.description, status.url %><br/>

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -11,11 +11,13 @@ describe ReleasesController do
     status_response = {
       state: "success",
       statuses: [
-        state: "success",
-        context: "oompa/loompa",
-        target_url: "https://chocolate-factory.com/test/wonka",
-        description: "Ooompa Loompa!",
-        created_at: Time.now.iso8601
+        {
+          state: "success",
+          context: "oompa/loompa",
+          target_url: "https://chocolate-factory.com/test/wonka",
+          description: "Ooompa Loompa!",
+          created_at: Time.now.iso8601
+        }
       ]
     }
 

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -7,6 +7,26 @@ describe ReleasesController do
   let(:project) { projects(:test) }
   let(:release) { releases(:test) }
 
+  before do
+    status_response = {
+      state: "success",
+      statuses: [
+        state: "success",
+        context: "oompa/loompa",
+        target_url: "https://chocolate-factory.com/test/wonka",
+        description: "Ooompa Loompa!",
+        created_at: Time.now.iso8601
+      ]
+    }
+
+    headers = {
+      "Content-Type" => "application/json",
+    }
+
+    stub_request(:get, "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/status").
+      to_return(status: 200, body: status_response.to_json, headers: headers)
+  end
+
   as_a_viewer do
     unauthorized :get, :new, project_id: :foo
     unauthorized :post, :create, project_id: :foo

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -689,6 +689,11 @@ describe ApplicationHelper do
       html.must_equal "<i title=\"bar\" class=\"glyphicon glyphicon-foo\"></i>"
       assert html.html_safe?
     end
+
+    it "allows passing in custom CSS classes" do
+      html = icon_tag("foo", class: "yolo")
+      html.must_equal "<i class=\"glyphicon glyphicon-foo yolo\"></i>"
+    end
   end
 
   describe "#deployed_or_running_list" do

--- a/test/helpers/releases_helper_test.rb
+++ b/test/helpers/releases_helper_test.rb
@@ -15,6 +15,26 @@ describe ReleasesHelper do
     end
   end
 
+  describe "#status_glyphicon" do
+    include ApplicationHelper
+
+    it "renders an icon for success" do
+      status_glyphicon("success").must_equal %(<i class="glyphicon glyphicon-ok text-success" data-toggle="tooltip" data-placement="right" title="Github status: success"></i>)
+    end
+
+    it "renders an icon for failure" do
+      status_glyphicon("failure").must_equal %(<i class="glyphicon glyphicon-remove text-danger" data-toggle="tooltip" data-placement="right" title="Github status: failure"></i>)
+    end
+
+    it "renders an icon for missing status" do
+      status_glyphicon("missing").must_equal %(<i class="glyphicon glyphicon-minus text-muted" data-toggle="tooltip" data-placement="right" title="Github status: missing"></i>)
+    end
+
+    it "renders an icon for pending status" do
+      status_glyphicon("pending").must_equal %(<i class="glyphicon glyphicon-hourglass text-primary" data-toggle="tooltip" data-placement="right" title="Github status: pending"></i>)
+    end
+  end
+
   describe "#link_to_deploy_stage" do
     let(:stage) { stages(:test_staging) }
     let(:release) { Release.new }

--- a/test/helpers/releases_helper_test.rb
+++ b/test/helpers/releases_helper_test.rb
@@ -15,32 +15,32 @@ describe ReleasesHelper do
     end
   end
 
-  describe "#status_glyphicon" do
+  describe "#github_commit_status_icon" do
     include ApplicationHelper
 
     it "renders an icon for success" do
-      html = status_glyphicon("success")
+      html = github_commit_status_icon("success")
       html.must_include "glyphicon-ok"
       html.must_include "text-success"
       html.must_include "Github status: success"
     end
 
     it "renders an icon for failure" do
-      html = status_glyphicon("failure")
+      html = github_commit_status_icon("failure")
       html.must_include "glyphicon-remove"
       html.must_include "text-danger"
       html.must_include "Github status: failure"
     end
 
     it "renders an icon for missing status" do
-      html = status_glyphicon("missing")
+      html = github_commit_status_icon("missing")
       html.must_include "glyphicon-minus"
       html.must_include "text-muted"
       html.must_include "Github status: missing"
     end
 
     it "renders an icon for pending status" do
-      html = status_glyphicon("pending")
+      html = github_commit_status_icon("pending")
       html.must_include "glyphicon-hourglass"
       html.must_include "text-primary"
       html.must_include "Github status: pending"

--- a/test/helpers/releases_helper_test.rb
+++ b/test/helpers/releases_helper_test.rb
@@ -19,19 +19,31 @@ describe ReleasesHelper do
     include ApplicationHelper
 
     it "renders an icon for success" do
-      status_glyphicon("success").must_equal %(<i class="glyphicon glyphicon-ok text-success" data-toggle="tooltip" data-placement="right" title="Github status: success"></i>)
+      html = status_glyphicon("success")
+      html.must_include "glyphicon-ok"
+      html.must_include "text-success"
+      html.must_include "Github status: success"
     end
 
     it "renders an icon for failure" do
-      status_glyphicon("failure").must_equal %(<i class="glyphicon glyphicon-remove text-danger" data-toggle="tooltip" data-placement="right" title="Github status: failure"></i>)
+      html = status_glyphicon("failure")
+      html.must_include "glyphicon-remove"
+      html.must_include "text-danger"
+      html.must_include "Github status: failure"
     end
 
     it "renders an icon for missing status" do
-      status_glyphicon("missing").must_equal %(<i class="glyphicon glyphicon-minus text-muted" data-toggle="tooltip" data-placement="right" title="Github status: missing"></i>)
+      html = status_glyphicon("missing")
+      html.must_include "glyphicon-minus"
+      html.must_include "text-muted"
+      html.must_include "Github status: missing"
     end
 
     it "renders an icon for pending status" do
-      status_glyphicon("pending").must_equal %(<i class="glyphicon glyphicon-hourglass text-primary" data-toggle="tooltip" data-placement="right" title="Github status: pending"></i>)
+      html = status_glyphicon("pending")
+      html.must_include "glyphicon-hourglass"
+      html.must_include "text-primary"
+      html.must_include "Github status: pending"
     end
   end
 

--- a/test/models/github_status_test.rb
+++ b/test/models/github_status_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe GithubStatus do
+  let(:repo) { "oompa/loompa" }
+  let(:ref) { "wonka" }
+
+  describe "#state" do
+    let(:status) { GithubStatus.fetch(repo, ref) }
+
+    it "returns `missing` if there's no response from Github" do
+      stub_api({}, 401)
+      status.state.must_equal "missing"
+    end
+
+    it "returns the Github state from the response" do
+      stub_api({ state: "party", statuses: [] }, 200)
+      status.state.must_equal "party"
+    end
+  end
+
+  describe "#statuses" do
+    let(:status) { GithubStatus.fetch(repo, ref) }
+
+    it "returns a single status per context" do
+      # The most recent status is used.
+      statuses = [
+        { context: "A", created_at: 1, state: "pending" },
+        { context: "B", created_at: 1, state: "success" },
+        { context: "A", created_at: 2, state: "failure" },
+      ]
+
+      stub_api({ state: "pending", statuses: statuses }, 200)
+
+      status.statuses.count.must_equal 2
+
+      status_a = status.statuses.first
+      status_b = status.statuses.last
+
+      assert status_a.failure?
+      assert status_b.success?
+    end
+
+    it "includes the state of each status" do
+      statuses = [
+        { context: "A", created_at: 1, state: "pending", state: "pending" },
+      ]
+
+      stub_api({ state: "pending", statuses: statuses }, 200)
+
+      status.statuses.first.state.must_equal "pending"
+
+      assert status.statuses.first.pending?
+      assert !status.statuses.first.success?
+      assert !status.statuses.first.failure?
+    end
+
+    it "includes the URL of each status" do
+      statuses = [
+        { context: "A", created_at: 1, state: "pending", target_url: "http://acme.com/123" },
+      ]
+
+      stub_api({ state: "pending", statuses: statuses }, 200)
+
+      status.statuses.first.url.must_equal "http://acme.com/123"
+    end
+
+    it "includes the description of each status" do
+      statuses = [
+        { context: "A", created_at: 1, state: "pending", description: "hello" },
+      ]
+
+      stub_api({ state: "pending", statuses: statuses }, 200)
+
+      status.statuses.first.description.must_equal "hello"
+    end
+  end
+
+  it "has a query method for each state" do
+    assert GithubStatus.new("success", []).success?
+    assert GithubStatus.new("failure", []).failure?
+    assert GithubStatus.new("pending", []).pending?
+    assert GithubStatus.new("missing", []).missing?
+
+    refute GithubStatus.new("wonka", []).success?
+    refute GithubStatus.new("wonka", []).failure?
+    refute GithubStatus.new("wonka", []).pending?
+    refute GithubStatus.new("wonka", []).missing?
+  end
+
+  def stub_api(body, status = 200)
+    stub_github_api "repos/#{repo}/commits/#{ref}/status", body, status
+  end
+end

--- a/test/models/github_status_test.rb
+++ b/test/models/github_status_test.rb
@@ -16,7 +16,7 @@ describe GithubStatus do
     end
 
     it "returns the Github state from the response" do
-      stub_api({ state: "party", statuses: [] }, 200)
+      stub_api({state: "party", statuses: []}, 200)
       status.state.must_equal "party"
     end
   end
@@ -27,12 +27,12 @@ describe GithubStatus do
     it "returns a single status per context" do
       # The most recent status is used.
       statuses = [
-        { context: "A", created_at: 1, state: "pending" },
-        { context: "B", created_at: 1, state: "success" },
-        { context: "A", created_at: 2, state: "failure" },
+        {context: "A", created_at: 1, state: "pending"},
+        {context: "B", created_at: 1, state: "success"},
+        {context: "A", created_at: 2, state: "failure"},
       ]
 
-      stub_api({ state: "pending", statuses: statuses }, 200)
+      stub_api({state: "pending", statuses: statuses}, 200)
 
       status.statuses.count.must_equal 2
 
@@ -45,10 +45,10 @@ describe GithubStatus do
 
     it "includes the state of each status" do
       statuses = [
-        { context: "A", created_at: 1, state: "pending", state: "pending" },
+        {context: "A", created_at: 1, state: "pending", state: "pending"},
       ]
 
-      stub_api({ state: "pending", statuses: statuses }, 200)
+      stub_api({state: "pending", statuses: statuses}, 200)
 
       status.statuses.first.state.must_equal "pending"
 
@@ -59,20 +59,20 @@ describe GithubStatus do
 
     it "includes the URL of each status" do
       statuses = [
-        { context: "A", created_at: 1, state: "pending", target_url: "http://acme.com/123" },
+        {context: "A", created_at: 1, state: "pending", target_url: "http://acme.com/123"},
       ]
 
-      stub_api({ state: "pending", statuses: statuses }, 200)
+      stub_api({state: "pending", statuses: statuses}, 200)
 
       status.statuses.first.url.must_equal "http://acme.com/123"
     end
 
     it "includes the description of each status" do
       statuses = [
-        { context: "A", created_at: 1, state: "pending", description: "hello" },
+        {context: "A", created_at: 1, state: "pending", description: "hello"},
       ]
 
-      stub_api({ state: "pending", statuses: statuses }, 200)
+      stub_api({state: "pending", statuses: statuses}, 200)
 
       status.statuses.first.description.must_equal "hello"
     end

--- a/test/models/github_status_test.rb
+++ b/test/models/github_status_test.rb
@@ -45,7 +45,7 @@ describe GithubStatus do
 
     it "includes the state of each status" do
       statuses = [
-        {context: "A", created_at: 1, state: "pending", state: "pending"},
+        {context: "A", created_at: 1, state: "pending"},
       ]
 
       stub_api({state: "pending", statuses: statuses}, 200)

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 2
+SingleCov.covered! uncovered: 3
 
 describe Release do
   let(:author) { users(:deployer) }


### PR DESCRIPTION
Adds an icon indicating the Github Status of each release's commit, as well as a full list of statuses with their descriptions on the release page.

![](https://cl.ly/f1a4aab849c2/Screen%20Recording%202018-08-22%20at%2003.24%20PM.gif)

### Tasks
- [ ] :+1: from team
- [ ] Caching and invalidation

### Risks
- Level: Med