### PR TITLE
Point to the URL of the status' page

### DIFF
--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -20,7 +20,7 @@
   <p>
     <% CommitStatus.new(@release.project, @release.commit).statuses.each do |status| %>
       <%= github_commit_status_icon(status.fetch(:state)) %>
-      <b><%= status[:context] %>:</b> <%= link_to status[:description], status[:url] %><br/>
+      <b><%= status[:context] %>:</b> <%= link_to status[:description], status[:target_url] %><br/>
     <% end %>
   </p>
 


### PR DESCRIPTION
The other URL points to the Github API endpoint. Try clicking on [one of these statuses](https://samson.zende.sk/projects/help_center/releases/v14771) and you'll be taken to a Github API error page.

/cc @zendesk/samson @grosser 