### PR TITLE
Broken link drove to a 404 page

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -2,7 +2,7 @@
 
 Samson can manage secrets for commands, environment variables or kubernetes deploys under `/secrets`.
 
-Lookup logic is in [lib/samson/secrets/key_resolver.rb](lib/samson/secrets/key_resolver.rb).
+Lookup logic is in [lib/samson/secrets/key_resolver.rb](/lib/samson/secrets/key_resolver.rb).
 
 Most usage is with `secret://some_key` that will be looked up in the secret store and resolved to the most specific secret,
 for example `some_key` might be resolved to `production/my-project/global/some_key`.


### PR DESCRIPTION
The **secrets** doc page included a relative link to a file which ended up navigating to a 404. 

### Screenshot:
![broken link](https://user-images.githubusercontent.com/321064/45614876-35b32500-ba6b-11e8-9d57-6e3527892107.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
