### PR TITLE
allow selecting what to deploy during mass-rollout

### DIFF
--- a/app/controllers/mass_rollouts_controller.rb
+++ b/app/controllers/mass_rollouts_controller.rb
@@ -53,7 +53,14 @@ class MassRolloutsController < ApplicationController
   def deploy
     stages_to_deploy = Stage.find(params.require(:stage_ids))
     deploy_references = stages_to_deploy.map do |stage|
-      reference = last_successful_template_reference(stage)
+      reference =
+        case params[:reference_source]
+        when 'template' then last_successful_template_reference(stage)
+        when 'redeploy' then stage.last_successful_deploy&.reference
+        else
+          return unsupported_option(:reference_source)
+        end
+
       [stage, reference] if reference
     end.compact
 

--- a/app/views/mass_rollouts/review_deploy.html.erb
+++ b/app/views/mass_rollouts/review_deploy.html.erb
@@ -28,8 +28,18 @@
         </table>
       </div>
 
-      <div class="admin-actions">
-        <div class="pull-right">
+      <div class="form-group">
+        <div class="col-lg-2">
+          <label>Deploy reference from</label>
+        </div>
+        <%= select_tag :reference_source, options_for_select([
+              ["Last successful deploy of template stage in same environment", "template"],
+              ["Last successful deploy", "redeploy"]
+            ]) %>
+      </div>
+
+      <div class="form-group">
+        <div class="col-lg-2">
           <%= submit_tag "Deploy selected stages", class: "btn btn-primary", data: {disable_with: "Deploying..."} %>
         </div>
       </div>


### PR DESCRIPTION
<img width="1161" alt="screen shot 2019-01-23 at 11 06 14 am" src="https://user-images.githubusercontent.com/11367/51631568-efcb0980-1f01-11e9-86c6-b2564a3aefbf.png">

should make this UI a little easier to understand and adds the option to just re-deploy which helps if projects don't have template stages

@dragonfax @zendesk/compute 