### PR TITLE
Render commands as json

### DIFF
--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -26,10 +26,10 @@ class CommandsController < ApplicationController
       end
 
       format.json do
-        render json: {commands: @commands.as_json}
+        @pagy, @commands = pagy(@commands, page: page, items: 50)
+        render_as_json :commands, @commands
       end
     end
-
   end
 
   def new

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -20,7 +20,16 @@ class CommandsController < ApplicationController
         @commands = @commands.where(project_id: project_id)
       end
     end
-    @pagy, @commands = pagy(@commands, page: page, items: 15)
+    respond_to do |format|
+      format.html do
+        @pagy, @commands = pagy(@commands, page: page, items: 15)
+      end
+
+      format.json do
+        render json: {commands: @commands.as_json}
+      end
+    end
+
   end
 
   def new

--- a/test/controllers/commands_controller_test.rb
+++ b/test/controllers/commands_controller_test.rb
@@ -44,6 +44,21 @@ describe CommandsController do
         get :index, params: {search: {project_id: 'global'}}
         assigns[:commands].must_equal [global]
       end
+
+      it "renders json" do
+        get :index, params: {format: 'json'}
+        result = JSON.parse(response.body)
+        commands = result['commands']
+        commands.length.must_equal 2
+
+        global_command = commands.first
+        global_command['command'].must_equal global['command']
+        global_command['project_id'].must_be_nil
+
+        hello_command = commands.second
+        hello_command['command'].must_equal hello['command']
+        hello_command['project_id'].must_equal hello['project_id']
+      end
     end
 
     describe '#show' do


### PR DESCRIPTION
Allow the commands controller to render JSON, similar to the projects controller.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low
