### PR TITLE
[BRE-964] Use correct api endpoint to get pr details for "branch" prs

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -96,9 +96,7 @@ class Changeset
   def find_pull_requests_for_branch
     return [] if not_pr_branch?
     org = repo.split("/", 2).first
-    GITHUB.pull_requests(repo, head: "#{org}:#{commit}").map do |github_pr|
-      Changeset::PullRequest.new(repo, github_pr)
-    end
+    GITHUB.pull_requests(repo, head: "#{org}:#{commit}").map { |github_pr| PullRequest.find(repo, github_pr.number) }
   rescue Octokit::Error, Faraday::ConnectionFailed => e
     Rails.logger.warn "Failed fetching pull requests for branch #{commit}:\n#{e}"
     []


### PR DESCRIPTION
We were getting 500s on the deploy review page, which was caused by certain expected fields in a `PullRequest` being absent, such as additions. This was because we were passing the data from the GitHub api call `pull_requests` directly to the `PullRequest` object, which is not equivalent to what is returned from the `pull_request` api call, which includes the required details. 

/cc @zendesk/samson @neerfri

### Tasks
 - [ ] 👍from team

### References
 - Jira link: [BRE-964](https://zendesk.atlassian.net/browse/BRE-964)

### Risks
- Level: Low
