### PR TITLE
PAAS-1999 allow locking per deploy group

### DIFF
--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -4,6 +4,7 @@ class DeployGroup < ActiveRecord::Base
   audited
 
   include Permalinkable
+  include Lockable
 
   belongs_to :environment
   belongs_to :vault_server, class_name: 'Samson::Secrets::VaultServer', optional: true
@@ -34,6 +35,10 @@ class DeployGroup < ActiveRecord::Base
   # faster alternative to stage_ids way of getting stage_ids
   def pluck_stage_ids
     deploy_groups_stages.pluck(:stage_id)
+  end
+
+  def locked_by?(lock)
+    super || (lock.resource_type == "Environment" && lock.resource_equal?(environment))
   end
 
   private

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Lock < ActiveRecord::Base
   include ActionView::Helpers::DateHelper
-  RESOURCE_TYPES = ['Stage', 'Project', 'Environment', nil].freeze # sorted by specificity
+  RESOURCE_TYPES = ['Stage', 'Project', 'DeployGroup', 'Environment', nil].freeze # sorted by specificity
   CACHE_KEY = 'lock-cache-key'
   ALL_CACHE_KEY = 'lock-all'
 

--- a/app/views/deploy_groups/index.html.erb
+++ b/app/views/deploy_groups/index.html.erb
@@ -16,7 +16,10 @@
       <tbody>
         <% @deploy_groups.each do |deploy_group| %>
           <tr>
-            <td><%= link_to deploy_group.name, deploy_group %></td>
+            <td>
+              <%= link_to deploy_group.name, deploy_group %>
+              <%= resource_lock_icon deploy_group %>
+            </td>
             <td><%= link_to deploy_group.environment.name, deploy_group.environment %></td>
             <td><%= deploy_group.env_value %></td>
             <%= Samson::Hooks.render_views(:deploy_group_table_cell, self, deploy_group: deploy_group) %>

--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -1,5 +1,7 @@
 <%= page_title @deploy_group.name %>
 
+<%= render_lock @deploy_group %>
+
 <section class="form-horizontal">
   <div class="form-group">
     <label class="col-lg-2 control-label">$DEPLOY_GROUPS value</label>
@@ -116,6 +118,7 @@
     <br>
     <div class="col-lg-offset-2 col-lg-10" style="margin-top: 10px;">
       <%= link_to "Edit", edit_deploy_group_path(@deploy_group), class: "btn btn-primary" %>
+      <%= render "locks/button", lock: @deploy_group.lock, resource: @deploy_group %>
       | <%= link_to_history @deploy_group %>
       | <%= link_to "Deploys", deploys_path(search: {group: "DeployGroup-#{@deploy_group.id}"}) %>
       | <%= link_to "Mass rollout", "#", data: {target: "#mass_rollout"}, class: 'toggle' if DeployGroup.enabled? %>

--- a/test/models/deploy_group_test.rb
+++ b/test/models/deploy_group_test.rb
@@ -177,4 +177,29 @@ describe DeployGroup do
       queries.first.wont_include "JOIN"
     end
   end
+
+  describe "#locked_by?" do
+    before { deploy_group }
+
+    it "is not locked by other" do
+      project = Project.first
+      assert_sql_queries 0 do
+        refute deploy_group.locked_by?(Lock.new(resource: project))
+      end
+    end
+
+    it "is locked by self" do
+      assert_sql_queries 0 do
+        assert deploy_group.locked_by?(Lock.new(resource: deploy_group))
+      end
+    end
+
+    it "is locked by own environment" do
+      assert deploy_group.locked_by?(Lock.new(resource: environment))
+    end
+
+    it "is not by locked other environment" do
+      refute deploy_group.locked_by?(Lock.new(resource: environments(:staging)))
+    end
+  end
 end


### PR DESCRIPTION
we'll be rolling out updates on a per cluster basis so having to lock all of production for each would be annoying.

@zendesk/compute @ragurney 

<img width="660" alt="screen shot 2018-08-28 at 7 57 26 am" src="https://user-images.githubusercontent.com/11367/44734068-e5652a80-aa9d-11e8-87aa-2838ced0c948.png">
<img width="459" alt="screen shot 2018-08-28 at 8 36 16 am" src="https://user-images.githubusercontent.com/11367/44734070-e5fdc100-aa9d-11e8-907f-e0bb4769973b.png">
<img width="595" alt="screen shot 2018-08-28 at 8 37 06 am" src="https://user-images.githubusercontent.com/11367/44734071-e5fdc100-aa9d-11e8-8624-cfbbea1c84c4.png">
<img width="654" alt="screen shot 2018-08-28 at 8 37 53 am" src="https://user-images.githubusercontent.com/11367/44734072-e6965780-aa9d-11e8-9137-cef70b7b112d.png">
<img width="495" alt="screen shot 2018-08-28 at 8 36 04 am" src="https://user-images.githubusercontent.com/11367/44734074-e72eee00-aa9d-11e8-805d-1edcd7f0b355.png">
