### PR TITLE
Bump pg

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,7 +398,7 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     path_expander (1.0.3)
-    pg (0.20.0)
+    pg (1.1.3)
     powerpack (0.1.2)
     pry (0.10.3)
       coderay (~> 1.1.0)


### PR DESCRIPTION
`pg` gem was pretty outdated, and was giving a seg fault when attempting to migrate on rails 2.5.1. 
![screen shot 2018-10-05 at 8 54 32 am](https://user-images.githubusercontent.com/15261525/46546572-3f67c580-c87e-11e8-980c-8b0851c9ebe8.png)
Curiously, 2.5.0 does not have the same issue. Bumping pg seems to solve the issue. 

/cc @zendesk/samson
