### PR TITLE
allow some percentage of failed pods so big deployments do not random…

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -211,3 +211,8 @@ Use an annotation to configure what will to be replaced:
 metadata.annotations.samson/set_via_env_json-metadata.labels.custom: SOME_ENV_VAR
 ```
 Then configure an ENV var with that same name and a value that is valid JSON.
+
+### Allow randomly not-ready pods during redines check
+
+Set `KUBERNETES_ALLOW_NOT_READY_PERCENT=10` to allow up to 10% of pods being not-ready,
+this is useful when dealing with large deployments that have some random failures.

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -675,6 +675,26 @@ describe Kubernetes::DeployExecutor do
     end
   end
 
+  describe "#allowed_not_ready" do
+    let(:log_string) { "Ignored" }
+
+    it "allows none when percent is not set" do
+      executor.send(:allowed_not_ready, 10).must_equal 0
+    end
+
+    it "allows given percentage" do
+      with_env KUBERNETES_ALLOW_NOT_READY_PERCENT: "30" do
+        executor.send(:allowed_not_ready, 10).must_equal 3
+      end
+    end
+
+    it "does not blow up on 0" do
+      with_env KUBERNETES_ALLOW_NOT_READY_PERCENT: "50" do
+        executor.send(:allowed_not_ready, 0).must_equal 0
+      end
+    end
+  end
+
   describe "blue green" do
     def add_service_to_release_doc
       kubernetes_fake_raw_template


### PR DESCRIPTION
…ly fail

@zendesk/compute 

```
[19:44:59] Now deploying other roles ...
[19:44:59] Deploying GroupK role server
[19:44:59] Waiting for pods to be created
[19:44:59] Ignored 1 notready pods
[19:44:59] Deploy status:
[19:44:59]   GroupK server: Missing
[19:44:59] SUCCESS
```