### PR TITLE
Add a webhook receiver for Github status events

### DIFF
--- a/app/controllers/github_status_updates_controller.rb
+++ b/app/controllers/github_status_updates_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# This controller receives Status Event webhook updates from Github and makes
+# sure all relevant Releases are touched such that caches based on the release
+# `updated_at` timestamps are invalidated.
+class GithubStatusUpdatesController < ApplicationController
+  HMAC_DIGEST = OpenSSL::Digest.new('sha1')
+  SECRET_TOKEN = ENV['GITHUB_HOOK_SECRET']
+
+  skip_before_action :login_user
+  skip_before_action :verify_authenticity_token
+
+  def create
+    project = Project.find_by_token(params[:token])
+    event_type = request.headers.fetch("X-GitHub-Event")
+
+    unless valid_signature?
+      render plain: "invalid signature", status: 401
+      return
+    end
+
+    if project && event_type == "status"
+      # Touch all releases of the sha in the project.
+      project.releases.where(commit: params[:sha].to_s).each(&:touch)
+    end
+
+    render plain: "OK COMPUTER", status: 200
+  end
+
+  private
+
+  # https://developer.github.com/webhooks/securing/
+  def valid_signature?
+    return true if SECRET_TOKEN.nil?
+
+    signature = request.headers.fetch('X-Hub-Signature').to_s
+    request_body = request.body.tap(&:rewind).read
+    hmac = OpenSSL::HMAC.hexdigest(HMAC_DIGEST, SECRET_TOKEN, request_body)
+
+    Rack::Utils.secure_compare(signature, "sha1=#{hmac}")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,8 @@ Samson::Application.routes.draw do
     end
   end
 
+  post "/github/status/:token" => "github_status_updates#create", as: :github_status
+
   namespace :integrations do
     post "/circleci/:token" => "circleci#create", as: :circleci_deploy
     post "/travis/:token" => "travis#create", as: :travis_deploy

--- a/test/controllers/github_status_updates_controller_test.rb
+++ b/test/controllers/github_status_updates_controller_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe GithubStatusUpdatesController do
+  let(:project) { projects(:test) }
+  let(:sha) { "dc395381e650f3bac18457909880829fc20e34ba" }
+
+  let(:payload) do
+    {
+      token: project.token,
+      sha: sha,
+      repository: {
+        full_name: "hello/world"
+      }
+    }
+  end
+
+  with_env GITHUB_HOOK_SECRET: 'test'
+
+  before do
+    request.headers["X-Hub-Signature"] = signature_for(payload)
+    request.headers["X-GitHub-Event"] = "status"
+  end
+
+  it "touches all releases related to the status event" do
+    release = project.releases.create!(
+      commit: sha,
+      author: users(:deployer)
+    )
+
+    # Fast forward the clock.
+    later = 1.minute.from_now
+    Time.stubs(:now).returns later
+
+    post :create, params: payload
+
+    assert_response :success
+
+    release.reload.updated_at.must_equal later
+  end
+
+  it "responds with status 401 if the signature is invalid" do
+    request.headers["X-Hub-Signature"] = "yolo"
+
+    post :create, params: payload
+
+    assert_response :success
+  end
+
+  def signature_for(payload)
+    hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['GITHUB_HOOK_SECRET'].to_s, payload.to_param)
+    "sha1=#{hmac}"
+  end
+end


### PR DESCRIPTION
This controller receives [Github status events](https://developer.github.com/v3/activity/events/types/#statusevent) and touches all the relevant Releases. This will allow us to base cache keys on `Release#updated_at`, and, since Release touches Project upon updates, `Project#updated_at`.

/cc @zendesk/samson

### Tasks
- [x] Figure out how to register the webhook in the Github repos.
- [ ] :+1: from team.

### Risks
- Level: Medium, could add extra load.
