### PR TITLE
keep buttons floating into the table and not into plugin content

### DIFF
--- a/app/views/projects/_header.html.erb
+++ b/app/views/projects/_header.html.erb
@@ -4,10 +4,10 @@
   <%= repository_web_link(project) %>
 </h1>
 
+<%= Samson::Hooks.render_views(:project_view, self, project: @project) %>
+
 <div class="project-lock-buttons">
   <%= render "locks/button", lock: project.lock, resource: @project %>
 </div>
-
-<%= Samson::Hooks.render_views(:project_view, self, project: @project) %>
 
 <%= render "shared/project_tabs", project: project, active: tab %>


### PR DESCRIPTION
before buttons floated into whatever content plugins added to `project_view`
now they'll stay in the table

fixup for https://github.com/zendesk/samson/pull/2909

/cc @dasch @ragurney 