### PR TITLE
rescue harder to make it not blow up migrations

### DIFF
--- a/db/migrate/20181111003546_remove_binary_builder.rb
+++ b/db/migrate/20181111003546_remove_binary_builder.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 class RemoveBinaryBuilder < ActiveRecord::Migration[5.2]
+  class Stage < ActiveRecord::Base
+  end
+
   def change
-    remove_column :stages, :docker_binary_plugin_enabled
-  rescue StandardError # rubocop:disable Lint/HandleExceptions
-    # user might have never installed the plugin
+    # postgres cannot rescue aleter statements, so we need to be sure the up migration for this ran
+    if Stage.column_names.include? 'docker_binary_plugin_enabled'
+      remove_column :stages, :docker_binary_plugin_enabled
+    end
   end
 end


### PR DESCRIPTION
fixes issue on https://github.com/zendesk/samson/pull/1889

@esselius can you provide more details on what the exception was exactly ?

PG::InFailedSqlTransaction