### PR TITLE
Allow configuration of the Kubernets stability check duration

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -133,6 +133,11 @@ using KUBERNETES_WAIT_FOR_PREREQUISITES env variable (specified in seconds).
 A deploy will wait for 10 minutes for pods to come alive. You can adjust this
 timeout using KUBERNETES_WAIT_FOR_LIVE (specified in seconds).
 
+### Deployment stability check
+
+A deploy will get checked for stability every 2 seconds for a minute, before being marked as stable.
+These can be configured (in seconds) using `KUBERNETES_STABILITY_CHECK_DURATION` and `KUBERNETES_STABILITY_CHECK_TICK` environment variables.
+
 ### StatefulSet
 
 On kubernetes <1.7 they can only be updated with `OnDelete` updateStrategy,

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -10,8 +10,8 @@ module Kubernetes
     end
     WAIT_FOR_LIVE = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_LIVE', '600'))
     WAIT_FOR_PREREQUISITES = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_PREREQUISITES', WAIT_FOR_LIVE))
-    STABILITY_CHECK_DURATION = 1.minute
-    TICK = 2.seconds
+    STABILITY_CHECK_DURATION = Integer(ENV.fetch('KUBERNETES_STABILITY_CHECK_DURATION', 1.minute))
+    TICK = Integer(ENV.fetch('KUBERNETES_STABILITY_CHECK_TICK', 2.seconds))
     RESTARTED = "Restarted"
 
     # TODO: this logic might be able to go directly into Pod, which would simplify the code here a bit


### PR DESCRIPTION
Allow configuration of the `STABILITY_CHECK_DURATION` via env variables

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
