### PR TITLE
do not fail jenkins when any comitter/user had no email

### DIFF
--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -249,6 +249,7 @@ module Samson
         emails.concat(deploy.changeset.commits.map(&:author_email))
       end
 
+      emails.compact!
       emails.select! { |e| e.include?('@') }
       emails.map! { |x| Mail::Address.new(x) }
       if restricted_domain = ENV["EMAIL_DOMAIN"]


### PR DESCRIPTION
was browsing rollbar for sth else and saw this ...
```
NoMethodError: undefined method `include?' for nil:NilClass
1
File "plugins/jenkins/app/models/samson/jenkins.rb" line 252 in block in notify_emails
```

@zendesk/compute 