### PR TITLE
K8s prereq timeout

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -125,6 +125,10 @@ Via [Template filler](/plugins/kubernetes/app/models/kubernetes/template_filler.
 Add a role with only a `Pod`, `metadata.annotations.samson/prerequisite: true`, and command to run a migrations.
 It will be executed before the rest is deployed.
 
+For default it waits for 10 minutes before timeout, you can change the timeout
+using KUBE_WAIT_FOR_PREREQ env variable (specified in seconds).
+
+
 ### StatefulSet
 
 On kubernetes <1.7 they can only be updated with `OnDelete` updateStrategy,

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -128,6 +128,10 @@ It will be executed before the rest is deployed.
 For default it waits for 10 minutes before timeout, you can change the timeout
 using KUBE_WAIT_FOR_PREREQ env variable (specified in seconds).
 
+### Deployment timeouts
+
+A deploy will wait for 10 minutes for pods to come alive. You can adjust this
+timeout using KUBE_WAIT_FOR_LIVE.
 
 ### StatefulSet
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -728,7 +728,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -757,7 +757,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -781,7 +781,7 @@ describe Kubernetes::DeployExecutor do
       executor.expects(:wait_for_resources_to_complete).returns([])
       executor.expects(:print_resource_events)
       executor.instance_variable_set(:@release, release)
-      refute executor.send(:deploy_and_watch, release.release_docs)
+      refute executor.send(:deploy_and_watch, release.release_docs, 60)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server


### PR DESCRIPTION
Having a different timeout for prerequisites is useful for us, as some jobs we run take more than what we want to wait for a deploy.

For backwards compatibility, the default value is the same as KUBE_WAIT_FOR_LIVE (so no workflow is affected unless explicitly changed).

@grosser What do you think? This is useful for us, and should not change anything for people not using it. And the code is not very complicated.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low