### PR TITLE
Fix ActionMailer for Gmail

### DIFF
--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -2,16 +2,17 @@
 require 'uri'
 
 smtp_url = URI.parse(ENV["SMTP_URL"] || "smtp://localhost")
-smtp_url.port ||= 25
-smtp_url.user ||= ENV["SMTP_USER"]
-smtp_url.password ||= ENV["SMTP_PASSWORD"]
+port = smtp_url.port || 25
+user = smtp_url.user || ENV["SMTP_USER"]
+password = smtp_url.password || ENV["SMTP_PASSWORD"]
+enable_starttls_auto = ENV["SMTP_ENABLE_STARTTLS_AUTO"] || false
 
 ActionMailer::Base.smtp_settings = {
-  port:                 smtp_url.port,
   address:              smtp_url.host,
-  user_name:            smtp_url.user,
-  password:             smtp_url.password,
+  port:                 port,
+  user_name:            user,
+  password:             password,
   authentication:       'plain',
-  enable_starttls_auto: false,
+  enable_starttls_auto: enable_starttls_auto,
   openssl_verify_mode:  'none'
 }


### PR DESCRIPTION
This fixes two things:

1) parsing the smtp settings when they contain a user with an @ symbol.

```
smtp_url = URI.parse(ENV["SMTP_URL"] || "smtp://localhost")
smtp_url.user = 'test@gmail.com' # process crash here
```
the URI.parse call fails with any @ symbols. By assigning the smtp_url
variable with a string containing '@' the process crashes.

2) allows the user to configure smtp over tls if provided in the
environment. This is required for gmails smtp servers.

Both changes should be backwards compatible.

![gmail](https://i.imgur.com/TSkppEa.png)

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low/Med/High
