### PR TITLE
Improved secret editor tooltip for visible checkbox

### DIFF
--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -40,7 +40,7 @@
 
       <%= form.input :comment, as: :text_area %>
 
-      <%= form.input :visible, as: :check_box, help: 'Visible to other users in samsons UI' %>
+      <%= form.input :visible, as: :check_box, help: 'Value will remain visible to users of the Samson UI' %>
 
       <% if @duplicate_secret_error %>
         <div class="alert-danger">


### PR DESCRIPTION
Small clarification to the secret editor "Visible" checkbox tooltip text.
