### PR TITLE
detect pull requests in Changeset using Github API

### DIFF
--- a/plugins/ledger/test/lib/samson_ledger/client_test.rb
+++ b/plugins/ledger/test/lib/samson_ledger/client_test.rb
@@ -29,6 +29,7 @@ describe SamsonLedger::Client do
       stub_github_api("repos/bar/foo/compare/abcabcaaabcabcaaabcabcaaabcabcaaabcabca1...staging", "x" => "y")
       GITHUB.stubs(:compare).with("bar/foo", "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1", "staging").returns(comparison)
       Changeset::PullRequest.stubs(:find).with("bar/foo", 42).returns(pull_request)
+      GITHUB.stubs(:pull_requests).with("bar/foo", head: "bar:staging").returns([])
 
       request_lambda = ->(request) do
         results << JSON.parse(request.body)['events'].first


### PR DESCRIPTION
At Applicaster we deploy branches to production before we merge them to master (a practice we've borrowed from github https://githubengineering.com/deploying-branches-to-github-com/)
We are also using the built-in slack_webhooks plugin.

The problem we have is that Samson will not detect the pull request in the changeset, and so the slack plugin [will warn that a deployment is made without a pull request](https://github.com/zendesk/samson/blob/79bbedb167738006f0021ff4fe215cf4790fe93e/plugins/slack_webhooks/app/views/samson_slack_webhooks/notification.text.erb#L8-L10)

This makes everyone jump to try to find out who is deploying without a pull request, which is never the case. But never say never :trollface: 
This is especially annoying since there's a `@chanell` keyword in the message so all members of the `deployments` channel are brought in.

This PR adds a call to Github's [List pull requests endpoint](https://developer.github.com/v3/pulls/#list-pull-requests) in an attempt to resolve the PR for the deployed branch.
It will skip calling the API if it detects that the reference (called `commit` in the code) is a commit SHA reference by matching it to a simple regular expression.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
