### PR TITLE
Allow selecting a preferred vault server when having to pick between …

### DIFF
--- a/app/controllers/vault_servers_controller.rb
+++ b/app/controllers/vault_servers_controller.rb
@@ -45,7 +45,8 @@ class VaultServersController < ApplicationController
   private
 
   def server_params
-    params.require(:vault_server).permit(:name, :address, :token, :versioned_kv, :ca_cert, :tls_verify)
+    params.require(:vault_server).
+      permit(:name, :address, :token, :versioned_kv, :ca_cert, :tls_verify, :preferred_reader)
   end
 
   def find_server

--- a/app/views/vault_servers/show.html.erb
+++ b/app/views/vault_servers/show.html.erb
@@ -20,6 +20,7 @@
       <%= form.input :address, as: :url_field, required: true %>
       <%= form.input :token, required: true, input_html: token_options %>
       <%= form.input :versioned_kv, as: :check_box, label: "Using versioned key/value secret engine" %>
+      <%= form.input :preferred_reader, as: :check_box, help: "Read from this server when picking from multiple servers" %>
       <%= form.input :tls_verify, as: :check_box %>
       <%= form.input :ca_cert, as: :text_area, input_html: {size: '80x5', style: 'width: auto'} %>
 

--- a/db/migrate/20190206191721_add_preferred_vault_server.rb
+++ b/db/migrate/20190206191721_add_preferred_vault_server.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreferredVaultServer < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vault_servers, :preferred_reader, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_24_171921) do
+ActiveRecord::Schema.define(version: 2019_02_06_191721) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -585,6 +585,7 @@ ActiveRecord::Schema.define(version: 2019_01_24_171921) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "versioned_kv", default: false, null: false
+    t.boolean "preferred_reader", default: false, null: false
     t.index ["name"], name: "index_vault_servers_on_name", unique: true, length: 191
   end
 

--- a/lib/samson/secrets/vault_client_manager.rb
+++ b/lib/samson/secrets/vault_client_manager.rb
@@ -112,7 +112,7 @@ module Samson
       end
 
       def clients
-        @clients ||= VaultServer.all.each_with_object({}) do |vault_server, all|
+        @clients ||= VaultServer.all.order(preferred_reader: :desc).each_with_object({}) do |vault_server, all|
           all[vault_server.id] = vault_server.client
         end
       end

--- a/test/lib/samson/secrets/vault_client_manager_test.rb
+++ b/test/lib/samson/secrets/vault_client_manager_test.rb
@@ -42,6 +42,14 @@ describe Samson::Secrets::VaultClientManager do
         manager.read('global/global/global/foo').class.must_equal(Vault::Secret)
       end
     end
+
+    it "reads from the preferred server" do
+      create_vault_server(address: 'http://pick-me.com', name: 'pod101', token: 'POD100-TOKEN', preferred_reader: true)
+      create_vault_server(address: 'http://not-me.com', name: 'pod102', token: 'POD100-TOKEN')
+      assert_vault_request(
+        :get, 'global/global/global/foo', address: 'http://pick-me.com', body: {data: {foo: :bar}}.to_json
+      ) { manager.read('global/global/global/foo') }
+    end
   end
 
   describe "#write" do

--- a/test/support/vault_request_helper.rb
+++ b/test/support/vault_request_helper.rb
@@ -7,12 +7,12 @@ module VaultRequestHelper
     end
   end
 
-  def assert_vault_request(method, path, options = {}, &block)
+  def assert_vault_request(method, path, address: "http://vault-land.com", **options, &block)
     options[:to_return] = {
       headers: options.delete(:headers) || {content_type: 'application/json'}, # does not parse json without
       body: options.delete(:body) || "{}", # errors need a basic response too
       status: options.delete(:status) || 200
     }
-    assert_request(method, "http://vault-land.com/v1/secret/apps/#{path}", options, &block)
+    assert_request(method, "#{address}/v1/secret/apps/#{path}", options, &block)
   end
 end


### PR DESCRIPTION
…multiple

usecase: we don't want to read all secrets from our staging vault, just because it is the first in the list

@zendesk/bre @aglover-zendesk 