### PR TITLE
Add annotation to show logs of prerequisite pods

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -18,6 +18,10 @@ module Kubernetes
         @pod.dig(:metadata, :namespace)
       end
 
+      def annotations
+        @pod[:metadata][:annotations] ||= {}
+      end
+
       def live?
         completed? || (phase == 'Running' && ready?)
       end

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -144,8 +144,11 @@ module Kubernetes
 
     def show_pods_logs_if_requested
       log_end_time = 0.seconds.from_now
+      @output.puts "\nXXX\n"
       pods = fetch_pods
       pods.each do |pod|
+        @output.puts "\nXXX: pod iter\n"
+        @output.puts "\n XXX: #{pod.annotations}\n"
         if pod.annotations[:'samson/show_logs_on_deploy'] == 'true'
           print_pod_logs(pod, log_end_time)
           @output.puts "\n------------------------------------------\n"

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -13,6 +13,9 @@ describe Kubernetes::Api::Pod do
         labels: {
           deploy_group_id: '123',
           role_id: '234',
+        },
+        annotations: {
+          'samson/show_logs_on_deploy': 'true'
         }
       },
       status: {
@@ -142,6 +145,12 @@ describe Kubernetes::Api::Pod do
   describe "#containers" do
     it 'reads' do
       pod.containers.first[:name].must_equal 'container1'
+    end
+  end
+
+  describe "#annotations" do
+    it 'reads' do
+      pod.annotations[:'samson/show_logs_on_deploy'].must_equal 'true'
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -272,7 +272,8 @@ describe Kubernetes::DeployExecutor do
           'apiVersion' => 'batch/v1',
           'spec' => {
             'template' => {
-              'metadata' => {'labels' => {'project' => 'foobar', 'role' => 'migrate'}},
+              'metadata' => {'labels' => {'project' => 'foobar', 'role' => 'migrate'},
+                             'annotations' => {'samson/show_logs_on_deploy' => 'true'}},
               'spec' => {
                 'containers' => [{'name' => 'job', 'image' => 'docker-registry.zende.sk/truth_service:latest'}],
                 'restartPolicy' => 'Never'
@@ -317,6 +318,13 @@ describe Kubernetes::DeployExecutor do
         out.must_include "stability" # testing deploy for stability
         out.must_include "deploying prerequisite" # announcing that we deploy prerequisites first
         out.must_include "other roles" # announcing that we have more to deploy
+      end
+
+      it "show logs after prerequisites deploys ends" do
+        assert execute, out
+        out.must_include "deploying prerequisite" # announcing that we deploy prerequisites
+        out.scan(/SUCCESS/).count.must_equal 2 # Nothing fails, so all deployments went fine
+        out.must_include "LOGS:" # and includes a "LOGS:" entry, so logs after prerequisites deploy are shown
       end
 
       it "fails when jobs fail" do

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -728,7 +728,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs, 60)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -757,7 +757,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs, 60)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -781,7 +781,7 @@ describe Kubernetes::DeployExecutor do
       executor.expects(:wait_for_resources_to_complete).returns([])
       executor.expects(:print_resource_events)
       executor.instance_variable_set(:@release, release)
-      refute executor.send(:deploy_and_watch, release.release_docs, 60)
+      refute executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server


### PR DESCRIPTION
* Adds annotation to show logs of executed prerequisite pods

Fixes: #3003 

@grosser does this make sense to you?

The only disadvantage I see is that the annotation is on the pod, not the job, so you need one annotation for prerequisite at the job kind and another at the pod spec inside the job.

I mean, something like:

```
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    samson/prerequisite: "true"
  name: data-migration
  labels:
    project: project
    role: data-migration
spec:
  template:
    metadata:
      labels:
        project: project
        role: data-migration
      annotations:
        samson/show_logs_on_success: "true"
    spec:
      restartPolicy: Never
      ...
```

I tried first using an env var, when I had that working I tried the annotation on the pod. But then I realized it's on the pod, not the job or something else, so tried to do it on the job. But not sure that part of the code can check easily for that. I think it's kind of tricky, as it needs to check for prerequisites (not sure that part of the code knows about them), but then check for annotations there and print for all pods that belong to that resource (following the owner reference, hopefully, but not sure that works fine in Kubernetes. On not sure on which versions)

Using just an annotation for the pod seems simpler, now that I think about it. But will try to look at adding the annotation at the job level.  

What do you think? Let me know if at the pod level it's fine (seems simpler, but not sure :))

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low