### PR TITLE
Handle Github commit status events

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -14,6 +14,8 @@ class Integrations::GithubController < Integrations::BaseController
   def create
     if github_event_type == "status"
       handle_commit_status_event
+
+      render plain: "OK", status: 200
     else
       super
     end

--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -12,13 +12,9 @@ class Integrations::GithubController < Integrations::BaseController
   end
 
   def create
-    if github_event_type == "status"
-      handle_commit_status_event
+    handle_commit_status_event if github_event_type == "status"
 
-      render json: {deploy_ids: [], messages: "status event received"}, status: :ok
-    else
-      super
-    end
+    super
   end
 
   protected

--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -15,7 +15,7 @@ class Integrations::GithubController < Integrations::BaseController
     if github_event_type == "status"
       handle_commit_status_event
 
-      render plain: "OK", status: 200
+      render json: {deploy_ids: [], messages: "status event received"}, status: :ok
     else
       super
     end

--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -11,7 +11,20 @@ class Integrations::GithubController < Integrations::BaseController
     ENV['GITHUB_HOOK_SECRET']
   end
 
+  def create
+    if github_event_type == "status"
+      handle_commit_status_event
+    else
+      super
+    end
+  end
+
   protected
+
+  def handle_commit_status_event
+    # Touch all releases of the sha in the project.
+    project.releases.where(commit: params[:sha].to_s).each(&:touch)
+  end
 
   def payload
     if payload = params[:payload]
@@ -69,7 +82,11 @@ class Integrations::GithubController < Integrations::BaseController
   end
 
   def webhook_handler
-    WEBHOOK_HANDLERS[request.headers['X-Github-Event']]
+    WEBHOOK_HANDLERS[github_event_type]
+  end
+
+  def github_event_type
+    request.headers['X-Github-Event']
   end
 
   def signature


### PR DESCRIPTION
A new commit status causes all releases of that commit to be touched, meaning that the status can be cached by `Release#updated_at`.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
