### PR TITLE
cache scan result with ttl instead of writing to activerecord to be able to catch new vulns for the image

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_27_191406) do
+ActiveRecord::Schema.define(version: 2019_01_11_195416) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -53,7 +53,6 @@ ActiveRecord::Schema.define(version: 2018_11_27_191406) do
     t.string "dockerfile", default: "Dockerfile"
     t.string "external_status"
     t.string "image_name"
-    t.integer "gcr_vulnerabilities_status_id", default: 0, null: false
     t.index ["created_by"], name: "index_builds_on_created_by"
     t.index ["git_sha", "dockerfile"], name: "index_builds_on_git_sha_and_dockerfile", unique: true
     t.index ["git_sha", "image_name"], name: "index_builds_on_git_sha_and_image_name", unique: true, length: 80

--- a/lib/samson/dynamic_ttl_cache.rb
+++ b/lib/samson/dynamic_ttl_cache.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Samson
+  class DynamicTtlCache
+    class << self
+      def cache_fetch_if(condition, key, expires_in:)
+        return yield unless condition
+
+        old = Rails.cache.read(key)
+        return old if old
+
+        current = yield
+        expires_in = expires_in.call(current)
+        Rails.cache.write(key, current, expires_in: expires_in) unless expires_in == 0
+        current
+      end
+    end
+  end
+end

--- a/plugins/gcloud/app/views/samson_gcloud/_build_show.html.erb
+++ b/plugins/gcloud/app/views/samson_gcloud/_build_show.html.erb
@@ -2,7 +2,7 @@
   <dt>Vulnerabilities</dt>
   <dd>
     <% url = SamsonGcloud::ImageScanner.result_url(@build.docker_repo_digest) %>
-    <%= link_to_if url, SamsonGcloud::ImageScanner.status(@build.gcr_vulnerabilities_status_id), url %>
+    <%= link_to_if url, SamsonGcloud::ImageScanner.status(SamsonGcloud::ImageScanner.scan(@build.docker_repo_digest)), url %>
     <%= additional_info "Images scan results are updated when deploying." %>
   </dd>
 <% end %>

--- a/plugins/gcloud/db/migrate/20190111195416_remove_scan_result_cache_col.rb
+++ b/plugins/gcloud/db/migrate/20190111195416_remove_scan_result_cache_col.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveScanResultCacheCol < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :builds, :gcr_vulnerabilities_status_id, :integer, default: 0, null: false
+  end
+end

--- a/plugins/gcloud/test/samson_gcloud/image_scanner_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/image_scanner_test.rb
@@ -79,6 +79,18 @@ describe SamsonGcloud::ImageScanner do
       Samson::CommandExecutor.unstub(:execute)
       SamsonGcloud::ImageScanner.scan('foo_image').must_equal SamsonGcloud::ImageScanner::ERROR
     end
+
+    it "caches final results" do
+      Samson::CommandExecutor.unstub(:execute)
+      SamsonGcloud::ImageScanner.expects(:uncached_scan).times(1).returns(SamsonGcloud::ImageScanner::SUCCESS)
+      2.times { SamsonGcloud::ImageScanner.scan('foo').must_equal SamsonGcloud::ImageScanner::SUCCESS }
+    end
+
+    it "does not cache pending results" do
+      Samson::CommandExecutor.unstub(:execute)
+      SamsonGcloud::ImageScanner.expects(:uncached_scan).times(2).returns(SamsonGcloud::ImageScanner::WAITING)
+      2.times { SamsonGcloud::ImageScanner.scan('foo').must_equal SamsonGcloud::ImageScanner::WAITING }
+    end
   end
 
   describe ".result_url" do

--- a/test/lib/samson/dynamic_ttl_cache_test.rb
+++ b/test/lib/samson/dynamic_ttl_cache_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::DynamicTtlCache do
+  describe "#cache_fetch_if" do
+    it "fetches old" do
+      Rails.cache.write('a', 1)
+      Samson::DynamicTtlCache.cache_fetch_if(true, 'a', expires_in: :raise) { 2 }.must_equal 1
+    end
+
+    it "does not cache when not requested" do
+      Rails.cache.write('a', 1)
+      Samson::DynamicTtlCache.cache_fetch_if(false, 'a', expires_in: :raise) { 2 }.must_equal 2
+      Rails.cache.read('a').must_equal 1
+    end
+
+    it "caches with expiration" do
+      Samson::DynamicTtlCache.cache_fetch_if(true, 'a', expires_in: ->(_) { 1 }) { 2 }.must_equal 2
+      Rails.cache.read('a').must_equal 2
+    end
+
+    it "does not cache when user did not want it cached" do
+      Rails.cache.expects(:write).never
+      Samson::DynamicTtlCache.cache_fetch_if(true, 'a', expires_in: ->(_) { 0 }) { 2 }.must_equal 2
+    end
+  end
+end

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -421,24 +421,6 @@ describe CommitStatus do
     end
   end
 
-  describe "#cache_fetch_if" do
-    it "fetches old" do
-      Rails.cache.write('a', 1)
-      status.send(:cache_fetch_if, true, 'a', expires_in: :raise) { 2 }.must_equal 1
-    end
-
-    it "does not cache when not requested" do
-      Rails.cache.write('a', 1)
-      status.send(:cache_fetch_if, false, 'a', expires_in: :raise) { 2 }.must_equal 2
-      Rails.cache.read('a').must_equal 1
-    end
-
-    it "caches with expiration" do
-      status.send(:cache_fetch_if, true, 'a', expires_in: ->(_) { 1 }) { 2 }.must_equal 2
-      Rails.cache.read('a').must_equal 2
-    end
-  end
-
   describe "#cache_duration" do
     it "is short when we do not know if the commit is new or old" do
       status.send(:cache_duration, CommitStatus::NO_STATUSES_REPORTED_RESULT).must_equal 5.minutes


### PR DESCRIPTION
@zendesk/compute @zendesk/bre 
