### PR TITLE
Handle icon for non-standard statuses

### DIFF
--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module ReleasesHelper
-  GITHUB_STATUS_ICONS = {
+  STATUS_ICONS = {
     "success" => "ok",
     "failure" => "remove",
     "missing" => "minus",
@@ -8,7 +8,7 @@ module ReleasesHelper
     "error" => "exclamation-sign"
   }.freeze
 
-  GITHUB_STATUS_TEXT_LABELS = {
+  STATUS_TEXT_LABELS = {
     "success" => "success",
     "failure" => "danger",
     "missing" => "muted",
@@ -26,10 +26,10 @@ module ReleasesHelper
     )
   end
 
-  def github_commit_status_icon(status_state)
-    icon = GITHUB_STATUS_ICONS.fetch(status_state, GITHUB_STATUS_ICONS[DEFAULT_STATUS])
-    text = GITHUB_STATUS_TEXT_LABELS.fetch(status_state, GITHUB_STATUS_TEXT_LABELS[DEFAULT_STATUS])
-    title = "Github status: #{status_state}"
+  def commit_status_icon(status_state)
+    icon = STATUS_ICONS.fetch(status_state, STATUS_ICONS[DEFAULT_STATUS])
+    text = STATUS_TEXT_LABELS.fetch(status_state, STATUS_TEXT_LABELS[DEFAULT_STATUS])
+    title = "Commit status: #{status_state}"
 
     icon_tag icon, class: "text-#{text}", 'data-toggle': "tooltip", 'data-placement': "right", title: title
   end

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -16,6 +16,8 @@ module ReleasesHelper
     "error" => "warning"
   }.freeze
 
+  DEFAULT_STATUS = "error".freeze
+
   def release_label(project, release)
     link_to(
       release.version,
@@ -25,8 +27,8 @@ module ReleasesHelper
   end
 
   def github_commit_status_icon(status_state)
-    icon = GITHUB_STATUS_ICONS.fetch(status_state)
-    text = GITHUB_STATUS_TEXT_LABELS.fetch(status_state)
+    icon = GITHUB_STATUS_ICONS.fetch(status_state, GITHUB_STATUS_ICONS[DEFAULT_STATUS])
+    text = GITHUB_STATUS_TEXT_LABELS.fetch(status_state, GITHUB_STATUS_TEXT_LABELS[DEFAULT_STATUS])
     title = "Github status: #{status_state}"
 
     icon_tag icon, class: "text-#{text}", 'data-toggle': "tooltip", 'data-placement': "right", title: title

--- a/app/helpers/releases_helper.rb
+++ b/app/helpers/releases_helper.rb
@@ -16,7 +16,7 @@ module ReleasesHelper
     "error" => "warning"
   }.freeze
 
-  DEFAULT_STATUS = "error".freeze
+  DEFAULT_STATUS = "error"
 
   def release_label(project, release)
     link_to(

--- a/app/views/releases/_release.html.erb
+++ b/app/views/releases/_release.html.erb
@@ -3,7 +3,7 @@
     <%= release_label(@project, release) %>
   </td>
   <td>
-    <%= github_commit_status_icon CommitStatus.new(release.project, release.commit).state %>
+    <%= commit_status_icon CommitStatus.new(release.project, release.commit).state %>
   </td>
   <td>
     <span style="white-space: nowrap">

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -19,7 +19,7 @@
   <legend>Commit Status</legend>
   <p>
     <% CommitStatus.new(@release.project, @release.commit).statuses.each do |status| %>
-      <%= github_commit_status_icon(status.fetch(:state)) %>
+      <%= commit_status_icon(status.fetch(:state)) %>
       <b><%= status[:context] %>:</b> <%= link_to status[:description], status[:target_url] %><br/>
     <% end %>
   </p>

--- a/test/helpers/releases_helper_test.rb
+++ b/test/helpers/releases_helper_test.rb
@@ -15,49 +15,49 @@ describe ReleasesHelper do
     end
   end
 
-  describe "#github_commit_status_icon" do
+  describe "#commit_status_icon" do
     include ApplicationHelper
 
     it "renders an icon for success" do
-      html = github_commit_status_icon("success")
+      html = commit_status_icon("success")
       html.must_include "glyphicon-ok"
       html.must_include "text-success"
-      html.must_include "Github status: success"
+      html.must_include "Commit status: success"
     end
 
     it "renders an icon for failure" do
-      html = github_commit_status_icon("failure")
+      html = commit_status_icon("failure")
       html.must_include "glyphicon-remove"
       html.must_include "text-danger"
-      html.must_include "Github status: failure"
+      html.must_include "Commit status: failure"
     end
 
     it "renders an icon for missing status" do
-      html = github_commit_status_icon("missing")
+      html = commit_status_icon("missing")
       html.must_include "glyphicon-minus"
       html.must_include "text-muted"
-      html.must_include "Github status: missing"
+      html.must_include "Commit status: missing"
     end
 
     it "renders an icon for pending status" do
-      html = github_commit_status_icon("pending")
+      html = commit_status_icon("pending")
       html.must_include "glyphicon-hourglass"
       html.must_include "text-primary"
-      html.must_include "Github status: pending"
+      html.must_include "Commit status: pending"
     end
 
     it "renders an icon for error status" do
-      html = github_commit_status_icon("error")
+      html = commit_status_icon("error")
       html.must_include "glyphicon-exclamation-sign"
       html.must_include "text-warning"
-      html.must_include "Github status: error"
+      html.must_include "Commit status: error"
     end
 
-    it "assumes 'error' as default status" do
-      html = github_commit_status_icon("key_not_found")
+    it "assumes 'error' for 1-off states produced by release status" do
+      html = commit_status_icon("key_not_found")
       html.must_include "glyphicon-exclamation-sign"
       html.must_include "text-warning"
-      html.must_include "Github status: error"
+      html.must_include "Commit status: key_not_found"
     end
   end
 

--- a/test/helpers/releases_helper_test.rb
+++ b/test/helpers/releases_helper_test.rb
@@ -46,11 +46,18 @@ describe ReleasesHelper do
       html.must_include "Github status: pending"
     end
 
-    it "renders an icon for pending status" do
-      html = github_commit_status_icon("pending")
-      html.must_include "glyphicon-hourglass"
-      html.must_include "text-primary"
-      html.must_include "Github status: pending"
+    it "renders an icon for error status" do
+      html = github_commit_status_icon("error")
+      html.must_include "glyphicon-exclamation-sign"
+      html.must_include "text-warning"
+      html.must_include "Github status: error"
+    end
+
+    it "assumes 'error' as default status" do
+      html = github_commit_status_icon("key_not_found")
+      html.must_include "glyphicon-exclamation-sign"
+      html.must_include "text-warning"
+      html.must_include "Github status: error"
     end
   end
 


### PR DESCRIPTION
## Handle Status Icon for keys other than success/failure/missing/pending/error

**`CommitStatus#statuses`** can produce values such as ` {:state=>"Old Release", :description=>"v4.3 was deployed to deploy groups in this stage by Production"}, {:state=>"Production Only Reference", :description=>"v4.2 has not been deployed to a non-production stage."}` in case of combined status using **`release_status`** and **`ref_statuses`**.

**Idea** is to suppress the exceptions and highlight concerns such as `Old Release` and `Production Only Reference` as `"error"/"warning"`.

**Other options** to handle is to use only `github_state` instead of [`combined_status`](https://github.com/zendesk/samson/blob/mugoyal/fix_key_error/app/models/commit_status.rb#L47), but that way we would suppress concerns such as `Old Release` and `Production Only Reference`.

cc @zendesk/samson, @zendesk/sustaining, @zendesk/bre 

### Tasks
 - [x] Refactor names (as `github` in the name is mis-leading) 
 - [ ] Test on Staging

### References
 - Jira link: https://zendesk.atlassian.net/browse/BRE-1340
 - Rollbar: https://rollbar-us.zendesk.com/Zendesk/Samson/items/1324/?item_page=0&#instances

### Risks
- Level: Low
