### PR TITLE
Allow environment variables as include for env groups index

### DIFF
--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -8,7 +8,9 @@ class EnvironmentVariableGroupsController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render_as_json :environment_variable_groups, @groups
+        render_as_json :environment_variable_groups, @groups, allowed_includes: [
+          :environment_variables,
+        ]
       end
     end
   end

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -88,6 +88,13 @@ describe EnvironmentVariableGroupsController do
         first_group['name'].must_equal "G1"
         first_group['variable_names'].must_equal ["X", "Y"]
       end
+
+      it "renders with envionment_variables if present" do
+        get :index, params: {includes: "environment_variables", format: :json}
+        assert_response :success
+        project = JSON.parse(response.body)
+        project.keys.must_include "environment_variables"
+      end
     end
 
     describe "#show" do


### PR DESCRIPTION
Risks:
  - Low: not surfaced in UI, and only used in JSON responses

/cc @zendesk/samson