### PR TITLE
allow any class to be requested via with_deleted

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -47,6 +47,7 @@ class DeploysController < ApplicationController
     end
   end
 
+  # TODO: use permitted deploy-params here and not pull from all params
   def new
     defaults = {reference: @stage.default_reference}
     deploy_params = params.except(:project_id, :stage_id).permit(:reference).merge(stage: @stage)
@@ -182,7 +183,7 @@ class DeploysController < ApplicationController
     if updated_at = search[:updated_at].presence
       deploys = deploys.where("updated_at between ? AND ?", *updated_at)
     end
-    deploys = deploys.where.not(deleted_at: nil) if search_with_deleted?
+    deploys = deploys.where.not(deleted_at: nil) if search_deleted
     pagy(deploys, page: page, items: 30)
   end
 

--- a/app/views/deploys/_deploy.html.erb
+++ b/app/views/deploys/_deploy.html.erb
@@ -11,7 +11,7 @@
       <% end %>
     </td>
     <td>
-      <%= link_to deploy.summary, [@project || deploy.project, deploy, with_deleted: deploy.deleted? ? true : nil] %>
+      <%= link_to deploy.summary, [@project || deploy.project, deploy, with_deleted: params[:with_deleted]] %>
     </td>
     <% unless @stage %>
       <td><%= link_to deploy.stage.name, [deploy.project, deploy.stage] %></td>

--- a/app/views/deploys/index.html.erb
+++ b/app/views/deploys/index.html.erb
@@ -32,7 +32,7 @@
       <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
       <div class="col-sm-1">
         <%= label_tag :Deleted %>
-        <%= check_box_tag 'search[deleted]', true, params.dig(:search, :deleted) %>
+        <%= check_box_tag 'search[deleted]', "Project,Stage,Deploy", params.dig(:search, :deleted) %>
       </div>
     <% end %>
   </div>

--- a/test/controllers/concerns/wrap_in_with_deleted_test.rb
+++ b/test/controllers/concerns/wrap_in_with_deleted_test.rb
@@ -28,20 +28,34 @@ class WrapInWithDeletedConcernTest < ActionController::TestCase
 
   it "fetch deleted deploy" do
     deploy.soft_delete!
-    get :show, params: {project_id: project.id, id: deploy.id, test_route: true, with_deleted: true}
+    get :show, params: {project_id: project, id: deploy, test_route: true, with_deleted: "Project,Stage,Deploy"}
     response.body.must_equal 'Deploy'
+  end
+
+  it "fetch deleted deploy when searching" do
+    deploy.soft_delete!
+    get :show, params: {project_id: project, id: deploy, test_route: true, search: {deleted: "Project,Stage,Deploy"}}
+    response.body.must_equal 'Deploy'
+  end
+
+  it "does not support posting since that would be super dangerous" do
+    deploy.soft_delete!
+    e = assert_raises RuntimeError do
+      post :show, params: {project_id: project, id: deploy, test_route: true, with_deleted: "Project,Stage,Deploy"}
+    end
+    e.message.must_equal "with_deleted is only supported for get requests"
   end
 
   it "fails without params" do
     deploy.soft_delete!
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {project_id: project.id, id: deploy.id, test_route: true}
+      get :show, params: {project_id: project, id: deploy, test_route: true}
     end
   end
 
   it "fetch deleted project" do
     project.soft_delete(validate: false)
-    get :project, params: {project_id: project.id, id: deploy.id, test_route: true, with_deleted: true}
+    get :project, params: {project_id: project, id: deploy, test_route: true, with_deleted: "Project,Stage,Deploy"}
     response.body.must_equal project.name
   end
 end

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -120,7 +120,7 @@ describe DeploysController do
 
       it "renders soft deleted" do
         deploy.soft_delete!
-        get :show, params: {project_id: project, id: deploy, with_deleted: true}
+        get :show, params: {project_id: project, id: deploy, with_deleted: "Project,Stage,Deploy"}
         assert_template :show
       end
 
@@ -211,7 +211,7 @@ describe DeploysController do
 
       it "renders with soft_delete" do
         deploy.soft_delete!
-        get :index, params: {with_deleted: "true"}
+        get :index, params: {with_deleted: "Project,Stage,Deploy"}
         assert_template :index
         assigns[:deploys].must_include deploy
       end
@@ -367,7 +367,7 @@ describe DeploysController do
 
       it "filters by deleted" do
         Deploy.last.soft_delete!
-        get :index, params: {search: {deleted: "true"}}, format: "json"
+        get :index, params: {search: {deleted: "Project,Stage,Deploy"}}, format: "json"
         assert_response :ok
         deploys["deploys"].count.must_equal 1
       end


### PR DESCRIPTION
 - existing code will pass on the value of with_deleted
 - search input is not sent when not clicked, so we don't need a "== true" check

/cc @zendesk/samson @zendesk/bre @sathishavm 