### PR TITLE
[BRE-946] Use block syntax for IO.popen to ensure Ruby closes the opened pipe

### DIFF
--- a/lib/samson/process_utils.rb
+++ b/lib/samson/process_utils.rb
@@ -7,13 +7,14 @@ module Samson
     class << self
       def ps_list
         whitelists = ENV.fetch('PROCESS_WHITELIST', '').split(',')
-        pipe = IO.popen("ps -eo #{ATTRIBUTES.join(',')}")
-        # Ignore known long-running processes so report is meaningful
-        filtered_processes = pipe.readlines[1..-1].reject do |lines|
-          whitelists.any? { |key| lines.include?(key) }
-        end
-        filtered_processes.map do |line|
-          Hash[ATTRIBUTES.zip line.lstrip.split(/\s+/, ATTRIBUTES.size)]
+        IO.popen("ps -eo #{ATTRIBUTES.join(',')}") do |pipe|
+          # Ignore known long-running processes so report is meaningful
+          filtered_processes = pipe.readlines[1..-1].reject do |lines|
+            whitelists.any? { |key| lines.include?(key) }
+          end
+          filtered_processes.map do |line|
+            Hash[ATTRIBUTES.zip line.lstrip.split(/\s+/, ATTRIBUTES.size)]
+          end
         end
       end
 


### PR DESCRIPTION
We were seeing thousands of defunct procs being created on Samson hosts, which eventually caused Samson to become unresponsive 😱I tracked it down to this Periodical task. The block syntax should ensure that Ruby closes the opened pipe. 

/cc @zendesk/samson @sathishavm 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: [BRE-946](https://zendesk.atlassian.net/browse/BRE-946)

### Risks
- Level: Low
