### PR TITLE
Adding the minitest-reporters gem for better test reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ end
 
 group :test do
   gem 'minitest-rails'
+  gem 'minitest-reporters'
   gem 'rails-controller-testing'
   gem 'maxitest'
   gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
       airbrake-ruby (~> 2.0)
       rack
       railties (>= 5.0.0, < 5.3.0)
+    ansi (1.5.0)
     ansible (0.2.2)
     ar_multi_threaded_transactional_tests (0.3.0)
       activerecord (>= 4.2.0, < 5.3.0)
@@ -342,6 +343,11 @@ GEM
     minitest-rails (3.0.0)
       minitest (~> 5.8)
       railties (~> 5.0)
+    minitest-reporters (1.3.5)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mixlib-shellout (2.2.7)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
@@ -587,6 +593,7 @@ DEPENDENCIES
   marco-polo
   maxitest
   minitest-rails
+  minitest-reporters
   mocha
   momentjs-rails
   mysql2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,12 @@ ENV["RAILS_ENV"] = "test"
 
 require 'bundler/setup'
 
+#Better test reporting
+# https://github.com/kern/minitest-reporters
+# To use the progress reporter MINITEST_REPORTER=ProgressReporter rails test
+require "minitest/reporters"
+Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
+
 # anything loaded before coverage will be uncovered
 require 'single_cov'
 SingleCov::APP_FOLDERS << 'decorators' << 'presenters'


### PR DESCRIPTION
* This is a popular MiniTest companion gem [MiniTest-Reporter](https://github.com/kern/minitest-reporters)
* I am looking for better visibility and reporting of the tests being executed
* I configured the reporter to be the "DefaultReporter" producing the same output as standard MiniTest
* To change the reporter use a command like `MINITEST_REPORTER=ProgressReporter rails test` 
/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low