### PR TITLE
Outbound webhooks to use ResourceController

### DIFF
--- a/app/controllers/outbound_webhooks_controller.rb
+++ b/app/controllers/outbound_webhooks_controller.rb
@@ -1,34 +1,47 @@
 # frozen_string_literal: true
 require 'samson/integration'
 
-class OutboundWebhooksController < ApplicationController
+class OutboundWebhooksController < ResourceController
   include CurrentProject
-
   before_action :authorize_project_deployer!
 
   def create
-    webhook = OutboundWebhook.new(outbound_webhook_params.merge(project_id: current_project.id))
+    webhook = OutboundWebhook.new(resource_params)
 
-    if webhook.save
-      flash.delete(:error)
-      redirect_to project_webhooks_path(current_project)
-    else
-      flash[:error] = webhook.errors.full_messages.join(', ')
-      @new_outbound_webhook = webhook
-      render 'webhooks/index'
+    respond_to do |format|
+      format.html do
+        if webhook.save
+          flash.delete(:error)
+          redirect_to project_webhooks_path(current_project)
+        else
+          flash[:error] = webhook.errors.full_messages.join(', ')
+          @new_outbound_webhook = webhook
+          render 'webhooks/index'
+        end
+      end
+      format.json do
+        webhook.save!
+        render_as_json :webhook, webhook
+      end
     end
-  end
-
-  def destroy
-    outbound_webhook = current_project.outbound_webhooks.find(params[:id])
-    outbound_webhook.soft_delete!(validate: false)
-
-    redirect_to project_webhooks_path(current_project)
   end
 
   private
 
-  def outbound_webhook_params
-    params.require(:outbound_webhook).permit(:stage_id, :project_id, :url, :username, :password)
+  def search_resources
+    @project.outbound_webhooks
+  end
+
+  def resource_path
+    [@project, 'webhooks']
+  end
+
+  def resources_path
+    [@project, 'webhooks']
+  end
+
+  def resource_params
+    params = [:stage_id, :project_id, :url, :username, :password]
+    super.permit(params).merge(project: current_project)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Samson::Application.routes.draw do
     resource :changelog, only: [:show]
     resource :stars, only: [:create]
     resources :webhooks, only: [:index, :create, :destroy]
-    resources :outbound_webhooks, only: [:create, :destroy]
+    resources :outbound_webhooks, only: [:create, :update, :destroy]
     resources :references, only: [:index]
     resources :user_project_roles, only: [:index]
 


### PR DESCRIPTION
Allows us to render the outbound webhooks as JSON.

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
