### PR TITLE
New newrelic key is altered in documentation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -146,7 +146,7 @@ Set the following variables in your `.env` file or set them as environment varia
       </td>
     </tr>
     <tr>
-      <td>NEWRELIC_API_KEY</td>
+      <td>NEW_RELIC_API_KEY</td>
       <td></td>
       <td>You may fill in using the instructions below if you would like a dynamic chart of response time and throughput during deploys.
           https://docs.newrelic.com/docs/features/getting-started-with-the-new-relic-rest-api#setup</td>

--- a/plugins/new_relic/app/views/samson_new_relic/_fields.html.erb
+++ b/plugins/new_relic/app/views/samson_new_relic/_fields.html.erb
@@ -21,6 +21,6 @@
       <div>Error fetching newrelic apps.</div>
     <% end %>
   <% else %>
-    <div>Set NEWRELIC_API_KEY to use NewRelic stats (disable the new_relic plugin to hide this warning).</div>
+    <div>Set NEW_RELIC_API_KEY to use NewRelic stats (disable the new_relic plugin to hide this warning).</div>
   <% end %>
 </fieldset>


### PR DESCRIPTION
Replace old NEWRELIC_API_KEY to NEW_RELIC_API_KEY in the documentation. 

/cc @zendesk/samson

### Risks
- Level: Low
