### PR TITLE
Add STS env vars to deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -243,3 +243,8 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # ROLLBAR_ACCESS_TOKEN= # API token
 # ROLLBAR_URL=https://api.rollbar.com # optional
 # ROLLBAR_WEB_BASE=https://rollbar.com # optional
+
+## Feature: STS Tokens (see plugins/aws_sts/README.md)
+# SAMSON_STS_AWS_ACCESS_KEY_ID=
+# SAMSON_STS_AWS_SECRET_ACCESS_KEY=
+# SAMSON_STS_AWS_REGION=

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,12 @@ PATH
       aws-sdk-ecr
 
 PATH
+  remote: plugins/aws_sts
+  specs:
+    samson_aws_sts (0.0.0)
+      aws-sdk-core
+
+PATH
   remote: plugins/datadog_tracer
   specs:
     samson_datadog_tracer (0.0.1)
@@ -619,6 +625,7 @@ DEPENDENCIES
   samson_airbrake_hook!
   samson_assertible!
   samson_aws_ecr!
+  samson_aws_sts!
   samson_datadog!
   samson_datadog_tracer!
   samson_deploy_env_vars!
@@ -654,4 +661,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.5

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -532,6 +532,8 @@ ActiveRecord::Schema.define(version: 2018_10_09_022203) do
     t.string "prerequisite_stage_ids"
     t.string "default_reference"
     t.boolean "full_checkout", default: false, null: false
+    t.string "aws_sts_iam_role_arn"
+    t.integer "aws_sts_iam_role_session_duration", default: 900, null: false
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -533,7 +533,7 @@ ActiveRecord::Schema.define(version: 2018_10_09_022203) do
     t.string "default_reference"
     t.boolean "full_checkout", default: false, null: false
     t.string "aws_sts_iam_role_arn"
-    t.integer "aws_sts_iam_role_session_duration", default: 900, null: false
+    t.integer "aws_sts_iam_role_session_duration"
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -11,6 +11,7 @@ Available plugins:
  - [Airbrake notification on deploy](https://github.com/zendesk/samson/tree/master/plugins/airbrake_hook)
  - [Airbrake error handling](https://github.com/zendesk/samson/tree/master/plugins/airbrake)
  - [AWS ECR credential refresher](https://github.com/zendesk/samson/tree/master/plugins/aws_ecr)
+ - [AWS STS Tokens](https://github.com/zendesk/samson/tree/master/plugins/aws_sts)
  - [Datadog monitoring and deploy tracking](https://github.com/zendesk/samson/tree/master/plugins/datadog)
  - [Datadog APM tracer](https://github.com/zendesk/samson/tree/master/plugins/datadog_tracer)
  - [Deploy Environment Variables](https://github.com/zendesk/samson/tree/master/plugins/deploy_env_vars)

--- a/plugins/aws_sts/README.md
+++ b/plugins/aws_sts/README.md
@@ -1,0 +1,18 @@
+# AWS STS Plugin
+
+Inject temporary AWS Role credentials into a deploy environment using [AWS STS](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) and [Assume role](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
+
+## Overview
+
+The plugin uses the assume role feature of STS and exposes the generated credentials
+as environment variables:
+  - STS_AWS_ACCESS_KEY_ID
+  - STS_AWS_SECRET_ACCESS_KEY
+  - STS_AWS_SESSION_TOKEN
+
+The plugin authenticates with AWS using the following samson environment variables:
+  - SAMSON_STS_AWS_ACCESS_KEY_ID
+  - SAMSON_STS_AWS_SECRET_ACCESS_KEY
+  - SAMSON_STS_AWS_REGION
+
+Specify the Amazon Resource Name (ARN) of the role to assume in the stage's settings page.

--- a/plugins/aws_sts/app/decorators/stage_decorator.rb
+++ b/plugins/aws_sts/app/decorators/stage_decorator.rb
@@ -29,7 +29,7 @@ Stage.class_eval do
         client.assume_role(
           role_arn: aws_sts_iam_role_arn,
           role_session_name: "validate_can_assume_role_#{SecureRandom.hex(4)}",
-          duration_seconds: 10
+          duration_seconds: SamsonAwsSts::SESSION_DURATION_MIN
         )
       rescue => e
         errors.add(:aws_sts_iam_role_arn, "Unable to assume role: #{e.message}")

--- a/plugins/aws_sts/app/decorators/stage_decorator.rb
+++ b/plugins/aws_sts/app/decorators/stage_decorator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+Stage.class_eval do
+  validates(
+    :aws_sts_iam_role_arn,
+    allow_blank: true,
+    format: {
+      with: /\Aarn:aws:iam::\d+:role\/.+\Z/,
+      message: "Must be of the form: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+    }
+  )
+
+  validates(
+    :aws_sts_iam_role_session_duration,
+    allow_blank: true,
+    numericality: {
+      only_integer: true,
+      greater_than_or_equal_to: SamsonAwsSts::SESSION_DURATION_MIN,
+      less_than_or_equal_to:    SamsonAwsSts::SESSION_DURATION_MAX
+    }
+  )
+
+  validate :validate_can_assume_role, if: -> { aws_sts_iam_role_arn.present? }
+
+  before_validation :set_default_session_duration
+
+  private
+
+  def set_default_session_duration
+    self.aws_sts_iam_role_session_duration ||= SamsonAwsSts::SESSION_DURATION_MIN
+  end
+
+  def validate_can_assume_role
+    SamsonAwsSts::Client.new(SamsonAwsSts.sts_client).assume_role(
+      role_arn: aws_sts_iam_role_arn,
+      role_session_name: "validate_can_assume_role_#{SecureRandom.hex(4)}"
+    )
+  rescue => e
+    errors.add(:aws_sts_iam_role_arn, "Unable to assume role: #{e.message}")
+  end
+end

--- a/plugins/aws_sts/app/decorators/stage_decorator.rb
+++ b/plugins/aws_sts/app/decorators/stage_decorator.rb
@@ -19,9 +19,8 @@ Stage.class_eval do
     }
   )
 
-  validate :validate_can_assume_role, if: -> { aws_sts_iam_role_arn.present? }
-
   before_validation :set_default_session_duration
+  validate :validate_can_assume_role, if: :aws_sts_iam_role_arn?
 
   private
 

--- a/plugins/aws_sts/app/views/samson_aws_sts/_fields.html.erb
+++ b/plugins/aws_sts/app/views/samson_aws_sts/_fields.html.erb
@@ -3,7 +3,21 @@
   <div class="col-lg-offset-2">
     <div class="form-group">
       <div class="col-lg-6">
-        <p>Tokens will be requested using the following user: <%= SamsonAwsSts::Client.new(SamsonAwsSts.sts_client).caller_user_id rescue "error connecting to aws, check SAMSON_STS_AWS_* env vars" %></p>
+        <p>
+          <% if client = SamsonAwsSts.sts_client %>
+            Tokens will be requested using the following user:
+            <%= Rails.cache.fetch("sts-caller-user-id-#{Process.pid}") do
+              begin
+                client.caller_user_id
+              rescue => e
+                "error connecting to aws, check SAMSON_STS_AWS_* env vars (#{e})"
+              end
+            end
+            %>
+          <% else %>
+            SAMSON_STS_AWS_* env vars not set.
+          <% end %>
+        </p>
         <span class="help-block">
           Use the following samson environment variables to change which user to authenticate with:
           <ul>
@@ -31,7 +45,7 @@
     <div class="form-group">
       <div class="col-lg-6">
         <p>The duration, in seconds, that the credentials should remain valid:</p>
-        <%= form.number_field :aws_sts_iam_role_session_duration, class: "form-control", placeholder: 900 %>
+        <%= form.text_field :aws_sts_iam_role_session_duration, class: "form-control", placeholder: 900 %>
         <span class="help-block">
           Optional. Defaults to <%= SamsonAwsSts::SESSION_DURATION_MIN %>.
           <ul>

--- a/plugins/aws_sts/app/views/samson_aws_sts/_fields.html.erb
+++ b/plugins/aws_sts/app/views/samson_aws_sts/_fields.html.erb
@@ -1,0 +1,45 @@
+<fieldset>
+  <legend>AWS STS Tokens</legend>
+  <div class="col-lg-offset-2">
+    <div class="form-group">
+      <div class="col-lg-6">
+        <p>Tokens will be requested using the following user: <%= SamsonAwsSts::Client.new(SamsonAwsSts.sts_client).caller_user_id rescue "error connecting to aws, check SAMSON_STS_AWS_* env vars" %></p>
+        <span class="help-block">
+          Use the following samson environment variables to change which user to authenticate with:
+          <ul>
+            <li>SAMSON_STS_AWS_ACCESS_KEY_ID</li>
+            <li>SAMSON_STS_AWS_SECRET_ACCESS_KEY</li>
+            <li>SAMSON_STS_AWS_REGION</li>
+          </ul>
+        </span>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-lg-6">
+        <p>AWS IAM Role ARN that should be assumed by the stage:</p>
+        <%= form.text_field :aws_sts_iam_role_arn, class: "form-control", placeholder: "e.g. arn:aws:iam::123456789012:role/S3Access" %>
+        <span class="help-block">
+          This will create the following environment variables which can be used by stage commands:
+          <ul>
+            <li>STS_AWS_ACCESS_KEY_ID</li>
+            <li>STS_AWS_SECRET_ACCESS_KEY</li>
+            <li>STS_AWS_SESSION_TOKEN</li>
+          </ul>
+        </span>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-lg-6">
+        <p>The duration, in seconds, that the credentials should remain valid:</p>
+        <%= form.number_field :aws_sts_iam_role_session_duration, class: "form-control", placeholder: 900 %>
+        <span class="help-block">
+          Optional. Defaults to <%= SamsonAwsSts::SESSION_DURATION_MIN %>.
+          <ul>
+            <li>Min: <%= SamsonAwsSts::SESSION_DURATION_MIN %> (<%= SamsonAwsSts::SESSION_DURATION_MIN / 60%> minutes)</li>
+            <li>Max: <%= SamsonAwsSts::SESSION_DURATION_MAX %> (<%= SamsonAwsSts::SESSION_DURATION_MAX / 60%> minutes)</li>
+          </ul>
+        </span>
+      </div>
+    </div>
+  </div>
+</fieldset>

--- a/plugins/aws_sts/db/migrate/20181001083613_add_aws_sts_arn_to_stages.rb
+++ b/plugins/aws_sts/db/migrate/20181001083613_add_aws_sts_arn_to_stages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddAwsStsArnToStages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stages, :aws_sts_iam_role_arn, :string
+    add_column :stages, :aws_sts_iam_role_session_duration, :integer, default: 900, null: false
+  end
+end

--- a/plugins/aws_sts/db/migrate/20181001083613_add_aws_sts_arn_to_stages.rb
+++ b/plugins/aws_sts/db/migrate/20181001083613_add_aws_sts_arn_to_stages.rb
@@ -3,6 +3,6 @@
 class AddAwsStsArnToStages < ActiveRecord::Migration[5.2]
   def change
     add_column :stages, :aws_sts_iam_role_arn, :string
-    add_column :stages, :aws_sts_iam_role_session_duration, :integer, default: 900, null: false
+    add_column :stages, :aws_sts_iam_role_session_duration, :integer
   end
 end

--- a/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
+++ b/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module SamsonAwsSts
+  SESSION_DURATION_MIN = 900 # 15 minutes
+  SESSION_DURATION_MAX = Rails.application.config.samson.deploy_timeout
+
+  class Engine < Rails::Engine
+  end
+
+  def self.sts_client
+    options = {
+      access_key_id:     ENV['SAMSON_STS_AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['SAMSON_STS_AWS_SECRET_ACCESS_KEY'],
+      region:            ENV['SAMSON_STS_AWS_REGION'],
+    }
+    return if options.any? { |_, v| v.blank? }
+
+    options[:stub_responses] = Rails.env.test?
+
+    Aws::STS::Client.new(options)
+  end
+
+  class Client
+    def initialize(sts_client)
+      @sts_client = sts_client
+    end
+
+    def caller_user_id
+      sts_client.get_caller_identity[:user_id]
+    end
+
+    def deploy_env_vars(deploy:)
+      creds = assume_role(
+        role_arn: deploy.stage.aws_sts_iam_role_arn,
+        role_session_name: session_name(deploy),
+        duration_seconds: deploy.stage.aws_sts_iam_role_session_duration || SESSION_DURATION_MIN
+      ).credentials
+
+      {
+        STS_AWS_ACCESS_KEY_ID:     "hidden://#{creds.access_key_id}",
+        STS_AWS_SECRET_ACCESS_KEY: "hidden://#{creds.secret_access_key}",
+        STS_AWS_SESSION_TOKEN:     "hidden://#{creds.session_token}"
+      }
+    end
+
+    def assume_role(role_arn:, role_session_name:, duration_seconds: SESSION_DURATION_MIN)
+      sts_client.assume_role(
+        role_arn: role_arn,
+        role_session_name: role_session_name,
+        duration_seconds: duration_seconds
+      )
+    end
+
+    private
+
+    attr_reader :sts_client
+
+    def session_name(deploy)
+      project_name = deploy.project.name.parameterize[0..15].tr('_', '-')
+      stage_name   = deploy.stage.name.parameterize[0..15].tr('_', '-')
+
+      "#{project_name}-#{stage_name}-deploy-#{deploy.id}"
+    end
+  end
+end
+
+Samson::Hooks.view :stage_form, 'samson_aws_sts/fields'
+
+Samson::Hooks.callback :stage_permitted_params do
+  [
+    :aws_sts_iam_role_arn,
+    :aws_sts_iam_role_session_duration
+  ]
+end
+
+Samson::Hooks.callback :deploy_env do |deploy|
+  next {} if deploy.stage.aws_sts_iam_role_arn.blank?
+
+  SamsonAwsSts::Client.new(SamsonAwsSts.sts_client).deploy_env_vars(deploy: deploy)
+end

--- a/plugins/aws_sts/samson_aws_sts.gemspec
+++ b/plugins/aws_sts/samson_aws_sts.gemspec
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Gem::Specification.new 'samson_aws_sts', '0.0.0' do |s|
+  s.summary = 'Samson AwsSts plugin'
+  s.authors = ['Gerard Cahill']
+  s.email = ['gcahill@zendesk.com']
+  s.files = Dir['{app,config,db,lib}/**/*']
+  s.add_runtime_dependency "aws-sdk-core"
+end

--- a/plugins/aws_sts/test/decorators/stage_decorator_test.rb
+++ b/plugins/aws_sts/test/decorators/stage_decorator_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe Stage do
+  let(:stage) { stages(:test_staging) }
+
+  describe "ARN syntax" do
+    before do
+      assert_valid stage
+    end
+
+    it "is not valid with bad syntax" do
+      SamsonAwsSts.stubs(:sts_client).returns(Aws::STS::Client.new(stub_responses: true))
+
+      stage.aws_sts_iam_role_arn = "should_not_work"
+      refute_valid stage
+      stage.errors.full_messages.must_include(
+        "Aws sts iam role arn Must be of the form: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+      )
+    end
+
+    describe 'when client can assume role' do
+      before do
+        SamsonAwsSts::Client.any_instance.expects(:assume_role).returns true
+      end
+
+      it "is valid" do
+        stage.aws_sts_iam_role_arn = "arn:aws:iam::1234:role/should_work"
+        assert_valid stage
+      end
+    end
+
+    describe 'when client can NOT assume role' do
+      it "is NOT valid" do
+        stage.aws_sts_iam_role_arn = "arn:aws:iam::1234:role/should_work"
+        refute_valid stage
+        stage.errors.full_messages.any? { |m| m =~ /Unable to assume role/ }.must_equal true
+      end
+    end
+  end
+
+  describe "session duration" do
+    before do
+      assert_valid stage
+    end
+
+    it "is not valid when too short" do
+      stage.aws_sts_iam_role_session_duration = SamsonAwsSts::SESSION_DURATION_MIN - 1
+      refute_valid stage
+      stage.errors.full_messages.must_equal [
+        "Aws sts iam role session duration must be greater than or equal to 900"
+      ]
+    end
+
+    it "is not valid when too long" do
+      stage.aws_sts_iam_role_session_duration = SamsonAwsSts::SESSION_DURATION_MAX + 1
+      refute_valid stage
+      stage.errors.full_messages.must_equal [
+        "Aws sts iam role session duration must be less than or equal to 7200"
+      ]
+    end
+
+    it "is valid when omitted" do
+      stage.aws_sts_iam_role_session_duration = nil
+      assert_valid stage
+    end
+  end
+
+  describe 'before save' do
+    it 'sets a default value for aws_sts_iam_role_session_duration' do
+      stage.aws_sts_iam_role_session_duration = nil
+      stage.save!
+      stage.reload.aws_sts_iam_role_session_duration.must_equal SamsonAwsSts::SESSION_DURATION_MIN
+    end
+  end
+end

--- a/plugins/aws_sts/test/decorators/stage_decorator_test.rb
+++ b/plugins/aws_sts/test/decorators/stage_decorator_test.rb
@@ -6,73 +6,74 @@ SingleCov.covered!
 describe Stage do
   let(:stage) { stages(:test_staging) }
 
-  describe "ARN syntax" do
-    before do
+  describe "validations" do
+    it "is valid" do
       assert_valid stage
     end
 
-    it "is not valid with bad syntax" do
-      SamsonAwsSts.stubs(:sts_client).returns(Aws::STS::Client.new(stub_responses: true))
+    describe "ARN" do
+      with_env SAMSON_STS_AWS_ACCESS_KEY_ID: 'x', SAMSON_STS_AWS_SECRET_ACCESS_KEY: 'y', SAMSON_STS_AWS_REGION: 'z'
 
-      stage.aws_sts_iam_role_arn = "should_not_work"
-      refute_valid stage
-      stage.errors.full_messages.must_include(
-        "Aws sts iam role arn Must be of the form: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-      )
-    end
-
-    describe 'when client can assume role' do
       before do
-        SamsonAwsSts::Client.any_instance.expects(:assume_role).returns true
+        stage.aws_sts_iam_role_arn = "arn:aws:iam::1234:role/should_work"
       end
 
       it "is valid" do
-        stage.aws_sts_iam_role_arn = "arn:aws:iam::1234:role/should_work"
+        Aws::STS::Client.any_instance.expects(:assume_role).returns true
         assert_valid stage
       end
-    end
 
-    describe 'when client can NOT assume role' do
-      it "is NOT valid" do
-        stage.aws_sts_iam_role_arn = "arn:aws:iam::1234:role/should_work"
+      it "is not valid with bad syntax" do
+        Aws::STS::Client.any_instance.unstub(:assume_role)
+        stage.aws_sts_iam_role_arn = "should_not_work"
         refute_valid stage
-        stage.errors.full_messages.any? { |m| m =~ /Unable to assume role/ }.must_equal true
+        stage.errors.full_messages.must_include(
+          "Aws sts iam role arn Must be of the form: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+        )
+      end
+
+      it "is not valid when client cannot assume" do
+        Aws::STS::Client.any_instance.expects(:assume_role).raises(RuntimeError)
+        refute_valid stage
+        stage.errors.full_messages.must_include(
+          "Aws sts iam role arn Unable to assume role: RuntimeError"
+        )
+      end
+
+      it "is not valid when env is not configured" do
+        with_env SAMSON_STS_AWS_ACCESS_KEY_ID: nil do
+          refute_valid stage
+          stage.errors.full_messages.must_include(
+            "Aws sts iam role arn SAMSON_STS_AWS_* env vars not set"
+          )
+        end
       end
     end
-  end
 
-  describe "session duration" do
-    before do
-      assert_valid stage
-    end
+    describe "session duration" do
+      before do
+        stage.aws_sts_iam_role_session_duration = SamsonAwsSts::SESSION_DURATION_MIN
+      end
 
-    it "is not valid when too short" do
-      stage.aws_sts_iam_role_session_duration = SamsonAwsSts::SESSION_DURATION_MIN - 1
-      refute_valid stage
-      stage.errors.full_messages.must_equal [
-        "Aws sts iam role session duration must be greater than or equal to 900"
-      ]
-    end
+      it "is valid" do
+        assert_valid stage
+      end
 
-    it "is not valid when too long" do
-      stage.aws_sts_iam_role_session_duration = SamsonAwsSts::SESSION_DURATION_MAX + 1
-      refute_valid stage
-      stage.errors.full_messages.must_equal [
-        "Aws sts iam role session duration must be less than or equal to 7200"
-      ]
-    end
+      it "is not valid when too short" do
+        stage.aws_sts_iam_role_session_duration = SamsonAwsSts::SESSION_DURATION_MIN - 1
+        refute_valid stage
+        stage.errors.full_messages.must_equal [
+          "Aws sts iam role session duration must be greater than or equal to 900"
+        ]
+      end
 
-    it "is valid when omitted" do
-      stage.aws_sts_iam_role_session_duration = nil
-      assert_valid stage
-    end
-  end
-
-  describe 'before save' do
-    it 'sets a default value for aws_sts_iam_role_session_duration' do
-      stage.aws_sts_iam_role_session_duration = nil
-      stage.save!
-      stage.reload.aws_sts_iam_role_session_duration.must_equal SamsonAwsSts::SESSION_DURATION_MIN
+      it "is not valid when too long" do
+        stage.aws_sts_iam_role_session_duration = SamsonAwsSts::SESSION_DURATION_MAX + 1
+        refute_valid stage
+        stage.errors.full_messages.must_equal [
+          "Aws sts iam role session duration must be less than or equal to 7200"
+        ]
+      end
     end
   end
 end

--- a/plugins/aws_sts/test/samson_aws_sts/samson_plugin_test.rb
+++ b/plugins/aws_sts/test/samson_aws_sts/samson_plugin_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered! uncovered: 4
+
+describe SamsonAwsSts do
+  let(:stage) { stages(:test_staging) }
+
+  def deploy_env_vars(stage)
+    SamsonAwsSts::Client.new(
+      Aws::STS::Client.new(stub_responses: true)
+    ).deploy_env_vars(deploy: stage.deploys.last)
+  end
+
+  describe '.sts_client' do
+    it 'returns nil if env vars are missing' do
+      SamsonAwsSts.sts_client.must_equal nil
+    end
+  end
+
+  describe '#deploy_env_vars' do
+    it 'returns a hash of additional env variables' do
+      stage.aws_sts_iam_role_arn = "some_arn"
+
+      deploy_env_vars(stage).must_equal(
+        STS_AWS_ACCESS_KEY_ID:     'hidden://accessKeyIdType',
+        STS_AWS_SECRET_ACCESS_KEY: 'hidden://accessKeySecretType',
+        STS_AWS_SESSION_TOKEN:     'hidden://tokenType'
+      )
+    end
+  end
+
+  describe '#assume_role' do
+    it "delegates to the embedded sts client" do
+      Aws::STS::Client.any_instance.expects(:assume_role).with(
+        role_arn: 'arn',
+        role_session_name: 'session',
+        duration_seconds: 900
+      )
+      SamsonAwsSts::Client.new(
+        Aws::STS::Client.new(stub_responses: true)
+      ).assume_role(role_arn: 'arn', role_session_name: 'session')
+    end
+  end
+
+  describe '#caller_user_id' do
+    it 'returns the user id' do
+      SamsonAwsSts::Client.new(
+        Aws::STS::Client.new(stub_responses: true)
+      ).caller_user_id.must_equal 'userIdType'
+    end
+  end
+
+  describe 'stage_permitted_params callback' do
+    it 'returns attributes used by the plugin' do
+      Samson::Hooks.only_callbacks_for_plugin('samson_aws_sts', :stage_permitted_params) do
+        Samson::Hooks.fire(:stage_permitted_params).must_equal(
+          [%i[
+            aws_sts_iam_role_arn
+            aws_sts_iam_role_session_duration
+          ]]
+        )
+      end
+    end
+  end
+
+  describe 'deploy_env_vars callback' do
+    it 'calls SamsonAwsSts.deploy_env_vars' do
+      stage.aws_sts_iam_role_arn = "some_arn"
+
+      SamsonAwsSts.stubs(:sts_client).returns(Aws::STS::Client.new(stub_responses: true))
+      Samson::Hooks.only_callbacks_for_plugin('samson_aws_sts', :deploy_env) do
+        Samson::Hooks.fire(:deploy_env, stage.deploys.last)
+      end
+    end
+  end
+end

--- a/plugins/aws_sts/test/samson_aws_sts/samson_plugin_test.rb
+++ b/plugins/aws_sts/test/samson_aws_sts/samson_plugin_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
+SingleCov.covered! uncovered: 1
+
 describe SamsonAwsSts do
   let(:stage) { stages(:test_staging) }
 
@@ -35,9 +37,13 @@ describe SamsonAwsSts do
       Aws::STS::Client.any_instance.expects(:assume_role).with(
         role_arn: 'arn',
         role_session_name: 'session',
-        duration_seconds: 10
+        duration_seconds: SamsonAwsSts::SESSION_DURATION_MIN
       )
-      SamsonAwsSts.sts_client.assume_role(role_arn: 'arn', role_session_name: 'session', duration_seconds: 10)
+      SamsonAwsSts.sts_client.assume_role(
+        role_arn: 'arn',
+        role_session_name: 'session',
+        duration_seconds: SamsonAwsSts::SESSION_DURATION_MIN
+      )
     end
   end
 

--- a/plugins/aws_sts/test/test_helper.rb
+++ b/plugins/aws_sts/test/test_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative '../../../test/test_helper'

--- a/plugins/deploy_env_vars/test/samson_deploy_env_vars/samson_plugin_test.rb
+++ b/plugins/deploy_env_vars/test/samson_deploy_env_vars/samson_plugin_test.rb
@@ -18,15 +18,15 @@ describe SamsonDeployEnvVars do
   end
 
   describe :deploy_env do
-    it "returns an empty hash" do
-      Samson::Hooks.fire(:deploy_env, deploy).must_equal([{}])
+    it "returns an array of hashes" do
+      Samson::Hooks.only_callbacks_for_plugin('deploy_env_vars', :deploy_env) do
+        Samson::Hooks.fire(:deploy_env, deploy).must_equal([{}])
+      end
     end
 
-    it "returns a hash with the deploy environment variables" do
+    it "returns an array of hashes containing the deploy environment variables" do
       deploy.environment_variables.create!(name: "TWO", value: "2")
-      Samson::Hooks.fire(:deploy_env, deploy).must_equal([{
-        "TWO" => "2"
-      }])
+      Samson::Hooks.fire(:deploy_env, deploy).must_include("TWO" => "2")
     end
   end
 end

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -171,6 +171,13 @@ describe TerminalExecutor do
         subject.execute('sh -c "echo 111"')
         output.string.must_equal("» sh -c \"echo 111\"\r\n111\r\n")
       end
+
+      describe 'hidden env vars' do
+        it 'replaces hidden value with "HIDDEN", removes hidden prefix' do
+          subject.execute('echo "export MY_VAR=hidden://some_value"')
+          output.string.must_equal %(» echo "export MY_VAR=HIDDEN"\r\nexport MY_VAR=some_value\r\n)
+        end
+      end
     end
 
     describe 'with secrets' do


### PR DESCRIPTION
Adds a plugin to allow Samson to inject temporary security credentials for an AWS Role.

The plugin uses the [assume role](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) feature of STS and exposes the generated credentials as environment variables:
  - STS_AWS_ACCESS_KEY_ID
  - STS_AWS_SECRET_ACCESS_KEY
  - STS_AWS_SESSION_TOKEN

Specify the Amazon Resource Name (ARN) of the role to assume in the stage's settings page.

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
