### PR TITLE
[CONNECTOPS-44] Wrap pull_requests call in Changeset::PullRequest

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -96,7 +96,9 @@ class Changeset
   def find_pull_requests_for_branch
     return [] if not_pr_branch?
     org = repo.split("/", 2).first
-    GITHUB.pull_requests(repo, head: "#{org}:#{commit}")
+    GITHUB.pull_requests(repo, head: "#{org}:#{commit}").map do |github_pr|
+      Changeset::PullRequest.new(repo, github_pr)
+    end
   rescue Octokit::Error, Faraday::ConnectionFailed => e
     Rails.logger.warn "Failed fetching pull requests for branch #{commit}:\n#{e}"
     []


### PR DESCRIPTION
* Add description here
PR #2915 introduced displaying open pull requests for deployed branches, but merged the `Changeset::PullRequest` array with members of the underlying `Sawyer` type returned by `GITHUB.pull_requests`.

This PR wraps them up correctly in `Changeset::PullRequest` objects too so all members of the array are of the same type.

* Add any screenshots if you are touching the UI
* Remember to add unit tests
/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/CONNECTOPS-44

### Risks
- Level: Low
