### PR TITLE
[BRE-943] Add styling to Rollbar tables to prevent overflow

### DIFF
--- a/plugins/rollbar_dashboards/app/assets/stylesheets/rollbar_dashboards/application.css
+++ b/plugins/rollbar_dashboards/app/assets/stylesheets/rollbar_dashboards/application.css
@@ -1,3 +1,24 @@
 .dashboard-container {
   margin-bottom: 20px;
 }
+
+.rollbar-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.rollbar-table__count {
+  width: 10%;
+}
+
+.rollbar-table__title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  width:75%;
+  max-width:75%;
+}
+
+.rollbar-table__env {
+  width: 15%;
+}

--- a/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_dashboard.html.erb
+++ b/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_dashboard.html.erb
@@ -5,11 +5,11 @@
   </div>
   <% items = dashboard_data.second %>
   <% if items.present? %>
-    <table class="table">
+    <table class="table rollbar-table">
       <tr>
-        <th>Count</th>
-        <th>Title</th>
-        <th>Environment</th>
+        <th class="rollbar-table__count">Count</th>
+        <th class="rollbar-table__title">Title</th>
+        <th class="rollbar-table__env">Environment</th>
       </tr>
       <%= render partial: 'rollbar_dashboards/item', collection: items, locals: {dashboard_setting: dashboard_data.first} %>
     </table>

--- a/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_item.html.erb
+++ b/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_item.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><span class="badge"><%= item[:occurrences] %></span></td>
-  <td><%= item_link(item[:title], item[:counter], dashboard_setting) %></td>
-  <td><%= item[:environment] %></td>
+  <td class="rollbar-table__count"><span class="badge"><%= item[:occurrences] %></span></td>
+  <td class="rollbar-table__title"><%= item_link(item[:title], item[:counter], dashboard_setting) %></td>
+  <td class="rollbar-table__env"><%= item[:environment] %></td>
 </tr>


### PR DESCRIPTION
Before:
<img width="1538" alt="screen shot 2018-09-04 at 12 09 39 pm" src="https://user-images.githubusercontent.com/15261525/45052460-b91c5180-b03b-11e8-8de3-67abbd7c54eb.png">
After:
<img width="1170" alt="screen shot 2018-09-04 at 12 09 32 pm" src="https://user-images.githubusercontent.com/15261525/45052457-b7528e00-b03b-11e8-9691-042eb521a74e.png">

/cc @zendesk/samson

### References
 - Jira link: [BRE-943](https://zendesk.atlassian.net/browse/BRE-943)

### Risks
- Level: Low



