### PR TITLE
stop thread naturally when user unsubscribes instead of risking a bad…

### DIFF
--- a/test/channels/job_outputs_channel_test.rb
+++ b/test/channels/job_outputs_channel_test.rb
@@ -79,6 +79,12 @@ describe JobOutputsChannel do
       job.update_column(:status, 'succeeded')
       maxitest_wait_for_extra_threads
     end
+
+    it "stops when user unsubscribes" do
+      channel.unsubscribed
+      channel.subscribed
+      maxitest_wait_for_extra_threads
+    end
   end
 
   describe "#unsubscribed" do


### PR DESCRIPTION
… db connection by killing the thread

@zendesk/bre 