### PR TITLE
PAAS-2142 do not allow setting 0/2+ replicas for resources that do not support …

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -85,7 +85,7 @@ module Kubernetes
       end
 
       def desired_pod_count
-        replica_source.dig_fetch(:spec, :replicas)
+        @delete_resource ? 0 : replica_source.dig(:spec, :replicas) || 1
       end
 
       private
@@ -467,10 +467,6 @@ module Kubernetes
       def deploy
         delete
         create
-      end
-
-      def desired_pod_count
-        @delete_resource ? 0 : 1
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -282,6 +282,16 @@ describe Kubernetes::Resource do
         resource.desired_pod_count.must_equal 2
       end
     end
+
+    it "is 1 when not set" do
+      template[:spec].delete :replicas
+      resource.desired_pod_count.must_equal 1
+    end
+
+    it "is 0 when pod is deleted" do
+      delete_resource!
+      resource.desired_pod_count.must_equal 0
+    end
   end
 
   describe "#loop_sleep" do
@@ -850,17 +860,6 @@ describe Kubernetes::Resource do
         assert_request(:get, url, to_return: {status: 404}) do
           resource.deploy
         end
-      end
-    end
-
-    describe "#desired_pod_count" do
-      it "is 1" do
-        resource.desired_pod_count.must_equal 1
-      end
-
-      it "is 0 when pod is deleted" do
-        delete_resource!
-        resource.desired_pod_count.must_equal 0
       end
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -686,6 +686,7 @@ describe Kubernetes::TemplateFiller do
       before do
         raw_template[:kind] = 'DaemonSet'
         raw_template[:spec].delete(:replicas)
+        doc.replica_target = 1
       end
 
       it "does not add replicas since they are not supported" do
@@ -701,6 +702,7 @@ describe Kubernetes::TemplateFiller do
         raw_template[:metadata].merge!(original_metadata)
         raw_template[:kind] = "Pod"
         raw_template[:spec].delete :replicas
+        doc.replica_target = 1
       end
 
       it "fills out everything" do
@@ -716,11 +718,26 @@ describe Kubernetes::TemplateFiller do
         result = template.to_hash
         refute result[:spec].key?(:replicas)
       end
+
+      it "complains on invalid replica settings" do
+        doc.replica_target = 0
+        assert_raises(Samson::Hooks::UserError) { template.to_hash }
+
+        doc.replica_target = 2
+        assert_raises(Samson::Hooks::UserError) { template.to_hash }
+      end
+
+      it "allows deletion" do
+        doc.replica_target = 0
+        doc.delete_resource = true
+        template.to_hash
+      end
     end
 
     describe "cronjob" do
       before do
         raw_template.replace(YAML.safe_load(read_kubernetes_sample_file('kubernetes_cron_job.yml')).deep_symbolize_keys)
+        doc.replica_target = 1
       end
 
       it "works" do


### PR DESCRIPTION
…replicas

@zendesk/compute 

the only place were 0 replicas makes somewhat sense is for deployments that we can later scale up / use as template for consoles ... for everything else it should be either 1 or deleted