### PR TITLE
explicity call out what should happen to dependencies when destroying

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -7,7 +7,7 @@ class Build < ActiveRecord::Base
   belongs_to :project
   belongs_to :docker_build_job, class_name: 'Job', optional: true
   belongs_to :creator, class_name: 'User', foreign_key: 'created_by'
-  has_many :deploys
+  has_many :deploys, dependent: nil
 
   before_validation :nil_out_blanks
   before_validation :make_default_dockerfile_and_image_name_not_collide, on: :create

--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -5,9 +5,9 @@ class Command < ActiveRecord::Base
   audited
   audits_on_association(:stages, :stage_commands, audit_name: :script, &:script)
 
-  has_many :stage_commands
+  has_many :stage_commands, dependent: nil
   has_many :stages, through: :stage_commands
-  has_many :projects, foreign_key: :build_command_id
+  has_many :projects, foreign_key: :build_command_id, dependent: nil
 
   belongs_to :project, optional: true
 

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -4,7 +4,7 @@ module Lockable
   extend ActiveSupport::Concern
 
   included do
-    has_one :lock, as: :resource
+    has_one :lock, as: :resource, dependent: :destroy
   end
 
   def locked_by?(lock)

--- a/app/models/concerns/soft_delete_with_destroy.rb
+++ b/app/models/concerns/soft_delete_with_destroy.rb
@@ -12,7 +12,7 @@ module SoftDeleteWithDestroy
         association.options[:dependent] == :destroy && !association.klass.method_defined?(:soft_delete!)
       end
 
-      to_destroy.each { |association| send(association.name).each(&:destroy!) }
+      to_destroy.each { |association| Array(send(association.name)).each(&:destroy!) }
     end
   end
 end

--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -9,7 +9,7 @@ class DeployGroup < ActiveRecord::Base
 
   belongs_to :environment
   belongs_to :vault_server, class_name: 'Samson::Secrets::VaultServer', optional: true
-  has_many :deploy_groups_stages
+  has_many :deploy_groups_stages, dependent: nil
   has_many :stages, through: :deploy_groups_stages
   has_many :template_stages, -> { where(is_template: true) }, through: :deploy_groups_stages, source: :stage
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -4,7 +4,7 @@ class Job < ActiveRecord::Base
   belongs_to :user, -> { unscope(where: :deleted_at) }
   belongs_to :canceller, -> { unscope(where: "deleted_at") }, class_name: 'User', optional: true
 
-  has_one :deploy
+  has_one :deploy, dependent: nil
 
   # Used by status_panel
   alias_attribute :start_time, :created_at

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,8 +38,8 @@ class Project < ActiveRecord::Base
   has_many :builds, dependent: :destroy
   has_many :releases, dependent: :destroy
   has_many :stages, dependent: :destroy
-  has_many :deploys
-  has_many :jobs, -> { order(id: :desc) }
+  has_many :deploys, dependent: nil
+  has_many :jobs, -> { order(id: :desc) }, dependent: nil
   has_many :webhooks, dependent: :destroy
   has_many :outbound_webhooks, dependent: :destroy
   has_many :commands, dependent: :destroy

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -19,9 +19,7 @@ class Stage < ActiveRecord::Base
   has_many :outbound_webhooks, dependent: :destroy
 
   belongs_to :template_stage, class_name: "Stage", optional: true
-  has_many :clones, class_name: "Stage", foreign_key: "template_stage_id"
-
-  has_one :lock, as: :resource
+  has_many :clones, class_name: "Stage", foreign_key: "template_stage_id", dependent: nil
 
   has_many :stage_commands, autosave: true, dependent: :destroy
   private :stage_commands, :stage_commands= # must use ordering via script/command_ids/command_ids=

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,7 @@ class User < ActiveRecord::Base
 
   audited except: [:last_seen_at, :last_login_at]
 
-  has_many :commands
-  has_many :stars
+  has_many :stars, dependent: :destroy
   has_many :locks, dependent: :destroy
   has_many :user_project_roles, dependent: :destroy
   has_many :projects, through: :user_project_roles

--- a/plugins/flowdock/app/decorators/stage_decorator.rb
+++ b/plugins/flowdock/app/decorators/stage_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Stage.class_eval do
-  has_many :flowdock_flows
+  has_many :flowdock_flows, dependent: :destroy
 
   accepts_nested_attributes_for :flowdock_flows, allow_destroy: true, reject_if: :no_flowdock_token?
 

--- a/plugins/jenkins/app/decorators/deploy_decorator.rb
+++ b/plugins/jenkins/app/decorators/deploy_decorator.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 Deploy.class_eval do
-  has_many :jenkins_jobs
+  has_many :jenkins_jobs, dependent: nil
 end

--- a/plugins/kubernetes/app/decorators/build_decorator.rb
+++ b/plugins/kubernetes/app/decorators/build_decorator.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 Build.class_eval do
-  has_many :kubernetes_releases, class_name: 'Kubernetes::Release'
+  has_many :kubernetes_releases, class_name: 'Kubernetes::Release', dependent: nil
 end

--- a/plugins/kubernetes/app/decorators/deploy_decorator.rb
+++ b/plugins/kubernetes/app/decorators/deploy_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Deploy.class_eval do
-  has_one :kubernetes_release, class_name: 'Kubernetes::Release'
+  has_one :kubernetes_release, class_name: 'Kubernetes::Release', dependent: nil
 
   before_create :copy_kubernetes_from_stage
 

--- a/plugins/kubernetes/app/decorators/deploy_group_decorator.rb
+++ b/plugins/kubernetes/app/decorators/deploy_group_decorator.rb
@@ -6,7 +6,8 @@ DeployGroup.class_eval do
     :cluster_deploy_group,
     class_name: 'Kubernetes::ClusterDeployGroup',
     foreign_key: :deploy_group_id,
-    inverse_of: :deploy_group
+    inverse_of: :deploy_group,
+    dependent: :destroy
   )
   has_one :kubernetes_cluster, class_name: 'Kubernetes::Cluster', through: :cluster_deploy_group, source: :cluster
   has_many :kubernetes_deploy_group_roles, class_name: 'Kubernetes::DeployGroupRole', dependent: :destroy

--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -2,7 +2,7 @@
 Project.class_eval do
   has_soft_deletion default_scope: true
 
-  has_many :kubernetes_releases, class_name: 'Kubernetes::Release'
+  has_many :kubernetes_releases, class_name: 'Kubernetes::Release', dependent: nil
   has_many :kubernetes_roles, class_name: 'Kubernetes::Role', dependent: :destroy
   has_many :kubernetes_deploy_group_roles, class_name: 'Kubernetes::DeployGroupRole', dependent: :destroy
   has_many :kubernetes_usage_limits, class_name: 'Kubernetes::UsageLimit', dependent: :destroy

--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -8,7 +8,10 @@ module Kubernetes
 
     IP_PREFIX_PATTERN = /\A(?:[\d]{1,3}\.){0,2}[\d]{1,3}\z/ # also used in js
 
-    has_many :cluster_deploy_groups, class_name: 'Kubernetes::ClusterDeployGroup', foreign_key: :kubernetes_cluster_id
+    has_many :cluster_deploy_groups,
+      class_name: 'Kubernetes::ClusterDeployGroup',
+      foreign_key: :kubernetes_cluster_id,
+      dependent: nil
     has_many :deploy_groups, through: :cluster_deploy_groups
 
     validates :name, presence: true, uniqueness: true

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -6,7 +6,10 @@ module Kubernetes
     belongs_to :user
     belongs_to :project
     belongs_to :deploy
-    has_many :release_docs, class_name: 'Kubernetes::ReleaseDoc', foreign_key: 'kubernetes_release_id'
+    has_many :release_docs,
+      class_name: 'Kubernetes::ReleaseDoc',
+      foreign_key: 'kubernetes_release_id',
+      dependent: :destroy
     has_many :deploy_groups, through: :release_docs
 
     attr_accessor :builds

--- a/plugins/new_relic/app/decorators/stage_decorator.rb
+++ b/plugins/new_relic/app/decorators/stage_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Stage.class_eval do
-  has_many :new_relic_applications
+  has_many :new_relic_applications, dependent: :destroy
   accepts_nested_attributes_for :new_relic_applications, allow_destroy: true, reject_if: :no_newrelic_name?
 
   private

--- a/plugins/rollbar_dashboards/app/decorators/project_decorator.rb
+++ b/plugins/rollbar_dashboards/app/decorators/project_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Project.class_eval do
-  has_many :rollbar_dashboards_settings, class_name: 'RollbarDashboards::Setting'
+  has_many :rollbar_dashboards_settings, class_name: 'RollbarDashboards::Setting', dependent: :destroy
 
   accepts_nested_attributes_for :rollbar_dashboards_settings, allow_destroy: true, reject_if: ->(a) do
     a.fetch(:base_url).blank? && a.fetch(:read_token).blank?

--- a/plugins/rollbar_hook/app/decorators/stage_decorator.rb
+++ b/plugins/rollbar_hook/app/decorators/stage_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Stage.class_eval do
-  has_many :rollbar_webhooks
+  has_many :rollbar_webhooks, dependent: :destroy
   accepts_nested_attributes_for :rollbar_webhooks, allow_destroy: true, reject_if: ->(a) {
     a.fetch(:webhook_url).blank?
   }

--- a/plugins/slack_webhooks/app/decorators/stage_decorator.rb
+++ b/plugins/slack_webhooks/app/decorators/stage_decorator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 Stage.class_eval do
-  has_many :slack_webhooks
+  has_many :slack_webhooks, dependent: :destroy
   accepts_nested_attributes_for :slack_webhooks, allow_destroy: true, reject_if: ->(a) { a.fetch(:webhook_url).blank? }
 end

--- a/test/models/deploy_group_test.rb
+++ b/test/models/deploy_group_test.rb
@@ -119,9 +119,9 @@ describe DeployGroup do
     end
   end
 
-  it_expires_stage :save
-  it_expires_stage :destroy
-  it_expires_stage :soft_delete
+  it_expires_stage :save!
+  it_expires_stage :destroy!
+  it_expires_stage :soft_delete!
 
   describe "#destroy_deploy_groups_stages" do
     let(:deploy_group) { deploy_groups(:pod100) }


### PR DESCRIPTION
too often we gloss over dependency cleanup and then we end up with orphan records
that breaks the UI, nevermore!

also adding docs for `nil` to rails here
https://github.com/rails/rails/pull/35504

@zendesk/compute @zendesk/bre 