### PR TITLE
allow deleting a resource to be able to change labels

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -137,6 +137,8 @@ module Kubernetes
       end
 
       def ensure_not_updating_match_labels
+        return if @delete_resource
+
         # blue-green deply is allowed to do this, see template_filler.rb + deploy_executor.rb
         return if @template.dig(:spec, :selector, :matchLabels, :blue_green)
 


### PR DESCRIPTION
error message says it should be deleted, but then it does not allow deleting 😖 

```
[23:05:06] JobExecution failed: Updating spec.selector.matchLabels from {:project=>"rollup", :role=>"runner"} to {:project=>"rollup", :role=>"resque-runner"} can only be done by deleting and redeploying or old pods would not be deleted.
```

@zendesk/compute 