### PR TITLE
Revert "[BRE-1009] Support GitHub's new Checks API for reference status on deploy review"

### DIFF
--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -47,8 +47,7 @@ function refStatusTypeahead(options){
       if (status.state != "success") {
         var item = $("<li>");
         $ref_problem_list.append(item);
-        // State and status comes from GitHub or Samson
-        item.html(status.state + ": " + status.description);
+        item.text(status.state + ": " + status.description);
         if(status.target_url) {
           item.append(' <a href="' + status.target_url + '">details</a>');
         }

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -21,38 +21,13 @@ describe ReleasesController do
         }
       ]
     }
-    check_suite_response = {check_suites: [{conclusion: 'success'}]}
-    check_run_response = {
-      check_runs: [
-        {
-          conclusion: 'success',
-          output: {summary: '<p>Huzzah!</p>'},
-          name: 'Travis CI',
-          html_url: 'https://coolbeans.com',
-          started_at: Time.now.iso8601,
-        }
-      ]
-    }
 
     headers = {
       "Content-Type" => "application/json",
     }
-    preview_headers = {
-      'Accept' => 'application/vnd.github.antiope-preview+json'
-    }
 
     stub_request(:get, "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/status").
       to_return(status: 200, body: status_response.to_json, headers: headers)
-
-    stub_request(
-      :get,
-      "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-suites"
-    ).to_return(status: 200, body: check_suite_response.to_json, headers: headers.merge(preview_headers))
-
-    stub_request(
-      :get,
-      "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-runs"
-    ).to_return(status: 200, body: check_run_response.to_json, headers: headers.merge(preview_headers))
   end
 
   as_a_viewer do

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -55,9 +55,6 @@ describe DeploysHelper do
 
       it "renders buddy check when waiting for buddy" do
         stub_github_api "repos/bar/foo/commits/staging/status", state: "success", statuses: []
-        stub_github_api "repos/bar/foo/commits/staging/check-suites", check_suites: []
-        stub_github_api "repos/bar/foo/commits/staging/check-runs", check_runs: []
-
         deploy.expects(:waiting_for_buddy?).returns(true)
         result.wont_include output
         result.must_include 'This deploy requires a buddy.'


### PR DESCRIPTION
Reverts zendesk/samson#3002

We're getting exceptions on the Help Center Releases page and elsewhere:

* [ActionView::Template::Error: Unknown Check conclusion: failure](https://rollbar-us.zendesk.com/Zendesk/Samson/items/889/occurrences/988691865/)
* [ActionView::Template::Error: can't modify frozen Hash](https://rollbar-us.zendesk.com/Zendesk/Samson/items/903/)