### PR TITLE
PAAS-2924 reload events before displaying them since some are added a…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -91,7 +91,8 @@ module Kubernetes
         events.any? && events_indicating_failure.all? { |e| e[:reason] == "FailedScheduling" }
       end
 
-      def events
+      def events(reload: false)
+        @events = nil if reload
         @events ||= raw_events.select do |event|
           # compare strings to avoid parsing time '2017-03-31T22:56:20Z'
           event.dig(:metadata, :creationTimestamp) >= @pod.dig(:status, :startTime).to_s

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -214,9 +214,10 @@ module Kubernetes
     end
 
     # show what happened in kubernetes internally since we might not have any logs
+    # reloading the events so we see things added during+after pod restart
     def print_pod_events(pod)
       @output.puts "POD EVENTS:"
-      print_events(pod.events)
+      print_events(pod.events(reload: true))
     end
 
     def print_events(events)

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -408,4 +408,23 @@ describe Kubernetes::Api::Pod do
       pod.init_containers.must_equal [{foo: "bar"}]
     end
   end
+
+  describe "#events" do
+    it "returns events" do
+      stub_request(:get, events_url).to_return(body: {items: events}.to_json)
+      pod_with_client.events.size.must_equal 1
+    end
+
+    it "caches events" do
+      request = stub_request(:get, events_url).to_return(body: {items: events}.to_json)
+      2.times { pod_with_client.events.size.must_equal 1 }
+      assert_requested request, times: 1
+    end
+
+    it "reloads events" do
+      request = stub_request(:get, events_url).to_return(body: {items: events}.to_json)
+      2.times { pod_with_client.events(reload: true).size.must_equal 1 }
+      assert_requested request, times: 2
+    end
+  end
 end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -407,7 +407,7 @@ describe Kubernetes::DeployExecutor do
       out.must_include "resque-worker: Error event\n"
       out.must_include "UNSTABLE"
 
-      assert_requested request, times: 5 # fetches pod events once and once for 4 different resources
+      assert_requested request, times: 6 # fetches pod events twice and once for 4 different resources
     end
 
     it "waits when node needs to auto-scale" do


### PR DESCRIPTION
…fter pod signals restart

before:

```
[22:46:55] POD EVENTS:
[22:46:55]   Normal Scheduled: Successfully assigned default/example-server-7d9dcf68c-nn6dj to docker-desktop
```

after:
```
[22:57:21] POD EVENTS:
[22:57:21]   Warning BackOff: Back-off restarting failed container
```

@zendesk/compute 