### PR TITLE
Add support for a deploy_group usage report

### DIFF
--- a/app/controllers/csv_exports_controller.rb
+++ b/app/controllers/csv_exports_controller.rb
@@ -21,6 +21,8 @@ class CsvExportsController < ApplicationController
       format.html do
         if params[:type] == "users"
           render :new_users
+        elsif params[:type] == "deploy_group_usage"
+          render :new_deploy_group_usage
         else
           @csv_export = CsvExport.new
         end
@@ -29,6 +31,9 @@ class CsvExportsController < ApplicationController
         if params[:type] == "users"
           options = user_filter
           send_data UserCsvPresenter.to_csv(options), type: :csv, filename: "Users_#{options[:datetime]}.csv"
+        elsif params[:type] == "deploy_group_usage"
+          date_time_now = Time.now.strftime "%Y%m%d_%H%M"
+          send_data DeployGroupUsageCsvPresenter.to_csv, type: :csv, filename: "DeployGroupUsage_#{date_time_now}.csv"
         else
           render body: "not found", status: :not_found
         end

--- a/app/presenters/deploy_group_usage_csv_presenter.rb
+++ b/app/presenters/deploy_group_usage_csv_presenter.rb
@@ -32,15 +32,17 @@ class DeployGroupUsageCsvPresenter
   end
 
   def self.csv_line(project, stage = nil, deploy_group = nil)
-    result = []
+    result = [project.name]
     if stage && deploy_group
-      result << stage.name
-      result << deploy_group.name
-      result << deploy_group.environment_id
-      result << deploy_group.environment.name
-      result << deploy_group.env_value
-      result << deploy_group.permalink
+      result.concat [
+        stage.name,
+        deploy_group.name,
+        deploy_group.environment_id,
+        deploy_group.environment.name,
+        deploy_group.env_value,
+        deploy_group.permalink
+      ]
     end
-    result.unshift(project.name)
+    result
   end
 end

--- a/app/presenters/deploy_group_usage_csv_presenter.rb
+++ b/app/presenters/deploy_group_usage_csv_presenter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class DeployGroupUsageCsvPresenter
+
+  def self.to_csv
+    CSV.generate do |csv|
+      csv << csv_header
+      Project.all.each do |project|
+        if project.stages.empty?
+          csv << csv_line(project)
+        else
+          project.stages.each do |stage|
+            stage.deploy_groups.each do |deploy_group|
+              csv << csv_line(project, stage, deploy_group)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def self.csv_header
+    [
+      "project_name",
+      "stage_name",
+      "deploy_group_name",
+      "deploy_group_environment_id",
+      "deploy_group_environment_name",
+      "deploy_group_env_value",
+      "deploy_group_permalink"
+    ]
+  end
+
+  def self.csv_line(project, stage=nil, deploy_group=nil)
+    result = []
+    if stage && deploy_group
+      result << stage.name
+      result << deploy_group.name
+      result << deploy_group.environment_id
+      result << deploy_group.environment.name
+      result << deploy_group.env_value
+      result << deploy_group.permalink
+    end
+    return result.unshift(project.name)
+  end
+end

--- a/app/presenters/deploy_group_usage_csv_presenter.rb
+++ b/app/presenters/deploy_group_usage_csv_presenter.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
-
 require 'csv'
 
 class DeployGroupUsageCsvPresenter
-
   def self.to_csv
     CSV.generate do |csv|
       csv << csv_header
@@ -33,7 +31,7 @@ class DeployGroupUsageCsvPresenter
     ]
   end
 
-  def self.csv_line(project, stage=nil, deploy_group=nil)
+  def self.csv_line(project, stage = nil, deploy_group = nil)
     result = []
     if stage && deploy_group
       result << stage.name
@@ -43,6 +41,6 @@ class DeployGroupUsageCsvPresenter
       result << deploy_group.env_value
       result << deploy_group.permalink
     end
-    return result.unshift(project.name)
+    result.unshift(project.name)
   end
 end

--- a/app/presenters/deploy_group_usage_csv_presenter.rb
+++ b/app/presenters/deploy_group_usage_csv_presenter.rb
@@ -2,47 +2,51 @@
 require 'csv'
 
 class DeployGroupUsageCsvPresenter
-  def self.to_csv
-    CSV.generate do |csv|
-      csv << csv_header
-      Project.all.each do |project|
-        if project.stages.empty?
-          csv << csv_line(project)
-        else
-          project.stages.each do |stage|
-            stage.deploy_groups.each do |deploy_group|
-              csv << csv_line(project, stage, deploy_group)
+  class << self
+    def to_csv
+      CSV.generate do |csv|
+        csv << csv_header
+        Project.all.each do |project|
+          if project.stages.empty?
+            csv << csv_line(project)
+          else
+            project.stages.each do |stage|
+              stage.deploy_groups.each do |deploy_group|
+                csv << csv_line(project, stage, deploy_group)
+              end
             end
           end
         end
       end
     end
-  end
 
-  def self.csv_header
-    [
-      "project_name",
-      "stage_name",
-      "deploy_group_name",
-      "deploy_group_environment_id",
-      "deploy_group_environment_name",
-      "deploy_group_env_value",
-      "deploy_group_permalink"
-    ]
-  end
+    private
 
-  def self.csv_line(project, stage = nil, deploy_group = nil)
-    result = [project.name]
-    if stage && deploy_group
-      result.concat [
-        stage.name,
-        deploy_group.name,
-        deploy_group.environment_id,
-        deploy_group.environment.name,
-        deploy_group.env_value,
-        deploy_group.permalink
+    def csv_header
+      [
+        "project_name",
+        "stage_name",
+        "deploy_group_name",
+        "deploy_group_environment_id",
+        "deploy_group_environment_name",
+        "deploy_group_env_value",
+        "deploy_group_permalink"
       ]
     end
-    result
+
+    def csv_line(project, stage = nil, deploy_group = nil)
+      result = [project.name]
+      if stage && deploy_group
+        result.concat [
+          stage.name,
+          deploy_group.name,
+          deploy_group.environment_id,
+          deploy_group.environment.name,
+          deploy_group.env_value,
+          deploy_group.permalink
+        ]
+      end
+      result
+    end
   end
 end

--- a/app/views/csv_exports/index.html.erb
+++ b/app/views/csv_exports/index.html.erb
@@ -4,7 +4,7 @@
   <div>
     <p><%= link_to "New Deploys Report", new_csv_export_path %></p>
     <p><%= link_to "New Users Report", new_csv_export_path(type: :users) %></p>
-    <%if DeployGroup.enabled? %>
+    <% if DeployGroup.enabled? %>
       <p><%= link_to "New Deploy Group Usage Report", new_csv_export_path(type: :deploy_group_usage) %></p>
     <% end %>
   </div>

--- a/app/views/csv_exports/index.html.erb
+++ b/app/views/csv_exports/index.html.erb
@@ -4,6 +4,9 @@
   <div>
     <p><%= link_to "New Deploys Report", new_csv_export_path %></p>
     <p><%= link_to "New Users Report", new_csv_export_path(type: :users) %></p>
+    <%if DeployGroup.enabled? %>
+      <p><%= link_to "New Deploy Group Usage Report", new_csv_export_path(type: :deploy_group_usage) %></p>
+    <% end %>
   </div>
   <% if @csv_exports.empty? %>
     <p>No current CSV Reports was found!</p>

--- a/app/views/csv_exports/new_deploy_group_usage.erb
+++ b/app/views/csv_exports/new_deploy_group_usage.erb
@@ -1,0 +1,16 @@
+<%= page_title "Deploy Group Usage Report" %>
+
+<section>
+
+  <div class="csv-users-filters clearfix">
+    <%= form_tag new_csv_export_path(format: :csv, type: :deploy_group_usage), method: :get, class: "form-horizontal" do %>
+      <%= hidden_field_tag :type, "deploy_group_usage" %>
+      <div class="form-group">
+        <div class="col-lg-offset-2 col-lg-10">
+          <%= submit_tag "Download Deploy Group Usage Report", class: 'btn btn-default' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+</section>

--- a/test/controllers/csv_exports_controller_test.rb
+++ b/test/controllers/csv_exports_controller_test.rb
@@ -124,6 +124,12 @@ describe CsvExportsController do
           end
         end
 
+        describe "deploy_group_usage type" do
+          options = options.merge(format: :csv, type: "deploy_group_usage")
+          get :new, params: options
+          assert_response :success
+        end
+
         describe "users type" do
           before { users(:super_admin).soft_delete! }
           let(:expected) do

--- a/test/controllers/csv_exports_controller_test.rb
+++ b/test/controllers/csv_exports_controller_test.rb
@@ -106,6 +106,14 @@ describe CsvExportsController do
             @response.body.must_include ">Super Admin</option>"
           end
         end
+
+        describe "deploy_group_usage type" do
+          it "renders form options" do
+            get :new, params: {type: :deploy_group_usage}
+            assert_select "h1", "Deploy Group Usage Report"
+            @response.body.must_include "Download Deploy Group Usage Report"
+          end
+        end
       end
 
       describe "as csv" do

--- a/test/controllers/csv_exports_controller_test.rb
+++ b/test/controllers/csv_exports_controller_test.rb
@@ -125,7 +125,7 @@ describe CsvExportsController do
         end
 
         describe "deploy_group_usage type" do
-          options = options.merge(format: :csv, type: "deploy_group_usage")
+          options = {format: :csv, type: "deploy_group_usage"}
           get :new, params: options
           assert_response :success
         end

--- a/test/controllers/csv_exports_controller_test.rb
+++ b/test/controllers/csv_exports_controller_test.rb
@@ -125,9 +125,10 @@ describe CsvExportsController do
         end
 
         describe "deploy_group_usage type" do
-          options = {format: :csv, type: "deploy_group_usage"}
-          get :new, params: options
-          assert_response :success
+          it "returns csv" do
+            get :new, params: {format: :csv, type: "deploy_group_usage"}
+            assert_response :success
+          end
         end
 
         describe "users type" do

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe DeployGroupUsageCsvPresenter do
+  
+  describe ".csv_header" do
+    it "returns the list of column headers" do
+      DeployGroupUsageCsvPresenter.csv_header(project).must_equal(
+        [
+          "project_name",
+          "stage_name",
+          "deploy_group_name",
+          "deploy_group_environment_id",
+          "deploy_group_environment_name",
+          "deploy_group_env_value",
+          "deploy_group_permalink"
+        ]
+      )
+    end
+
+  describe ".csv_line" do
+    let(:project) { projects(:test) }
+    let(:stage){ stages(:test_staging) }
+    let(:deploy_group) { DeployGroup.create!(name: 'Pod 101', environment: env, 
+        env_value: 'test env value', permalink: 'test permalink value') }
+
+    it "returns a project line when only a project is available" do
+      DeployGroupUsageCsvPresenter.csv_line(project).must_equal(
+        [project.name]
+      )
+    end
+
+    it "returns a project line when a project and a stage is available but no deploy_group" do
+      DeployGroupUsageCsvPresenter.csv_line(project, stage).must_equal(
+        [project.name]
+      )
+    end
+
+    it "returns a project line when a project, stage, and eploy_group are available" do
+      DeployGroupUsageCsvPresenter.csv_line(project, stage, deploy_group).must_equal(
+        [
+           project.name,
+           stage.name,
+           deploy_group.name,
+           deploy_group.environment_id,
+           deploy_group.environment.name,
+           deploy_group.env_value,
+           deploy_group.permalink
+        ]
+      )
+    end        
+  end
+end

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -42,19 +42,19 @@ describe DeployGroupUsageCsvPresenter do
     let(:deploy_group) { deploy_groups(:pod1) }
 
     it "returns a project line when only a project is available" do
-      DeployGroupUsageCsvPresenter.csv_line(project).must_equal(
+      DeployGroupUsageCsvPresenter.send(:csv_line, project).must_equal(
         [project.name]
       )
     end
 
     it "returns a project line when a project and a stage is available but no deploy_group" do
-      DeployGroupUsageCsvPresenter.csv_line(project, stage).must_equal(
+      DeployGroupUsageCsvPresenter.send(:csv_line, project, stage).must_equal(
         [project.name]
       )
     end
 
     it "returns a project line when a project, stage, and deploy_group are available" do
-      DeployGroupUsageCsvPresenter.csv_line(project, stage, deploy_group).must_equal(
+      DeployGroupUsageCsvPresenter.send(:csv_line, project, stage, deploy_group).must_equal(
         [
           project.name,
           stage.name,

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -22,9 +22,15 @@ describe DeployGroupUsageCsvPresenter do
 
   describe ".csv_line" do
     let(:project) { projects(:test) }
-    let(:stage){ stages(:test_staging) }
-    let(:deploy_group) { DeployGroup.create!(name: 'Pod 101', environment: env, 
-        env_value: 'test env value', permalink: 'test permalink value') }
+    let(:stage) { stages(:test_staging) }
+    let(:deploy_group) do
+      DeployGroup.create!(
+        name: 'Pod 101',
+        environment: env,
+        env_value: 'test env value',
+        permalink: 'test permalink value'
+      )
+    end
 
     it "returns a project line when only a project is available" do
       DeployGroupUsageCsvPresenter.csv_line(project).must_equal(
@@ -41,15 +47,15 @@ describe DeployGroupUsageCsvPresenter do
     it "returns a project line when a project, stage, and eploy_group are available" do
       DeployGroupUsageCsvPresenter.csv_line(project, stage, deploy_group).must_equal(
         [
-           project.name,
-           stage.name,
-           deploy_group.name,
-           deploy_group.environment_id,
-           deploy_group.environment.name,
-           deploy_group.env_value,
-           deploy_group.permalink
+          project.name,
+          stage.name,
+          deploy_group.name,
+          deploy_group.environment_id,
+          deploy_group.environment.name,
+          deploy_group.env_value,
+          deploy_group.permalink
         ]
       )
-    end        
+    end
   end
 end

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -8,10 +8,14 @@ describe DeployGroupUsageCsvPresenter do
     it "generates csv" do
       expected_csv_rows = 1
       Project.all.each do |project|
-        expected_csv_rows += project.stages.empty? ? 1 : project.stages.count
+        if project.stages.empty?
+          expected_csv_rows += 1
+        else
+          project.stages.each do |stage|
+            expected_csv_rows += stage.deploy_groups.count
+          end
+        end
       end
-      puts "GOOBER: #{DeployGroupUsageCsvPresenter.to_csv}"
-      expect("dummy string").to eq(DeployGroupUsageCsvPresenter.to_csv.to_s)
       DeployGroupUsageCsvPresenter.to_csv.split("\n").size.must_equal expected_csv_rows
     end
   end

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -10,6 +10,8 @@ describe DeployGroupUsageCsvPresenter do
       Project.all.each do |project|
         expected_csv_rows += project.stages.empty? ? 1 : project.stages.count
       end
+      puts "GOOBER: #{DeployGroupUsageCsvPresenter.to_csv}"
+      expect("dummy string").to eq(DeployGroupUsageCsvPresenter.to_csv.to_s)
       DeployGroupUsageCsvPresenter.to_csv.split("\n").size.must_equal expected_csv_rows
     end
   end

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -22,7 +22,7 @@ describe DeployGroupUsageCsvPresenter do
 
   describe ".csv_header" do
     it "returns the list of column headers" do
-      DeployGroupUsageCsvPresenter.csv_header.must_equal(
+      DeployGroupUsageCsvPresenter.send(:csv_header).must_equal(
         [
           "project_name",
           "stage_name",

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -4,6 +4,13 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe DeployGroupUsageCsvPresenter do
+  describe ".to_csv" do
+    it "generates csv" do
+      csv_header_rows
+      DeployGroupUsageCsvPresenter.to_csv.split("\n").size.must_equal Project.count + csv_header_rows
+    end
+  end
+
   describe ".csv_header" do
     it "returns the list of column headers" do
       DeployGroupUsageCsvPresenter.csv_header.must_equal(

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -23,15 +23,7 @@ describe DeployGroupUsageCsvPresenter do
   describe ".csv_line" do
     let(:project) { projects(:test) }
     let(:stage) { stages(:test_staging) }
-    let(:environment) { environments(:production) }
-    let(:deploy_group) do
-      DeployGroup.create!(
-        name: 'Pod 101',
-        environment: environment,
-        env_value: 'test env value',
-        permalink: 'test permalink value'
-      )
-    end
+    let(:deploy_group) { deploy_groups(:pod1) }    
 
     it "returns a project line when only a project is available" do
       DeployGroupUsageCsvPresenter.csv_line(project).must_equal(
@@ -45,7 +37,7 @@ describe DeployGroupUsageCsvPresenter do
       )
     end
 
-    it "returns a project line when a project, stage, and eploy_group are available" do
+    it "returns a project line when a project, stage, and deploy_group are available" do
       DeployGroupUsageCsvPresenter.csv_line(project, stage, deploy_group).must_equal(
         [
           project.name,

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -4,7 +4,6 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe DeployGroupUsageCsvPresenter do
-  
   describe ".csv_header" do
     it "returns the list of column headers" do
       DeployGroupUsageCsvPresenter.csv_header(project).must_equal(
@@ -19,6 +18,7 @@ describe DeployGroupUsageCsvPresenter do
         ]
       )
     end
+  end
 
   describe ".csv_line" do
     let(:project) { projects(:test) }

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -6,7 +6,7 @@ SingleCov.covered!
 describe DeployGroupUsageCsvPresenter do
   describe ".to_csv" do
     it "generates csv" do
-      csv_header_rows
+      csv_header_rows = 1
       DeployGroupUsageCsvPresenter.to_csv.split("\n").size.must_equal Project.count + csv_header_rows
     end
   end

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -6,7 +6,7 @@ SingleCov.covered!
 describe DeployGroupUsageCsvPresenter do
   describe ".csv_header" do
     it "returns the list of column headers" do
-      DeployGroupUsageCsvPresenter.csv_header(project).must_equal(
+      DeployGroupUsageCsvPresenter.csv_header.must_equal(
         [
           "project_name",
           "stage_name",
@@ -23,10 +23,11 @@ describe DeployGroupUsageCsvPresenter do
   describe ".csv_line" do
     let(:project) { projects(:test) }
     let(:stage) { stages(:test_staging) }
+    let(:environment) { environments(:production) }
     let(:deploy_group) do
       DeployGroup.create!(
         name: 'Pod 101',
-        environment: env,
+        environment: environment,
         env_value: 'test env value',
         permalink: 'test permalink value'
       )

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -23,7 +23,7 @@ describe DeployGroupUsageCsvPresenter do
   describe ".csv_line" do
     let(:project) { projects(:test) }
     let(:stage) { stages(:test_staging) }
-    let(:deploy_group) { deploy_groups(:pod1) }    
+    let(:deploy_group) { deploy_groups(:pod1) }
 
     it "returns a project line when only a project is available" do
       DeployGroupUsageCsvPresenter.csv_line(project).must_equal(

--- a/test/presenters/deploy_group_usage_csv_presenter_test.rb
+++ b/test/presenters/deploy_group_usage_csv_presenter_test.rb
@@ -6,8 +6,11 @@ SingleCov.covered!
 describe DeployGroupUsageCsvPresenter do
   describe ".to_csv" do
     it "generates csv" do
-      csv_header_rows = 1
-      DeployGroupUsageCsvPresenter.to_csv.split("\n").size.must_equal Project.count + csv_header_rows
+      expected_csv_rows = 1
+      Project.all.each do |project|
+        expected_csv_rows += project.stages.empty? ? 1 : project.stages.count
+      end
+      DeployGroupUsageCsvPresenter.to_csv.split("\n").size.must_equal expected_csv_rows
     end
   end
 


### PR DESCRIPTION
**Use Case**
- I want a report that shows all the `deploy_groups` where all `projects` are deploying code.
- This is partially supported today by going to the `deploy_groups` page and inspecting each individual `deploy_group`, however this is kind of a pain when I am trying to do management over a large number of `projects`, each with a number of `stages`, and each of those going to a variable number of `deploy_groups`.

**Solution**
- Enable a new report option (when `DeployGroup.enabled?`) that generates a CSV containing a list of all `projects`, their `stages`, and information about their `deploy_groups`
- Based on code block previously (and manually) run against the database
```
Project.all.each do |project|
  project.stages.each do |stage|
    stage.deploy_groups.each do |deploy_group|
      puts "#{project.name}\t#{stage.name}\t#{deploy_group.name}\t#{deploy_group.environment_id}\t#{deploy_group.environment.name}\t#{deploy_group.env_value}\t#{deploy_group.permalink}"
    end
  end
  puts "#{project.name}" if project.stages.empty?
end; nil
```
**Screenshots**
![image](https://user-images.githubusercontent.com/9309340/54079420-2a5deb00-4291-11e9-939d-e3d6c2be6386.png)
_Reports screen when DEPLOY_GROUP_FEATURE is not enabled_


![image](https://user-images.githubusercontent.com/9309340/54079438-5b3e2000-4291-11e9-9538-36add9fea6da.png)
_Reports screen when DEPLOY_GROUP_FEATURE is enabled_


![image](https://user-images.githubusercontent.com/9309340/54079427-42ce0580-4291-11e9-9490-cb492d0ce653.png)
_The New Deploy Group Usage Report screen_


![image](https://user-images.githubusercontent.com/9309340/54079442-6a24d280-4291-11e9-94f4-5f17b6c72e27.png)
_CSC Download generated after clicking on the Download Deploy Group Usage Report button_


![image](https://user-images.githubusercontent.com/9309340/54079451-8de81880-4291-11e9-9b69-db0a609a2a2e.png)
_Example CSV results_


/cc @zendesk/samson, @grosser, @pduchemin

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Low
