### PR TITLE
Make API documentation more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Samson will:
 
 ### Documentation
 
-* [Getting started](/master/docs/setup.md)
-* [Permissions](/master/docs/permissions.md)
-* [Continuous Integration](/master/docs/ci.md)
-* [Extra features](/master/docs/extra_features.md)
-* [Plugins](/master/docs/plugins.md)
-* [Statistics](/blob/master/docs/stats.md)
-* [API](/blob/master/docs/api.md)
+* [Getting started](/docs/setup.md)
+* [Permissions](/docs/permissions.md)
+* [Continuous Integration](/docs/ci.md)
+* [Extra features](/docs/extra_features.md)
+* [Plugins](/docs/plugins.md)
+* [Statistics](/docs/stats.md)
+* [API](/docs/api.md)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Samson will:
 * [Extra features](https://github.com/zendesk/samson/blob/master/docs/extra_features.md)
 * [Plugins](https://github.com/zendesk/samson/blob/master/docs/plugins.md)
 * [Statistics](https://github.com/zendesk/samson/blob/master/docs/stats.md)
+* [API](https://github.com/zendesk/samson/blob/master/docs/api.md)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Samson will:
 
 ### Documentation
 
-* [Getting started](https://github.com/zendesk/samson/blob/master/docs/setup.md)
-* [Permissions](https://github.com/zendesk/samson/blob/master/docs/permissions.md)
-* [Continuous Integration](https://github.com/zendesk/samson/blob/master/docs/ci.md)
-* [Extra features](https://github.com/zendesk/samson/blob/master/docs/extra_features.md)
-* [Plugins](https://github.com/zendesk/samson/blob/master/docs/plugins.md)
-* [Statistics](https://github.com/zendesk/samson/blob/master/docs/stats.md)
-* [API](https://github.com/zendesk/samson/blob/master/docs/api.md)
+* [Getting started](/master/docs/setup.md)
+* [Permissions](/master/docs/permissions.md)
+* [Continuous Integration](/master/docs/ci.md)
+* [Extra features](/master/docs/extra_features.md)
+* [Plugins](/master/docs/plugins.md)
+* [Statistics](/blob/master/docs/stats.md)
+* [API](/blob/master/docs/api.md)
 
 ### Contributing
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 Many endpoints offer a `.json` response, open PRs for missing ones.
 
-Api authentication is done via OAuth tokens and scopes, see [lib/warden/strategies/doorkeeper_strategy.rb](https://github.com/zendesk/samson/blob/master/lib/warden/strategies/doorkeeper_strategy.rb) for details.
+Api authentication is done via OAuth tokens and scopes, see [/lib/warden/strategies/doorkeeper_strategy.rb](/lib/warden/strategies/doorkeeper_strategy.rb) for details.
 
 Scopes are default="all" ... locks="allowed to read+write locks".
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 Many endpoints offer a `.json` response, open PRs for missing ones.
 
-Api authentication is done via OAuth tokens and scopes, see [lib/warden/strategies/doorkeeper_strategy.rb]() for details.
+Api authentication is done via OAuth tokens and scopes, see [lib/warden/strategies/doorkeeper_strategy.rb](https://github.com/zendesk/samson/blob/master/lib/warden/strategies/doorkeeper_strategy.rb) for details.
 
 Scopes are default="all" ... locks="allowed to read+write locks".
 


### PR DESCRIPTION
While trying to access Samson API, I missed the docs folder. I believe adding a link to the API doc in the main, github-visible `README` will help future devs find this nice feature of Samson.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - [Context JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1051)

### Risks
- Level: Low
Only improving documentation