### PR TITLE
set lazy image-pull policy when we use a digest, which is always cach…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -368,6 +368,7 @@ module Kubernetes
         build = Samson::BuildFinder.detect_build_by_selector!(builds, *build_selector,
           fail: true, project: project)
         container[:image] = build.docker_repo_digest
+        container[:imagePullPolicy] = 'IfNotPresent' if container[:imagePullPolicy] == 'Always'
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -374,6 +374,11 @@ describe Kubernetes::TemplateFiller do
           )
         end
 
+        it "overrides Always imagePullPolicy since it does not make sense and slows us down" do
+          add_init_container imagePullPolicy: 'Always'
+          init_containers[0]["imagePullPolicy"].must_equal "IfNotPresent"
+        end
+
         describe "when project does not build images" do
           before do
             project.docker_image_building_disabled = true


### PR DESCRIPTION
…eable

@zendesk/compute 