### PR TITLE
Cache GithubStatus by Release

### DIFF
--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -33,8 +33,12 @@ class GithubStatus
     @statuses = statuses
   end
 
-  def self.fetch(repo, ref)
-    cache_key = [name, repo, ref]
+  def self.fetch(release)
+    repo, ref = release.project.repository_path, release.commit
+
+    # Base the cache key on the Release, so that an update to it effectively
+    # clears the cache.
+    cache_key = [name, release]
 
     response = Rails.cache.read(cache_key)
 

--- a/app/models/github_status.rb
+++ b/app/models/github_status.rb
@@ -34,7 +34,8 @@ class GithubStatus
   end
 
   def self.fetch(release)
-    repo, ref = release.project.repository_path, release.commit
+    repo = release.project.repository_path
+    ref = release.commit
 
     # Base the cache key on the Release, so that an update to it effectively
     # clears the cache.

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -33,7 +33,7 @@ class Release < ActiveRecord::Base
   end
 
   def github_status
-    @github_status ||= GithubStatus.fetch(project.repository_path, commit)
+    @github_status ||= GithubStatus.fetch(self)
   end
 
   def self.find_by_param!(version)

--- a/test/models/github_status_test.rb
+++ b/test/models/github_status_test.rb
@@ -6,9 +6,11 @@ SingleCov.covered!
 describe GithubStatus do
   let(:repo) { "oompa/loompa" }
   let(:ref) { "wonka" }
+  let(:project) { stub("project", repository_path: repo) }
+  let(:release) { stub("release", project: project, commit: ref) }
 
   describe "#state" do
-    let(:status) { GithubStatus.fetch(repo, ref) }
+    let(:status) { GithubStatus.fetch(release) }
 
     it "returns `missing` if there's no response from Github" do
       stub_api({}, 401)
@@ -22,7 +24,7 @@ describe GithubStatus do
   end
 
   describe "#statuses" do
-    let(:status) { GithubStatus.fetch(repo, ref) }
+    let(:status) { GithubStatus.fetch(release) }
 
     it "returns a single status per context" do
       # The most recent status is used.


### PR DESCRIPTION
This will allow busting the cache by updating the Release's `updated_at` attribute.

/cc @zendesk/samson @grosser 

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
