### PR TITLE
[SAMSON-393] Bump `resource_template` size

### DIFF
--- a/db/migrate/20190124171416_bump_resource_template_size.rb
+++ b/db/migrate/20190124171416_bump_resource_template_size.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BumpResourceTemplateSize < ActiveRecord::Migration[5.2]
+  def change
+    change_column :kubernetes_release_docs, :resource_template, :text, limit: 16777215
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_11_195416) do
+ActiveRecord::Schema.define(version: 2019_01_24_171416) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -235,7 +235,7 @@ ActiveRecord::Schema.define(version: 2019_01_11_195416) do
     t.integer "deploy_group_id"
     t.decimal "limits_cpu", precision: 6, scale: 2, null: false
     t.integer "limits_memory", null: false
-    t.text "resource_template"
+    t.text "resource_template", limit: 16777215
     t.decimal "requests_cpu", precision: 6, scale: 2, null: false
     t.integer "requests_memory", null: false
     t.boolean "delete_resource", default: false, null: false


### PR DESCRIPTION
Bumps the size of `resource_template` from the default 65536 to 16777215.

/cc @zendesk/samson

### Tasks
 - [ ] : 1: from team

### References
 - Jira link: [SAMSON-393](https://zendesk.atlassian.net/browse/SAMSON-393)

### Risks
- Level: Low
