### PR TITLE
Make ErrorNotifier test behavior more obvious

### DIFF
--- a/lib/error_notifier.rb
+++ b/lib/error_notifier.rb
@@ -7,7 +7,9 @@ module ErrorNotifier
     def notify(exception, options = {})
       debug_info = Samson::Hooks.fire(:error, exception, options).compact.detect { |result| result.is_a?(String) }
       if ::Rails.env.test?
-        raise exception # tests have to use ErrorNotifier.expects(:notify) to silence intended errors
+        message = "ErrorNotifier caught exception: #{exception.message}. Use use ErrorNotifier.expects(:notify) to " \
+          "silence in tests"
+        raise RuntimeError, message, exception.backtrace
       else
         # TODO: Don't spam logs twice if any exception plugin is enabled
         message_body =

--- a/test/lib/error_notifier_test.rb
+++ b/test/lib/error_notifier_test.rb
@@ -18,10 +18,16 @@ describe ErrorNotifier do
     end
 
     it 'raises if in the test environment' do
-      exception = ArgumentError
-      assert_raises exception do
+      exception = ArgumentError.new('motherofgod')
+      exception.set_backtrace(["neatbacktraceyougotthere"])
+      e = assert_raises RuntimeError do
         ErrorNotifier.notify(exception)
       end
+
+      expected_message = "ErrorNotifier caught exception: motherofgod. Use use ErrorNotifier.expects(:notify)" \
+        " to silence in tests"
+      e.message.must_equal expected_message
+      e.backtrace.must_equal ['neatbacktraceyougotthere']
     end
 
     it 'logs error if not in test environment' do


### PR DESCRIPTION
Makes behavior of ErrorNotifier more obvious when writing tests.

/cc @zendesk/samson