### PR TITLE
PAAS-2064 allow opting out of label validation for services that match multiple deployments

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -98,12 +98,12 @@ module Kubernetes
     def validate_project_and_role_consistent
       labels = @elements.flat_map do |resource|
         kind = resource[:kind]
+        allow_cross_match = resource.dig(:metadata, :annotations, :"samson/service_selector_across_roles") == "true"
+
         label_paths = metadata_paths(resource).map { |p| p + [:labels] } +
           case kind
           when 'Service'
-            [
-              [:spec, :selector]
-            ]
+            allow_cross_match ? [] : [[:spec, :selector]]
           when 'PodDisruptionBudget'
             [
               [:spec, :selector, :matchLabels]

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -353,6 +353,12 @@ describe Kubernetes::RoleValidator do
         ]
       end
 
+      it "allows cross-matching services when opted in" do
+        role[1][:spec][:selector].delete(:role)
+        role[1][:metadata][:annotations] = {"samson/service_selector_across_roles": "true"}
+        errors.must_be_nil
+      end
+
       it "reports missing label section" do
         role.first[:spec][:template][:metadata].delete(:labels)
         errors.must_equal [


### PR DESCRIPTION
```
bring up a debug instance of our service for testing, e.g.:
• 3 replicas of account-service `app-server` role running
• 1 replica of account-serivce `app-server-debug` role running
• All 4 replicas getting sent traffic
```

@zendesk/compute @henders 
