### PR TITLE
[BRE-72] Add SoftDeleteWithDestroy to Deploy

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 class Deploy < ActiveRecord::Base
   include Samson::BumpTouch
+
   has_soft_deletion default_scope: true
+
+  include SoftDeleteWithDestroy
 
   belongs_to :stage, touch: true
   belongs_to :build, optional: true

--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -5,6 +5,7 @@ class DeployGroup < ActiveRecord::Base
 
   include Permalinkable
   include Lockable
+  include SoftDeleteWithDestroy
 
   belongs_to :environment
   belongs_to :vault_server, class_name: 'Samson::Secrets::VaultServer', optional: true

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -5,6 +5,7 @@ class Environment < ActiveRecord::Base
 
   include Lockable
   include Permalinkable
+  include SoftDeleteWithDestroy
 
   has_many :deploy_groups, dependent: :destroy
   has_many :template_stages, -> { where(is_template: true) }, through: :deploy_groups, class_name: 'Stage'

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -9,6 +9,8 @@ class Lock < ActiveRecord::Base
 
   has_soft_deletion default_scope: true
 
+  include SoftDeleteWithDestroy
+
   belongs_to :resource, polymorphic: true, optional: true
   belongs_to :user
   belongs_to :environment, optional: true

--- a/app/models/outbound_webhook.rb
+++ b/app/models/outbound_webhook.rb
@@ -4,6 +4,7 @@ require 'faraday'
 
 class OutboundWebhook < ActiveRecord::Base
   has_soft_deletion default_scope: true
+  include SoftDeleteWithDestroy
 
   belongs_to :project
   belongs_to :stage

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -8,6 +8,7 @@ class Stage < ActiveRecord::Base
 
   include Lockable
   include Permalinkable
+  include SoftDeleteWithDestroy
 
   audited except: [:order]
 

--- a/app/models/stage_command.rb
+++ b/app/models/stage_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class StageCommand < ActiveRecord::Base
   has_soft_deletion default_scope: true
+  include SoftDeleteWithDestroy
 
   belongs_to :stage
   belongs_to :command, autosave: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ActiveRecord::Base
   TIME_FORMATS = ['local', 'utc', 'relative'].freeze
 
   has_soft_deletion default_scope: true
+  include SoftDeleteWithDestroy
 
   audited except: [:last_seen_at, :last_login_at]
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Webhook < ActiveRecord::Base
   has_soft_deletion default_scope: true
+  include SoftDeleteWithDestroy
+
   validates :branch, uniqueness: {
     scope: [:stage_id],
     conditions: -> { where("deleted_at IS NULL") },

--- a/plugins/kubernetes/app/decorators/deploy_group_decorator.rb
+++ b/plugins/kubernetes/app/decorators/deploy_group_decorator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 DeployGroup.class_eval do
   has_soft_deletion default_scope: true
+
   has_one(
     :cluster_deploy_group,
     class_name: 'Kubernetes::ClusterDeployGroup',
@@ -17,13 +18,7 @@ DeployGroup.class_eval do
     reject_if: lambda { |h| h[:kubernetes_cluster_id].blank? }
   )
 
-  after_soft_delete :delete_kubernetes_deploy_group_roles
-
   def kubernetes_namespace
     cluster_deploy_group.try(:namespace)
-  end
-
-  def delete_kubernetes_deploy_group_roles
-    kubernetes_deploy_group_roles.destroy_all
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -27,6 +27,8 @@ module Kubernetes
     has_soft_deletion
     audited
 
+    include SoftDeleteWithDestroy
+
     belongs_to :project, inverse_of: :kubernetes_roles
     has_many :kubernetes_deploy_group_roles,
       class_name: 'Kubernetes::DeployGroupRole',
@@ -48,8 +50,6 @@ module Kubernetes
     validates :manual_deletion_acknowledged, presence: {message: "must be set"}, if: :manual_deletion_required?
 
     scope :not_deleted, -> { where(deleted_at: nil) }
-
-    after_soft_delete :delete_kubernetes_deploy_group_roles
 
     attr_accessor :manual_deletion_acknowledged
 
@@ -153,10 +153,6 @@ module Kubernetes
     def parse_resource_value(v, possible)
       return unless v.to_s =~ /^(\d+(?:\.\d+)?)(#{possible.keys.join('|')})$/
       $1.to_f * possible.fetch($2)
-    end
-
-    def delete_kubernetes_deploy_group_roles
-      kubernetes_deploy_group_roles.destroy_all
     end
 
     def strip_config_file


### PR DESCRIPTION
From `SoftDeleteWithDestroy`: 
> soft_deletion gem doesn't destroy relations with dependent: :destroy, only safe_delete's them if they are safe_deletable. This leads to orphaned records of safe_deleted objects. This fills in the missing logic in the gem -- finding all child records which are not safe_deletable and have the dependent: :destroy callback and deleting

It's a good idea to add this to all Samson models using the gem with dependent: :destroy associations. 

/cc @zendesk/samson

### Tasks
 - [ ] 👍from team

### References
 - Jira link: [BRE-72](https://zendesk.atlassian.net/browse/BRE-72)

### Risks
- Level: Med, could lead to failed deletions
