### PR TITLE
Fix spelling in help txt string

### DIFF
--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module SamsonEnv
   HELP_TEXT = "$VAR / ${VAR} replacements supported. Priority is DeployGroup, Environment, All. " \
-    "Secrets can be used with secret://key_of_secrect."
+    "Secrets can be used with secret://key_of_secret."
 
   class Engine < Rails::Engine
   end


### PR DESCRIPTION
Simple spelling fix

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: `N/A`

### Risks
- **Level:** Low, just changes spelling in a string
