### PR TITLE
make reference required so we do not have to go through a create/fail…

### DIFF
--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -27,6 +27,7 @@
                 class: "form-control",
                 autofocus: true,
                 placeholder: "e.g. v2.1.43, master, fa0b4671",
+                required: true,
                 data: { prefetch_url: project_references_path(@project, format: "json") }
             %>
           </div>


### PR DESCRIPTION
… cycle to get an error

@zendesk/samson @ragurney 

<img width="411" alt="screen shot 2018-10-01 at 9 04 31 am" src="https://user-images.githubusercontent.com/11367/46300660-234fe580-c559-11e8-8d98-ed35b17996af.png">
