### PR TITLE
simplify cancel logic to use exceptions

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -77,7 +77,7 @@ class Job < ActiveRecord::Base
     update_attribute(:canceller, canceller) unless self.canceller
 
     if ex
-      ex.cancel # switches job status in the runner thread for consistent status in after_deploy hooks
+      JobQueue.cancel(id) # switches job status in the runner thread for consistent status in after_deploy hooks
     else
       cancelled!
     end

--- a/plugins/gcloud/test/samson_gcloud/image_builder_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/image_builder_test.rb
@@ -119,7 +119,7 @@ describe SamsonGcloud::ImageBuilder do
 
     it "uses executor timeout" do
       executor.expects(:execute).with do |*commands|
-        commands.join.must_include("--timeout 7200")
+        commands.join.must_include("--timeout 5")
       end.returns(true)
       build_image
     end

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -201,7 +201,7 @@ describe DeployService do
         DeployMailer.expects(bypass_email: stub(deliver_now: true))
         deploy.buddy = user
         service.confirm_deploy(deploy)
-        job_execution.send(:run)
+        job_execution.perform
       end
     end
   end
@@ -220,7 +220,7 @@ describe DeployService do
     it "sends before_deploy hook" do
       record_hooks(:before_deploy) do
         service.deploy(stage, reference: reference)
-        job_execution.send(:run)
+        job_execution.perform
       end.map(&:first).must_equal [deploy]
     end
   end
@@ -228,7 +228,7 @@ describe DeployService do
   describe "finish callbacks" do
     def run_deploy
       service.deploy(stage, reference: reference)
-      job_execution.send(:run)
+      job_execution.perform
     end
 
     before do
@@ -275,7 +275,7 @@ describe DeployService do
       def run_deploy(redeploy)
         service.deploy(stage, reference: reference)
         service.expects(:deploy).capture(deploy_args).times(redeploy ? 1 : 0).returns(deploy) # stub to avoid loops
-        job_execution.send(:run)
+        job_execution.perform
       end
 
       let(:deploy_args) { [] }

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -264,12 +264,17 @@ describe Job do
     with_full_job_execution
 
     it "cancels an executing job" do
+      # get the job running
       ex = JobExecution.new('master', job) { sleep 10 }
       JobQueue.perform_later(ex)
       sleep 0.1 # make the job spin up properly
-
       assert JobQueue.executing?(ex.id)
+
+      # cancel it
       job.cancel(user)
+      maxitest_wait_for_extra_threads
+
+      # it is cancelled ?
       assert job.cancelled? # job execution callbacks sets it to cancelled
       job.canceller.must_equal user
     end
@@ -302,6 +307,7 @@ describe Job do
 
       job.cancel(user)
       executing_job.cancel(user)
+      maxitest_wait_for_extra_threads
 
       assert job.cancelled?
       refute JobQueue.queued?(job.id)


### PR DESCRIPTION
this makes everything more serial and less "threads that work in parallel to do stuff"
also removes all the cancellation logic that @adammw pointed out as being 💩 

@zendesk/bre @zendesk/compute 