### PR TITLE
scan hardcoded images for vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.11.0)
-    single_cov (1.1.0)
+    single_cov (1.3.0)
     slop (3.6.0)
     socksify (1.7.1)
     soft_deletion (1.3.1)

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -48,6 +48,7 @@ module Samson
       :deploy_permitted_params,
       :ensure_build_is_successful,
       :error,
+      :ensure_docker_image_has_no_vulnerabilities,
       :ignore_error,
       :deploy_env,
       :link_parts_for_resource,

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -982,6 +982,13 @@ describe Kubernetes::TemplateFiller do
       template.build_selectors.must_equal []
     end
 
+    it "calls vulnerability scanner for hardcoded images" do
+      raw_template[:spec][:template][:spec][:containers][0][:'samson/dockerfile'] = 'none'
+      raw_template[:spec][:template][:spec][:containers][0][:image] = 'foo.com/example/bar'
+      SamsonGcloud.expects(:ensure_docker_image_has_no_vulnerabilities)
+      template.build_selectors
+    end
+
     describe "when user selected to not enforce docker images" do
       with_env KUBERNETES_ADDITIONAL_CONTAINERS_WITHOUT_DOCKERFILE: 'true'
 


### PR DESCRIPTION
might break projects that use vulnerability scanner but have non-gcr sidecars/other containers, those can disable the flag on the stage to make their deploys work while they move everything to gcr.

flag can be disabled on the stage edit page.
ie. projects/truth_service/stages/master/edit
![screen shot 2019-01-14 at 9 26 08 am](https://user-images.githubusercontent.com/4632428/51129141-83078f00-17de-11e9-84c9-c51b8a29d258.png)


@zendesk/compute @zendesk/bre 