### PR TITLE
tell users they need any of the scopes, not all of them

### DIFF
--- a/app/controllers/unauthorized_controller.rb
+++ b/app/controllers/unauthorized_controller.rb
@@ -18,10 +18,10 @@ class UnauthorizedController < ActionController::Metal
   end
 
   def respond
-    message = "You are not #{request.env['warden']&.user ? "authorized to view this page" : "logged in"}."
+    message = "You are not #{request.env['warden']&.user ? "authorized to view this page" : "logged in"}"
     respond_to do |format|
       format.json do
-        render json: {error: message + " See docs/api.md on how to authenticate."}, status: :unauthorized
+        render json: {error: message + ", see docs/api.md on how to authenticate"}, status: :unauthorized
       end
       format.html do
         flash[:authorization_error] = message

--- a/lib/warden/strategies/doorkeeper_strategy.rb
+++ b/lib/warden/strategies/doorkeeper_strategy.rb
@@ -17,7 +17,8 @@ class Warden::Strategies::Doorkeeper < ::Warden::Strategies::Base
     elsif !token.accessible?
       halt_json "Bearer token is expired"
     elsif !token.acceptable?(requested_scopes)
-      halt_json "Bearer token needs scope #{requested_scopes.to_sentence(last_word_connector: ', or ')}"
+      sentence = requested_scopes.to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')
+      halt_json "Bearer token needs scope #{sentence}"
     elsif !(user = User.find_by_id(token.resource_owner_id))
       halt_json "Bearer token belongs to deleted user #{token.resource_owner_id}"
     else

--- a/test/controllers/unauthorized_controller_test.rb
+++ b/test/controllers/unauthorized_controller_test.rb
@@ -28,7 +28,7 @@ describe 'Unauthorized' do
 
       it 'sets the flash' do
         flash = last_request.env['action_dispatch.request.flash_hash']
-        flash[:authorization_error].must_equal('You are not logged in.')
+        flash[:authorization_error].must_equal('You are not logged in')
       end
 
       describe 'when user is not authorized' do
@@ -36,7 +36,7 @@ describe 'Unauthorized' do
 
         it 'uses a custom flash message' do
           flash = last_request.env['action_dispatch.request.flash_hash']
-          flash[:authorization_error].must_equal('You are not authorized to view this page.')
+          flash[:authorization_error].must_equal('You are not authorized to view this page')
         end
       end
 

--- a/test/lib/warden/strategies/doorkeeper_strategy_test.rb
+++ b/test/lib/warden/strategies/doorkeeper_strategy_test.rb
@@ -9,6 +9,10 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
     get path, headers: {HTTP_AUTHORIZATION: authorization}
   end
 
+  def error
+    JSON.parse(response.body).fetch("error")
+  end
+
   let(:path) { +"/deploys/active_count.json" }
   let!(:user) { users(:admin) }
   let(:token) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id, scopes: 'deploys') }
@@ -19,30 +23,34 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
     assert_response :success, response.body
   end
 
-  it "does not set a session since oauth requests are not suppoed to log in a browser" do
+  it "does not set a session since oauth requests are not supposed to log in a browser" do
     perform_get valid_header
     response.headers['Set-Cookie'].must_be_nil
   end
 
   it "does not check and fails without header" do
     assert_sql_queries(0) { perform_get nil }
+    error.must_equal "You are not logged in, see docs/api.md on how to authenticate"
     assert_response :unauthorized
   end
 
   it "checks and fails with invalid header" do
     assert_sql_queries(1) { perform_get(valid_header + Base64.encode64('foo')) }
+    error.must_equal "Bearer token is invalid"
     assert_response :unauthorized
   end
 
   it "checks and fails with unfound user" do
     user.delete
     assert_sql_queries(3) { perform_get(valid_header) } # FYI queries are: find token, revoke token, find user
+    error.must_equal "Bearer token belongs to deleted user #{user.id}"
     assert_response :unauthorized
   end
 
   it "checks and fails with missing scope access" do
     token.update_column(:scopes, 'foobar')
     assert_sql_queries(2) { perform_get(valid_header) } # FYI queries are: find token, revoke token
+    error.must_equal "Bearer token needs scope default or deploys"
     assert_response :unauthorized
   end
 
@@ -51,6 +59,7 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
 
     it "checks and fails when using restricted token" do
       perform_get(valid_header)
+      error.must_equal "Bearer token needs scope default or profiles"
       assert_response :unauthorized
     end
 
@@ -70,11 +79,13 @@ describe 'Warden::Strategies::DoorkeeperStrategy Integration' do
   it "checks and fails with expired token" do
     token.update_attributes(expires_in: 1, created_at: 1.day.ago)
     assert_sql_queries(2) { perform_get(valid_header) } # FYI queries are: find token, revoke token
+    error.must_equal "Bearer token is expired"
     assert_response :unauthorized
   end
 
   it "does not check and fails with non matching header" do
     assert_sql_queries(0) { perform_get "oops" + valid_header }
+    error.must_equal "You are not logged in, see docs/api.md on how to authenticate"
     assert_response :unauthorized
   end
 


### PR DESCRIPTION
before it said `Bearer token needs scope default and deploy_groups`
