### PR TITLE
Fix pending migration error in docker-compose up

### DIFF
--- a/script/docker_dev_server
+++ b/script/docker_dev_server
@@ -9,9 +9,9 @@ if [ ! -f .env ]; then
 fi
 
 if [ -f db/development.sqlite3 ]; then
-    bundle exec rake db:migrate
+    bundle exec rake db:migrate 
 else
-    bundle exec rake db:setup
+    bundle exec rake db:setup || bundle exec rake db:migrate
 fi
 
 exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
This commit fixes the "You have x pending migration:"  error when executing docker-compose up for the first time.

How to reproduce?
clone the repo 
docker-compose up 

sample error message
```
samson_1_d3b74ca294d3 | You have 1 pending migration:
samson_1_d3b74ca294d3 |   20181111003546 RemoveBinaryBuilder

```

* Add description here
* Add any screenshots if you are touching the UI
* Remember to add unit tests

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
