### PR TITLE
Display build record validation errors

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -2,7 +2,7 @@
 class Build < ActiveRecord::Base
   SHA1_REGEX = /\A[0-9a-f]{40}\Z/i
   SHA256_REGEX = /\A(sha256:)?[0-9a-f]{64}\Z/i
-  DIGEST_REGEX = /\A[\w.-]+[\w.-]*(:\d+)?[\w\/-]*@sha256:[0-9a-f]{64}\Z/i
+  DIGEST_REGEX = /\A[\w.-]+[\w.-]*(:\d+)?[\w.\/-]*@sha256:[0-9a-f]{64}\Z/i
 
   belongs_to :project
   belongs_to :docker_build_job, class_name: 'Job', optional: true

--- a/plugins/gcloud/app/controllers/gcloud_controller.rb
+++ b/plugins/gcloud/app/controllers/gcloud_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 class GcloudController < ApplicationController
-  class GcloudCommandError < StandardError; end
-
   STATUSMAP = {
     "SUCCESS" => "succeeded",
     "QUEUED" => "pending",
@@ -17,7 +15,7 @@ class GcloudController < ApplicationController
     path = [build.project, build]
 
     if (error = update_build(build))
-      redirect_to path, alert: "Failed to sync: #{e}"
+      redirect_to path, alert: "Failed to sync: #{error}"
     else
       redirect_to path, notice: "Synced!"
     end

--- a/plugins/gcloud/app/controllers/gcloud_controller.rb
+++ b/plugins/gcloud/app/controllers/gcloud_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class GcloudController < ApplicationController
+  class GcloudCommandError < StandardError; end
+
   STATUSMAP = {
     "SUCCESS" => "succeeded",
     "QUEUED" => "pending",
@@ -14,8 +16,8 @@ class GcloudController < ApplicationController
     build = Build.find(params[:id])
     path = [build.project, build]
 
-    if error = update_build(build)
-      redirect_to path, alert: "Failed to sync: #{error}"
+    if (error = update_build(build))
+      redirect_to path, alert: "Failed to sync: #{e}"
     else
       redirect_to path, notice: "Synced!"
     end
@@ -44,7 +46,7 @@ class GcloudController < ApplicationController
       end
     end
 
-    build.save!
+    return "Failed to save build #{build.errors.full_messages}" unless build.save
     nil
   end
 end

--- a/plugins/gcloud/test/controllers/gcloud_controller_test.rb
+++ b/plugins/gcloud/test/controllers/gcloud_controller_test.rb
@@ -51,6 +51,19 @@ describe GcloudController do
         assert flash[:alert]
       end
 
+      describe "with invalid image name" do
+        let(:image_name) { "gcr.io/foo*baz+bing/#{build.image_name}" }
+
+        it "fails when digest does not pass validations" do
+          Samson::CommandExecutor.expects(:execute).returns([true, result.to_json])
+
+          do_sync
+
+          assert flash[:alert]
+          build.reload.docker_repo_digest.wont_equal repo_digest
+        end
+      end
+
       it "fails when image is not found" do
         result[:results][:images].last[:name] = "gcr.io/other"
         Samson::CommandExecutor.expects(:execute).returns([true, result.to_json])


### PR DESCRIPTION
Display build record validation errors

Also fix an issue where builds with periods in the folder name would not work due to failed regex match, e.g. `	
gcr.io/docker-images-180022/github.com/zendesk/consul:b04f39140a9aaf9685462584f5041b4e64f210b9`

/cc @zendesk/samson 

### Tasks
 - [x] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
