### PR TITLE
Provide restful JSON endpoints for projects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   include CurrentUser # must be after protect_from_forgery, so that authenticate! is called
   include JsonExceptions
   include JsonRenderer
+  include MultiFormatRenderer
   include Pagy::Backend
 
   # show error details to users and do not bother ExceptionNotifier

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -39,6 +39,12 @@ class CommandsController < ApplicationController
   end
 
   def show
+    respond_to do |format|
+      format.html
+      format.json do
+        render_as_json :command, @command
+      end
+    end
   end
 
   def update

--- a/app/controllers/concerns/multi_format_renderer.rb
+++ b/app/controllers/concerns/multi_format_renderer.rb
@@ -11,25 +11,13 @@ module MultiFormatRenderer
   )
     respond_to do |format|
       format.html do
-        if successful
-          on_success_html.call
-        else
-          on_error_html.call
-        end
+        (successful ? on_success_html : on_error_html).call
       end
       format.json do
-        if successful
-          on_success_json.call
-        else
-          on_error_json.call
-        end
+        (successful ? on_success_json : on_error_json).call
       end
       format.js do
-        if successful
-          on_success_js.call
-        else
-          on_error_js.call
-        end
+        (successful ? on_success_js : on_error_js).call
       end
     end
   end

--- a/app/controllers/concerns/multi_format_renderer.rb
+++ b/app/controllers/concerns/multi_format_renderer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module MultiFormatRenderer
+  def multi_format_render(
+    successful: nil,
+    on_success_html: nil,
+    on_error_html: nil,
+    on_success_json: nil,
+    on_error_json: nil,
+    on_success_js: nil,
+    on_error_js: nil
+  )
+    respond_to do |format|
+      format.html do
+        if successful
+          on_success_html.call
+        else
+          on_error_html.call
+        end
+      end
+      format.json do
+        if successful
+          on_success_json.call
+        else
+          on_error_json.call
+        end
+      end
+      format.js do
+        if successful
+          on_success_js.call
+        else
+          on_error_js.call
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -67,7 +67,7 @@ class ProjectsController < ApplicationController
         if saved
           render_as_json :project, @project
         else
-          render_as_json :errors, @project.errors, status: :bad_request
+          render_as_json :errors, @project.errors, status: :unprocessable_entity
         end
       end
     end
@@ -102,7 +102,7 @@ class ProjectsController < ApplicationController
         if updated
           render_as_json :project, @project
         else
-          render_as_json :errors, @project.errors, status: :bad_request
+          render_as_json :errors, @project.errors, status: :unprocessable_entity
         end
       end
     end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -54,11 +54,23 @@ class StagesController < ApplicationController
     # Need to ensure project is already associated
     @stage = @project.stages.build
     @stage.attributes = stage_params
+    saved = @stage.save
 
-    if @stage.save
-      redirect_to [@project, @stage]
-    else
-      render :new
+    respond_to do |format|
+      format.html do
+        if saved
+          redirect_to [@project, @stage]
+        else
+          render :new
+        end
+      end
+      format.json do
+        if saved
+          render_as_json :stage, @stage
+        else
+          render_as_json :errors, @stage.errors
+        end
+      end
     end
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -259,6 +259,23 @@ describe ProjectsController do
           put :update, params: params
         end
       end
+
+      describe "as JSON" do
+        it "updates" do
+          put :update, params: params, format: :json
+          assert_response :success
+          project = JSON.parse(response.body)['project']
+          project['name'].must_equal "Hi-yo"
+        end
+
+        it "does not update invalid" do
+          params[:project][:name] = ""
+          put :update, params: params, format: :json
+          assert_response :bad_request
+          result = JSON.parse(response.body)
+          assert_equal result, "errors" => {"name" => ["can't be blank"]}
+        end
+      end
     end
 
     describe "#destroy" do
@@ -283,6 +300,14 @@ describe ProjectsController do
           project.update_column(:name, "")
           delete :destroy, params: {id: project.to_param}
         end
+      end
+
+      it "as JSON" do
+        delete :destroy, params: {id: project.to_param}, format: :json
+        assert_response :success
+        result = JSON.parse(response.body)
+        expected = {"message" => "Project removed."}
+        assert_equal expected, result
       end
     end
   end
@@ -332,6 +357,13 @@ describe ProjectsController do
           mail.subject.include?("Samson Project Created")
           mail.subject.include?(project.name)
         end
+
+        it "renders JSON" do
+          post :create, params: params, format: :json
+          assert_response :success
+          project = JSON.parse(response.body)['project']
+          project['name'].must_equal "Hello"
+        end
       end
 
       describe "with invalid parameters" do
@@ -339,6 +371,20 @@ describe ProjectsController do
 
         it "renders new template" do
           assert_template :new
+        end
+
+        it "returns errors in JSON" do
+          post :create, params: params, format: :json
+          assert_response :bad_request
+          result = JSON.parse(response.body)
+          expected = {
+            "errors" => {
+              "permalink" => ["can't be blank"],
+              "name" => ["can't be blank"],
+              "repository_url" => ["can't be blank"]
+            }
+          }
+          assert_equal expected, result
         end
       end
     end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -268,9 +268,10 @@ describe ProjectsController do
           project['name'].must_equal "Hi-yo"
         end
 
-        it "does not update invalid" do
+        it "returns errors for invalid properties" do
           params[:project][:name] = ""
           put :update, params: params, format: :json
+          puts('daninho', response.status)
           assert_response :unprocessable_entity
           result = JSON.parse(response.body)
           assert_equal result, "errors" => {"name" => ["can't be blank"]}
@@ -302,12 +303,10 @@ describe ProjectsController do
         end
       end
 
-      it "as JSON" do
+      it "returns empty body for JSON" do
         delete :destroy, params: {id: project.to_param}, format: :json
-        assert_response :success
-        result = JSON.parse(response.body)
-        expected = {"message" => "Project removed."}
-        assert_equal expected, result
+        assert_response :ok
+        response.body.must_equal ""
       end
     end
   end
@@ -361,6 +360,7 @@ describe ProjectsController do
         it "renders JSON" do
           post :create, params: params, format: :json
           assert_response :success
+          puts 'body', response.body
           project = JSON.parse(response.body)['project']
           project['name'].must_equal "Hello"
         end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -271,7 +271,7 @@ describe ProjectsController do
         it "does not update invalid" do
           params[:project][:name] = ""
           put :update, params: params, format: :json
-          assert_response :bad_request
+          assert_response :unprocessable_entity
           result = JSON.parse(response.body)
           assert_equal result, "errors" => {"name" => ["can't be blank"]}
         end
@@ -375,7 +375,7 @@ describe ProjectsController do
 
         it "returns errors in JSON" do
           post :create, params: params, format: :json
-          assert_response :bad_request
+          assert_response :unprocessable_entity
           result = JSON.parse(response.body)
           expected = {
             "errors" => {


### PR DESCRIPTION
I'm currently working on a Samson module for Ansible. The use case of the module is to streamline project, stage and command setup and specify the Samson object hierarchy as code. An example might explain this better:

```yaml
---
- name: Create Samson project
  samson_project:
    samson_url: https://mysamson.org.com
    token: xxxx
    state: present
    name: My project
    repository_url: https://github.com/zendesk/samson
    permalink: samson

- name: Create staging stage
  samson_stage:
    samson_url: https://mysamson.org.com
    token: xxxx
    state: present
    name: staging
    project_id: '{{ samson_project.project.id }}'
    production: false

- name: Remove the testing stage
  samson_stage:
    samson_url: https://mysamson.org.com
    token: xxxx
    state: absent
    premalink: testing
    project_id: '{{ samson_project.project.id }}'
```

Ansible uses the HTTP API to create these resources and the module is currently fairly complex because the Samson API is not restful. I rely on redirect status codes and parsing html for errors in order to know if a resource was created as intended.

Having a more restful-like approach to status codes and errors when he JSON endpoints are targeted simplifies the http client quite a lot.

There has been another attempt at creating Samson projects through Terraform which I think would also benefit from this PR - https://github.com/tolgaakyuz/samson-go.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
