### PR TITLE
document and allow opt-out from preStop since it causes warnings from…

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -163,3 +163,9 @@ Set `KUBERNETES_NO_CPU_LIMIT_ALLOWED=1`, see [#2820](https://github.com/zendesk/
 
 Knowing which team owns each component is useful, set `KUBERNETES_ENFORCE_TEAMS=true` 
 to make all kubernetes deploys that do not use a `metadata.labels.team` / `spec.template.metadata.labels.team` fail.
+
+### Preventing request loss with preStop
+
+Samson automatically adds `container[].lifecycle.preStop` `sleep 3` if a preStop hook is not set and
+`container[].samson/preStop` is not set to `disabled`, to prevent in-flight requests from getting lost when taking a pod
+out of rotation.

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -465,6 +465,7 @@ module Kubernetes
 
     def set_pre_stop
       containers.each do |container|
+        next if container[:"samson/preStop"] == "disabled"
         (container[:lifecycle] ||= {})[:preStop] ||= {exec: {command: ["sleep", "3"]}}
       end
     end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -731,6 +731,11 @@ describe Kubernetes::TemplateFiller do
           preStop: "OLD"
         )
       end
+
+      it "does not add preStop when opted out" do
+        raw_template.dig_fetch(:spec, :template, :spec, :containers, 0)[:"samson/preStop"] = "disabled"
+        refute template.to_hash.dig_fetch(:spec, :template, :spec, :containers, 0).key?(:lifecycle)
+      end
     end
 
     describe "HorizontalPodAutoscaler" do


### PR DESCRIPTION
… containers that do not have sleep

```
Exec lifecycle hook ([sleep 3]) for Container "healthz" in Pod "-r9fnb_pod999(9ef757da-a884-11e8-8c23-0eda5c34567c)" failed - error: command 'sleep 3' exited with 126: , message: "rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:262: starting container process caused \"exec: \\\"sleep\\\": executable file not found in $PATH\"\n\r\n
```

@zendesk/compute 