### PR TITLE
Allow reusing form input to generate multiple similar roles

### DIFF
--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -3,6 +3,8 @@ require 'csv'
 
 # Abstract controller that handles all resources, subclasses handle custom logic by overwriting
 class ResourceController < ApplicationController
+  ADD_MORE = 'Save and add another'
+
   include JsonRenderer
 
   def index(paginate: true)
@@ -33,7 +35,9 @@ class ResourceController < ApplicationController
       format.html do
         if @resource.save
           create_callback
-          redirect_to(redirect_to_from_params || resource_path, notice: "Created!")
+
+          flash[:notice] = "Created!"
+          redirect_after_save
         else
           flash[:alert] = "Failed to create!"
           render template
@@ -61,7 +65,8 @@ class ResourceController < ApplicationController
     respond_to do |format|
       format.html do
         if @resource.update(resource_params)
-          redirect_to(redirect_to_from_params || resource_path, notice: "Updated!")
+          flash[:notice] = "Updated!"
+          redirect_after_save
         else
           render template
         end
@@ -102,6 +107,14 @@ class ResourceController < ApplicationController
   end
 
   private
+
+  def redirect_after_save
+    if params[:commit] == ADD_MORE
+      redirect_to action: :new, resource_name => params.fetch(resource_name).to_unsafe_h
+    else
+      redirect_to(redirect_to_from_params || resource_path)
+    end
+  end
 
   def search_resources
     resource_class

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class SecretsController < ApplicationController
-  ADD_MORE = 'Save and add another'
   UPDATEDABLE_ATTRIBUTES = [:value, :visible, :deprecated_at, :comment].freeze
 
   include CurrentProject
@@ -134,7 +133,7 @@ class SecretsController < ApplicationController
 
   def successful_response(notice)
     flash[:notice] = notice
-    if params[:commit] == ADD_MORE
+    if params[:commit] == ResourceController::ADD_MORE
       redirect_to new_secret_path(secret: params[:secret].except(:value).to_unsafe_h)
     else
       redirect_to action: :index

--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -66,7 +66,7 @@
       <div class="form-group">
         <div class="col-lg-offset-2 col-lg-10">
           <%= submit_tag 'Save', class: 'btn btn-primary' %>
-          <%= submit_tag SecretsController::ADD_MORE, class: 'btn btn-default' %>
+          <%= submit_tag ResourceController::ADD_MORE, class: 'btn btn-default' %>
           <% if id %>
             <%= link_to "Duplicates", secrets_path(search: {value_from: id}) %>
             <%= link_to_delete secret_path(id) %>

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
@@ -44,7 +44,8 @@
     <%# use form.actions with delete: true, history: true and block %>
     <div class="form-group">
       <div class="col-lg-offset-2 col-lg-10">
-        <%= form.submit form.object.persisted? ? 'Save' : 'Create', class: "btn btn-primary" %>
+        <%= form.submit 'Save', class: "btn btn-primary" %>
+        <%= submit_tag ResourceController::ADD_MORE, class: 'btn btn-default' %>
         <%= link_to_delete form.object, class: 'btn btn-default' if form.object.persisted? %>
         <%= link_to "Cancel", :back, class: 'btn btn-default' %>
         <%= link_to_history form.object %>

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -128,6 +128,11 @@ describe "ResourceController Integration" do
           assert_redirected_to Project.last
         end
 
+        it "can redirect to new" do
+          post projects_url, params: {project: project_params, commit: ResourceController::ADD_MORE}
+          assert_redirected_to "/projects/new?#{{project: project_params}.to_query}"
+        end
+
         it "fails to creates" do
           project_params[:name] = ""
           post projects_url, params: {project: project_params}
@@ -216,10 +221,16 @@ describe "ResourceController Integration" do
     end
 
     describe "#update" do
+      let(:project_params) { {name: "Baz2", description: "Gah2"} }
       describe "html" do
         it "updates" do
-          patch project_url(project), params: {project: {name: "Baz2", description: "Gah2"}}
+          patch project_url(project), params: {project: project_params}
           assert_redirected_to project
+        end
+
+        it "can redirect to new" do
+          patch project_url(project), params: {project: project_params, commit: ResourceController::ADD_MORE}
+          assert_redirected_to "/projects/new?#{{project: project_params}.to_query}"
         end
 
         it "fails to update" do
@@ -230,7 +241,7 @@ describe "ResourceController Integration" do
 
       describe "json" do
         it "updates" do
-          patch project_url(project, :json), params: {project: {name: "Baz2", description: "desc2"}}
+          patch project_url(project, :json), params: {project: project_params}
           assert_response :success
           assert_rendered_resource
         end

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -236,7 +236,7 @@ describe SecretsController do
       end
 
       it "redirects to new form when user wants to create another secret" do
-        post :create, params: {secret: attributes, commit: SecretsController::ADD_MORE}
+        post :create, params: {secret: attributes, commit: ResourceController::ADD_MORE}
         flash[:notice].wont_be_nil
         redirect_params = attributes.except(:value).merge(visible: false, deprecated_at: nil)
         assert_redirected_to "/secrets/new?#{{secret: redirect_params}.to_query}"


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/3210

@zendesk/bre @zendesk/compute 

... this might be useful for some other resources too, where many similar things need to be created, for now adding them 1-by-1 but baking it into the shared resource-controller for easy reuse

opted not to use permitted-params since we often merge project into that

<img width="690" alt="screen shot 2019-03-06 at 11 10 34 am" src="https://user-images.githubusercontent.com/11367/53906872-d2a95080-4000-11e9-9275-4e69f02d495f.png">
<img width="756" alt="screen shot 2019-03-06 at 11 10 49 am" src="https://user-images.githubusercontent.com/11367/53906871-d2a95080-4000-11e9-8dd9-e49b37ff0b8c.png">
