### PR TITLE
send along the original exception when mkdir seems to make sure we do…

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -277,8 +277,8 @@ class JobExecution
     Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}") do |dir|
       result = yield dir
     end
-  rescue Errno::ENOTEMPTY, Errno::ENOENT
-    ErrorNotifier.notify("Notify: make_tempdir error #{$!.message.split('@').first}")
+  rescue Errno::ENOTEMPTY, Errno::ENOENT => e
+    ErrorNotifier.notify(e, message: "Notify: make_tempdir error")
     result # tempdir ensure sometimes fails ... not sure why ... return normally
   ensure
     @repository.prune_worktree

--- a/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
+++ b/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
@@ -10,8 +10,9 @@ end
 
 Samson::Hooks.callback :error do |exception, options|
   sync = options[:sync]
-  options = options.without(:sync)
-  data = Rollbar.error(exception, options)
+  message = options[:message]
+  options = options.without(:sync, :message)
+  data = Rollbar.error(exception, message, options)
 
   if sync
     Rollbar::Util.uuid_rollbar_url(data, Rollbar.configuration) if data.is_a?(Hash)

--- a/plugins/rollbar/test/samson_rollbar/samson_plugin_test.rb
+++ b/plugins/rollbar/test/samson_rollbar/samson_plugin_test.rb
@@ -11,13 +11,18 @@ describe SamsonRollbar do
     around { |t| Samson::Hooks.only_callbacks_for_plugin('rollbar', :error, &t) }
 
     it 'reports error' do
-      Rollbar.expects(:error).with(exception, foo: 'bar').returns(123)
+      Rollbar.expects(:error).with(exception, nil, foo: 'bar').returns(123)
       Samson::Hooks.fire(:error, exception, foo: 'bar').must_equal [123]
+    end
+
+    it "can override display message" do
+      Rollbar.expects(:error).with(exception, "hello", foo: 'bar').returns(123)
+      Samson::Hooks.fire(:error, exception, foo: 'bar', message: "hello").must_equal [123]
     end
 
     describe "with sync" do
       it 'returns url' do
-        Rollbar.expects(:error).with(exception, foo: 'bar').returns(uuid: '123')
+        Rollbar.expects(:error).with(exception, nil, foo: 'bar').returns(uuid: '123')
         Samson::Hooks.fire(:error, exception, foo: 'bar', sync: true).must_equal(
           ["https://rollbar.com/instance/uuid?uuid=123"]
         )


### PR DESCRIPTION
… not swallow other bugs

saw some deploy failing with mktmpdir but nothing else, my guess is it just got swallowed

@zendesk/bre @adammw 