### PR TITLE
rename label to avoid confusion

### DIFF
--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
@@ -2,7 +2,7 @@
   <legend>Kubernetes</legend>
   <%= form.input :kubernetes, as: :check_box, label: "Deploy via kubernetes / ignore commands" %>
 
-  <h3>Roles to ignore</h3>
+  <h3>Role config</h3>
   <% @stage.kubernetes_roles.build %>
   <% roles = @project.kubernetes_roles.not_deleted.pluck(:name, :id).unshift ["", nil] %>
   <%= form.fields_for :kubernetes_roles, @stage.kubernetes_roles do |fields| %>


### PR DESCRIPTION
already has a ignored checkbox, so it was confusing to have it twice