### PR TITLE
Add support for the `error` status

### DIFF
--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -4,14 +4,16 @@ module ReleasesHelper
     "success" => "ok",
     "failure" => "remove",
     "missing" => "minus",
-    "pending" => "hourglass"
+    "pending" => "hourglass",
+    "error" => "exclamation-sign"
   }.freeze
 
   GITHUB_STATUS_TEXT_LABELS = {
     "success" => "success",
     "failure" => "danger",
     "missing" => "muted",
-    "pending" => "primary"
+    "pending" => "primary",
+    "error" => "warning"
   }.freeze
 
   def release_label(project, release)


### PR DESCRIPTION
Did not realize that was an option...

Fixes [this exception](https://rollbar-us.zendesk.com/Zendesk/Samson/items/569/)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
