### PR TITLE
Show logs on success when requested

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -184,3 +184,9 @@ To override it, set the namespace to either `default` or `kube-system` and set `
 Samson automatically adds `container[].lifecycle.preStop` `sleep 3` if a preStop hook is not set and
 `container[].samson/preStop` is not set to `disabled`, to prevent in-flight requests from getting lost when taking a pod
 out of rotation (alternatively set `metadata.annoations.container-nameofcontainer-samson/preStop: disabled`).
+
+### Showing logs on successful deploys
+
+Set `metadata.annoations.samson/show_logs_on_deploy: 'true'` on pods, to see logs when the deploy succeeds.
+This can be useful for Migrations (see above).
+(On failure, samson always shows all pod logs)

--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -18,6 +18,10 @@ module Kubernetes
         @pod.dig(:metadata, :namespace)
       end
 
+      def annotations
+        @pod[:metadata][:annotations] ||= {}
+      end
+
       def live?
         completed? || (phase == 'Running' && ready?)
       end

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -85,7 +85,7 @@ module Kubernetes
         statuses = pod_statuses(release_docs)
         if statuses.none?
           @output.puts "No pods were created"
-          return success
+          return success, statuses
         end
         not_ready = statuses.reject(&:live)
 
@@ -93,23 +93,23 @@ module Kubernetes
           if not_ready.any?
             print_statuses(statuses)
             unstable!('one or more pods are not live', not_ready)
-            return statuses
+            return false, statuses
           else
             @output.puts "Testing for stability: #{stable_time_remaining}s"
-            return success if stable?
+            return success, statuses if stable?
           end
         else
           print_statuses(statuses)
           if not_ready.any?
             if stopped = not_ready.select(&:stop).presence
               unstable!('one or more pods stopped', stopped)
-              return statuses
+              return false, statuses
             elsif seconds_waiting > timeout
               @output.puts "TIMEOUT, pods took too long to get live"
-              return statuses
+              return false, statuses
             end
           elsif statuses.all? { |s| s.pod.completed? }
-            return success
+            return success, statuses
           else
             @output.puts "READY, starting stability test"
             @testing_for_stability = Time.now.to_i
@@ -117,7 +117,7 @@ module Kubernetes
         end
 
         sleep TICK
-        return statuses if cancelled?
+        return false, statuses if cancelled?
       end
     end
 
@@ -142,17 +142,8 @@ module Kubernetes
       end
     end
 
-    def show_logs_on_deploy_if_requested(release_docs)
-      pods = fetch_pods
-
-      # only pods who opted in
-      pods.select! { |p| p.annotations[:'samson/show_logs_on_deploy'] == 'true' }
-
-      # only pods from given roles
-      role_ids = release_docs.map(&:kubernetes_role_id)
-      pods.select! { |p| role_ids.include? p.role_id }
-
-      # print
+    def show_logs_on_deploy_if_requested(statuses)
+      pods = statuses.map(&:pod).compact.select { |p| p.annotations[:'samson/show_logs_on_deploy'] == 'true' }
       pods.each { |pod| print_pod_details(pod, Time.now, events: false) }
     rescue StandardError
       info = ErrorNotifier.notify($!, sync: true)
@@ -417,15 +408,15 @@ module Kubernetes
 
     def deploy_and_watch(release_docs, timeout)
       deploy(release_docs)
-      result = wait_for_resources_to_complete(release_docs, timeout)
-      if result == true
+      success, statuses = wait_for_resources_to_complete(release_docs, timeout)
+      if success == true
         if blue_green = release_docs.select(&:blue_green_color).presence
           finish_blue_green_deployment(blue_green)
         end
-        show_logs_on_deploy_if_requested(release_docs)
+        show_logs_on_deploy_if_requested(statuses)
         true
       else
-        show_failure_cause(release_docs, result)
+        show_failure_cause(release_docs, statuses)
         rollback(release_docs) if @job.deploy.kubernetes_rollback
         @output.puts "DONE"
         false

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -144,8 +144,11 @@ module Kubernetes
 
     def show_pods_logs_if_requested
       log_end_time = 0.seconds.from_now
+      @output.puts "\nXXX\n"
       pods = fetch_pods
       pods.each do |pod|
+        @output.puts "\nXXX: pod iter\n"
+        @output.puts "\n XXX: #{pod.annotations}\n"
         if pod.annotations[:'samson/show_logs_on_deploy'] == 'true'
           print_pod_logs(pod, log_end_time)
           @output.puts "\n------------------------------------------\n"

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -13,6 +13,9 @@ describe Kubernetes::Api::Pod do
         labels: {
           deploy_group_id: '123',
           role_id: '234',
+        },
+        annotations: {
+          'samson/show_logs_on_deploy': 'true'
         }
       },
       status: {
@@ -142,6 +145,12 @@ describe Kubernetes::Api::Pod do
   describe "#containers" do
     it 'reads' do
       pod.containers.first[:name].must_equal 'container1'
+    end
+  end
+
+  describe "#annotations" do
+    it 'reads' do
+      pod.annotations[:'samson/show_logs_on_deploy'].must_equal 'true'
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -13,9 +13,6 @@ describe Kubernetes::Api::Pod do
         labels: {
           deploy_group_id: '123',
           role_id: '234',
-        },
-        annotations: {
-          'samson/show_logs_on_deploy': 'true'
         }
       },
       status: {
@@ -149,8 +146,15 @@ describe Kubernetes::Api::Pod do
   end
 
   describe "#annotations" do
+    it 'creates when missing' do
+      pod.annotations.must_equal({})
+      pod.annotations[:x] = 1
+      pod.annotations.must_equal(x: 1)
+    end
+
     it 'reads' do
-      pod.annotations[:'samson/show_logs_on_deploy'].must_equal 'true'
+      pod_attributes[:metadata][:annotations] = {x: 1}
+      pod.annotations.must_equal x: 1
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -736,7 +736,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -765,7 +765,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -789,7 +789,7 @@ describe Kubernetes::DeployExecutor do
       executor.expects(:wait_for_resources_to_complete).returns([])
       executor.expects(:print_resource_events)
       executor.instance_variable_set(:@release, release)
-      refute executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
+      refute executor.send(:deploy_and_watch, release.release_docs, 60)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -272,7 +272,8 @@ describe Kubernetes::DeployExecutor do
           'apiVersion' => 'batch/v1',
           'spec' => {
             'template' => {
-              'metadata' => {'labels' => {'project' => 'foobar', 'role' => 'migrate'}},
+              'metadata' => {'labels' => {'project' => 'foobar', 'role' => 'migrate'},
+                             'annotations' => {'samson/show_logs_on_deploy' => 'true'}},
               'spec' => {
                 'containers' => [{'name' => 'job', 'image' => 'docker-registry.zende.sk/truth_service:latest'}],
                 'restartPolicy' => 'Never'
@@ -317,6 +318,13 @@ describe Kubernetes::DeployExecutor do
         out.must_include "stability" # testing deploy for stability
         out.must_include "deploying prerequisite" # announcing that we deploy prerequisites first
         out.must_include "other roles" # announcing that we have more to deploy
+      end
+
+      it "show logs after prerequisites deploys ends" do
+        assert execute, out
+        out.must_include "deploying prerequisite" # announcing that we deploy prerequisites
+        out.scan(/SUCCESS/).count.must_equal 2 # Nothing fails, so all deployments went fine
+        out.must_include "LOGS:" # and includes a "LOGS:" entry, so logs after prerequisites deploy are shown
       end
 
       it "fails when jobs fail" do

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -278,8 +278,7 @@ describe Kubernetes::DeployExecutor do
           'apiVersion' => 'batch/v1',
           'spec' => {
             'template' => {
-              'metadata' => {'labels' => {'project' => 'foobar', 'role' => 'migrate'},
-                             'annotations' => {'samson/show_logs_on_deploy' => 'true'}},
+              'metadata' => {'labels' => {'project' => 'foobar', 'role' => 'migrate'}},
               'spec' => {
                 'containers' => [{'name' => 'job', 'image' => 'docker-registry.zende.sk/truth_service:latest'}],
                 'restartPolicy' => 'Never'

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -728,7 +728,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs, 60)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -757,7 +757,7 @@ describe Kubernetes::DeployExecutor do
 
       executor.expects(:wait_for_resources_to_complete).returns(true)
       executor.instance_variable_set(:@release, release)
-      assert executor.send(:deploy_and_watch, release.release_docs, 60)
+      assert executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server
@@ -781,7 +781,7 @@ describe Kubernetes::DeployExecutor do
       executor.expects(:wait_for_resources_to_complete).returns([])
       executor.expects(:print_resource_events)
       executor.instance_variable_set(:@release, release)
-      refute executor.send(:deploy_and_watch, release.release_docs, 60)
+      refute executor.send(:deploy_and_watch, release.release_docs, 60, show_logs_if_requested: false)
 
       out.must_equal <<~OUT
         Deploying BLUE resources for Pod1 role app-server


### PR DESCRIPTION
this is meant for pre-requisite pods like migrations, but can also be useful when wanting to see what pods started up with

refactor of https://github.com/zendesk/samson/pull/3005

@zendesk/compute 