### PR TITLE
plugins/kubernetes: Add env var to never add a preStop

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -181,6 +181,8 @@ To override it, set the namespace to either `default` or `kube-system` and set `
 
 ### Preventing request loss with preStop
 
+To enable the following functionality you need to set `KUBERNETES_ADD_PRESTOP=true`.
+
 Samson automatically adds `container[].lifecycle.preStop` `sleep 3` if a preStop hook is not set and
 `container[].samson/preStop` is not set to `disabled`, to prevent in-flight requests from getting lost when taking a pod
 out of rotation (alternatively set `metadata.annoations.container-nameofcontainer-samson/preStop: disabled`).

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -6,6 +6,7 @@ module Kubernetes
 
     CUSTOM_UNIQUE_LABEL_KEY = 'rc_unique_identifier'
     SECRET_PULLER_IMAGE = ENV['SECRET_PULLER_IMAGE'].presence
+    KUBERNETES_ADD_PRESTOP = !!(ENV.fetch('KUBERNETES_ADD_PRESTOP', false))
     SECRET_PREFIX = "secret/"
 
     def initialize(release_doc, template, index:)
@@ -509,6 +510,7 @@ module Kubernetes
     end
 
     def set_pre_stop
+      return if ! KUBERNETES_ADD_PRESTOP
       containers.each do |container|
         next if samson_container_config(container, :"samson/preStop") == "disabled"
         (container[:lifecycle] ||= {})[:preStop] ||= {exec: {command: ["sleep", "3"]}}

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -6,7 +6,7 @@ module Kubernetes
 
     CUSTOM_UNIQUE_LABEL_KEY = 'rc_unique_identifier'
     SECRET_PULLER_IMAGE = ENV['SECRET_PULLER_IMAGE'].presence
-    KUBERNETES_ADD_PRESTOP = !!(ENV.fetch('KUBERNETES_ADD_PRESTOP', false))
+    KUBERNETES_ADD_PRESTOP = ENV['KUBERNETES_ADD_PRESTOP'] == 'true'
     SECRET_PREFIX = "secret/"
 
     def initialize(release_doc, template, index:)

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -510,7 +510,7 @@ module Kubernetes
     end
 
     def set_pre_stop
-      return if ! KUBERNETES_ADD_PRESTOP
+      return unless KUBERNETES_ADD_PRESTOP
       containers.each do |container|
         next if samson_container_config(container, :"samson/preStop") == "disabled"
         (container[:lifecycle] ||= {})[:preStop] ||= {exec: {command: ["sleep", "3"]}}

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -755,6 +755,15 @@ describe Kubernetes::TemplateFiller do
         raw_template.dig_fetch(:spec, :template, :spec, :containers, 0)[:"samson/preStop"] = "disabled"
         refute template.to_hash.dig_fetch(:spec, :template, :spec, :containers, 0).key?(:lifecycle)
       end
+
+      around do |test|
+        stub_const Kubernetes::TemplateFiller, :KUBERNETES_ADD_PRESTOP, false, &test
+      end
+
+      it "does not add preStop when it is disabled to all" do
+        refute template.to_hash.dig_fetch(:spec, :template, :spec, :containers, 0).key?(:lifecycle)
+      end
+
     end
 
     describe "HorizontalPodAutoscaler" do


### PR DESCRIPTION
* Add env variable to disable preStop injection in kubernetes plugin

Relates to #3080

The reason is the one explained in the bug: it's TOO much to modify all yamls to add this annotation. Just having an option to change the default is way more easy for us.  What do you think? Does it make sense? 

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low