### PR TITLE
PAAS-2466 do not expect pods for cronjobs since they run randomly and…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -450,6 +450,12 @@ module Kubernetes
       end
     end
 
+    class CronJob < VersionedUpdate
+      def desired_pod_count
+        0 # we don't know when it will run
+      end
+    end
+
     class Pod < Immutable
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -743,6 +743,17 @@ describe Kubernetes::Resource do
     end
   end
 
+  describe Kubernetes::Resource::CronJob do
+    let(:kind) { 'CronJob' }
+    let(:api_version) { 'batch/v1' }
+
+    describe "#desired_pod_count" do
+      it "is 0 since we do not know when it will run" do
+        resource.desired_pod_count.must_equal 0
+      end
+    end
+  end
+
   describe Kubernetes::Resource::Service do
     let(:api_version) { 'v1' }
     let(:kind) { 'Service' }


### PR DESCRIPTION
… might have no pods when deployed

@zendesk/compute