### PR TITLE
allow booting docker-compose when schema in image is not up-to-date

### DIFF
--- a/script/docker_dev_server
+++ b/script/docker_dev_server
@@ -11,7 +11,8 @@ fi
 if [ -f db/development.sqlite3 ]; then
     bundle exec rake db:migrate
 else
-    bundle exec rake db:setup db:migrate
+    # NOTE: db:setup fails when schema is not up to date, so we need to do the create+load instead
+    bundle exec rake db:create db:schema:load db:migrate
 fi
 
 exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
to reproduce make sure to delete config/database.yml and rm db/development.sqlite3

replaces https://github.com/zendesk/samson/pull/3057 and finally solves https://github.com/zendesk/samson/issues/3054

@zendesk/bre @shyamjos 