### PR TITLE
Add keep_name annotation to keep resource names

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -193,8 +193,16 @@ to make all kubernetes deploys that do not use a `metadata.labels.team` / `spec.
 ### Using custom namespace
 
 Samson overrides each resources namespace with to the deploygroups `kubernetes_namespace`.
-To make samson not override the namespace, set `metadata.annotations.samson/keep_namespace: 'true'` 
+
+To make Samson not override the namespace, set `metadata.annotations.samson/keep_namespace: 'true'`
 (or `metadata.labels.kubernetes.io/cluster-service: 'true'`)
+
+### Using custom resource names
+
+Samson overrides each resource name in a particular role with the resource and service name set in the UI to prevent
+collision between resources in the same namespace from different projects unintentionally.
+
+To make Samson leave your resource name alone, set `metadata.annotations.samson/keep_name: 'true'`
 
 ### Preventing request loss with preStop
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -156,7 +156,12 @@ module Kubernetes
       end
     end
 
+    def keep_name?
+      template.dig(:metadata, :annotations, :'samson/keep_name') == 'true'
+    end
+
     def set_service_name
+      return if keep_name?
       template[:metadata][:name] = generate_service_name(template[:metadata][:name])
     end
 
@@ -329,7 +334,11 @@ module Kubernetes
     end
 
     def set_name
-      name = @doc.kubernetes_role.resource_name
+      name = if keep_name?
+        template.dig_fetch(:metadata, :name)
+      else
+        @doc.kubernetes_role.resource_name
+      end
       name += "-#{blue_green_color}" if blue_green_color
       template.dig_set [:metadata, :name], name
     end


### PR DESCRIPTION
Add keep_name annotation to keep resource names.

/cc @zendesk/samson @zendesk/compute 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
