### PR TITLE
better ignore cursor movement for less spammy docker builds

### DIFF
--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -129,8 +129,8 @@ describe TerminalExecutor do
     end
 
     it "does not log cursor movement ... special output coming from docker builds" do
-      assert subject.execute("ruby -e 'puts \"Hello\\r\e[1B\\nWorld\\n\"'")
-      output.string.must_equal "Hello\rWorld\r\n"
+      assert subject.execute("ruby -e 'puts \"Hello\\r\e[1B\\nWorld\\n\e[1K\"'")
+      output.string.must_equal "Hello\rWorld\r\n\r\n"
     end
 
     describe "with script-executor" do


### PR DESCRIPTION
@zendesk/samson @zendesk/compute 

while running builds we see lots of spammy escape keys (not when reloading after build is done though)

```
[1A[1K[K
d2a57127c4cc: Already exists 
[1A[1K[K
5431b748d027: Already exists 

```

travis is a bunch of different random errors :/