### PR TITLE
PAAS-1240 allow ignoring roles from kubernetes stages

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -271,6 +271,12 @@ ActiveRecord::Schema.define(version: 2019_02_06_191721) do
     t.index ["service_name", "deleted_at"], name: "index_kubernetes_roles_on_service_name_and_deleted_at", unique: true, length: { service_name: 191 }
   end
 
+  create_table "kubernetes_stage_roles" do |t|
+    t.integer "stage_id", null: false
+    t.integer "kubernetes_role_id", null: false
+    t.boolean "ignored", default: false, null: false
+  end
+
   create_table "kubernetes_usage_limits" do |t|
     t.integer "project_id"
     t.integer "scope_id"

--- a/plugins/kubernetes/app/decorators/stage_decorator.rb
+++ b/plugins/kubernetes/app/decorators/stage_decorator.rb
@@ -6,6 +6,11 @@ Stage.class_eval do
   after_create :seed_kubernetes_roles
   validate :validate_not_using_non_kubernetes_rollback, if: :kubernetes?
 
+  has_many :kubernetes_roles, class_name: "Kubernetes::StageRole", dependent: :destroy
+  accepts_nested_attributes_for :kubernetes_roles,
+    allow_destroy: true,
+    reject_if: ->(a) { a[:kubernetes_role_id].blank? }
+
   private
 
   def validate_deploy_groups_have_a_cluster

--- a/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
@@ -25,11 +25,12 @@ module Kubernetes
 
     # The matrix is a list of deploy group and its roles + deploy-group-roles
     def self.matrix(stage)
+      ignored_role_ids = stage.kubernetes_roles.where(ignored: true).pluck(:kubernetes_role_id)
       project_dg_roles = Kubernetes::DeployGroupRole.where(
         project_id: stage.project_id,
         deploy_group_id: stage.deploy_groups.map(&:id)
-      ).to_a
-      roles = stage.project.kubernetes_roles.not_deleted.sort_by(&:name)
+      ).where.not(kubernetes_role_id: ignored_role_ids).to_a
+      roles = stage.project.kubernetes_roles.where.not(id: ignored_role_ids).not_deleted.sort_by(&:name)
 
       stage.deploy_groups.sort_by(&:natural_order).map do |deploy_group|
         dg_roles = project_dg_roles.select { |r| r.deploy_group_id == deploy_group.id }

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -34,6 +34,10 @@ module Kubernetes
       class_name: 'Kubernetes::DeployGroupRole',
       foreign_key: :kubernetes_role_id,
       dependent: :destroy
+    has_many :stage_roles,
+      class_name: "Kubernetes::StageRole",
+      foreign_key: :kubernetes_role_id,
+      dependent: :destroy
 
     before_validation :nilify_service_name
     before_validation :strip_config_file

--- a/plugins/kubernetes/app/models/kubernetes/stage_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/stage_role.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Kubernetes
+  class StageRole < ActiveRecord::Base
+    self.table_name = 'kubernetes_stage_roles'
+
+    belongs_to :kubernetes_role, class_name: 'Kubernetes::Role'
+    belongs_to :stage
+  end
+end

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
@@ -1,6 +1,32 @@
 <fieldset>
   <legend>Kubernetes</legend>
   <%= form.input :kubernetes, as: :check_box, label: "Deploy via kubernetes / ignore commands" %>
+
+  <h3>Roles to ignore</h3>
+  <% @stage.kubernetes_roles.build %>
+  <% roles = @project.kubernetes_roles.not_deleted.pluck(:name, :id).unshift ["", nil] %>
+  <%= form.fields_for :kubernetes_roles, @stage.kubernetes_roles do |fields| %>
+    <div class="form-group">
+      <div class="col-lg-3">
+        <%= fields.select :kubernetes_role_id, roles, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
+      </div>
+
+      <div class="col-lg-2">
+        <%= fields.input :ignored, as: :check_box %>
+      </div>
+
+      <% if fields.object.persisted? %>
+        <div class="col-lg-1 checkbox">
+          <%= fields.label :_destroy do %>
+            <%= fields.check_box :_destroy %>
+            Delete
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= link_to "Add row", "#", class: "duplicate_previous_row" %>
 </fieldset>
 
 <script>

--- a/plugins/kubernetes/db/migrate/20190109161216_add_kubernetes_stage_roles.rb
+++ b/plugins/kubernetes/db/migrate/20190109161216_add_kubernetes_stage_roles.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddKubernetesStageRoles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :kubernetes_stage_roles do |t|
+      t.column :stage_id, :integer, null: false
+      t.column :kubernetes_role_id, :integer, null: false
+      t.column :ignored, :boolean, null: false, default: false
+    end
+  end
+end

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -36,7 +36,12 @@ Samson::Hooks.view :deploy_group_table_cell, "samson_kubernetes/deploy_group_tab
 Samson::Hooks.callback :deploy_group_permitted_params do
   {cluster_deploy_group_attributes: [:kubernetes_cluster_id, :namespace]}
 end
-Samson::Hooks.callback(:stage_permitted_params) { :kubernetes }
+Samson::Hooks.callback(:stage_permitted_params) do
+  [
+    :kubernetes,
+    {kubernetes_roles_attributes: [:kubernetes_role_id, :ignored, :_destroy, :id]}
+  ]
+end
 Samson::Hooks.callback(:deploy_permitted_params) { [:kubernetes_rollback, :kubernetes_reuse_build] }
 Samson::Hooks.callback(:link_parts_for_resource) do
   [

--- a/plugins/kubernetes/test/decorators/stage_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/stage_decorator_test.rb
@@ -36,6 +36,22 @@ describe Stage do
     end
   end
 
+  describe "#kubernetes_roles" do
+    it "accepts attributes" do
+      stage = Stage.new(
+        kubernetes_roles_attributes: {0 => {kubernetes_role_id: kubernetes_roles(:app_server).id, ignored: true}}
+      )
+      stage.kubernetes_roles.size.must_equal 1
+    end
+
+    it "ignores blank attributes" do
+      stage = Stage.new(
+        kubernetes_roles_attributes: {0 => {kubernetes_role_id: "", ignored: true}}
+      )
+      stage.kubernetes_roles.size.must_equal 0
+    end
+  end
+
   describe "#seed_kubernetes_roles" do
     let(:stage) do
       stage = stages(:test_staging).dup

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -167,7 +167,7 @@ describe Kubernetes::DeployExecutor do
     end
 
     it "does limited amounts of queries" do
-      assert_sql_queries(27) do
+      assert_sql_queries(28) do
         assert execute, out
       end
     end
@@ -249,13 +249,22 @@ describe Kubernetes::DeployExecutor do
         doc.limits_memory.must_equal config.limits_memory
       end
 
-      it "fails when role config is missing" do
-        worker_role.delete
-        e = assert_raises(Samson::Hooks::UserError) { execute }
-        e.message.must_equal(
-          "Role resque-worker for Pod 100 is not configured, but in repo at #{commit}. " \
+      describe "with missing role" do
+        before { worker_role.delete }
+
+        it "fails" do
+          e = assert_raises(Samson::Hooks::UserError) { execute }
+          e.message.must_equal(
+            "Role resque-worker for Pod 100 is not configured, but in repo at #{commit}. " \
           "Remove it from the repo or configure it via the stage page."
-        )
+          )
+        end
+
+        it "passes when ignored" do
+          stage.kubernetes_roles.create!(kubernetes_role: worker_role.kubernetes_role, ignored: true)
+          execute
+          out.must_include "SUCCESS"
+        end
       end
 
       it "fails when no role is setup in the project" do

--- a/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
@@ -99,6 +99,18 @@ describe Kubernetes::DeployGroupRole do
         ]]
       )
     end
+
+    it "ignores stage-roles that are ignored" do
+      stage.kubernetes_roles.create!(kubernetes_role: kubernetes_roles(:resque_worker), ignored: true)
+      Kubernetes::DeployGroupRole.matrix(stage).must_equal(
+        [[
+          stage.deploy_groups.first,
+          [
+            [kubernetes_roles(:app_server), kubernetes_deploy_group_roles(:test_pod100_app_server)]
+          ]
+        ]]
+      )
+    end
   end
 
   describe ".usage" do

--- a/plugins/kubernetes/test/models/kubernetes/stage_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/stage_role_test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require_relative "../../test_helper"
+
+SingleCov.covered!
+
+describe Kubernetes::StageRole do
+end

--- a/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
+++ b/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
@@ -7,13 +7,13 @@ SingleCov.covered!
 describe SamsonKubernetes do
   describe :stage_permitted_params do
     it "adds ours" do
-      Samson::Hooks.fire(:stage_permitted_params).must_include :kubernetes
+      Samson::Hooks.fire(:stage_permitted_params).flatten(1).must_include :kubernetes
     end
   end
 
   describe :deploy_permitted_params do
     it "adds ours" do
-      params = Samson::Hooks.fire(:deploy_permitted_params).flatten
+      params = Samson::Hooks.fire(:deploy_permitted_params).flatten(1)
       params.must_include :kubernetes_rollback
       params.must_include :kubernetes_reuse_build
     end
@@ -21,7 +21,7 @@ describe SamsonKubernetes do
 
   describe :deploy_group_permitted_params do
     it "adds ours" do
-      params = Samson::Hooks.fire(:deploy_group_permitted_params).flatten
+      params = Samson::Hooks.fire(:deploy_group_permitted_params).flatten(1)
       params.must_include cluster_deploy_group_attributes: [:kubernetes_cluster_id, :namespace]
     end
   end


### PR DESCRIPTION
We can store the "is this role ignored on this stage" information on a new role-stage join table that is managed via stage edit view.
(trying to avoid having to add one for every possible permutation, but instead defining them when users want them)

<img width="636" alt="screen shot 2019-01-09 at 5 44 00 pm" src="https://user-images.githubusercontent.com/11367/50914572-264f5180-1437-11e9-8c95-2a9c37e79f54.png">


@zenhao @aglover-zendesk @adammw @tmcinerney 

/cc @zendesk/compute 