### PR TITLE
make docker build service lock expire after 10 seconds and not 5 min …

### DIFF
--- a/app/models/docker_builder_service.rb
+++ b/app/models/docker_builder_service.rb
@@ -43,9 +43,10 @@ class DockerBuilderService
   private
 
   # In development, memcache can be down and we don't want that to stop builds
+  # Note: we need raw: true because of https://github.com/rails/rails/pull/34026
   def same_build_in_progress?
     !Rails.env.development? &&
-      !Rails.cache.write("build-service-#{@build.id}", true, unless_exist: true, expires_in: 10.seconds)
+      !Rails.cache.write("build-service-#{@build.id}", true, unless_exist: true, expires_in: 10.seconds, raw: true)
   end
 
   def execute_build_command(tmp_dir, command)


### PR DESCRIPTION
…and 10 seconds: 

See PR: https://github.com/rails/rails/pull/34026


/cc @zendesk/samson @zendesk/compute 
