### PR TITLE
make sure we have a reasonable minimum timeout for clone/fetch

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -130,12 +130,12 @@ class GitRepository
   end
 
   def clone!
-    executor.execute "git -c core.askpass=true clone --mirror #{repository_url} #{repo_cache_dir}"
+    executor.execute "git -c core.askpass=true clone --mirror #{repository_url} #{repo_cache_dir}", min_timeout: 30
   end
   add_tracer :clone!
 
   def update!
-    executor.execute("cd #{repo_cache_dir}", 'git fetch -p')
+    executor.execute "cd #{repo_cache_dir}", 'git fetch -p', min_timeout: 30
   end
   add_tracer :update!
 

--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -32,7 +32,8 @@ class TerminalExecutor
     @cancel_timeout = cancel_timeout
   end
 
-  def execute(*commands, timeout: @timeout)
+  def execute(*commands, timeout: @timeout, min_timeout: 0)
+    timeout = [timeout, min_timeout].max
     script_as_executable(script(commands)) do |command|
       output, _, pid = PTY.spawn(whitelisted_env, command, in: '/dev/null', unsetenv_others: true)
       record_pid(pid) do

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -9,7 +9,7 @@ describe TerminalExecutor do
 
   before { freeze_time }
 
-  describe '#execute!' do
+  describe '#execute' do
     it 'records stdout' do
       subject.execute('echo "hi"', 'echo "hello"')
       output.string.must_equal("hi\r\nhello\r\n")
@@ -117,6 +117,12 @@ describe TerminalExecutor do
     it "can timeout" do
       refute subject.execute('echo hello; sleep 10', timeout: 1)
       `ps -ef | grep "[s]leep 10"`.wont_include "sleep 10" # process got killed
+      output.string.must_equal("hello\r\nTimeout: execution took longer then 1s and was terminated\n")
+    end
+
+    it "can optionally override too short timeouts" do
+      subject.instance_variable_set(:@timeout, 0)
+      refute subject.execute('echo hello; sleep 10', min_timeout: 1)
       output.string.must_equal("hello\r\nTimeout: execution took longer then 1s and was terminated\n")
     end
 


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/3217

the core issue was that the default 5s timeout was also used for close,
which can take a bit longer for medium/large proejcts and would break creating new builds

this is kinda hacky and not super reliable since it would not work for giant projects ... so would be better to use github api :/