### PR TITLE
read apiVersion from yml files

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/clusters_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/clusters_controller.rb
@@ -107,16 +107,20 @@ class Kubernetes::ClustersController < ApplicationController
     }
 
     if secret_exist?(secret)
-      @cluster.client.update_secret(secret)
+      secrets_client.update_secret(secret)
     else
-      @cluster.client.create_secret(secret)
+      secrets_client.create_secret(secret)
     end
   end
 
   def secret_exist?(secret)
-    @cluster.client.get_secret(secret.fetch(:metadata).fetch(:name), secret.fetch(:metadata).fetch(:namespace))
+    secrets_client.get_secret(secret.fetch(:metadata).fetch(:name), secret.fetch(:metadata).fetch(:namespace))
     true
   rescue *SamsonKubernetes.connection_errors
     false
+  end
+
+  def secrets_client
+    @cluster.client('v1')
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -19,7 +19,7 @@ module Kubernetes
 
     before_destroy :ensure_unused
 
-    def client(type = :default)
+    def client(type)
       (@client ||= {})[type] ||= build_client(type)
     end
 
@@ -28,7 +28,7 @@ module Kubernetes
     end
 
     def namespaces
-      client.get_namespaces.fetch(:items).map { |ns| ns.dig(:metadata, :name) } - %w[kube-system]
+      client('v1').get_namespaces.fetch(:items).map { |ns| ns.dig(:metadata, :name) } - %w[kube-system]
     end
 
     def kubeconfig
@@ -36,16 +36,16 @@ module Kubernetes
     end
 
     def schedulable_nodes
-      nodes = client.get_nodes.fetch(:items)
+      nodes = client('v1').get_nodes.fetch(:items)
       nodes.reject { |n| n.dig(:spec, :unschedulable) }
-    rescue
+    rescue *SamsonKubernetes.connection_errors
       Rails.logger.error("Error loading nodes from cluster #{id}: #{$!}")
       []
     end
 
     def server_version
       version = Rails.cache.fetch(cache_key, expires_in: 1.hour) do
-        JSON.parse(client.create_rest_client('version').get.body).fetch('gitVersion')[1..-1]
+        JSON.parse(client('v1').create_rest_client('version').get.body).fetch('gitVersion')[1..-1]
       end
       Gem::Version.new(version)
     end
@@ -53,18 +53,14 @@ module Kubernetes
     private
 
     def connection_valid?
-      client.api_valid?
+      client('v1').api_valid?
     rescue *SamsonKubernetes.connection_errors
       false
     end
 
     def build_client(type)
       endpoint = context.api_endpoint
-      if type == :default
-        type = context.api_version
-      else
-        endpoint = endpoint.sub(/\/api$/, '') + '/apis'
-      end
+      endpoint += '/apis' unless type.match? /^v\d+/ # TODO: remove by fixing via https://github.com/abonas/kubeclient/issues/284
 
       Kubeclient::Client.new(
         endpoint,

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -184,7 +184,7 @@ module Kubernetes
           selector << "involvedObject.uid=#{uid}"
         end
 
-        events = doc.deploy_group.kubernetes_cluster.client.get_events(
+        events = doc.deploy_group.kubernetes_cluster.client('v1').get_events(
           namespace: resource.namespace,
           field_selector: selector.join(',')
         ).fetch(:items)

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -59,7 +59,7 @@ module Kubernetes
         ]
       end
       # avoiding doing a .uniq on clients which might do weird stuff
-      scopes.uniq.map { |group, query| [group.kubernetes_cluster.client, query] }
+      scopes.uniq.map { |group, query| [group.kubernetes_cluster.client('v1'), query] }
     end
 
     def url

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -211,11 +211,11 @@ module Kubernetes
       end
 
       def client
-        pod_client
+        @deploy_group.kubernetes_cluster.client(@template.fetch(:apiVersion))
       end
 
       def pod_client
-        @deploy_group.kubernetes_cluster.client
+        @deploy_group.kubernetes_cluster.client('v1')
       end
 
       def loop_sleep
@@ -241,11 +241,6 @@ module Kubernetes
     end
 
     class HorizontalPodAutoscaler < Base
-      private
-
-      def client
-        @deploy_group.kubernetes_cluster.client('autoscaling/v1')
-      end
     end
 
     class Service < Base
@@ -285,10 +280,6 @@ module Kubernetes
 
         # delete the actual deployment
         super
-      end
-
-      def client
-        @deploy_group.kubernetes_cluster.client('extensions/v1beta1')
       end
     end
 
@@ -357,10 +348,6 @@ module Kubernetes
         resource.dig_fetch(:status, :currentNumberScheduled) + resource.dig_fetch(:status, :numberMisscheduled)
       end
 
-      def client
-        @deploy_group.kubernetes_cluster.client('extensions/v1beta1')
-      end
-
       def wait_for_termination_of_all_pods
         30.times do
           loop_sleep
@@ -421,10 +408,6 @@ module Kubernetes
       ensure
         client.headers['Content-Type'] = old
       end
-
-      def client
-        @deploy_group.kubernetes_cluster.client('apps/v1beta1')
-      end
     end
 
     class Job < Base
@@ -444,18 +427,9 @@ module Kubernetes
       def request_delete
         delete_pods { super }
       end
-
-      def client
-        @deploy_group.kubernetes_cluster.client('batch/v1')
-      end
     end
 
     class CronJob < Base
-      private
-
-      def client
-        @deploy_group.kubernetes_cluster.client('batch/v1beta1')
-      end
     end
 
     class Pod < Base
@@ -470,12 +444,6 @@ module Kubernetes
       def deploy
         delete
         create unless @template[:delete] # allow deletion through release_doc logic
-      end
-
-      private
-
-      def client
-        @deploy_group.kubernetes_cluster.client('policy/v1beta1')
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -24,6 +24,7 @@ module Kubernetes
       validate_name
       validate_namespace
       validate_kinds
+      validate_api_version
       validate_containers
       validate_container_name
       validate_job_restart_policy
@@ -83,6 +84,10 @@ module Kubernetes
       supported = SUPPORTED_KINDS.map { |c| c.join(' + ') }.join(', ')
       @errors << "Unsupported combination of kinds: #{kinds.join(' + ')}" \
         ", supported combinations are: #{supported} and #{IGNORED.join(", ")}"
+    end
+
+    def validate_api_version
+      @errors << "Needs apiVersion specified" if map_attributes([:apiVersion]).any?(&:nil?)
     end
 
     # spec actually allows this, but blows up when used

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -471,7 +471,7 @@ module Kubernetes
 
       docker_credentials = Rails.cache.fetch(["docker_credentials", cluster], expires_in: 1.hour) do
         secrets = SamsonKubernetes.retry_on_connection_errors do
-          cluster.client.get_secrets(namespace: template.dig_fetch(:metadata, :namespace)).fetch(:items)
+          cluster.client('v1').get_secrets(namespace: template.dig_fetch(:metadata, :namespace)).fetch(:items)
         end
         secrets.
           select { |secret| docker_configs.include? secret.fetch(:type) }.

--- a/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
@@ -25,7 +25,7 @@
   <div class="form-group">
     <label class="col-lg-2 control-label">URL</label>
     <div class="col-lg-4">
-      <p class="form-control-static"><%= @cluster.client.api_endpoint %></p>
+      <p class="form-control-static"><%= @cluster.client('v1').api_endpoint %></p>
     </div>
   </div>
 

--- a/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
@@ -21,7 +21,7 @@ describe Kubernetes::ClustersController do
       end
 
       it "renders capacity" do
-        stub_request(:get, "http://foobar.server/api/v1/nodes").to_return(body: "[]")
+        stub_request(:get, "http://foobar.server/api/v1/nodes").to_return(body: {items: []}.to_json)
         get :index, params: {capacity: true}
         assert_template :index
       end

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -35,7 +35,7 @@ describe Kubernetes::Api::Pod do
   let(:pod_with_client) do
     Kubernetes::Api::Pod.new(
       pod_attributes,
-      client: deploy_groups(:pod1).kubernetes_cluster.client
+      client: deploy_groups(:pod1).kubernetes_cluster.client('v1')
     )
   end
   let(:start_time) { "2017-03-31T22:56:20Z" }

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -60,11 +60,11 @@ describe Kubernetes::Cluster do
 
   describe '#client' do
     it 'creates a client' do
-      cluster.client.must_be_kind_of Kubeclient::Client
+      cluster.client('v1').must_be_kind_of Kubeclient::Client
     end
 
     it 'caches' do
-      cluster.client.object_id.must_equal cluster.client.object_id
+      cluster.client('v1').object_id.must_equal cluster.client('v1').object_id
     end
 
     it 'can build for other types' do

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -269,6 +269,7 @@ describe Kubernetes::DeployExecutor do
         Kubernetes::ReleaseDoc.any_instance.unstub(:raw_template)
         GitRepository.any_instance.stubs(:file_content).with('kubernetes/resque_worker.yml', commit).returns({
           'kind' => 'Job',
+          'apiVersion' => 'batch/v1',
           'spec' => {
             'template' => {
               'metadata' => {'labels' => {'project' => 'foobar', 'role' => 'migrate'}},
@@ -508,6 +509,7 @@ describe Kubernetes::DeployExecutor do
       it "rolls back when previous resource existed" do
         old = {
           kind: 'Service',
+          apiVersion: 'v1',
           metadata: {uid: '123', name: 'some-project', namespace: 'staging', resourceVersion: 'X'},
           spec: {clusterIP: "Y"}
         }

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -27,9 +27,11 @@ describe Kubernetes::Resource do
 
   let(:origin) { "http://foobar.server" }
   let(:kind) { 'Service' }
+  let(:api_version) { 'v1' }
   let(:template) do
     {
       kind: kind,
+      apiVersion: api_version,
       metadata: {name: 'some-project', namespace: 'pod1'},
       spec: {
         replicas: 2,
@@ -77,6 +79,7 @@ describe Kubernetes::Resource do
 
   describe "#deploy" do
     let(:kind) { 'Deployment' }
+    let(:api_version) { 'extensions/v1beta1' }
     let(:url) { "#{origin}/apis/extensions/v1beta1/namespaces/pod1/deployments/some-project" }
 
     it "creates when missing" do
@@ -323,6 +326,7 @@ describe Kubernetes::Resource do
     end
 
     let(:kind) { 'DaemonSet' }
+    let(:api_version) { 'extensions/v1beta1' }
     let(:url) { "#{origin}/apis/extensions/v1beta1/namespaces/pod1/daemonsets/some-project" }
 
     describe "#client" do
@@ -411,13 +415,14 @@ describe Kubernetes::Resource do
 
     describe "#revert" do
       let(:kind) { 'DaemonSet' }
+      let(:api_version) { 'extensions/v1beta1' }
       let(:base_url) { "#{origin}/apis/extensions/v1beta1/namespaces/bar/daemonsets" }
 
       it "reverts to previous version" do
         # checks if it exists and then creates the old resource
         assert_request(:get, "#{base_url}/foo", to_return: {status: 404}) do
           assert_request(:post, base_url, to_return: {body: "{}"}) do
-            resource.revert(metadata: {name: 'foo', namespace: 'bar'}, kind: kind)
+            resource.revert(metadata: {name: 'foo', namespace: 'bar'}, kind: kind, apiVersion: api_version)
           end
         end
       end
@@ -438,6 +443,7 @@ describe Kubernetes::Resource do
     end
 
     let(:kind) { 'Deployment' }
+    let(:api_version) { 'extensions/v1beta1' }
     let(:url) { "#{origin}/apis/extensions/v1beta1/namespaces/pod1/deployments/some-project" }
 
     describe "#client" do
@@ -481,7 +487,7 @@ describe Kubernetes::Resource do
 
     describe "#revert" do
       it "reverts to previous version" do
-        basic = {kind: 'Deployment', metadata: {name: 'some-project', namespace: 'pod1'}}
+        basic = {kind: 'Deployment', apiVersion: api_version, metadata: {name: 'some-project', namespace: 'pod1'}}
         previous = basic.deep_merge(metadata: {uid: 'UID'}).freeze
 
         with = ->(request) { request.body.must_equal basic.to_json }
@@ -508,6 +514,7 @@ describe Kubernetes::Resource do
     end
 
     let(:kind) { 'StatefulSet' }
+    let(:api_version) { 'apps/v1beta1' }
     let(:url) { "#{origin}/apis/apps/v1beta1/namespaces/pod1/statefulsets/some-project" }
 
     describe "#client" do
@@ -643,6 +650,7 @@ describe Kubernetes::Resource do
 
   describe Kubernetes::Resource::Job do
     let(:kind) { 'Job' }
+    let(:api_version) { 'batch/v1' }
     let(:url) { "#{origin}/apis/batch/v1/namespaces/pod1/jobs/some-project" }
 
     describe "#client" do
@@ -691,6 +699,7 @@ describe Kubernetes::Resource do
 
   describe Kubernetes::Resource::CronJob do
     let(:kind) { 'CronJob' }
+    let(:api_version) { 'batch/v1beta1' }
     let(:url) { "#{origin}/apis/batch/v1beta1/namespaces/pod1/cronjobs/some-project" }
 
     describe "#client" do
@@ -716,6 +725,7 @@ describe Kubernetes::Resource do
   describe Kubernetes::Resource::Service do
     describe "#deploy" do
       let(:old) { {metadata: {resourceVersion: "A", foo: "B"}, spec: {clusterIP: "C"}} }
+      let(:api_version) { 'v1' }
       let(:expected_body) { template.deep_merge(metadata: {resourceVersion: "A"}, spec: {clusterIP: "C"}) }
 
       it "creates when missing" do
@@ -792,6 +802,7 @@ describe Kubernetes::Resource do
 
   describe Kubernetes::Resource::ConfigMap do
     let(:kind) { 'ConfigMap' }
+    let(:api_version) { 'v1' }
     let(:url) { "#{origin}/api/v1/namespaces/pod1/configmaps/some-project" }
 
     # a simple test to make sure basics work
@@ -808,6 +819,7 @@ describe Kubernetes::Resource do
 
   describe Kubernetes::Resource::Pod do
     let(:kind) { 'Pod' }
+    let(:api_version) { 'v1' }
 
     describe "#deploy" do
       let(:url) { "#{origin}/api/v1/namespaces/pod1/pods/some-project" }
@@ -863,6 +875,7 @@ describe Kubernetes::Resource do
   describe Kubernetes::Resource::HorizontalPodAutoscaler do
     describe "#deploy" do
       let(:kind) { 'HorizontalPodAutoscaler' }
+      let(:api_version) { 'autoscaling/v1' }
       let(:url) { "#{origin}/apis/autoscaling/v1/namespaces/pod1/horizontalpodautoscalers/some-project" }
 
       it "updates" do
@@ -885,6 +898,7 @@ describe Kubernetes::Resource do
     end
 
     let(:kind) { 'PodDisruptionBudget' }
+    let(:api_version) { 'policy/v1beta1' }
     let(:url) { "#{origin}/apis/policy/v1beta1/namespaces/pod1/poddisruptionbudgets/some-project" }
     let(:create_url) { File.dirname(url) }
 

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -27,6 +27,7 @@ describe Kubernetes::Role do
   let(:pod) do
     {
       kind: 'Pod',
+      apiVersion: 'v1',
       metadata: {name: 'foo', labels: {role: 'migrate', project: 'bar'}},
       spec: {containers: [{name: 'foo', resources: {limits: {cpu: '0.5', memory: '300M'}}}]}
     }
@@ -273,7 +274,7 @@ describe Kubernetes::Role do
     end
 
     it "raises when a role is invalid so the deploy is cancelled" do
-      assert config_content_yml.sub!('Deployment', 'Broken')
+      assert config_content_yml.sub!('Service', 'Pod')
       write_config role.config_file, config_content_yml
 
       assert_raises Samson::Hooks::UserError do
@@ -327,6 +328,7 @@ describe Kubernetes::Role do
       labels = {project: 'some-project', role: 'some-role'}
       map = {
         kind: 'ConfigMap',
+        apiVersion: 'v1',
         metadata: {name: 'datadog', labels: labels},
         namespace: 'default',
         labels: labels
@@ -380,7 +382,7 @@ describe Kubernetes::Role do
     end
 
     it "ignores when config is invalid" do
-      assert config_content_yml.sub!('Deployment', 'Deploymentx')
+      assert config_content_yml.sub!('Service', 'Deployment')
       refute role.defaults
     end
   end


### PR DESCRIPTION
- simplified code for determining apiVersion
- make adding new resources easy
- allow users to use whatever api they choose

risks:
- medium: breaks existing deployments if yml does not include apiVersion

* Add description here
* Add any screenshots if you are touching the UI
* Remember to add unit tests

/cc @zendesk/samson @zendesk/compute 
