### PR TITLE
allow namespaceless resources to not have a namspace, do not let apis…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -3,6 +3,7 @@ module Kubernetes
   class RoleValidator
     VALID_LABEL = /\A[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?\z/ # also used in js ... cannot use /i
     ALLOWED_DUPLICATE_KINDS = ['ConfigMap', 'Service'].freeze
+    NAMESPACELESS_KINDS = ['APIService', 'ClusterRoleBinding'].freeze
 
     def initialize(elements)
       @elements = elements.compact
@@ -63,7 +64,9 @@ module Kubernetes
     end
 
     def validate_namespace
-      @errors << "Namespaces need to be unique" if map_attributes([:metadata, :namespace]).uniq.size != 1
+      elements = @elements.reject { |e| NAMESPACELESS_KINDS.include? e[:kind] }
+      namespaces = map_attributes([:metadata, :namespace], elements: elements)
+      @errors << "Namespaces need to be unique" if namespaces.uniq.size != 1
     end
 
     # multiple pods in a single role will make validations misbehave (recommend they all have the same role etc)

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -18,11 +18,13 @@ module Kubernetes
       @to_hash ||= begin
         kind = template[:kind]
 
-        set_namespace
+        set_namespace unless Kubernetes::RoleValidator::NAMESPACELESS_KINDS.include? kind
         set_project_labels if template.dig(:metadata, :annotations, :"samson/override_project_label")
         set_deploy_url
 
         case kind
+        when 'APIService' # rubocop:disable Lint/EmptyWhen
+          # api service names have a fixed pattern so we cannot override it.
         when 'HorizontalPodAutoscaler'
           set_name
           set_hpa_scale_target_name

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -25,6 +25,14 @@ describe Kubernetes::Resource do
     resource.instance_variable_set(:@delete_resource, true)
   end
 
+  def assert_create_and_delete_requests(**args, &block)
+    assert_request(:get, url, to_return: [{body: '{}'}, {status: 404}]) do
+      assert_request(:delete, url, to_return: {body: '{}'}) do
+        assert_request(:post, base_url, **args, to_return: {body: '{}'}, &block)
+      end
+    end
+  end
+
   let(:origin) { "http://foobar.server" }
   let(:template) do
     {
@@ -85,6 +93,11 @@ describe Kubernetes::Resource do
     describe "#namespace" do
       it "returns the namespace" do
         resource.namespace.must_equal 'pod1'
+      end
+
+      it "does not blow up if namespace is nil" do
+        template[:metadata].delete(:namespace)
+        resource.namespace.must_equal nil
       end
     end
 
@@ -185,6 +198,14 @@ describe Kubernetes::Resource do
           assert_request(:get, url, to_return: {status: 404}) do
             resource.deploy
           end
+        end
+      end
+    end
+
+    describe "#create" do
+      it "shows error location when create returns 404" do
+        assert_request(:post, base_url, to_return: {status: 404}) do
+          assert_raises(Samson::Hooks::UserError) { resource.send(:create) }
         end
       end
     end
@@ -784,17 +805,6 @@ describe Kubernetes::Resource do
           end
         end
       end
-
-      it "works with kind APIService" do
-        template[:kind] = "APIService"
-        template[:apiVersion] = "apiregistration.k8s.io/v1beta1"
-        url = "http://foobar.server/apis/apiregistration.k8s.io/v1beta1/namespaces/pod1/apiservices/some-project"
-        assert_request(:get, url, to_return: {body: old.to_json}) do
-          assert_request(:put, url, to_return: {body: "{}"}) do
-            resource.deploy
-          end
-        end
-      end
     end
   end
 
@@ -853,18 +863,20 @@ describe Kubernetes::Resource do
     end
   end
 
-  describe Kubernetes::Resource::PodDisruptionBudget do
-    def assert_create_and_delete_requests(**args, &block)
-      assert_request(:get, url, to_return: [{body: '{}'}, {status: 404}]) do
-        assert_request(:delete, url, to_return: {body: '{}'}) do
-          assert_request(:post, create_url, **args, to_return: {body: '{}'}, &block)
-        end
+  describe Kubernetes::Resource::APIService do
+    let(:kind) { "APIService" }
+    let(:api_version) { "apiregistration.k8s.io/v1beta1" }
+
+    it "copies resourceVersion when updating to satisfy kubernetes validations" do
+      assert_create_and_delete_requests do
+        resource.deploy
       end
     end
+  end
 
+  describe Kubernetes::Resource::PodDisruptionBudget do
     let(:kind) { 'PodDisruptionBudget' }
     let(:api_version) { 'policy/v1beta1' }
-    let(:create_url) { File.dirname(url) }
 
     describe "#deploy" do
       it "updates" do

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -161,6 +161,13 @@ describe Kubernetes::RoleValidator do
       errors.to_s.must_include "Namespaces need to be unique"
     end
 
+    it "allows resources without namespaces to not have a namespace" do
+      role[0][:metadata].delete(:namespace)
+      role[0][:kind] = 'APIService'
+      role[1][:metadata][:namespace] = 'other'
+      refute errors
+    end
+
     it "allows multiple services" do
       role << role.last.dup
       errors.must_be_nil

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -143,6 +143,13 @@ describe Kubernetes::TemplateFiller do
       template.to_hash[:metadata][:name].must_equal "test-app-server"
     end
 
+    it "does not set override name for resources that follow a fixed naming pattern" do
+      raw_template[:kind] = 'APIService'
+      raw_template[:metadata].delete(:namespace)
+      template.to_hash[:metadata][:name].must_equal "some-project-rc"
+      template.to_hash[:metadata][:namespace].must_equal nil
+    end
+
     describe "unqiue deployments" do
       let(:labels) do
         hash = template.to_hash


### PR DESCRIPTION
…erver name to be overridden because it must follow a fixed pattern

/cc @zendesk/samson @zendesk/compute 


