### PR TITLE
cache header projects a little to avoid heavy queries on every page load

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,16 +13,18 @@
               </a>
             </li>
             <li class="divider"></li>
-            <% Project.ordered_for_user(current_user).each do |project| %>
-              <li class="filtered-projects">
-                <%= link_to project do %>
-                  <% starred = current_user.starred_project?(project) %>
-                  <span class="glyphicon <%= 'glyphicon-star star starred' if starred %>">
-                    <%= '&nbsp;'.html_safe unless starred %>
-                  </span>
-                  <%= project.name %>
-                <% end %>
-              </li>
+            <% cache [:header_projects, current_user.id], expires_in: 1.minute do  %>
+              <% Project.ordered_for_user(current_user).each do |project| %>
+                <li class="filtered-projects">
+                  <%= link_to project do %>
+                    <% starred = current_user.starred_project?(project) %>
+                    <span class="glyphicon <%= 'glyphicon-star star starred' if starred %>">
+                      <%= '&nbsp;'.html_safe unless starred %>
+                    </span>
+                    <%= project.name %>
+                  <% end %>
+                </li>
+              <% end %>
             <% end %>
           </ul>
         </li>


### PR DESCRIPTION
Avoid this query on every page
`Project Load (11.4ms)  SELECT projects.*, count(stars.id) as star_count FROM `projects` left outer join stars on stars.user_id = 1382 and stars.project_id = projects.id WHERE `projects`.`deleted_at` IS NULL GROUP BY projects.id ORDER BY star_count desc, name`

@sathishavm @ragurney 

... ideally cache this longer, but we'd have to expire on every project save+star