### PR TITLE
allow filtering for limits that are on all projects or all scopes and…

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -17,7 +17,7 @@ class Environment < ActiveRecord::Base
   def self.env_deploy_group_array(include_all: true)
     all = include_all ? [["All", nil]] : []
     envs = Environment.all.map { |env| [env.name, "Environment-#{env.id}"] }
-    separator = [["----", nil]]
+    separator = [["----", "disabled", {disabled: true}]]
     deploy_groups = DeployGroup.all.sort_by(&:natural_order).map { |dg| [dg.name, "DeployGroup-#{dg.id}"] }
     all + envs + separator + deploy_groups
   end

--- a/plugins/kubernetes/app/views/kubernetes/usage_limits/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/usage_limits/index.html.erb
@@ -4,8 +4,8 @@
   <%= page_title "Kubernetes Limits" %>
 
   <%= search_form do %>
-    <%= search_select :project_id, [['All', '']] + @projects.map { |p| [p.name, p.id] }, live: true, size: 3 %>
-    <%= search_select :scope_type_and_id, @env_deploy_group_array, live: true, size: 3, label: "Scope" %>
+    <%= search_select :project_id, [['All', Kubernetes::UsageLimitsController::ALL]] + @projects.map { |p| [p.name, p.id] }, live: true, size: 3 %>
+    <%= search_select :scope_type_and_id, [['All', Kubernetes::UsageLimitsController::ALL]] + @env_deploy_group_array, live: true, size: 3, label: "Scope" %>
   <% end %>
 
   <br/>

--- a/plugins/kubernetes/test/controllers/kubernetes/usage_limits_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/usage_limits_controller_test.rb
@@ -41,9 +41,19 @@ describe Kubernetes::UsageLimitsController do
         assigns(:usage_limits).map(&:id).must_equal [usage_limit.id]
       end
 
+      it "can find limits that apply to all projects" do
+        get :index, params: {search: {project_id: 'all'}}
+        assigns(:usage_limits).map(&:id).must_equal [other.id]
+      end
+
       it "can find by scope" do
         get :index, params: {search: {scope_type_and_id: "#{usage_limit.scope_type}-#{usage_limit.scope_id}"}}
         assigns(:usage_limits).map(&:id).must_equal [usage_limit.id]
+      end
+
+      it "can find limits that apply to all scopes" do
+        get :index, params: {search: {scope_type_and_id: 'all'}}
+        assigns(:usage_limits).map(&:id).must_equal [other.id]
       end
     end
 

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -31,7 +31,7 @@ describe Environment do
           ["All", nil],
           ["Production", "Environment-X"],
           ["Staging", "Environment-X"],
-          ["----", nil],
+          ["----", "disabled"],
           ["Pod1", "DeployGroup-X"],
           ["Pod2", "DeployGroup-X"],
           ["Pod 100", "DeployGroup-X"]


### PR DESCRIPTION
… disable seperator

 - before "All" just showed all projects/scopes but not "where project is all"
 - searching for no scope would match the `----` option and show that which was ugly

@zendesk/bre @zendesk/compute 

<img width="712" alt="screen shot 2018-10-30 at 2 14 25 pm" src="https://user-images.githubusercontent.com/11367/47751281-8dd66d00-dc4e-11e8-9f47-f2d7fce764fd.png">
