### PR TITLE
make deploy-group deletion not be 1-off controller logic, but use mod…

### DIFF
--- a/app/controllers/deploy_groups_controller.rb
+++ b/app/controllers/deploy_groups_controller.rb
@@ -61,12 +61,11 @@ class DeployGroupsController < ApplicationController
   end
 
   def destroy
-    if deploy_group.deploy_groups_stages.empty?
-      deploy_group.soft_delete!(validate: false)
+    if deploy_group.soft_delete(validate: false)
       flash[:notice] = "Successfully deleted deploy group: #{deploy_group.name}"
       redirect_to action: :index
     else
-      flash[:error] = "Deploy group is still in use."
+      flash[:error] = "Deploy group could not be deleted because: #{deploy_group.errors.full_messages.join(', ')}"
       redirect_to deploy_group
     end
   end
@@ -101,7 +100,8 @@ class DeployGroupsController < ApplicationController
   end
 
   def custom_env(deploy_group)
-    EnvironmentVariable.where(scope: deploy_group).each_with_object({}) do |e, h|
+    supported = [Project.name, EnvironmentVariableGroup.name]
+    EnvironmentVariable.where(scope: deploy_group, parent_type: supported).each_with_object({}) do |e, h|
       h[[e.name, e.parent_type, e.parent_id]] = e
     end
   end

--- a/app/models/concerns/permalinkable.rb
+++ b/app/models/concerns/permalinkable.rb
@@ -9,7 +9,7 @@ module Permalinkable
 
     # making permalink and soft-delete dependent is a bit weird, but if a model is important enough to have a permalink
     # then it should also be soft_deleted ... also otherwise setup order is non obvious and could fail silently
-    before_soft_delete :free_permalink_for_deletion
+    around_soft_delete :free_permalink_for_deletion
   end
 
   module ClassMethods
@@ -56,5 +56,11 @@ module Permalinkable
 
   def free_permalink_for_deletion
     self.permalink = "#{permalink}-deleted-#{Time.now.to_i}"
+    success = yield
+    self.permalink = permalink_was unless success
+    success
+  rescue StandardError
+    self.permalink = permalink_was
+    raise
   end
 end

--- a/app/models/concerns/soft_delete_with_destroy.rb
+++ b/app/models/concerns/soft_delete_with_destroy.rb
@@ -1,18 +1,30 @@
 # frozen_string_literal: true
 
-# soft_deletion gem doesn't destroy relations with dependent: :destroy, only safe_delete's them if they are
-# safe_deletable. This leads to orphaned records of safe_deleted objects. This fills in the missing logic in the
-# gem -- finding all child records which are not safe_deletable and have the dependent: :destroy callback and deleting
+# soft_deletion gem doesn't destroy relations with dependent: :destroy, only soft_delete's them if they are
+# soft_deletable. This leads to orphaned records of soft_deleted objects. This fills in the missing logic in the
+# gem -- finding all child records which are not soft_deletable and have the `dependent: :destroy` callback and deleting
 # them.
+# Setting a new instance var, to avoid having saving an already deleted record delete it's associations
+#
+# Inside the transaction so it rolls back if anything fails
 module SoftDeleteWithDestroy
   def self.included(base)
-    base.before_soft_delete do
-      mark_as_deleted # We need associations to skip validations during deletion of their parent
-      to_destroy = base.reflect_on_all_associations.select do |association|
-        association.options[:dependent] == :destroy && !association.klass.method_defined?(:soft_delete!)
-      end
+    base.attr_accessor :in_soft_delete
+    base.around_soft_delete do |_, inner|
+      @in_soft_delete = true
+      inner.call
+    ensure
+      @in_soft_delete = false
+    end
 
-      to_destroy.each { |association| Array(send(association.name)).each(&:destroy!) }
+    base.before_update do
+      if @in_soft_delete
+        to_destroy = base.reflect_on_all_associations.select do |association|
+          association.options[:dependent] == :destroy && !association.klass.method_defined?(:soft_delete!)
+        end
+
+        to_destroy.each { |association| Array(send(association.name)).each(&:destroy!) }
+      end
     end
   end
 end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -214,7 +214,7 @@ class Deploy < ActiveRecord::Base
   def csv_line
     [
       id, project.name, summary, commit, job.status, updated_at, start_time, user.try(:name), user.try(:email),
-      buddy_name, buddy_email, stage.name, stage.production?, !stage.no_code_deployed, project.deleted_at,
+      buddy_name, buddy_email, stage.name, production, !stage.no_code_deployed, project.deleted_at,
       stage.deploy_group_names.join('|')
     ]
   end

--- a/plugins/kubernetes/test/decorators/deploy_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/deploy_decorator_test.rb
@@ -25,25 +25,4 @@ describe Deploy do
       create_deploy.kubernetes.must_equal false
     end
   end
-
-  describe "#delete_kubernetes_deploy_group_roles" do
-    let(:role) { kubernetes_roles(:app_server) }
-    let(:project) { role.project }
-    it "cleanes up deploy group roles on delete" do
-      deploy_group = deploy_groups(:pod2)
-      Kubernetes::DeployGroupRole.create!(
-        kubernetes_role: role,
-        project: project,
-        replicas: 1,
-        requests_cpu: 0.5,
-        requests_memory: 5,
-        limits_cpu: 1,
-        limits_memory: 10,
-        deploy_group: deploy_group
-      )
-      deploy_group.kubernetes_deploy_group_roles.wont_equal []
-      deploy_group.soft_delete!(validate: false)
-      deploy_group.reload.kubernetes_deploy_group_roles.must_equal []
-    end
-  end
 end

--- a/plugins/kubernetes/test/decorators/deploy_group_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/deploy_group_decorator_test.rb
@@ -8,8 +8,7 @@ describe DeployGroup do
 
   describe "cluster_deploy_group" do
     it "accepts nested attributes" do
-      group = DeployGroup.new(cluster_deploy_group_attributes: {namespace: 'Foo',
-                                                                kubernetes_cluster_id: 1})
+      group = DeployGroup.new(cluster_deploy_group_attributes: {namespace: 'Foo', kubernetes_cluster_id: 1})
       group.cluster_deploy_group.namespace.must_equal "Foo"
     end
 
@@ -36,8 +35,9 @@ describe DeployGroup do
     let(:group_role) { kubernetes_deploy_group_roles(:test_pod1_app_server) }
 
     it "destroys deploy_group_roles after soft delete" do
+      deploy_group.deploy_groups_stages.clear
       refute_empty deploy_group.kubernetes_deploy_group_roles
-      deploy_group.soft_delete!
+      deploy_group.soft_delete!(validate: false)
       assert_empty deploy_group.reload.kubernetes_deploy_group_roles
     end
   end

--- a/test/controllers/environments_controller_test.rb
+++ b/test/controllers/environments_controller_test.rb
@@ -65,8 +65,9 @@ describe EnvironmentsController do
       end
     end
 
-    describe '#delete' do
+    describe '#destroy' do
       it 'succeeds' do
+        DeployGroupsStage.delete_all
         env = environments(:production)
         delete :destroy, params: {id: env}
         assert_redirected_to environments_path

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -110,9 +110,10 @@ describe "cleanliness" do
     end
   end
 
+  # rails does not run validations on :destroy, so we should not run them on soft-delete (which is an update)
   it 'discourages use of soft_delete without validate: false' do
     assert_content all_code do |content|
-      if content.match?(/soft_delete\!?$/)
+      if content.match?(/[\. ]soft_delete\!?$/)
         'prefer soft_delete(validate: false)'
       end
     end

--- a/test/models/concerns/permalinkable_test.rb
+++ b/test/models/concerns/permalinkable_test.rb
@@ -149,6 +149,26 @@ describe Permalinkable do
     it "frees the permalink when soft deleting" do
       project.soft_delete!(validate: false)
       project.permalink.must_match /\Afoo-deleted-\d+\z/
+      project.reload.permalink.must_match /\Afoo-deleted-\d+\z/
+    end
+
+    it "creates an audit that points to the new permalink" do
+      project.soft_delete!(validate: false)
+      project.audits.last.audited_changes.keys.must_equal ["permalink", "deleted_at"]
+    end
+
+    it "does not change the permalink when before_soft_delete fail" do
+      failed_transaction = Class.new(Project) { before_soft_delete { throw :abort } }.find(project.id)
+      refute failed_transaction.soft_delete(validate: false)
+      failed_transaction.permalink.must_equal "foo"
+      failed_transaction.reload.permalink.must_equal "foo"
+    end
+
+    it "does not change the permalink when validations fail" do
+      failed_transaction = Class.new(Project) { before_save { throw :abort } }.find(project.id)
+      refute failed_transaction.soft_delete(validate: false)
+      failed_transaction.permalink.must_equal "foo"
+      failed_transaction.reload.permalink.must_equal "foo"
     end
   end
 end

--- a/test/models/concerns/soft_delete_with_destroy_test.rb
+++ b/test/models/concerns/soft_delete_with_destroy_test.rb
@@ -6,11 +6,37 @@ SingleCov.covered!
 
 describe SoftDeleteWithDestroy do
   describe 'destroy' do
-    it 'destroys dependent: :destroy relations before soft_delete' do
-      project = projects(:test)
+    let(:project) { projects(:test) }
 
+    it 'destroys dependent: :destroy relations before soft_delete' do
       assert_difference 'StageCommand.count', -2 do
         project.soft_delete!(validate: false)
+      end
+    end
+
+    it "does not destroy when validations fail" do
+      assert_difference 'StageCommand.count', 0 do
+        project.name = nil
+        refute project.soft_delete
+      end
+    end
+
+    it 'does nothing on regular save' do
+      assert_difference 'StageCommand.count', 0 do
+        project.save!
+      end
+    end
+
+    it 'does not destroy when already deleted' do
+      assert_difference 'StageCommand.count', 0 do
+        project.update_attributes!(deleted_at: Time.now)
+      end
+    end
+
+    it "restores when transaction fails" do
+      failed_transaction = Class.new(Project) { before_save { throw :abort } }.find(project.id)
+      assert_difference 'StageCommand.count', 0 do
+        refute failed_transaction.soft_delete(validate: false)
       end
     end
   end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -587,21 +587,21 @@ describe Deploy do
     describe "with deleted objects" do
       before do
         # replicate worse case scenario where any referenced associations are soft deleted
-        prod_deploy.update_attributes(buddy_id: other_user.id)
+        prod_deploy.update_column(:buddy_id, other_user.id)
         prod_deploy.job.user.soft_delete!(validate: false)
         prod_deploy.buddy.soft_delete!(validate: false)
-        prod_deploy.stage.deploy_groups.first.environment.soft_delete!(validate: false)
-        # next 2 are false soft_deletions: there are dependent destroys that would result in
+        # next are fake soft_deletions: there are dependent destroys that would result in
         # deploy_groups_stages to be cleared which would make this test condition to likely
         # never occur in production but could exist
-        prod_deploy.stage.project.update_attribute(:deleted_at, Time.new(2016, 1, 1))
-        prod_deploy.stage.update_attribute(:deleted_at, Time.now)
+        prod_deploy.stage.deploy_groups.first.environment.update_column(:deleted_at, Time.now)
+        prod_deploy.stage.project.update_column(:deleted_at, Time.new(2016, 1, 1))
+        prod_deploy.stage.update_column(:deleted_at, Time.now)
         prod_deploy.reload
       end
 
       it "returns array with deleted object values with DeployGroups" do
         DeployGroup.stubs(enabled?: true)
-        prod.update_attribute(:production, false) # make sure response is from environment
+        prod.update_column(:production, false) # make sure response is from environment
 
         # the with_deleted calls would be done in CsvJob
         CsvExportJob.new(nil).send(:with_deleted) do

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -56,9 +56,14 @@ describe Environment do
     end
   end
 
-  describe "#soft_delete!" do
-    it "also deletes deploy groups" do
-      environments(:production).soft_delete!
+  describe "#soft_delete" do
+    it "refuses when groups are used" do
+      refute environments(:production).soft_delete(validate: false)
+    end
+
+    it "deletes unused deploy groups" do
+      DeployGroupsStage.delete_all
+      assert environments(:production).soft_delete(validate: false)
       assert DeployGroup.with_deleted { DeployGroup.find(deploy_groups(:pod1).id) }.deleted_at
     end
   end


### PR DESCRIPTION
…el validations

 - controllers should only use "save/destroy/soft_delete" and not know about model validations
 - models should know when they are valid / when they are allowed to be deleted

 - fixed that we should not destroy dependencies before soft_delete hook is started (SoftDeleteWithDestroy bug) 
 - fixed we should not set a permalink before validations are done so redirects do not break and forms do not show weird permalinks

![screen shot 2019-03-07 at 1 44 40 pm](https://user-images.githubusercontent.com/11367/53994550-72d9a500-40e7-11e9-87fd-ea98570b00ce.png)
