### PR TITLE
do not do deletions when using RollingUpdate strategy on 1.9+

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -374,7 +374,9 @@ module Kubernetes
 
     class StatefulSet < Base
       def patch_replace?
-        [nil, "OnDelete"].include?(@template.dig(:spec, :updateStrategy)) && running?
+        deprecated = @template.dig(:spec, :updateStrategy) # supporting pre 1.9 clusters
+        strategy = (deprecated.is_a?(String) ? deprecated : @template.dig(:spec, :updateStrategy, :type))
+        [nil, "OnDelete"].include?(strategy) && running?
       end
 
       # StatefulSet cannot be updated normally when OnDelete is used or kubernetes <1.7

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -523,6 +523,15 @@ describe Kubernetes::Resource do
         end
       end
 
+      it "updates when running and using RollingUpdate" do
+        template[:spec][:updateStrategy] = {type: "RollingUpdate"}
+        assert_request(:get, url, to_return: {body: "{}"}) do
+          assert_request(:put, url, to_return: {body: "{}"}) do
+            resource.deploy
+          end
+        end
+      end
+
       it "patches and deletes pods when using OnDelete (default)" do
         set = {
           spec: {


### PR DESCRIPTION
@zendesk/compute 

... new deployments went into the `use real updates` and failed :D 