### PR TITLE
ignore rollbar errors without raising

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,7 +474,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rollbar (2.15.5)
+    rollbar (2.19.1)
       multi_json
     rollbar-user_informer (0.1.0)
       rollbar (~> 2.15)

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -17,7 +17,7 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
 
     # ignore errors we do not want to send to Rollbar
     config.before_process << proc do |options|
-      raise Rollbar::Ignore if Samson::Hooks.fire(:ignore_error, options[:exception].class.name).any?
+      "ignored" if Samson::Hooks.fire(:ignore_error, options[:exception].class.name).any?
     end
 
     Rollbar::UserInformer.user_information_placeholder = ErrorNotifier::USER_INFORMATION_PLACEHOLDER


### PR DESCRIPTION
@zendesk/bre 

uses https://github.com/rollbar/rollbar-gem/pull/824

 - [rollbar](https://rubygems.org/gems/rollbar) [v2.15.5 -> v2.19.1](https://github.com/rollbar/rollbar-gem/compare/v2.15.5...v2.19.1)