### PR TITLE
ignore Dockerfile if Dockerfile is in dockerignore so docker build wi…

### DIFF
--- a/plugins/gcloud/test/samson_gcloud/image_builder_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/image_builder_test.rb
@@ -138,6 +138,12 @@ describe SamsonGcloud::ImageBuilder do
       File.read("some-dir/.gcloudignore").must_equal "#!include:.gitignore\n#!include:.dockerignore"
     end
 
+    it "ignores Dockerfile if Dockerfile is in dockerignore" do
+      File.write("some-dir/.dockerignore", "foo\nDockerfile\nbar")
+      build_image
+      File.read("some-dir/.dockerignore").must_equal "foo\n\nbar"
+    end
+
     it "does not include missing files and ignores .git by default" do
       build_image
       File.read("some-dir/.gcloudignore").must_equal ".git"


### PR DESCRIPTION
…ll still work

Error message:
```
[20:57:49] BUILD
[20:57:49] Already have image (with digest): gcr.io/cloud-builders/docker
[20:57:49] unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /workspace/Dockerfile: no such file or directory
[20:57:49] ERROR
[20:57:49] ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 1
```

/cc @zendesk/samson @zendesk/compute 


