### PR TITLE
Make caching more fine-grained

### DIFF
--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -14,7 +14,11 @@
       <%= github_user_avatar(user) %>
     <% end %>
   </td>
-  <td width="100%"><%= deployed_or_running_list @stages, release.version %></td>
+  <td width="100%">
+    <% cache ["deployed-stages", release, @stages] do %>
+      <%= deployed_or_running_list @stages, release.version %>
+    <% end %>
+  </td>
   <td><%= relative_time(release.created_at) %></td>
   <td>
     <% if deployer_for_project? %>

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -2,47 +2,45 @@
 
 <%= render 'projects/header', project: @project, tab: "releases" %>
 
-<% cache [@project, @pagy.page, deployer_for_project?] do %>
-  <section class="clearfix tabs">
-    <% if @project.release_branch.blank? %>
-      <div class="alert alert-warning">
-        <p>Configure a <%= link_to "release branch", edit_project_path(@project, anchor: "project_release_branch") %> to automatically create releases whenever a branch is pushed to.</p>
-      </div>
-    <% end %>
+<section class="clearfix tabs">
+  <% if @project.release_branch.blank? %>
+    <div class="alert alert-warning">
+      <p>Configure a <%= link_to "release branch", edit_project_path(@project, anchor: "project_release_branch") %> to automatically create releases whenever a branch is pushed to.</p>
+    </div>
+  <% end %>
 
-    <% if @releases.any? %>
-      <table class="table table-hover release-list">
-        <thead>
-          <tr>
-            <th></th>
-            <th></th>
-            <th></th>
-            <th>Deployed to</th>
-            <th>Created</th>
-            <th></th>
-          </tr>
-        </thead>
+  <% if @releases.any? %>
+    <table class="table table-hover release-list">
+      <thead>
+        <tr>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th>Deployed to</th>
+          <th>Created</th>
+          <th></th>
+        </tr>
+      </thead>
 
-        <tbody>
-          <%= render partial: 'release', collection: @releases %>
-        </tbody>
-      </table>
+      <tbody>
+        <%= render partial: 'release', collection: @releases %>
+      </tbody>
+    </table>
 
-      <%= paginate @pagy %>
+    <%= paginate @pagy %>
 
-      <p class="pull-right">
+    <p class="pull-right">
+      <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
+    </p>
+  <% elsif @project.release_branch.present? %>
+    <div class="alert alert-warning">
+      <p>No release created from release branch <%= @project.release_branch %>.</p>
+      <p>Add a webhook to samson from your CI to trigger releases on green builds or from your Code host to get releases on merge.</p>
+      <p>Samsons Github user needs write permisson to the repo to create tags.</p>
+
+      <p>
         <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
       </p>
-    <% elsif @project.release_branch.present? %>
-      <div class="alert alert-warning">
-        <p>No release created from release branch <%= @project.release_branch %>.</p>
-        <p>Add a webhook to samson from your CI to trigger releases on green builds or from your Code host to get releases on merge.</p>
-        <p>Samsons Github user needs write permisson to the repo to create tags.</p>
-
-        <p>
-          <%= link_to "Create release manually", new_project_release_path(@project), class: "btn btn-default" %>
-        </p>
-      </div>
-    <% end %>
-  </section>
-<% end %>
+    </div>
+  <% end %>
+</section>


### PR DESCRIPTION
Since the cache keys currently can't take into account the Github status checks, it's better to just cache the expensive parts of the page.

I'll try to see if there's a good way to `touch` a `Release` when the Github status changes, but we'd need to either poll the repo's Github event API or subscribe to another Github webhook. This is an immediate fix, and I think it'll be fine from a performance point of view, since we can cache the expensive parts separately. As far as I can see, only the deployed stages list actually fires off SQL queries.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
