### PR TITLE
Fix help text for generic endpoint

### DIFF
--- a/app/helpers/webhooks_helper.rb
+++ b/app/helpers/webhooks_helper.rb
@@ -20,7 +20,7 @@ module WebhooksHelper
 
   def webhook_help_text(source)
     case source
-    when 'ci_pipeline'
+    when 'generic'
       help_text = <<~HTML.html_safe
         Generic endpoint to start deploys, expects payload in the form of:
         <br>

--- a/test/helpers/webhooks_helper_test.rb
+++ b/test/helpers/webhooks_helper_test.rb
@@ -29,7 +29,7 @@ describe WebhooksHelper do
 
   describe '#webhook_help_text' do
     it 'renders help text for ci_pipeline source' do
-      webhook_help_text('ci_pipeline').must_include('Generic endpoint to start deploys')
+      webhook_help_text('generic').must_include('Generic endpoint to start deploys')
     end
 
     it 'renders nothing if no source matches' do


### PR DESCRIPTION
Adds back help bubble. 

/cc @zendesk/samson
