### PR TITLE
make streaming from pending deploys work

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -12,7 +12,7 @@ module DeploysHelper
   }.freeze
 
   def deploy_output
-    output = ActiveSupport::SafeBuffer.new
+    output = "".html_safe
 
     if JobQueue.enabled
       output << Samson::Hooks.render_views(:deploy_view, self, deploy: @deploy, project: @project)


### PR DESCRIPTION
by waiting until the execution is ready

fixes fallout from https://github.com/zendesk/samson/pull/3013
which declared the job done when it ran on a pending deploy

@zendesk/bre @adammw 