### PR TITLE
PAAS-2251 creating 2 budgets that match a single pod causes alerts du…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -112,8 +112,10 @@ module Kubernetes
         [replica_target - 1, Integer(min_available)].min
       end
       target = 0 if target < 0
+
       annotations = (resource.dig(:metadata, :annotations) || {}).dup
       annotations[:"samson/updateTimestamp"] = Time.now.utc.iso8601
+
       budget = {
         apiVersion: "policy/v1beta1",
         kind: "PodDisruptionBudget",

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -59,6 +59,9 @@ module Kubernetes
           set_image_pull_secrets
           set_resource_blue_green if blue_green_color
           set_init_containers
+        when 'PodDisruptionBudget'
+          set_name
+          set_match_labels_blue_green if blue_green_color
         else
           set_name
         end
@@ -115,8 +118,12 @@ module Kubernetes
 
     def set_resource_blue_green
       template.dig_set([:metadata, :labels, :blue_green], blue_green_color)
-      template.dig_set([:spec, :selector, :matchLabels, :blue_green], blue_green_color)
+      set_match_labels_blue_green
       template.dig_set([:spec, :template, :metadata, :labels, :blue_green], blue_green_color)
+    end
+
+    def set_match_labels_blue_green
+      template.dig_set([:spec, :selector, :matchLabels, :blue_green], blue_green_color)
     end
 
     # TODO: unify into with label verification logic in role_validator

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -770,6 +770,15 @@ describe Kubernetes::TemplateFiller do
       end
     end
 
+    describe "PodDisruptionBudget" do
+      it "modified name" do
+        raw_template[:kind] = 'PodDisruptionBudget'
+        hash = template.to_hash
+        hash.dig_fetch(:metadata, :name).must_equal 'test-app-server'
+        refute hash.dig(:spec, :selector, :matchLabels).key?(:blue_green)
+      end
+    end
+
     describe "blue-green" do
       before do
         doc.kubernetes_role.blue_green = true
@@ -788,6 +797,13 @@ describe Kubernetes::TemplateFiller do
         hash.dig_fetch(:metadata, :labels, :blue_green).must_equal 'green'
         hash.dig_fetch(:spec, :selector, :matchLabels, :blue_green).must_equal 'green'
         hash.dig_fetch(:spec, :template, :metadata, :labels, :blue_green).must_equal 'green'
+      end
+
+      it "modified budgets so we do not get errors when 2 budgets match the same pod" do
+        raw_template[:kind] = 'PodDisruptionBudget'
+        hash = template.to_hash
+        hash.dig_fetch(:metadata, :name).must_equal 'test-app-server-green'
+        hash.dig_fetch(:spec, :selector, :matchLabels, :blue_green).must_equal 'green'
       end
     end
   end


### PR DESCRIPTION
…ring deploy

```
[00:52:00]   MultiplePodDisruptionBudgets: Pod "pod1"/"foo-web-green-6649d44d94-gfs4p" matches multiple PodDisruptionBudgets.  Chose "foo-web-green" arbitrarily.

```

@zendesk/compute @dragonfax @iamliamnorton 