### PR TITLE
Remove CGI escape from ref in GitHub check API call

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -71,7 +71,7 @@ class CommitStatus
   # transition to new API. See https://developer.github.com/v3/checks/runs/ and
   # https://developer.github.com/v3/checks/suites/ for details
   def github_check
-    base_url = "repos/#{@project.repository_path}/commits/#{CGI.escape(@reference)}"
+    base_url = "repos/#{@project.repository_path}/commits/#{@reference}"
     preview_header = {Accept: 'application/vnd.github.antiope-preview+json'}
 
     check_suites = GITHUB.get("#{base_url}/check-suites", headers: preview_header)[:check_suites]


### PR DESCRIPTION
Removes CGI escape which breaks the API call to GitHub's API. Turns out it actually expects branches with '/'s to keep them, for example:
```
https://api.github.com/repos/zendesk/explore_rails/commits/bboccara/chore/cleanup-bimeanalytics-references/check-runs
```
`combined_status` does the same thing:
```
https://api.github.com/repos/zendesk/explore_rails/commits/bboccara/chore/cleanup-bimeanalytics-references/status
```
/cc @zendesk/samson
