### PR TITLE
Move manual release button to the bottom of the page

### DIFF
--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -36,6 +36,10 @@
         <p>No release created from release branch <%= @project.release_branch %>.</p>
         <p>Add a webhook to samson from your CI to trigger releases on green builds or from your Code host to get releases on merge.</p>
         <p>Samsons Github user needs write permisson to the repo to create tags.</p>
+
+        <p>
+          <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
+        </p>
       </div>
     <% end %>
   </section>

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -4,10 +4,6 @@
 
 <% cache [@project, @pagy.page, deployer_for_project?] do %>
   <section class="clearfix tabs">
-    <p class="pull-right">
-      <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
-    </p>
-
     <% if @project.release_branch.blank? %>
       <div class="alert alert-warning">
         <p>Configure a <%= link_to "release branch", edit_project_path(@project, anchor: "project_release_branch") %> to automatically create releases whenever a branch is pushed to.</p>
@@ -31,6 +27,10 @@
       </table>
 
       <%= paginate @pagy %>
+
+      <p class="pull-right">
+        <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
+      </p>
     <% elsif @project.release_branch.present? %>
       <div class="alert alert-warning">
         <p>No release created from release branch <%= @project.release_branch %>.</p>


### PR DESCRIPTION
Currently, the "create release manually" button takes up screen real estate at the top of the page. However, this button should hardly ever be used.

This PR:

1) Uses a separate, non-right-aligned button in case there are no releases.
2) Moves the normal button to the bottom right, next to the pagination controls.

![](https://cl.ly/ede0a6db6d94/Image%202018-08-24%20at%2012.53.09%20PM.png)
 
/cc @zendesk/samson

### Tasks
 - [x] :+1: from team

### Risks
- Level: Low
