### PR TITLE
PAAS-2771 do not blow up when cluster config is bad/unreadable

### DIFF
--- a/plugins/kubernetes/app/views/kubernetes/clusters/edit.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/edit.html.erb
@@ -1,5 +1,5 @@
 <%= page_title(@cluster.new_record? ? "New Kubernetes Cluster" : "Edit Kubernetes Cluster") %>
-<% config_contexts = (@cluster.config_filepath ? @cluster.kubeconfig.contexts : []) %>
+<% config_contexts = (@cluster.config_filepath ? @cluster.kubeconfig.contexts : []) rescue [] %>
 
 <section>
   <%= form_for @cluster, html: { class: "form-horizontal" } do |form| %>

--- a/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
@@ -25,7 +25,7 @@
   <div class="form-group">
     <label class="col-lg-2 control-label">URL</label>
     <div class="col-lg-4">
-      <p class="form-control-static"><%= @cluster.client('v1').api_endpoint %></p>
+      <p class="form-control-static"><%= @cluster.client('v1').api_endpoint rescue "Error finding api endpoint: #{$!}" %></p>
     </div>
   </div>
 

--- a/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
@@ -5,7 +5,7 @@ SingleCov.covered!
 
 describe Kubernetes::ClustersController do
   def self.use_example_config
-    around { |t| with_example_kube_config { |f| with_env "KUBE_CONFIG_FILE": f, &t } }
+    around { |t| with_example_kube_config { |f| with_env KUBE_CONFIG_FILE: f, &t } }
   end
 
   let(:cluster) { create_kubernetes_cluster }
@@ -33,6 +33,13 @@ describe Kubernetes::ClustersController do
       it "renders" do
         get :show, params: {id: cluster.id}
         assert_template :show
+      end
+
+      it "does not blow up when client cannot connect" do
+        with_env KUBE_CONFIG_FILE: "nope.txt" do
+          get :show, params: {id: cluster.id}
+          assert_template :show
+        end
       end
     end
   end
@@ -143,6 +150,12 @@ describe Kubernetes::ClustersController do
       use_example_config
 
       it "renders" do
+        get :edit, params: {id: cluster.id}
+        assert_template :edit
+      end
+
+      it "does not blow up when client cannot connect" do
+        cluster.update_column(:config_filepath, 'nope.txt')
         get :edit, params: {id: cluster.id}
         assert_template :edit
       end


### PR DESCRIPTION
allows fixing config or deleting the cluster

@zendesk/compute 