### PR TITLE
Add a multi-layer dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,6 @@
 # git history is big, do not add it
 .git
 
-# tests are big and not needed
-test
-
 # user might chose to have local gem installs, they can be quiet big
 vendor/bundle
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,70 @@
-FROM ruby:2.5.3-slim
+FROM ruby:2.5.3-slim AS base
 
-RUN apt-get update && apt-get install -y build-essential default-libmysqlclient-dev libpq-dev libsqlite3-dev wget apt-transport-https git curl
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && apt-get install nodejs -y
-RUN curl -fsSL https://get.docker.com | bash -
+# Install dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      default-libmysqlclient-dev \
+      libpq-dev \
+      libsqlite3-dev \
+      wget \
+      apt-transport-https \
+      git \
+      curl \
+      gnupg2 \
+  && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+  && apt-get install nodejs -y \
+  && curl -fsSL https://get.docker.com | bash - \
+  && wget -qc https://github.com/betalo-sweden/await/releases/download/v0.4.0/await-linux-amd64 \
+  && install await-linux-amd64 /usr/local/bin/await \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Mostly static
-COPY config.ru /app/
-COPY Rakefile /app/
-COPY bin /app/bin
-COPY public /app/public
-COPY db /app/db
-COPY .env.bootstrap /app/.env
-COPY .env.virtualbox /app/
-COPY .ruby-version /app/.ruby-version
+# -------------------------------------
+FROM base AS bundle
 
-# NPM
+COPY .ruby-version Gemfile Gemfile.lock /app/
+COPY plugins /app/plugins
+RUN bundle install --jobs 4
+
+# -------------------------------------
+FROM base as node_modules
+
 COPY package.json /app/package.json
 RUN npm install --silent
 
-# Gems
-COPY Gemfile /app/
-COPY Gemfile.lock /app/
-COPY plugins /app/plugins
+# -------------------------------------
+FROM base AS samson
 
-RUN bundle install --quiet --jobs 4
+# Drop privs to samson user as some tests expect non-root
+RUN groupadd -r samson && useradd -r -g samson -d /app samson \
+  && chown -R samson:samson /app
 
-# Code
-COPY config /app/config
-COPY app /app/app
-COPY lib /app/lib
+# Copy rubygem and npm results from other stages
+COPY --from=bundle /usr/local/bundle /usr/local/bundle
+COPY --chown=samson:samson --from=node_modules /app/node_modules /app/node_modules
 
-# Assets
-COPY vendor/assets /app/vendor/assets
-RUN echo "takes 5 minute" && ./bin/decode_dot_env .env && RAILS_ENV=production PRECOMPILE=1 bundle exec rake assets:precompile
+USER samson
+
+# Copy source code
+COPY --chown=samson:samson . /app/
+COPY --chown=samson:samson .env.bootstrap /app/.env
+RUN ./bin/decode_dot_env .env
+
+# -------------------------------------
+FROM samson AS samson-test
+
+ARG RAILS_ENV=development
+RUN bundle exec rake assets:precompile
+
+# -------------------------------------
+FROM samson AS samson-puma
+
+ARG RAILS_ENV=production
+ARG PRECOMPILE=1
+RUN bundle exec rake assets:precompile
 
 EXPOSE 9080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,12 @@
-version: "2"
+version: "3.6"
+
 services:
-  samson:
-    image: zendesk/samson:latest # replace with `build: .` to use Dockerfile (--build to rebuild it)
+  # run samson locally for dev bound to port 3000
+  samson-dev:
+    image: zendesk/samson:latest
+    build:
+      context: .
+      target: samson-puma
     ports:
       - "3000:9080"
     volumes:
@@ -10,3 +15,71 @@ services:
       DATABASE_URL: "sqlite3:///app/db/development.sqlite3"
       RAILS_LOG_TO_STDOUT: 1
     command: ["./script/docker_dev_server"]
+
+  # run samson in test mode
+  samson-test: &test
+    build:
+      context: .
+      target: samson-test
+    environment:
+      BUNDLE_WITHOUT: postgres:mysql
+
+  # run samson in test mode against sqlite
+  samson-test-sqlite:
+    <<: *test
+    environment:
+      DATABASE_URL: "sqlite3:///app/db/test.sqlite3"
+      SILENCE_MIGRATIONS: 1
+      RAILS_ENV: test
+    command: ["bundle", "exec", "rake", "db:create", "db:migrate", "default"]
+
+  # run samson in test with mysql
+  samson-test-mysql:
+    <<: *test
+    environment:
+      DATABASE_URL: mysql2://root@mysql/samson_test?reconnect=true
+      USE_UTF8MB4: 1
+      SILENCE_MIGRATIONS: 1
+      RAILS_ENV: test
+    command: ["await", "-v", "mysql://root@mysql:3306", "--", "bundle", "exec", "rake", "db:create", "db:migrate", "default"]
+    depends_on:
+      - mysql
+
+  # run samson in test with mysql (no plugins)
+  samson-test-mysql-no-plugins:
+    <<: *test
+    environment:
+      PLUGINS: ""
+      DATABASE_URL: mysql2://root@mysql/samson_test?reconnect=true
+      USE_UTF8MB4: 1
+      SILENCE_MIGRATIONS: 1
+      RAILS_ENV: test
+    command: ["await", "-v", "mysql://root@mysql:3306", "--", "bundle", "exec", "rake", "db:create", "test:migrate_without_plugins"]
+    depends_on:
+      - mysql
+
+  # run samson in test with postgres
+  samson-test-postgres:
+    <<: *test
+    environment:
+      PLUGINS: ""
+      DATABASE_URL: postgresql://postgres@postgres/samson_test
+      SILENCE_MIGRATIONS: 1
+      RAILS_ENV: test
+    command: ["await", "-v", "tcp4://postgres:5432", "--", "bundle", "exec", "rake", "db:create", "db:migrate", "default"]
+    depends_on:
+      - postgres
+
+  # types of database to test against
+  # ---------------------------------
+
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_ROOT_HOST: "%"
+
+  postgres:
+    image: postgres:9.2-alpine
+    environment:
+      POSTGRES_PASSWORD: ""


### PR DESCRIPTION
This adds a multi-layer dockerfile that can build both production and test docker images.

These are reflected in the `docker-compose.yml` file, which include the database dependencies for running tests against sqlite, mysql and postgres environments:

```
docker-compose run samson-test-sqlite
docker-compose run samson-test-mysql
docker-compose run samson-test-postgres
```

Both sqlite and mysql run and pass, postgres doesn't. Is this working in Travis? 

I figured this might be a useful thing for reproducible test environments in CI vs local development. Feel free to close if not!