### PR TITLE
do not check github during our requests

### DIFF
--- a/.env.bootstrap
+++ b/.env.bootstrap
@@ -5,7 +5,7 @@ AUTH_GITHUB=true
 RAILS_MIN_THREADS=2
 RAILS_MAX_THREADS=10
 CACHE_STORE=memory
-PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600
+PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60
 
 # random string, do not use in live server
 bin/decode_dot_env-U0VDUkVUX1RPS0VOPWUzNzExYzc3N2I0OWE5YmE2ZjRjZDQ0NTM5ZjRjNjc3ZTc2ZjdjMDhjMzQ2ODc1ZTUwYjExMTE5YzYxODM5ZDM4NWIyNzA5ZjFmZDhhYzJkODk5YjMyZGM4MThkMTQ1OWIyNjVjZmY5MWY2ZGNjNjM1NDA2YTQ3M2NkOTAzZjRh

--- a/.env.example
+++ b/.env.example
@@ -86,8 +86,9 @@ GITHUB_TOKEN=
 # report_process_stats:60
 # periodical_deploy:86400
 # cancel_stalled_builds:3600
+# repo_provider_status:60 (for plugins that use repo_provider_status hook, like samson_github)
 # Recommended setup:
-PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600
+PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60
 
 ## Buddy Check feature: deploys to production require a buddy
 # BUDDY_CHECK_FEATURE=1 # enable

--- a/app.json
+++ b/app.json
@@ -59,11 +59,12 @@
     },
     "CACHE_STORE": {
       "description": "Caching backend",
-      "value": "memcached"
+      "value": "memcached",
+      "required": true
     },
     "PERIODICAL": {
       "description": "Tasks to run periodically inside the server process",
-      "value": "stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600"
+      "value": "stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60"
     }
   },
   "scripts": {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,11 +19,10 @@
       <div class="container">
         <%= render "layouts/alerts" %>
 
-        <% unless github_ok? %>
+        <% Samson::RepoProviderStatus.errors.each do |error| %>
           <div class="alert alert-warning alert-dismissable">
-            <%= image_tag image_url('github.png'), style: 'height: 20px; background: #8a6d3b' %>
             <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-            GitHub may be having problems. Please monitor their <a href="<%= Rails.application.config.samson.github.status_url %>">status page</a> for more details.
+            <%= autolink(error).html_safe %></li><br/>
           </div>
         <% end %>
 

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -3,11 +3,7 @@
     <%= release_label(@project, release) %>
   </td>
   <td>
-    <% if github_ok? %>
-      <%= github_commit_status_icon CommitStatus.new(release.project, release.commit).state %>
-    <% else %>
-      <%= github_commit_status_icon "missing" %>
-    <% end %>
+    <%= github_commit_status_icon CommitStatus.new(release.project, release.commit).state %>
   </td>
   <td>
     <span style="white-space: nowrap">

--- a/config/application.rb
+++ b/config/application.rb
@@ -104,7 +104,6 @@ module Samson
     config.samson.github.deploy_team = ENV["GITHUB_DEPLOY_TEAM"].presence
     config.samson.github.web_url = deprecated_url.call("GITHUB_WEB_URL") || 'https://github.com'
     config.samson.github.api_url = deprecated_url.call("GITHUB_API_URL") || 'https://api.github.com'
-    config.samson.github.status_url = deprecated_url.call("GITHUB_STATUS_URL") || 'https://status.github.com'
 
     # Configuration for LDAP
     config.samson.ldap = ActiveSupport::OrderedOptions.new

--- a/config/initializers/periodical.rb
+++ b/config/initializers/periodical.rb
@@ -37,13 +37,17 @@ Samson::Periodical.register :periodical_deploy, "Deploy periodical stages", cons
   Samson::PeriodicalDeploy.run
 end
 
+Samson::Periodical.register :report_process_stats, "Report process stats" do
+  Samson::ProcessUtils.report_to_statsd
+end
+
+Samson::Periodical.register :repo_provider_status, "Refresh repo provider status" do
+  Samson::RepoProviderStatus.refresh
+end
+
 if ENV['SERVER_MODE']
   Rails.application.config.after_initialize do
     Samson::Periodical.enabled = true
     Samson::Periodical.run
   end
-end
-
-Samson::Periodical.register :report_process_stats, "Report process stats" do
-  Samson::ProcessUtils.report_to_statsd
 end

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -60,7 +60,8 @@ module Samson
       :stage_permitted_params,
       :trace_method,
       :trace_scope,
-      :asynchronous_performance_tracer
+      :asynchronous_performance_tracer,
+      :repo_provider_status
     ].freeze
 
     # Hooks that are slow and we want performance info on

--- a/lib/samson/repo_provider_status.rb
+++ b/lib/samson/repo_provider_status.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Samson
+  class RepoProviderStatus
+    CACHE_KEY = name
+
+    class << self
+      def errors
+        (
+          Rails.cache.read(CACHE_KEY) ||
+          ["To see repo provider status information, add repo_provider_status:60 to PERIODICAL environment variable."]
+        )
+      end
+
+      def refresh
+        Rails.cache.write(CACHE_KEY, Samson::Hooks.fire(:repo_provider_status).compact)
+      end
+    end
+  end
+end

--- a/plugins/github/lib/samson_github/samson_plugin.rb
+++ b/plugins/github/lib/samson_github/samson_plugin.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module SamsonGithub
+  STATUS_URL = ENV["GITHUB_STATUS_URL"] || 'https://status.github.com'
+
   class Engine < Rails::Engine
   end
 end
@@ -26,5 +28,17 @@ Samson::Hooks.callback :after_deploy do |deploy, _buddy|
 
   if deploy.stage.use_github_deployment_api? && deployment = deploy.instance_variable_get(:@deployment)
     GithubDeployment.new(deploy).update(deployment)
+  end
+end
+
+Samson::Hooks.callback :repo_provider_status do
+  error = "GitHub may be having problems. Please check their status page #{SamsonGithub::STATUS_URL} for details."
+  begin
+    response = Faraday.get("#{SamsonGithub::STATUS_URL}/api/status.json") do |req|
+      req.options.timeout = req.options.open_timeout = 1
+    end
+    error unless response.status == 200 && JSON.parse(response.body)['status'] == 'good'
+  rescue StandardError
+    error
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -169,48 +169,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#github_ok?" do
-    let(:status_url) { "#{Rails.application.config.samson.github.status_url}/api/status.json" }
-
-    it "returns cached true" do
-      Rails.cache.write(github_status_cache_key, true)
-      assert github_ok?
-    end
-
-    it "returns cached false" do
-      Rails.cache.write(github_status_cache_key, false)
-      refute github_ok?
-    end
-
-    it "caches good response" do
-      assert_request(:get, status_url, to_return: {body: {status: 'good'}.to_json}) do
-        assert github_ok?
-        Rails.cache.read(github_status_cache_key).must_equal true
-      end
-    end
-
-    it "caches bad response" do
-      assert_request(:get, status_url, to_return: {body: {status: 'bad'}.to_json}) do
-        refute github_ok?
-        Rails.cache.read(github_status_cache_key).must_equal false
-      end
-    end
-
-    it "caches invalid response" do
-      assert_request(:get, status_url, to_return: {status: 400}) do
-        refute github_ok?
-        Rails.cache.read(github_status_cache_key).must_equal false
-      end
-    end
-
-    it "caches timeout" do
-      assert_request(:get, status_url, to_timeout: []) do
-        refute github_ok?
-        Rails.cache.read(github_status_cache_key).must_equal false
-      end
-    end
-  end
-
   describe "#breadcrumb" do
     let(:stage) { stages(:test_staging) }
     let(:project) { projects(:test) }

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -274,4 +274,13 @@ describe "cleanliness" do
       end
     end
   end
+
+  it "uses/recommends consistent PERIODICAL" do
+    values = [
+      File.read('.env.bootstrap')[/PERIODICAL=(.*)/, 1],
+      JSON.parse(File.read('app.json')).dig("env", "PERIODICAL", "value"),
+      File.read('.env.example')[/PERIODICAL=(.*)/, 1],
+    ]
+    values.uniq.size.must_equal 1, "Expected all places to use consistent PERIODICAL value, but found #{values.inspect}"
+  end
 end

--- a/test/lib/samson/periodical_test.rb
+++ b/test/lib/samson/periodical_test.rb
@@ -196,12 +196,13 @@ describe Samson::Periodical do
   end
 
   it "lists all example periodical tasks in the .env.example" do
-    configureable = File.read('config/initializers/periodical.rb').scan(/\.register.*?:([a-z\d_]+)/)
-    mentioned = File.read('.env.example')[/## Periodical tasks .*^PERIODICAL=/m].scan(/# ([a-z\d_]+):\d+/)
+    configureable = File.read('config/initializers/periodical.rb').scan(/\.register.*?:([a-z\d_]+)/).flatten
+    mentioned = File.read('.env.example')[/## Periodical tasks .*^PERIODICAL=/m].scan(/# ([a-z\d_]+):\d+/).flatten
     configureable.sort.must_equal mentioned.sort
   end
 
   it "runs everything" do
+    stub_request(:get, "https://status.github.com/api/status.json")
     Samson::Periodical.send(:registered).each_key do |task|
       Samson::Periodical.run_once task
     end

--- a/test/lib/samson/repo_provider_status_test.rb
+++ b/test/lib/samson/repo_provider_status_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require_relative "../../test_helper"
+
+SingleCov.covered!
+
+describe Samson::RepoProviderStatus do
+  describe ".errors" do
+    it "shows error when periodical is not running" do
+      Samson::RepoProviderStatus.errors.first.must_include "PERIODICAL"
+    end
+
+    it "is empty when everything is fine" do
+      Samson::Hooks.with_callback(:repo_provider_status) do
+        Samson::RepoProviderStatus.refresh
+      end
+      Samson::RepoProviderStatus.errors.must_equal []
+    end
+
+    it "can show multiple errors" do
+      Samson::Hooks.with_callback(:repo_provider_status, -> { "Foo" }, -> { nil }, -> { "Bar" }) do
+        Samson::RepoProviderStatus.refresh
+      end
+      Samson::RepoProviderStatus.errors.must_equal ["Foo", "Bar"]
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -198,10 +198,6 @@ ActiveSupport::TestCase.class_eval do
     ENV['DOCKER_REGISTRIES'] = old
   end
 
-  def stub_github_status_check
-    stub_request(:get, "#{Rails.application.config.samson.github.status_url}/api/status.json").to_return(body: "{}")
-  end
-
   def silence_thread_exceptions
     old = Thread.report_on_exception
     Thread.report_on_exception = false
@@ -297,7 +293,6 @@ ActionController::TestCase.class_eval do
     middleware = Rails.application.config.middleware.detect { |m| m.name == 'Warden::Manager' }
     manager = Warden::Manager.new(nil, &middleware.block)
     request.env['warden'] = Warden::Proxy.new(request.env, manager)
-    stub_github_status_check
   end
 
   after do
@@ -332,10 +327,4 @@ ActionController::TestCase.class_eval do
       response
     end
   end)
-end
-
-ActionDispatch::IntegrationTest.class_eval do
-  before do
-    stub_github_status_check
-  end
 end


### PR DESCRIPTION
currently we block each request if caching it somehow did not work,
this moves it to our periodical background thread so we do not block our requests

also prepares for multiple repo providers in the future

<img width="698" alt="screen shot 2018-10-06 at 8 15 39 pm" src="https://user-images.githubusercontent.com/11367/46577872-bf3c7f80-c9a5-11e8-8c57-412dce30252f.png">
<img width="535" alt="screen shot 2018-10-06 at 8 12 24 pm" src="https://user-images.githubusercontent.com/11367/46577874-c2d00680-c9a5-11e8-8fca-27651bcf4d27.png">

@zendesk/samson 
/fyi @pingfr one thing that's no longer hardcoded to github :)

# Risks:
 - low: annoying warning when not adding `repo_provider_status` to PERIODICAL