### PR TITLE
cleanup locking authorizzation more

### DIFF
--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -19,10 +19,9 @@ class AccessControl
         when :read then true
         when :write
           case scope.class.to_s
-          when 'NilClass' then user.admin? # global locks
-          when 'Project' then user.admin_for?(scope) # project locks
-          when 'Stage' then can_lock_stage?(user, scope) # stage locks
-          else false
+          when "Project" then user.admin_for?(scope) # project locks
+          when "Stage" then can_lock_stage?(user, scope) # stage locks
+          else user.admin? # global / env / deploy-group
           end
         else raise ArgumentError, "Unsupported action #{action}"
         end

--- a/test/models/access_control_test.rb
+++ b/test/models/access_control_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered!
 
 # each test is written as a pair of the lowest level that allows access and the one below that forbids access
 describe AccessControl do
@@ -165,6 +165,16 @@ describe AccessControl do
           with_env 'PRODUCTION_STAGE_LOCK_REQUIRES_ADMIN' => 'true' do
             refute can?(deployer, :write, prod_stage)
           end
+        end
+      end
+
+      describe "other" do
+        it "allows admins to update" do
+          assert can?(admin, :write, Environment.new)
+        end
+
+        it "forbids deployers to update" do
+          refute can?(deployer, :write, Environment.new)
         end
       end
 


### PR DESCRIPTION
 - remove indirection by getting the correct lock for each scenario
 - protect against deleting with only a `type` or only an `id`
 - add some docs about the weird "" = "global" magic
 - also ask access-control about env/deploy-group so all decisions are made there

@zendesk/bre 