### PR TITLE
Allow use GitHub for deployment environment variable 

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -388,6 +388,7 @@ ActiveRecord::Schema.define(version: 2018_10_09_022203) do
     t.boolean "show_gcr_vulnerabilities", default: false, null: false
     t.boolean "kubernetes_allow_writing_to_root_filesystem", default: false, null: false
     t.boolean "jenkins_status_checker", default: false, null: false
+    t.boolean "use_env_repo", default: false, null: false
     t.index ["build_command_id"], name: "index_projects_on_build_command_id"
     t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: 191
     t.index ["token"], name: "index_projects_on_token", unique: true, length: 191

--- a/plugins/env/README.md
+++ b/plugins/env/README.md
@@ -1,4 +1,35 @@
+## Env Plugin
 Plugin to manage ENV settings for projects and write .env files during deploy.
 
-Includes `/projects/:permalink/environment?deploy_group=permalink` endpoint that returns the .env content
+Includes `/projects/:permalink/environment?deploy_group=permalink` endpoint that returns the `.env` content
 for a project and deploy_group.
+
+## GitHub to manage environment variables
+This plugin has an option to use a GitHub repository as source for environment variables. 
+The DEPLOYMENT_ENV_REPO must be set in samson's start up. Each project must opt-in to it via project settings.
+
+The expected structure of this repository is a directory named `generated` with a sub directory for each 
+_project permalink_ samson deploys.  Within this directory for a project are the deploy group .env files using the name
+of the _deploy group permalink_ with a `.env` extension.  For a project with the permalink `data_processor` and 
+the deploy group permalinks `staging1`, `prod1` and `prod2` samson expects to see this directory tree:
+```bash
+# ls ./
+generated
+# ls generated/
+data_processor
+# ls generated/data_processor
+staging1.env  prod1.env  prod2.env
+```
+The contents of the `.env` file is a sequence of environment variable key and value pairs.
+```bash
+# cat generated/data_processor/staging1.env
+MAX_RETRY_ATTEMPTS=10
+SECRETE_TOKEN=/secrets/SECRET_TOKEN
+RAILS_THREAD_MIN=3
+RAILS_THREAD_MAX=5 
+```
+###### Merging enviroment variables stored in the database with those in the repo 
+The generated enviornment variables is the merger of deploy_group env variables, if the samson `deploy_group plugin` is 
+activated, the `project` environment variables in the samson database and the environment variables in the github `repo`.
+The order of precedence for variables with the same key name: `deploy_group` replaces `project` which replaces `repo` variables.
+

--- a/plugins/env/README.md
+++ b/plugins/env/README.md
@@ -13,16 +13,21 @@ _project permalink_ samson deploys.  Within this directory for a project are the
 of the _deploy group permalink_ with a `.env` extension.  For a project with the permalink `data_processor` and 
 the deploy group permalinks `staging1`, `prod1` and `prod2` samson expects to see this directory tree:
 ```bash
-# ls ./
-generated
-# ls generated/
-data_processor
-# ls generated/data_processor
-staging1.env  prod1.env  prod2.env
+.
+├── deploy_groups.yml
+├── generated
+│   └── fake_project
+│       ├── staging1.env
+│       ├── prod1.env
+│       └── prod2.env
+├── projects
+│   └── fake_project.env.erb
+└── shared
+    └── env_three.env.erb
 ```
 The contents of the `.env` file is a sequence of environment variable key and value pairs.
 ```bash
-# cat generated/data_processor/staging1.env
+# cat generated/fake_project/staging1.env
 MAX_RETRY_ATTEMPTS=10
 SECRETE_TOKEN=/secrets/SECRET_TOKEN
 RAILS_THREAD_MIN=3
@@ -32,4 +37,3 @@ RAILS_THREAD_MAX=5
 The generated enviornment variables is the merger of deploy_group env variables, if the samson `deploy_group plugin` is 
 activated, the `project` environment variables in the samson database and the environment variables in the github `repo`.
 The order of precedence for variables with the same key name: `deploy_group` replaces `project` which replaces `repo` variables.
-

--- a/plugins/env/app/views/samson_env/_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_fields.html.erb
@@ -1,8 +1,14 @@
 <fieldset>
   <legend>
-    Env variables written to the .env file or added to kubernetes before deploy
+    Environment Variables
     <%= additional_info SamsonEnv::HELP_TEXT %>
   </legend>
+
+  <% if ENV['DEPLOYMENT_ENV_REPO'] %>
+    <%= form.input :use_env_repo, label: "Use GitHub repository to manage deployment environment variables",
+                   as: :check_box
+    %>
+  <% end %>
 
   <% scopes = Environment.env_deploy_group_array %>
   <% sorted_env_vars = EnvironmentVariable.sort_by_scopes(form.object.environment_variables, scopes) %>

--- a/plugins/env/app/views/samson_env/_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_fields.html.erb
@@ -5,7 +5,7 @@
   </legend>
 
   <% if ENV['DEPLOYMENT_ENV_REPO'] %>
-    <%= form.input :use_env_repo, label: "Use GitHub repository to manage deployment environment variables",
+    <%= form.input :use_env_repo, label: "Use GitHub repository #{ENV['DEPLOYMENT_ENV_REPO']} to manage deployment environment variables",
                    as: :check_box
     %>
   <% end %>

--- a/plugins/env/db/migrate/20181023212711_add_use_env_repo_to_project.rb
+++ b/plugins/env/db/migrate/20181023212711_add_use_env_repo_to_project.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUseEnvRepoToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :use_env_repo, :boolean, default: false, null: false
+  end
+end

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -53,9 +53,13 @@ Samson::Hooks.view :deploy_confirmation_tab_nav, "samson_env/deploy_tab_nav"
 Samson::Hooks.view :deploy_confirmation_tab_body, "samson_env/deploy_tab_body"
 Samson::Hooks.view :deploy_tab_nav, "samson_env/deploy_tab_nav"
 Samson::Hooks.view :deploy_tab_body, "samson_env/deploy_tab_body"
-
 Samson::Hooks.callback :project_permitted_params do
-  AcceptsEnvironmentVariables::ASSIGNABLE_ATTRIBUTES.merge(environment_variable_group_ids: [])
+  [
+    AcceptsEnvironmentVariables::ASSIGNABLE_ATTRIBUTES.merge(
+      environment_variable_group_ids: []
+    ),
+    :use_env_repo
+  ]
 end
 
 Samson::Hooks.callback :after_deploy_setup do |dir, job|


### PR DESCRIPTION
* Adding the feature to allow using a GitHub repository to manage deployment environment variables.  It is a an optional feature to the Samson env plugin.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:[BRE-1033](https://zendesk.atlassian.net/browse/BRE-1033)

### Risks
- Level: Medium 
Its an optional feature for the samson server and is an optional feature for projects managed by Samson.