### PR TITLE
stream output for already finished deploys since they failed fast

### DIFF
--- a/test/channels/job_outputs_channel_test.rb
+++ b/test/channels/job_outputs_channel_test.rb
@@ -48,7 +48,7 @@ describe JobOutputsChannel do
   describe "#subscribed" do
     before do
       channel.stubs(:current_user).returns(user)
-      channel.params[:id] = "123"
+      channel.params[:id] = jobs(:succeeded_test).id
     end
 
     it "subscribes to self" do
@@ -59,8 +59,8 @@ describe JobOutputsChannel do
       maxitest_wait_for_extra_threads
     end
 
-    # TODO: should stream job output instead ?
-    it "noops when execution is finished" do
+    it "streams fake output when execution was already finished" do
+      channel.expects(:transmit).times(3) # start, message, finished
       channel.subscribed
     end
   end


### PR DESCRIPTION
rework of https://github.com/zendesk/samson/pull/2814

reproduction:
 - deploy a bad sha
 - it streams the output briefly and then goes into finished state

![oct-21-2018 10-34-39](https://user-images.githubusercontent.com/11367/47270198-f4f07500-d51c-11e8-919c-9791717fb500.gif)


@adammw 
/cc @zendesk/bre