### PR TITLE
do not crash on rm_rf when Dir.mktmpdir was interrupted and did not r…

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -264,7 +264,9 @@ class JobExecution
     dir = Dir.mktmpdir("samson-#{@job.project.permalink}-#{@job.id}")
     yield dir
   ensure
-    FileUtils.rm_rf dir # mktmpdir with block often raised errors when tempfolder got removed early
-    @repository.prune_worktree
+    if dir
+      FileUtils.rm_rf dir # mktmpdir with block often raised errors when tempfolder got removed early
+      @repository.prune_worktree
+    end
   end
 end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -462,6 +462,11 @@ describe JobExecution do
       end.must_equal 111
     end
 
+    it "does not crash when mktmpdir was interrupted" do
+      Dir.expects(:mktmpdir).raises ArgumentError
+      assert_raises(ArgumentError) { execution.send(:make_tempdir) }
+    end
+
     it "removes deleted worktrees" do
       project.repository.unstub(:prune_worktree)
       before = `cd #{project.repository.repo_cache_dir} && git worktree list`


### PR DESCRIPTION
…eturn a dir

```
ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:1456:in `path': ErrorNotifier caught exception: no implicit conversion of nil into String. Use ErrorNotifier.expects(:notify) to silence in tests (RuntimeError)
  from ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:572:in `rm_rf'
  from app/models/job_execution.rb:267:in `ensure in make_tempdir'
```

@zendesk/bre 