### PR TITLE
show logs from init containers on 1.7+ clusters

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -181,13 +181,13 @@ module Kubernetes
     def print_pod_logs(pod, end_time)
       @output.puts "LOGS:"
 
-      containers = (pod.containers + pod.init_containers).map { |c| c.fetch(:name) }
-      containers.each do |container|
-        @output.puts "Container #{container}" if containers.size > 1
+      containers_names = (pod.containers + pod.init_containers).map { |c| c.fetch(:name) }.uniq
+      containers_names.each do |container_name|
+        @output.puts "Container #{container_name}" if containers_names.size > 1
 
         # Display the first and last n_lines of the log
         max = Integer(ENV['KUBERNETES_LOG_LINES'] || '50')
-        lines = (pod.logs(container, end_time) || "No logs found").split("\n")
+        lines = (pod.logs(container_name, end_time) || "No logs found").split("\n")
         lines = lines.first(max / 2) + ['...'] + lines.last(max / 2) if lines.size > max
         lines.each { |line| @output.puts "  #{line}" }
       end

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -512,9 +512,7 @@ module Kubernetes
     end
 
     def init_containers
-      @init_containers ||=
-        JSON.parse(pod_annotations[Kubernetes::Api::Pod::INIT_CONTAINER_KEY] || '[]', symbolize_names: true) +
-        (pod_template.dig(:spec, :initContainers) || [])
+      @init_containers ||= Api::Pod.init_containers(pod_template)
     end
 
     def containers

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -349,7 +349,12 @@ describe Kubernetes::Api::Pod do
       pod.init_containers.must_equal []
     end
 
-    it "finds init containers" do
+    it "finds modern json containers" do
+      pod_attributes[:spec][:initContainers] = [{foo: "bar"}]
+      pod.init_containers.must_equal [{foo: "bar"}]
+    end
+
+    it "finds old json containers" do
       pod_attributes[:metadata][:annotations] = {'pod.beta.kubernetes.io/init-containers': '[{"foo": "bar"}]'}
       pod.init_containers.must_equal [{foo: "bar"}]
     end


### PR DESCRIPTION
also unifies init container logic which caused this bug / https://github.com/zendesk/samson/pull/2616

@zendesk/compute 