### PR TITLE
add missing migration number

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_09_022203) do
+ActiveRecord::Schema.define(version: 2018_10_23_212711) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/3054

fallout from https://github.com/zendesk/samson/pull/3043 which added a column but did not bump the schema number
@bcolferzd 