### PR TITLE
Generic CI Pipeline Webhook

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -11,7 +11,7 @@ class Integrations::BaseController < ApplicationController
   def create
     if !deploy? || skip?
       record_log :info, "Request is not supposed to trigger a deploy"
-      return render plain: @recorded_log.to_s
+      return render json: {deploy_ids: [], messages: @recorded_log.to_s}
     end
 
     if branch
@@ -27,14 +27,18 @@ class Integrations::BaseController < ApplicationController
     end
 
     stages = project.webhook_stages_for(branch, service_type, service_name)
-    failed = deploy_to_stages(release, stages)
+    deploy_results = deploy_to_stages(release, stages)
 
-    if failed
+    if failed = deploy_results[:failed_stage]
       record_log :error, "Failed to start deploy to #{failed.name}"
     else
       record_log :info, "Deploying to #{stages.size} stages"
     end
-    render plain: @recorded_log.to_s, status: (failed ? :unprocessable_entity : :ok)
+
+    render(
+      json: {deploy_ids: deploy_results[:deploy_ids], messages: @recorded_log.to_s},
+      status: (failed ? :unprocessable_entity : :ok)
+    )
   end
 
   protected
@@ -63,14 +67,18 @@ class Integrations::BaseController < ApplicationController
     ReleaseService.new(project).release(release_params)
   end
 
-  # returns stage that failed to deploy or nil
+  # returns failed stage and any successfully started deploy ids
   def deploy_to_stages(release, stages)
     deploy_service = DeployService.new(user)
-    stages.detect do |stage|
+    stages.each_with_object(failed_stage: nil, deploy_ids: []) do |stage, result_hash|
       deploy = deploy_service.deploy(stage, reference: release&.version || commit)
-      if deploy.new_record?
+
+      if deploy.persisted?
+        result_hash[:deploy_ids] << deploy.id
+      else
         record_log :error, "Deploy to #{stage.name} failed: #{deploy.errors.full_messages}"
-        true
+        result_hash[:failed_stage] = stage
+        break result_hash
       end
     end
   end
@@ -105,7 +113,7 @@ class Integrations::BaseController < ApplicationController
   end
 
   def validate_token
-    project || render(plain: "Invalid token", status: :unauthorized)
+    project || render(json: {deploy_ids: [], messages: 'Invalid token'}, status: :unauthorized)
   end
 
   def hide_token

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -126,7 +126,8 @@ class Integrations::BaseController < ApplicationController
   end
 
   def service_name
-    @service_name ||= self.class.name.demodulize.sub('Controller', '').downcase
+    # keep in sync with lib/samson/integration.rb regex
+    @service_name ||= self.class.name.demodulize.sub('Controller', '').underscore
   end
 
   def create_docker_images

--- a/app/controllers/integrations/generic_controller.rb
+++ b/app/controllers/integrations/generic_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Integrations
+  class GenericController < Integrations::BaseController
+    private
+
+    def deploy?
+      true
+    end
+
+    def deploy
+      @deploy ||= params.require(:deploy)
+    end
+
+    def commit_params
+      @commit_params ||= deploy.require(:commit)
+    end
+
+    def branch
+      deploy[:branch]
+    end
+
+    def commit
+      commit_params.require(:sha)
+    end
+
+    def message
+      commit_params[:message]
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -224,7 +224,7 @@ module ApplicationHelper
 
   def additional_info(text, overrides = {})
     data_attrs = if text.html_safe?
-      {content: h(h(text).to_str), html: true}
+      {content: ERB::Util.h(ERB::Util.h(text).to_str), html: true}
     else
       {content: text}
     end.merge(BOOTSTRAP_TOOLTIP_PROPS)

--- a/app/helpers/webhooks_helper.rb
+++ b/app/helpers/webhooks_helper.rb
@@ -17,4 +17,28 @@ module WebhooksHelper
   def sources_for_select(sources)
     sources.map { |source| [source.titleize, source] }.to_a
   end
+
+  def webhook_help_text(source)
+    case source
+    when 'ci_pipeline'
+      help_text = <<~HTML.html_safe
+        Generic endpoint to start deploys, expects payload in the form of:
+        <br>
+        <pre>
+        {
+          deploy: {
+            branch: &ltname&gt,
+            commit: {
+              sha: &ltsha&gt,
+              message: &ltmessage&gt
+            }
+          }
+        }
+        </pre>
+      HTML
+      additional_info(help_text)
+    else
+      ''
+    end
+  end
 end

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -13,7 +13,9 @@
   <dl>
     <% Samson::Integration::SOURCES.each do |source| %>
       <dt>
-        <%= source.titleize %>:</dt><dd><%= send("integrations_#{source}_deploy_url", @project.token) %>
+        <%= source.titleize %><%= webhook_help_text source %>
+      </dt>
+      <dd><%= send("integrations_#{source}_deploy_url", @project.token) %>
         <% if source == 'github' && token = Integrations::GithubController.secret_token %>
           <br/>
           <% if current_user.admin_for?(@project) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,7 @@ Samson::Application.routes.draw do
     post "/jenkins/:token" => "jenkins#create", as: :jenkins_deploy
     post "/buildkite/:token" => "buildkite#create", as: :buildkite_deploy
     post "/github/:token" => "github#create", as: :github_deploy
+    post "/generic/:token" => "generic#create", as: :generic_deploy
   end
 
   get '/ping', to: 'ping#show'

--- a/lib/samson/integration.rb
+++ b/lib/samson/integration.rb
@@ -2,6 +2,7 @@
 module Samson
   class Integration
     SOURCES = Rails.root.join('app', 'controllers', 'integrations').children(false).map do |controller_path|
+      # keep in sync with app/controllers/integrations/base_controller.rb#service_name
       controller_path.to_s[/\A(?!base)(\w+)_controller.rb\z/, 1]
     end.compact.freeze
   end

--- a/test/controllers/integrations/generic_controller_test.rb
+++ b/test/controllers/integrations/generic_controller_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Integrations::GenericController do
+  extend IntegrationsControllerTestHelper
+
+  def payload(overrides = {})
+    @payload ||= {
+      deploy: {
+        commit: {
+          sha: commit,
+          message: 'Hello world!'
+        },
+        branch: 'origin/dev'
+      }
+    }.merge(overrides).with_indifferent_access
+  end
+
+  let(:commit) { 'dc395381e650f3bac18457909880829fc20e34ba' }
+  let(:project) { projects(:test) }
+
+  before do
+    Deploy.delete_all
+    project.webhooks.create!(stage: stages(:test_staging), branch: "origin/dev", source: 'generic')
+  end
+
+  test_regular_commit "Generic",
+    no_mapping: {deploy: {branch: "foobar"}}, failed: nil
+end

--- a/test/helpers/webhooks_helper_test.rb
+++ b/test/helpers/webhooks_helper_test.rb
@@ -26,4 +26,14 @@ describe WebhooksHelper do
       ]
     end
   end
+
+  describe '#webhook_help_text' do
+    it 'renders help text for ci_pipeline source' do
+      webhook_help_text('ci_pipeline').must_include('Generic endpoint to start deploys')
+    end
+
+    it 'renders nothing if no source matches' do
+      webhook_help_text('badabingbadaboom').must_equal ''
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,7 @@ Dir["test/support/*"].each { |f| require File.expand_path(f) }
 
 # Helpers for all tests
 ActiveSupport::TestCase.class_eval do
+  include ApplicationHelper
   include Warden::Test::Helpers
 
   fixtures :all


### PR DESCRIPTION
In the process of us investigating a new CI tool, we found ourselves in need of an endpoint to kick off deploys in Samson. It seemed that the most correct and convenient thing to do would be to create a generic webhook with a clearly defined acceptable payload to kick off a deploy that any future in house integrations could use.

<img width="585" alt="screen shot 2018-08-24 at 10 48 43 am" src="https://user-images.githubusercontent.com/15261525/44600221-7d58d080-a78d-11e8-981a-6c924192bcd2.png">

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/BRE-923

### Risks
- Level: Low
