### PR TITLE
allow static configuration to be a prerequisite

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -231,7 +231,7 @@ module Kubernetes
     def validate_prerequisites
       allowed = ["Job", "Pod"]
       bad = (@elements + templates).any? do |e|
-        e.dig(*RoleConfigFile::PREREQUISITE) && !allowed.include?(e[:kind])
+        e.dig(*RoleConfigFile::PREREQUISITE) && !allowed.include?(e[:kind]) && RoleConfigFile.primary?(e)
       end
       @errors << "Only elements with type #{allowed.join(", ")} can be prerequisites." if bad
     end

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -322,6 +322,12 @@ describe Kubernetes::RoleValidator do
         role.first[:kind] = "Deployment"
         errors.must_include "Only elements with type Job, Pod can be prerequisites."
       end
+
+      it "allows static configuration" do
+        role.first[:kind] = "ServiceAccount"
+        role.first[:spec].delete(:template)
+        refute errors
+      end
     end
 
     describe 'pod' do


### PR DESCRIPTION
/cc @zendesk/samson @zendesk/compute 

we needed serviceaccount live before deployment goes live
