### PR TITLE
allow project admins to inline edit project commands

### DIFF
--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -91,7 +91,9 @@ class CommandsController < ApplicationController
       if action_name == 'create'
         [project_from_params]
       elsif action_name == 'update'
-        [project_from_params, @command.project]
+        projects = [@command.project]
+        projects << project_from_params if command_params.key?(:project_id) # when moving, need to be able to write both
+        projects
       else
         [@command.project]
       end

--- a/test/controllers/commands_controller_test.rb
+++ b/test/controllers/commands_controller_test.rb
@@ -85,7 +85,8 @@ describe CommandsController do
     end
 
     describe '#update' do
-      let(:params) { {id: commands(:echo).id, command: {command: 'echo hi', project_id: project.id}} }
+      let(:command) { commands(:echo) }
+      let(:params) { {id: command.id, command: {command: 'echo hi', project_id: project.id}} }
 
       it "can update html" do
         patch :update, params: params
@@ -102,6 +103,13 @@ describe CommandsController do
         params[:id] = commands(:global).id
         patch :update, params: params
         assert_response :unauthorized
+      end
+
+      it "can update when not changing project" do
+        params[:command].delete(:project_id)
+        patch :update, params: params
+        assert_response :redirect
+        command.reload.project.wont_be_nil
       end
 
       describe "moving projects" do


### PR DESCRIPTION
previously, the stage does not send project id when doing inline edits so controller assumes user wants to modify global command



/cc @zendesk/samson @zendesk/compute 


