### PR TITLE
set resourceVersion for CustomResourceDefinition so it can update

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -259,6 +259,16 @@ module Kubernetes
       end
     end
 
+    # normally we don't want to set the resourceVersion since that causes conflicts when our version is out of date
+    # but some resources require it to be set or fail with "metadata.resourceVersion: must be specified for an update"
+    class VersionedUpdate < Base
+      def template_for_update
+        t = super
+        t[:metadata][:resourceVersion] = resource.dig(:metadata, :resourceVersion)
+        t
+      end
+    end
+
     class Service < Base
       private
 
@@ -453,7 +463,7 @@ module Kubernetes
     class APIService < Immutable
     end
 
-    class CustomResourceDefinition < Immutable
+    class CustomResourceDefinition < VersionedUpdate
     end
 
     def self.build(*args)

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -919,4 +919,18 @@ describe Kubernetes::Resource do
       end
     end
   end
+
+  describe Kubernetes::Resource::CustomResourceDefinition do
+    let(:kind) { 'CustomResourceDefinition' }
+    let(:api_version) { 'apiextensions.k8s.io/v1beta1' }
+
+    it "updates when resourceVersion so it does not fail" do
+      assert_request(:get, url, to_return: {body: {metadata: {resourceVersion: "123"}}.to_json}) do
+        args = ->(x) { x.body.must_include '"resourceVersion":"123"'; true }
+        assert_request(:put, url, to_return: {body: "{}"}, with: args) do
+          resource.deploy
+        end
+      end
+    end
+  end
 end

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -155,6 +155,12 @@ class ActiveSupport::TestCase
       "resources" => [
         {"name" => "apiservices", "namespaced" => true, "kind" => "APIService"}
       ]
+    },
+    "apiextensions.k8s.io/v1beta1" => {
+      "kind" => "APIResourceList",
+      "resources" => [
+        {"name" => "customresourcedefinitions", "namespaced" => true, "kind" => "CustomResourceDefinition"}
+      ]
     }
   }.freeze
 


### PR DESCRIPTION
previous create-delete workflow was causing all managed resoruces to get deleted too, not good :)
... now it will fail when user requests an impossible change and then the user has to manually delete / create via the "delete resource" checkbox

@zendesk/compute 