### PR TITLE
[BRE-936] Filter out nil authors and author names in Changeset

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -47,11 +47,11 @@ class Changeset
   end
 
   def authors
-    commits.map(&:author).uniq
+    commits.map(&:author).compact.uniq
   end
 
   def author_names
-    commits.map(&:author_name).uniq
+    commits.map(&:author_name).compact.uniq
   end
 
   def empty?

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -134,6 +134,17 @@ describe Changeset do
       )
       changeset.authors.must_equal ["foo", "bar"]
     end
+
+    it "does not include nil authors" do
+      changeset.expects(:commits).returns(
+        [
+          stub("c1", author: "foo"),
+          stub("c2", author: "bar"),
+          stub("c3", author: nil)
+        ]
+      )
+      changeset.authors.must_equal ["foo", "bar"]
+    end
   end
 
   describe "#author_names" do
@@ -143,6 +154,17 @@ describe Changeset do
           stub("c1", author_name: "foo"),
           stub("c2", author_name: "foo"),
           stub("c3", author_name: "bar")
+        ]
+      )
+      changeset.author_names.must_equal ["foo", "bar"]
+    end
+
+    it "doesnot include nil author names" do
+      changeset.expects(:commits).returns(
+        [
+          stub("c1", author_name: "foo"),
+          stub("c2", author_name: "bar"),
+          stub("c3", author_name: nil)
         ]
       )
       changeset.author_names.must_equal ["foo", "bar"]


### PR DESCRIPTION
There can sometimes be nil authors for git commits, which caused 500's. This makes it so `Changeset#authors` and `Changeset#author_names` doesn't return unexpected nil values.

/cc @zendesk/samson @zendesk/bre

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/BRE-936

### Risks
- Level: Low
