### PR TITLE
[BRE-1009] Support GitHub's new Checks API for reference status on deploy review

### DIFF
--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -47,7 +47,8 @@ function refStatusTypeahead(options){
       if (status.state != "success") {
         var item = $("<li>");
         $ref_problem_list.append(item);
-        item.text(status.state + ": " + status.description);
+        // State and status comes from GitHub or Samson
+        item.html(status.state + ": " + status.description);
         if(status.target_url) {
           item.append(' <a href="' + status.target_url + '">details</a>');
         }

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -7,6 +7,22 @@ class CommitStatus
   # - missing is our own state that means we could not determine the status
   STATE_PRIORITY = [:success, :pending, :missing, :failure, :error, :fatal].freeze
   UNDETERMINED = ["pending", "missing"].freeze
+  CHECK_STATE = {
+    error: ['action_required', 'canceled', 'timed_out'],
+    failure: ['failed'],
+    success: ['success', 'neutral']
+  }.freeze
+  NO_STATUSES_REPORTED_RESULT = {
+    state: 'pending',
+    statuses: [
+      {
+        state: 'pending',
+        description:
+          "No status was reported for this commit on GitHub. See https://developer.github.com/v3/checks/ and " \
+            "https://github.com/blog/1227-commit-status-api for details."
+      }
+    ]
+  }.freeze
 
   def initialize(project, reference, stage: nil)
     @project = project
@@ -19,16 +35,7 @@ class CommitStatus
   end
 
   def statuses
-    list = combined_status.fetch(:statuses).map(&:to_h)
-    if list.empty?
-      list << {
-        state: 'pending',
-        description:
-          "No status was reported for this commit on GitHub. " \
-          "See https://github.com/blog/1227-commit-status-api for details."
-      }
-    end
-    list
+    combined_status.fetch(:statuses).map(&:to_h)
   end
 
   def expire_cache(commit)
@@ -39,38 +46,78 @@ class CommitStatus
 
   def combined_status
     @combined_status ||= begin
-      statuses = [github_status]
+      statuses = [github_state]
       statuses += [release_status, *ref_statuses].compact if @stage
-      statuses[1..-1].each_with_object(statuses[0]) { |status, merged| merge(merged, status) }
+      merge_statuses(statuses)
     end
   end
 
-  def merge(a, b)
-    a[:state] = [a.fetch(:state), b.fetch(:state)].max_by { |state| STATE_PRIORITY.index(state.to_sym) }
-    a.fetch(:statuses).concat b.fetch(:statuses)
-  end
-
+  # Gets a reference's state, combining results from both the Status and Checks API
   # NOTE: reply is an api object that does not support .fetch
-  def github_status
+  def github_state
     static = @reference.match?(Build::SHA1_REGEX) || @reference.match?(Release::VERSION_REGEX)
     expires_in = ->(reply) { cache_duration(reply) }
     cache_fetch_if static, cache_key(@reference), expires_in: expires_in do
-      GITHUB.combined_status(@project.repository_path, @reference).to_h
+      checks_result = with_octokit_client_error_rescue { github_check }
+      status_result = with_octokit_client_error_rescue { github_status }
+
+      results_with_statuses = [checks_result, status_result].select { |result| result[:statuses].any? }
+
+      results_with_statuses.empty? ? NO_STATUSES_REPORTED_RESULT : merge_statuses(results_with_statuses)
     end
-  rescue Octokit::NotFound
-    {
-      state: "missing",
-      statuses: [{
-        context: "Reference", # for releases/show.html.erb
-        state: "missing",
-        description: "'#{@reference}' does not exist"
-      }]
-    }
   end
 
-  def cache_duration(github_status)
-    statuses = github_status[:statuses]
-    if statuses.empty? # does not have any statuses, chances are commit is new
+  # Gets commit statuses using GitHub's check API. Currently parsing it to match status structure to better facilitate
+  # transition to new API. See https://developer.github.com/v3/checks/runs/ and
+  # https://developer.github.com/v3/checks/suites/ for details
+  def github_check
+    base_url = "repos/#{@project.repository_path}/commits/#{CGI.escape(@reference)}"
+    preview_header = {Accept: 'application/vnd.github.antiope-preview+json'}
+
+    check_suites = GITHUB.get("#{base_url}/check-suites", headers: preview_header)[:check_suites]
+    checks = GITHUB.get("#{base_url}/check-runs", headers: preview_header)
+
+    overall_state = check_suites.
+      map { |suite| check_state_equivalent(suite[:conclusion]) }.
+      max_by { |state| STATE_PRIORITY.index(state.to_sym) }
+
+    statuses = checks[:check_runs].map do |check_run|
+      {
+        state: check_state_equivalent(check_run[:conclusion]),
+        description: ApplicationController.helpers.markdown(check_run[:output][:summary]),
+        context: check_run[:name],
+        target_url: check_run[:html_url],
+        updated_at: check_run[:started_at]
+      }
+    end
+
+    {state: overall_state || 'pending', statuses: statuses}
+  end
+
+  def github_status
+    GITHUB.combined_status(@project.repository_path, @reference).to_h
+  end
+
+  def merge_statuses(statuses)
+    statuses[1..-1].each_with_object(statuses[0]) do |status, merged|
+      merged[:state] = [merged.fetch(:state), status.fetch(:state)].max_by { |s| STATE_PRIORITY.index(s.to_sym) }
+      merged.fetch(:statuses).concat(status.fetch(:statuses))
+    end
+  end
+
+  def check_state_equivalent(check_conclusion)
+    case check_conclusion
+    when *CHECK_STATE[:success] then 'success'
+    when *CHECK_STATE[:error] then 'error'
+    when *CHECK_STATE[:failure] then 'failure'
+    when nil then 'pending'
+    else raise "Unknown Check conclusion: #{check_conclusion}"
+    end
+  end
+
+  def cache_duration(github_result)
+    statuses = github_result[:statuses]
+    if github_result == NO_STATUSES_REPORTED_RESULT # does not have any statuses, chances are commit is new
       5.minutes # NOTE: could fetch commit locally without pulling to check it's age
     elsif (Time.now - statuses.map { |s| s[:updated_at] }.max) > 1.hour # no new updates expected
       1.day
@@ -146,5 +193,18 @@ class CommitStatus
 
   def deploy_scope
     @deploy_scope ||= Deploy.reorder(nil).successful.where(stage_id: @stage.influencing_stage_ids).group(:stage_id)
+  end
+
+  def with_octokit_client_error_rescue
+    yield
+  rescue Octokit::ClientError
+    {
+      state: "missing",
+      statuses: [{
+        context: "Reference", # for releases/show.html.erb
+        state: "missing",
+        description: "There was a problem getting the status for reference '#{@reference}': #{$!.message}"
+      }]
+    }
   end
 end

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -21,13 +21,38 @@ describe ReleasesController do
         }
       ]
     }
+    check_suite_response = {check_suites: [{conclusion: 'success'}]}
+    check_run_response = {
+      check_runs: [
+        {
+          conclusion: 'success',
+          output: {summary: '<p>Huzzah!</p>'},
+          name: 'Travis CI',
+          html_url: 'https://coolbeans.com',
+          started_at: Time.now.iso8601,
+        }
+      ]
+    }
 
     headers = {
       "Content-Type" => "application/json",
     }
+    preview_headers = {
+      'Accept' => 'application/vnd.github.antiope-preview+json'
+    }
 
     stub_request(:get, "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/status").
       to_return(status: 200, body: status_response.to_json, headers: headers)
+
+    stub_request(
+      :get,
+      "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-suites"
+    ).to_return(status: 200, body: check_suite_response.to_json, headers: headers.merge(preview_headers))
+
+    stub_request(
+      :get,
+      "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-runs"
+    ).to_return(status: 200, body: check_run_response.to_json, headers: headers.merge(preview_headers))
   end
 
   as_a_viewer do

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -55,6 +55,9 @@ describe DeploysHelper do
 
       it "renders buddy check when waiting for buddy" do
         stub_github_api "repos/bar/foo/commits/staging/status", state: "success", statuses: []
+        stub_github_api "repos/bar/foo/commits/staging/check-suites", check_suites: []
+        stub_github_api "repos/bar/foo/commits/staging/check-runs", check_runs: []
+
         deploy.expects(:waiting_for_buddy?).returns(true)
         result.wont_include output
         result.must_include 'This deploy requires a buddy.'

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -17,156 +17,322 @@ describe CommitStatus do
     end
   end
 
-  def success!
-    stub_github_api(url, statuses: [{foo: "bar", updated_at: 1.day.ago}], state: "success")
-  end
-
   def failure!
     stub_github_api(url, nil, 404)
   end
 
-  def status(stage_param: stage, reference_param: reference)
+  def build_status(stage_param: stage, reference_param: reference)
     CommitStatus.new(stage_param.project, reference_param, stage: stage_param)
   end
 
   let(:stage) { stages(:test_staging) }
   let(:reference) { 'master' }
-  let(:url) { "repos/#{stage.project.repository_path}/commits/#{reference}/status" }
+  let(:status) { build_status }
 
-  describe "#state" do
-    it "returns state" do
-      success!
-      status.state.must_equal 'success'
+  describe "using state api" do
+    def success!
+      stub_github_api(url, statuses: [{foo: "bar", updated_at: 1.day.ago}], state: "success")
     end
 
-    it "is missing when not found" do
-      failure!
-      status.state.must_equal 'missing'
+    def stub_checks_api(commit_status: status)
+      commit_status.stubs(:github_check).returns(state: 'pending', statuses: [])
     end
 
-    it "works without stage" do
-      success!
-      s = status
-      s.instance_variable_set(:@stage, nil)
-      s.state.must_equal "success"
-    end
+    before { stub_checks_api } # user only using Status API
 
-    it "does not cache changing references" do
-      request = success!
-      status.state.must_equal 'success'
-      status.state.must_equal 'success'
-      assert_requested request, times: 2
-    end
+    let(:url) { "repos/#{stage.project.repository_path}/commits/#{reference}/status" }
 
-    describe "caching static references" do
-      let(:reference) { 'v4.2' }
-
-      it "caches github state accross instances" do
-        request = success!
+    describe "#state" do
+      it "returns state" do
+        success!
         status.state.must_equal 'success'
-        status.state.must_equal 'success'
-        assert_requested request, times: 1
       end
 
-      it "can expire cache" do
+      it "is missing when not found" do
+        failure!
+        status.state.must_equal 'missing'
+      end
+
+      it "works without stage" do
+        success!
+        s = status
+        s.instance_variable_set(:@stage, nil)
+        s.state.must_equal "success"
+      end
+
+      it "does not cache changing references" do
         request = success!
         status.state.must_equal 'success'
-        status.expire_cache reference
-        status.state.must_equal 'success'
+        new_status = build_status
+        stub_checks_api(commit_status: new_status)
+        new_status.state.must_equal 'success'
         assert_requested request, times: 2
       end
-    end
 
-    describe "when deploying a previous release" do
-      deploying_a_previous_release
+      describe "caching static references" do
+        let(:reference) { 'v4.2' }
 
-      it "warns" do
-        success!
-        assert_sql_queries 10 do
-          status.state.must_equal 'error'
+        it "caches github state accross instances" do
+          request = success!
+          status.state.must_equal 'success'
+          new_status = build_status
+          stub_checks_api(commit_status: new_status)
+          new_status.state.must_equal 'success'
+          assert_requested request, times: 1
+        end
+
+        it "can expire cache" do
+          request = success!
+          status.state.must_equal 'success'
+          status.expire_cache reference
+          new_status = build_status
+          stub_checks_api(commit_status: new_status)
+          new_status.state.must_equal 'success'
+          assert_requested request, times: 2
         end
       end
 
-      it "warns when an older deploy has a lower version (grouping + ordering test)" do
-        deploys(:succeeded_test).update_column(:stage_id, deploy.stage_id) # need 2 successful deploys on the same stage
-        deploys(:succeeded_test).update_column(:reference, 'v4.1') # old is lower
-        deploy.update_column(:reference, 'v4.3') # new is higher
-        success!
-        status.state.must_equal 'error'
-      end
-
-      it "ignores when previous deploy was the same or lower" do
-        deploy.update_column(:reference, reference)
-        success!
-        status.state.must_equal 'success'
-      end
-
-      describe "when previous deploy was higher numerically" do
-        before { deploy.update_column(:reference, 'v4.10') }
+      describe "when deploying a previous release" do
+        deploying_a_previous_release
 
         it "warns" do
           success!
-          status = status()
-          status.state.must_equal 'error'
-          status.statuses[1][:description].must_equal(
-            "v4.10 was deployed to deploy groups in this stage by Production"
-          )
+          assert_sql_queries 10 do
+            status.state.must_equal 'error'
+          end
         end
 
-        it "warns with multiple higher deploys" do
-          other = deploys(:succeeded_test)
-          other.update_column(:reference, 'v4.9')
-
+        it "warns when an older deploy has a lower version (grouping + ordering test)" do
+          deploys(:succeeded_test).update_column(:stage_id, deploy.stage_id) # need 2 successful deploys on same stage
+          deploys(:succeeded_test).update_column(:reference, 'v4.1') # old is lower
+          deploy.update_column(:reference, 'v4.3') # new is higher
           success!
-          status = status()
           status.state.must_equal 'error'
-          status.statuses[1][:description].must_equal(
-            "v4.9, v4.10 was deployed to deploy groups in this stage by Staging, Production"
-          )
+        end
+
+        it "ignores when previous deploy was the same or lower" do
+          deploy.update_column(:reference, reference)
+          success!
+          status.state.must_equal 'success'
+        end
+
+        describe "when previous deploy was higher numerically" do
+          before { deploy.update_column(:reference, 'v4.10') }
+
+          it "warns" do
+            success!
+            status = status()
+            status.state.must_equal 'error'
+            status.statuses[1][:description].must_equal(
+              "v4.10 was deployed to deploy groups in this stage by Production"
+            )
+          end
+
+          it "warns with multiple higher deploys" do
+            other = deploys(:succeeded_test)
+            other.update_column(:reference, 'v4.9')
+
+            success!
+            status = status()
+            status.state.must_equal 'error'
+            status.statuses[1][:description].must_equal(
+              "v4.9, v4.10 was deployed to deploy groups in this stage by Staging, Production"
+            )
+          end
+        end
+
+        it "ignores when previous deploy was not a version" do
+          deploy.update_column(:reference, 'master')
+          success!
+          status.state.must_equal 'success'
+        end
+
+        it "ignores when previous deploy was failed" do
+          deploy.job.update_column(:status, 'faild')
+          success!
+          status.state.must_equal 'success'
         end
       end
+    end
 
-      it "ignores when previous deploy was not a version" do
-        deploy.update_column(:reference, 'master')
+    describe "#statuses" do
+      it "returns list" do
         success!
-        status.state.must_equal 'success'
+        status.statuses.map { |s| s[:foo] }.must_equal ["bar"]
       end
 
-      it "ignores when previous deploy was failed" do
-        deploy.job.update_column(:status, 'faild')
-        success!
-        status.state.must_equal 'success'
+      it "shows that github is waiting for statuses to come when non has arrived yet ... or none are set up" do
+        stub_github_api(url, statuses: [], state: "pending")
+        list = status.statuses
+        list.map { |s| s[:state] }.must_equal ["pending"]
+        list.first[:description].must_include "No status was reported"
+      end
+
+      it "returns Reference context for release/show display" do
+        failure!
+        status.statuses.map { |s| s[:context] }.must_equal ["Reference"]
+      end
+
+      describe "when deploying a previous release" do
+        deploying_a_previous_release
+
+        it "merges" do
+          success!
+          status.statuses.each { |s| s.delete(:updated_at) }.must_equal [
+            {foo: "bar"},
+            {state: "Old Release", description: "v4.3 was deployed to deploy groups in this stage by Production"}
+          ]
+        end
       end
     end
   end
 
-  describe "#statuses" do
-    it "returns list" do
-      success!
-      status.statuses.map { |s| s[:foo] }.must_equal ["bar"]
+  describe "using checks api" do
+    let(:check_suite_url) { "repos/#{stage.project.repository_path}/commits/#{reference}/check-suites" }
+    let(:check_run_url) { "repos/#{stage.project.repository_path}/commits/#{reference}/check-runs" }
+
+    before { status.expects(:github_status).returns(state: 'pending', statuses: []) } # user only using Checks API
+
+    describe '#state' do
+      before do
+        stub_github_api(
+          check_run_url,
+          check_runs: [
+            {
+              conclusion: 'success',
+              output: {summary: '<p>Huzzah!</p>'},
+              name: 'Travis CI',
+              html_url: 'https://coolbeans.com',
+              started_at: Time.now,
+            }
+          ]
+        )
+      end
+
+      it 'returns state' do
+        stub_github_api(check_suite_url, check_suites: [{conclusion: 'success'}])
+
+        status.state.must_equal 'success'
+      end
+
+      it 'returns pending if no check suite exists for reference' do
+        stub_github_api(check_suite_url, check_suites: [])
+
+        status.state.must_equal 'pending'
+      end
+
+      it 'returns pending if check suite does not have conclusion yet' do
+        stub_github_api(check_suite_url, check_suites: [{conclusion: nil}])
+
+        status.state.must_equal 'pending'
+      end
+
+      it 'maps check status to state equivalent' do
+        stub_github_api(check_suite_url, check_suites: [{conclusion: 'action_required'}])
+
+        status.state.must_equal 'error'
+      end
+
+      it 'picks highest priority check conclusion/status equivalent' do
+        stub_github_api(
+          check_suite_url,
+          check_suites: [
+            {conclusion: 'action_required'},
+            {conclusion: 'canceled'},
+            {conclusion: 'timed_out'},
+            {conclusion: 'failed'},
+            {conclusion: 'success'},
+            {conclusion: 'neutral'}
+          ]
+        )
+
+        status.state.must_equal 'error'
+      end
+
+      it 'raises with unknown conclusion' do
+        status.unstub(:github_status)
+
+        stub_github_api(
+          check_suite_url,
+          check_suites: [{conclusion: 'bingbong'}]
+        )
+
+        e = assert_raises RuntimeError do
+          status.state
+        end
+
+        e.message.must_equal "Unknown Check conclusion: bingbong"
+      end
     end
 
-    it "shows that github is waiting for statuses to come when non has arrived yet ... or none are set up" do
-      stub_github_api(url, statuses: [], state: "pending")
-      list = status.statuses
-      list.map { |s| s[:state] }.must_equal ["pending"]
-      list.first[:description].must_include "No status was reported"
+    describe '#statuses' do
+      before { stub_github_api(check_suite_url, check_suites: []) }
+
+      let(:started_at) { '2018-10-12 20:55:58 UTC'.to_time(:utc) }
+
+      it 'returns list' do
+        stub_github_api(
+          check_run_url, check_runs: [{
+            conclusion: 'success',
+            output: {summary: '<p>Huzzah!</p>'},
+            name: 'Travis CI',
+            html_url: 'https://coolbeans.com',
+            started_at: started_at,
+          }]
+        )
+
+        status.statuses.must_equal(
+          [{
+            state: 'success',
+            description: "<p>Huzzah!</p>\n",
+            target_url: 'https://coolbeans.com',
+            context: 'Travis CI',
+            updated_at: started_at
+          }]
+        )
+      end
+
+      it 'sanitizes output' do
+        stub_github_api(
+          check_run_url, check_runs: [{
+            conclusion: 'success',
+            output: {summary: '<script>alert("Attack!")</script>'},
+            name: 'Travis CI',
+            html_url: 'https://coolbeans.com',
+            started_at: started_at,
+          }]
+        )
+
+        status.statuses.must_equal(
+          [{
+            state: 'success',
+            description: "alert(\"Attack!\")\n",
+            context: 'Travis CI',
+            target_url: 'https://coolbeans.com',
+            updated_at: started_at
+          }]
+        )
+      end
+
+      it 'gives help message when no statuses are present' do
+        stub_github_api(check_run_url, check_runs: [])
+
+        status.statuses.must_equal([{
+          state: 'pending',
+          description: "No status was reported for this commit on GitHub. " \
+          "See https://developer.github.com/v3/checks/ and https://github.com/blog/1227-commit-status-api for details."
+        }])
+      end
     end
+  end
 
-    it "returns Reference context for release/show display" do
-      failure!
-      status.statuses.map { |s| s[:context] }.must_equal ["Reference"]
-    end
+  describe 'using both status and checks api' do
+    describe '#state' do
+      it 'prioritizes success of one api result over pending of another' do
+        status.expects(:github_check).returns(state: 'pending', statuses: [])
+        status.expects(:github_status).returns(state: 'success', statuses: [{foo: "bar", updated_at: 1.day.ago}])
 
-    describe "when deploying a previous release" do
-      deploying_a_previous_release
-
-      it "merges" do
-        success!
-        status.statuses.each { |s| s.delete(:updated_at) }.must_equal [
-          {foo: "bar"},
-          {state: "Old Release", description: "v4.3 was deployed to deploy groups in this stage by Production"}
-        ]
+        status.state.must_equal('success')
       end
     end
   end
@@ -181,7 +347,7 @@ describe CommitStatus do
     it 'returns nothing if ref has been deployed to non-production stage' do
       production_stage.project.expects(:deployed_reference_to_non_production_stage?).returns(true)
 
-      status(stage_param: production_stage).send(:ref_statuses).must_equal []
+      build_status(stage_param: production_stage).send(:ref_statuses).must_equal []
     end
 
     it 'returns status if ref has not been deployed to non-production stage' do
@@ -199,7 +365,7 @@ describe CommitStatus do
         }
       ]
 
-      status(stage_param: production_stage).send(:ref_statuses).must_equal expected_hash
+      build_status(stage_param: production_stage).send(:ref_statuses).must_equal expected_hash
     end
 
     it 'includes plugin statuses' do
@@ -229,7 +395,7 @@ describe CommitStatus do
 
   describe "#cache_duration" do
     it "is short when we do not know if the commit is new or old" do
-      status.send(:cache_duration, statuses: []).must_equal 5.minutes
+      status.send(:cache_duration, CommitStatus::NO_STATUSES_REPORTED_RESULT).must_equal 5.minutes
     end
 
     it "is long when we do not expect new updates" do


### PR DESCRIPTION
<img width="940" alt="screen shot 2018-10-15 at 12 25 43 pm" src="https://user-images.githubusercontent.com/15261525/46973677-cc78fe80-d076-11e8-96ed-ac677405f903.png">

We've switched over to using the new Travic CI integration for all Zendesk repositories, which uses GitHub's new Checks API. This broke Samson's reference status logic on the Deploy review page and elsewhere. This PR introduces ~~a new environment variable `USE_GITHUB_CHECKS_API` which will allow users to use the Checks API to get the reference status instead of the Status API.~~ logic to show results from both the Status and Checks APIs.

/cc @zendesk/samson

### Tasks
 - [x] :+1: from team
 - [ ] Test in Staging

### References
 - Jira link: [BRE-1009](https://zendesk.atlassian.net/browse/BRE-1009)

### Risks
 - Low