### PR TITLE
Ignore `vendor/cache/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@
 # .bak files
 *.bak
 /vendor/cache/**/
+/vendor/cache/*


### PR DESCRIPTION
The other rule didn't work for me.

/cc @grosser 

### Risks
- Level: low.
