### PR TITLE
most new resources require a resourceVersion so make that the default

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -463,11 +463,8 @@ module Kubernetes
     class APIService < Immutable
     end
 
-    class CustomResourceDefinition < VersionedUpdate
-    end
-
     def self.build(*args)
-      klass = "Kubernetes::Resource::#{args.first.fetch(:kind)}".safe_constantize || Base
+      klass = "Kubernetes::Resource::#{args.first.fetch(:kind)}".safe_constantize || VersionedUpdate
       klass.new(*args)
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -72,9 +72,9 @@ describe Kubernetes::Resource do
       template_modified.must_equal restore_usages + 4
     end
 
-    it "falls back to using Base" do
+    it "falls back to using VersionedUpdate" do
       Kubernetes::Resource.build({kind: 'ConfigMap'}, deploy_group, autoscaled: false, delete_resource: false).
-        class.must_equal Kubernetes::Resource::Base
+        class.must_equal Kubernetes::Resource::VersionedUpdate
     end
 
     describe ".build" do
@@ -920,7 +920,7 @@ describe Kubernetes::Resource do
     end
   end
 
-  describe Kubernetes::Resource::CustomResourceDefinition do
+  describe Kubernetes::Resource::VersionedUpdate do
     let(:kind) { 'CustomResourceDefinition' }
     let(:api_version) { 'apiextensions.k8s.io/v1beta1' }
 


### PR DESCRIPTION
seeing `JobExecution failed: Kubernetes error  "example" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update`

opened https://github.com/kubernetes/kubernetes/issues/70674 to get a solution in the api, but doubt that will work out
`
@zendesk/compute 