### PR TITLE
Move "warn" and "lock" buttons to the right

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -179,7 +179,8 @@ pre.pre-inline {
 }
 
 .project-lock-buttons {
-  margin: 1em 0 1em 0;
+  margin: .5em 0 0 0;
+  float: right;
 }
 
 // Labels with tooltips.


### PR DESCRIPTION
Makes the "warn" and "lock" buttons take up less of the valuable vertical space.

**Before:**
![Before](https://cl.ly/3f00e7c89a85/Image%202018-08-29%20at%203.38.05%20PM.png)

**After:**
![After](https://cl.ly/3610c20f8ed4/Image%202018-08-29%20at%203.36.31%20PM.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
