### PR TITLE
fix rake breaking in local development because of RollbarTestController

### DIFF
--- a/lib/samson/boot_check.rb
+++ b/lib/samson/boot_check.rb
@@ -13,7 +13,7 @@ module Samson
           # make sure we do not regress into slow startup time by preloading too much
           bad = [
             ActiveRecord::Base.descendants.map(&:name) - ["Audited::Audit"],
-            ActionController::Base.descendants.map(&:name),
+            ActionController::Base.descendants.map(&:name) - ["RollbarTestController"],
             (const_defined?(:Mocha) && "mocha"),
             ((Thread.list.count != 1) && "Extra threads: #{Thread.list - [Thread.current]}")
           ].flatten.select { |x| x }


### PR DESCRIPTION
```
rake db:migrate
rake aborted!
RollbarTestController should not be loaded
lib/samson/boot_check.rb:20:in `check'
config/application.rb:153:in `block in <class:Application>'
```

rollbar gem now defines a controller in it's rake tasks, which are loaded because we use the rollbar engine ... going to ignore it instead of hunting it down :(