### PR TITLE
allow replacing paths that themselves include a /

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -217,6 +217,8 @@ For custom things that need to be different between environments/deploy-groups.
 Use an annotation to configure what will to be replaced:
 ```
 metadata.annotations.samson/set_via_env_json-metadata.labels.custom: SOME_ENV_VAR
+or for paths failing dns name validations:
+metadata.annotations.samson-set-via-env-json-metadata.labels.custom: SOME_ENV_VAR
 ```
 Then configure an ENV var with that same name and a value that is valid JSON.
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -79,7 +79,7 @@ module Kubernetes
 
     def set_via_env_json
       (template[:metadata][:annotations] || {}).dup.each do |k, v|
-        next unless path = k[/^samson\/set_via_env_json-(.*)/, 1]
+        next unless path = k[/^(?:samson\/set_via_env_json|samson-set-via-env-json)-(.*)/, 1]
         path = path.split(/\.(labels|annotations)\./) # make sure we do not split inside of labels or annotations
         path[0..0] = path[0].split(".")
         path.map! { |k| k.match?(/^\d+$/) ? Integer(k) : k.to_sym }

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -87,7 +87,7 @@ module Kubernetes
         begin
           template.dig_set(path, JSON.parse(static_env.fetch(v), symbolize_names: true))
         rescue KeyError, JSON::ParserError => e
-          raise Samson::Hooks::UserError, "Unable to set key #{k}: #{e.message}"
+          raise Samson::Hooks::UserError, "Unable to set key #{k}: #{e.class} #{e.message}"
         end
       end
     end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -919,19 +919,23 @@ describe Kubernetes::TemplateFiller do
           "samson/set_via_env_json-foo.bar.foo" => "FOO"
         }
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
-        e.message.must_equal "Unable to set key samson/set_via_env_json-foo.bar.foo: key not found: [:foo, :bar]"
+        e.message.must_equal(
+          "Unable to set key samson/set_via_env_json-foo.bar.foo: KeyError key not found: [:foo, :bar]"
+        )
       end
 
       it "fails nicely with invalid json" do
         environment.update_column(:value, 'foo')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
-        e.message.must_equal "Unable to set key samson/set_via_env_json-spec.foo: 765: unexpected token at 'foo'"
+        e.message.must_equal(
+          "Unable to set key samson/set_via_env_json-spec.foo: JSON::ParserError 765: unexpected token at 'foo'"
+        )
       end
 
       it "fails nicely with env is missing" do
         environment.update_column(:name, 'BAR')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
-        e.message.must_equal "Unable to set key samson/set_via_env_json-spec.foo: key not found: \"FOO\""
+        e.message.must_equal "Unable to set key samson/set_via_env_json-spec.foo: KeyError key not found: \"FOO\""
       end
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -881,6 +881,13 @@ describe Kubernetes::TemplateFiller do
         template.to_hash[:spec][:foo].must_equal "bar"
       end
 
+      it "supports - mode to make name valid dns name when user uses /" do
+        raw_template[:metadata][:annotations] = {
+          "samson-set-via-env-json-spec.foo" => "FOO"
+        }
+        template.to_hash[:spec][:foo].must_equal "bar"
+      end
+
       it "sets podless roles" do
         raw_template[:spec] = {}
         template.to_hash[:spec][:foo].must_equal "bar"


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/3167

```
[15:34:55] JobExecution failed: Kubernetes error feed-management-operations datapipeline Data Pipeline Stage: Deployment.apps "feed-management-operations" is invalid: metadata.annotations: Invalid value: "samson/set_via_env_json-spec.template.annotations.iam.amazonaws.com/role": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```

@zendesk/compute 