### PR TITLE
allow doing multiple deploys in a row that request previous builds

### DIFF
--- a/lib/samson/build_finder.rb
+++ b/lib/samson/build_finder.rb
@@ -91,7 +91,8 @@ module Samson
       commits = [@job.commit]
 
       if defined?(SamsonKubernetes) && @job.deploy.kubernetes_reuse_build
-        previous = @job.deploy.previous_deploy&.job&.commit
+        previous_scope = @job.deploy.stage.deploys.prior_to(@job.deploy).where(kubernetes_reuse_build: false)
+        previous = previous_scope.first&.job&.commit
         commits.unshift previous if previous
       end
 


### PR DESCRIPTION
previously we only looked at the previous deploys builds,
but when multiple deploys in a row want to use `previous builds` then
we need to find the first deploy in that stage that did not use the flag to find a deploy with an actual build

confirmed working in staging with a redeploy chain

@zendesk/compute 