### PR TITLE
Add 'failure' to failure commit status list

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -9,7 +9,7 @@ class CommitStatus
   UNDETERMINED = ["pending", "missing"].freeze
   CHECK_STATE = {
     error: ['action_required', 'canceled', 'timed_out'],
-    failure: ['failed'],
+    failure: ['failure', 'failed'],
     success: ['success', 'neutral']
   }.freeze
   NO_STATUSES_REPORTED_RESULT = {


### PR DESCRIPTION
GitHub is now returning this new status

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
