### PR TITLE
remove strange tagline from login screen

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,6 @@
 <% page_title "Login" %>
 <div class="login-wrapper fade-in">
   <h1 class="login-brand">Samson</h1>
-  <p>Understand what is being deployed.</p>
   <div class="login">
     <% if Rails.application.config.samson.auth.values.none? %>
       You cannot signup or login since no auth provider is configured.<br/>


### PR DESCRIPTION
before:
<img width="424" alt="screen shot 2018-09-05 at 11 59 34 am" src="https://user-images.githubusercontent.com/11367/45116560-f5b57f00-b107-11e8-8828-c0339f0591ab.png">


after:
<img width="407" alt="screen shot 2018-09-05 at 11 59 20 am" src="https://user-images.githubusercontent.com/11367/45116563-f9490600-b107-11e8-9bdf-588f0c2ee5b8.png">

@ragurney @bcolferzd 