### PR TITLE
Environment variables for project stages

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -72,10 +72,7 @@ class ProjectsController < ResourceController
   end
 
   def allowed_includes
-    [
-      :environment_variable_groups,
-      :environment_variables_with_scope,
-    ]
+    Samson::Hooks.fire(:project_allowed_includes).flatten
   end
 
   def resource_params

--- a/app/models/concerns/group_scope.rb
+++ b/app/models/concerns/group_scope.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module GroupScope
   def self.included(base)
-    base.validates :scope_type, inclusion: ["Environment", "DeployGroup", nil]
+    base.validates :scope_type, inclusion: ["Environment", "DeployGroup", "Stage", nil]
     base.belongs_to :scope, polymorphic: true, optional: true
   end
 
@@ -19,13 +19,14 @@ module GroupScope
     "#{scope_type}-#{scope_id}"
   end
 
-  def matches_scope?(deploy_group)
+  def matches_scope?(deploy_group, stage = nil)
     return true unless scope_id # for all
     return false unless deploy_group # unscoped -> no specific groups
 
     case scope_type
     when "DeployGroup" then scope_id == deploy_group.id # matches deploy group
     when "Environment" then scope_id == deploy_group.environment_id # matches deploy group's environment
+    when "Stage"       then stage && scope_id == stage.id
     else raise "Unsupported scope #{scope_type}"
     end
   end
@@ -34,9 +35,10 @@ module GroupScope
     [
       (project? ? 0 : 1),
       case scope_type
-      when nil then 2
-      when "Environment" then 1
-      when "DeployGroup" then 0
+      when nil then 3
+      when "Environment" then 2
+      when "DeployGroup" then 1
+      when "Stage"       then 0
       else raise "Unsupported scope #{scope_type}"
       end
     ]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -195,7 +195,7 @@ class Project < ActiveRecord::Base
   end
 
   def environment_variables_with_scope
-    scopes = Environment.env_deploy_group_array
+    scopes = Environment.env_stage_deploy_group_array(project: self)
     EnvironmentVariable.sort_by_scopes(
       environment_variables, scopes
     )

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -194,13 +194,6 @@ class Project < ActiveRecord::Base
     Rails.application.routes.url_helpers.project_url(self)
   end
 
-  def environment_variables_with_scope
-    scopes = Environment.env_stage_deploy_group_array(project: self)
-    EnvironmentVariable.sort_by_scopes(
-      environment_variables, scopes
-    )
-  end
-
   def as_json(options = {})
     super(
       {

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -54,6 +54,7 @@ module Samson
       :link_parts_for_resource,
       :project_docker_build_method_options,
       :project_permitted_params,
+      :project_allowed_includes,
       :ref_status,
       :release_deploy_conditions,
       :stage_clone,

--- a/plugins/deploy_env_vars/app/views/samson_deploy_env_vars/_deploy_form.html.erb
+++ b/plugins/deploy_env_vars/app/views/samson_deploy_env_vars/_deploy_form.html.erb
@@ -2,7 +2,11 @@
   <legend>
     Extra Environment Variables for this deploy <%= additional_info SamsonEnv::HELP_TEXT %>
   </legend>
-
-  <%= render "samson_env/environment_variables_fields",
-        form: form, environment_variables: @deploy.environment_variables %>
+  <% env_vars = @deploy.environment_variables %>
+  <% env_vars << EnvironmentVariable.new %>
+  <%= form.fields_for :environment_variables, env_vars do |fields| %>
+		<%= render "samson_env/environment_variables_fields", fields: fields %>
+	<% end %>
+	<%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
+	<%= link_to "Paste", "#", class: "paste_env_variables" %>
 </fieldset>

--- a/plugins/deploy_env_vars/app/views/samson_deploy_env_vars/_deploy_form.html.erb
+++ b/plugins/deploy_env_vars/app/views/samson_deploy_env_vars/_deploy_form.html.erb
@@ -1,10 +1,10 @@
 <fieldset>
-  <legend>
-    Extra Environment Variables for this deploy <%= additional_info SamsonEnv::HELP_TEXT %>
-  </legend>
-  <% env_vars = @deploy.environment_variables %>
-  <% env_vars << EnvironmentVariable.new %>
-  <%= form.fields_for :environment_variables, env_vars do |fields| %>
+	<legend>
+		Extra Environment Variables for this deploy <%= additional_info SamsonEnv::HELP_TEXT %>
+	</legend>
+	<% env_vars = @deploy.environment_variables %>
+	<% env_vars << EnvironmentVariable.new %>
+	<%= form.fields_for :environment_variables, env_vars do |fields| %>
 		<%= render "samson_env/environment_variables_fields", fields: fields %>
 	<% end %>
 	<%= link_to "Add row", "#", class: "duplicate_previous_row" %> |

--- a/plugins/deploy_env_vars/app/views/samson_deploy_env_vars/_deploy_form.html.erb
+++ b/plugins/deploy_env_vars/app/views/samson_deploy_env_vars/_deploy_form.html.erb
@@ -1,12 +1,8 @@
 <fieldset>
-	<legend>
-		Extra Environment Variables for this deploy <%= additional_info SamsonEnv::HELP_TEXT %>
-	</legend>
-	<% env_vars = @deploy.environment_variables %>
-	<% env_vars << EnvironmentVariable.new %>
-	<%= form.fields_for :environment_variables, env_vars do |fields| %>
-		<%= render "samson_env/environment_variables_fields", fields: fields %>
-	<% end %>
-	<%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
-	<%= link_to "Paste", "#", class: "paste_env_variables" %>
+  <legend>
+    Extra Environment Variables for this deploy <%= additional_info SamsonEnv::HELP_TEXT %>
+  </legend>
+
+  <%= render "samson_env/environment_variables_fields",
+        form: form, environment_variables: @deploy.environment_variables %>
 </fieldset>

--- a/plugins/env/app/decorators/deploy_decorator.rb
+++ b/plugins/env/app/decorators/deploy_decorator.rb
@@ -10,7 +10,7 @@ Deploy.class_eval do
   private
 
   def serialized_environment_variables
-    if groups = SamsonEnv.env_groups(project, stage.deploy_groups, preview: true, resolve_secrets: false)
+    if groups = SamsonEnv.env_groups(project, stage.deploy_groups, stage, preview: true, resolve_secrets: false)
       groups.map do |name, data|
         name = name.empty? ? '' : "# #{name.delete('.').titleize}\n"
         "#{name}#{SamsonEnv.generate_dotenv(data)}"

--- a/plugins/env/app/decorators/project_decorator.rb
+++ b/plugins/env/app/decorators/project_decorator.rb
@@ -25,6 +25,13 @@ Project.class_eval do
     EnvironmentVariable.serialize(variables, @env_scopes)
   end
 
+  def environment_variables_with_scope
+    scopes = Environment.env_stage_deploy_group_array(project: self)
+    EnvironmentVariable.sort_by_scopes(
+      environment_variables, scopes
+    )
+  end
+
   private
 
   def environment_variables_changes

--- a/plugins/env/app/decorators/project_decorator.rb
+++ b/plugins/env/app/decorators/project_decorator.rb
@@ -21,7 +21,7 @@ Project.class_eval do
 
   def serialized_environment_variables
     variables = EnvironmentVariable.nested_variables(self)
-    @env_scopes ||= Environment.env_deploy_group_array # cache since each save needs them twice
+    @env_scopes ||= Environment.env_stage_deploy_group_array(project: self) # cache since each save needs them twice
     EnvironmentVariable.serialize(variables, @env_scopes)
   end
 

--- a/plugins/env/app/decorators/stage_decorator.rb
+++ b/plugins/env/app/decorators/stage_decorator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Stage.class_eval do
+  include ScopesEnvironmentVariables
+
+  accepts_nested_attributes_for :scoped_environment_variables, allow_destroy: true, reject_if: ->(a) { a[:name].blank? }
+  validate :validate_unique_scoped_environment_variables
+
+  def scoped_environment_variables_attributes=(attrs)
+    attrs.values.each do |attr|
+      attr['parent_id'] = project_id
+      attr['parent_type'] = 'Project'
+    end
+    super(attrs)
+  end
+
+  private
+
+  def validate_unique_scoped_environment_variables
+    variables = scoped_environment_variables.map(&:name)
+    dup_variables = variables.select { |e| variables.count(e) > 1 }
+    return if dup_variables.empty?
+
+    errors.add :base, "Non-Unique environment variables found for: #{dup_variables.uniq.join(", ")}"
+  end
+end

--- a/plugins/env/app/models/concerns/scopes_environment_variables.rb
+++ b/plugins/env/app/models/concerns/scopes_environment_variables.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module ScopesEnvironmentVariables
+  ASSIGNABLE_ATTRIBUTES = {scoped_environment_variables_attributes: [:name, :value, :_destroy, :id]}.freeze
+
   def self.included(base)
     base.class_eval do
       has_many :scoped_environment_variables, as: :scope, dependent: :destroy, class_name: 'EnvironmentVariable'

--- a/plugins/env/app/views/samson_env/_environment_variables.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables.html.erb
@@ -1,5 +1,5 @@
-<% scopes = Environment.env_deploy_group_array %>
-<% sorted_env_vars = EnvironmentVariable.sort_by_scopes(form.object.environment_variables, scopes) %>
+<% scopes ||= Environment.env_deploy_group_array %>
+<% sorted_env_vars ||= EnvironmentVariable.sort_by_scopes(form.object.environment_variables, scopes) %>
 <%= render "samson_env/environment_variables_fields",
       form: form, environment_variables: sorted_env_vars, scopes: scopes %>
 

--- a/plugins/env/app/views/samson_env/_environment_variables.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables.html.erb
@@ -1,10 +1,4 @@
 <% scopes ||= Environment.env_deploy_group_array %>
 <% sorted_env_vars ||= EnvironmentVariable.sort_by_scopes(form.object.environment_variables, scopes) %>
-<% sorted_env_vars << EnvironmentVariable.new %>
-<%= form.fields_for :environment_variables, sorted_env_vars do |fields| %>
-	<%= render "samson_env/environment_variables_fields", fields: fields, scopes: scopes %>
-<% end %>
-<%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
-<%= link_to "Paste", "#", class: "paste_env_variables" %>
-
-<div id="env_paste_dialog"></div>
+<%= render "samson_env/environment_variables_fields",
+  form: form, environment_variables: sorted_env_vars, scopes: scopes %>

--- a/plugins/env/app/views/samson_env/_environment_variables.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables.html.erb
@@ -2,8 +2,7 @@
 <% sorted_env_vars ||= EnvironmentVariable.sort_by_scopes(form.object.environment_variables, scopes) %>
 <% sorted_env_vars << EnvironmentVariable.new %>
 <%= form.fields_for :environment_variables, sorted_env_vars do |fields| %>
-	<%= render "samson_env/environment_variables_fields",
-    fields: fields, scopes: scopes %>
+	<%= render "samson_env/environment_variables_fields", fields: fields, scopes: scopes %>
 <% end %>
 <%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
 <%= link_to "Paste", "#", class: "paste_env_variables" %>

--- a/plugins/env/app/views/samson_env/_environment_variables.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables.html.erb
@@ -1,6 +1,11 @@
 <% scopes ||= Environment.env_deploy_group_array %>
 <% sorted_env_vars ||= EnvironmentVariable.sort_by_scopes(form.object.environment_variables, scopes) %>
-<%= render "samson_env/environment_variables_fields",
-      form: form, environment_variables: sorted_env_vars, scopes: scopes %>
+<% sorted_env_vars << EnvironmentVariable.new %>
+<%= form.fields_for :environment_variables, sorted_env_vars do |fields| %>
+	<%= render "samson_env/environment_variables_fields",
+    fields: fields, scopes: scopes %>
+<% end %>
+<%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
+<%= link_to "Paste", "#", class: "paste_env_variables" %>
 
 <div id="env_paste_dialog"></div>

--- a/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
@@ -1,29 +1,35 @@
-<div class="form-group">
-  <div class="col-lg-3">
-    <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
+<% environment_variables << EnvironmentVariable.new %>
+<% form_name ||= "environment_variables" %>
+<%= form.fields_for form_name, environment_variables do |fields| %>
+  <div class="form-group">
+    <div class="col-lg-3">
+      <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
+    </div>
+
+    <div class="col-lg-5">
+      <%# using a text area so users can resize them with browser controls %>
+      <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
+    </div>
+
+    <% if DeployGroup.enabled? && defined?(scopes) %>
+      <div class="col-lg-2">
+        <%= fields.select :scope_type_and_id, scopes, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
+      </div>
+    <% end %>
+
+    <% if fields.object.persisted? %>
+      <div class="col-lg-1 checkbox">
+        <%= link_to_history fields.object, counter: false %>
+      </div>
+      <div class="col-lg-1 checkbox">
+        <%= fields.label :_destroy do %>
+          <%= fields.check_box :_destroy if fields.object.persisted? %>
+          Delete
+        <% end %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="col-lg-5">
-    <%# using a text area so users can resize them with browser controls %>
-    <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
-  </div>
-
-  <% if DeployGroup.enabled? && defined?(scopes) %>
-    <div class="col-lg-2">
-      <%= fields.select :scope_type_and_id, scopes, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
-    </div>
-  <% end %>
-
-  <% if fields.object.persisted? %>
-    <div class="col-lg-1 checkbox">
-      <%= link_to_history fields.object, counter: false %>
-    </div>
-    <div class="col-lg-1 checkbox">
-      <%= fields.label :_destroy do %>
-        <%= fields.check_box :_destroy if fields.object.persisted? %>
-        Delete
-      <% end %>
-    </div>
-  <% end %>
-</div>
-
+<% end %>
+<div id="env_paste_dialog"></div>
+<%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
+<%= link_to "Paste", "#", class: "paste_env_variables" %>

--- a/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
@@ -1,33 +1,29 @@
-<% environment_variables << EnvironmentVariable.new %>
-<%= form.fields_for :environment_variables, environment_variables do |fields| %>
-  <div class="form-group">
-    <div class="col-lg-3">
-      <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
-    </div>
-
-    <div class="col-lg-5">
-      <%# using a text area so users can resize them with browser controls %>
-      <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
-    </div>
-
-    <% if DeployGroup.enabled? && defined?(scopes) %>
-      <div class="col-lg-2">
-        <%= fields.select :scope_type_and_id, scopes, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
-      </div>
-    <% end %>
-
-    <% if fields.object.persisted? %>
-      <div class="col-lg-1 checkbox">
-        <%= link_to_history fields.object, counter: false %>
-      </div>
-      <div class="col-lg-1 checkbox">
-        <%= fields.label :_destroy do %>
-          <%= fields.check_box :_destroy if fields.object.persisted? %>
-          Delete
-        <% end %>
-      </div>
-    <% end %>
+<div class="form-group">
+  <div class="col-lg-3">
+    <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
   </div>
-<% end %>
-<%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
-<%= link_to "Paste", "#", class: "paste_env_variables" %>
+
+  <div class="col-lg-5">
+    <%# using a text area so users can resize them with browser controls %>
+    <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
+  </div>
+
+  <% if DeployGroup.enabled? && defined?(scopes) %>
+    <div class="col-lg-2">
+      <%= fields.select :scope_type_and_id, scopes, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
+    </div>
+  <% end %>
+
+  <% if fields.object.persisted? %>
+    <div class="col-lg-1 checkbox">
+      <%= link_to_history fields.object, counter: false %>
+    </div>
+    <div class="col-lg-1 checkbox">
+      <%= fields.label :_destroy do %>
+        <%= fields.check_box :_destroy if fields.object.persisted? %>
+        Delete
+      <% end %>
+    </div>
+  <% end %>
+</div>
+

--- a/plugins/env/app/views/samson_env/_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_fields.html.erb
@@ -15,13 +15,12 @@
     %>
   <% end %>
 
-  <% scopes = Environment.env_deploy_group_array %>
-  <% sorted_env_vars = EnvironmentVariable.sort_by_scopes(form.object.environment_variables, scopes) %>
-  <% sorted_env_vars << EnvironmentVariable.new %>
-  <%= render "samson_env/environment_variables", form: form, environment_variables: sorted_env_vars %>
+  <% project = form.object %>
+  <% scopes = Environment.env_stage_deploy_group_array(project: project) %>
+  <% sorted_env_vars = EnvironmentVariable.sort_by_scopes(project.environment_variables, scopes) %>
+  <%= render "samson_env/environment_variables", form: form, sorted_env_vars: sorted_env_vars, scopes: scopes %>
 
   <h4>Groups</h4>
-  <% project = form.object %>
   <% ids = project.environment_variable_group_ids + [nil] %>
   <% environment_variable_groups = EnvironmentVariableGroup.order(:name).map { |g| [g.name, g.id] } %>
   <% if environment_variable_groups.any? %>

--- a/plugins/env/app/views/samson_env/_stage_env_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_stage_env_fields.html.erb
@@ -1,0 +1,38 @@
+<fieldset>
+  <legend>
+    Environment Variables
+    <%= additional_info SamsonEnv::HELP_TEXT %>
+  </legend>
+  <div>
+    <% stage = form.object %>
+    <% sorted_env_vars = stage.scoped_environment_variables.sort_by{ |env| env.name } %>
+    <% sorted_env_vars << EnvironmentVariable.new %>
+    <div id="env_paste_dialog"></div>
+    <%= form.fields_for :scoped_environment_variables, sorted_env_vars do |fields| %>
+      <div class="form-group">
+        <div class="col-lg-3">
+          <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
+        </div>
+
+        <div class="col-lg-5">
+          <%# using a text area so users can resize them with browser controls %>
+          <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
+        </div>
+
+        <% if fields.object.persisted? %>
+          <div class="col-lg-1 checkbox">
+            <%= link_to_history fields.object, counter: false %>
+          </div>
+          <div class="col-lg-1 checkbox">
+            <%= fields.label :_destroy do %>
+              <%= fields.check_box :_destroy if fields.object.persisted? %>
+              Delete
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+    <%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
+    <%= link_to "Paste", "#", class: "paste_env_variables" %>
+  </div>
+</fieldset>

--- a/plugins/env/app/views/samson_env/_stage_env_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_stage_env_fields.html.erb
@@ -1,17 +1,12 @@
 <fieldset>
-  <legend>
-    Environment Variables
-    <%= additional_info SamsonEnv::HELP_TEXT %>
-  </legend>
-  <div>
-    <% stage = form.object %>
-    <% sorted_env_vars = stage.scoped_environment_variables.sort_by{ |env| env.name } %>
-    <% sorted_env_vars << EnvironmentVariable.new %>
-    <div id="env_paste_dialog"></div>
-    <%= form.fields_for :scoped_environment_variables, sorted_env_vars do |fields| %>
-      <%= render "samson_env/environment_variables_fields", fields: fields %>
-    <% end %>
-    <%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
-    <%= link_to "Paste", "#", class: "paste_env_variables" %>
-  </div>
+	<legend>
+		Environment Variables
+		<%= additional_info SamsonEnv::HELP_TEXT %>
+	</legend>
+	<div>
+		<% stage = form.object %>
+		<% sorted_env_vars = stage.scoped_environment_variables.sort_by{ |env| env.name } %>
+		<%= render "samson_env/environment_variables_fields",
+      form: form, environment_variables: sorted_env_vars, form_name: "scoped_environment_variables" %>
+	</div>
 </fieldset>

--- a/plugins/env/app/views/samson_env/_stage_env_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_stage_env_fields.html.erb
@@ -9,28 +9,7 @@
     <% sorted_env_vars << EnvironmentVariable.new %>
     <div id="env_paste_dialog"></div>
     <%= form.fields_for :scoped_environment_variables, sorted_env_vars do |fields| %>
-      <div class="form-group">
-        <div class="col-lg-3">
-          <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
-        </div>
-
-        <div class="col-lg-5">
-          <%# using a text area so users can resize them with browser controls %>
-          <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
-        </div>
-
-        <% if fields.object.persisted? %>
-          <div class="col-lg-1 checkbox">
-            <%= link_to_history fields.object, counter: false %>
-          </div>
-          <div class="col-lg-1 checkbox">
-            <%= fields.label :_destroy do %>
-              <%= fields.check_box :_destroy if fields.object.persisted? %>
-              Delete
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <%= render "samson_env/environment_variables_fields", fields: fields %>
     <% end %>
     <%= link_to "Add row", "#", class: "duplicate_previous_row" %> |
     <%= link_to "Paste", "#", class: "paste_env_variables" %>

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -62,9 +62,17 @@ Samson::Hooks.callback :project_permitted_params do
     :use_env_repo
   ]
 end
+
 Samson::Hooks.callback :stage_permitted_params do
   [
     ScopesEnvironmentVariables::ASSIGNABLE_ATTRIBUTES
+  ]
+end
+
+Samson::Hooks.callback :project_allowed_includes do
+  [
+    :environment_variable_groups,
+    :environment_variables_with_scope,
   ]
 end
 

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -128,7 +128,7 @@ describe EnvironmentVariableGroupsController do
       end
 
       it "calls env with preview" do
-        EnvironmentVariable.expects(:env).with(anything, anything, preview: true).times(3)
+        EnvironmentVariable.expects(:env).with(anything, anything, anything, preview: true).times(3)
         get :preview, params: {group_id: env_group.id}
         assert_response :success
       end

--- a/plugins/env/test/decorators/project_decorator_test.rb
+++ b/plugins/env/test/decorators/project_decorator_test.rb
@@ -5,10 +5,10 @@ SingleCov.covered!
 
 describe Project do
   let(:project) { projects(:test) }
+  let(:env_attributes) { {name: "A", value: "B", scope_type_and_id: "Environment-#{environments(:production)}"} }
 
   describe "auditing" do
     let(:group) { EnvironmentVariableGroup.create!(name: "Foo", environment_variables_attributes: [env_attributes]) }
-    let(:env_attributes) { {name: "A", value: "B", scope_type_and_id: "Environment-#{environments(:production)}"} }
 
     it "does not audit when var did not change" do
       project.update_attributes!(name: 'Bar')
@@ -54,6 +54,16 @@ describe Project do
         environment_variables_attributes: [env_attributes.merge(id: existing.id)]
       )
       refute project.audits.last
+    end
+  end
+
+  describe "#environment_variables_with_scope" do
+    let(:stage_attributes) { {name: "A1", value: "B", scope_type_and_id: "Stage-X"} }
+
+    it "sort environment_variables by scope" do
+      environment_env = project.environment_variables.create!(env_attributes)
+      stage_env = project.environment_variables.create!(stage_attributes)
+      project.environment_variables_with_scope.must_equal [environment_env, stage_env]
     end
   end
 end

--- a/plugins/env/test/decorators/stage_decorator_test.rb
+++ b/plugins/env/test/decorators/stage_decorator_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe Stage do
+  let(:stage) { stages(:test_staging) }
+  let(:project) { stage.project }
+  let(:env_attributes) { {0 => {name: "A", value: "B"}} }
+
+  it "has scoped_environment_variables" do
+    stage.scoped_environment_variables.must_equal []
+  end
+
+  describe "accept nested scoped_environment_variables" do
+    def create_scoped_environment_variable
+      stage.update_attributes!(scoped_environment_variables_attributes: env_attributes)
+    end
+
+    it "create scoped environment variables" do
+      assert_difference "stage.scoped_environment_variables.count", +1 do
+        create_scoped_environment_variable
+      end
+    end
+
+    it "updates old environment variable" do
+      create_scoped_environment_variable
+      assert_difference "stage.scoped_environment_variables.count", 0 do
+        env_attributes.values.first[:id] = stage.scoped_environment_variables.first.id
+        stage.update_attributes!(
+          scoped_environment_variables_attributes: env_attributes
+        )
+      end
+    end
+
+    it "invalid without parent scope" do
+      stage.scoped_environment_variables.build(name: "A1", value: "B1")
+      refute_valid stage
+      stage.errors.full_messages.must_equal ["Scoped environment variables parent must exist"]
+    end
+
+    it "update parent scope with nested attributes" do
+      create_scoped_environment_variable
+      env_variable = stage.scoped_environment_variables.first
+      env_variable.parent_id.must_equal project.id
+      env_variable.parent_type.must_equal 'Project'
+    end
+
+    it "does not audit when var change" do
+      stage.update_attributes!(
+        name: 'Bar',
+        scoped_environment_variables_attributes: env_attributes
+      )
+      stage.audits.map(&:audited_changes).must_equal([{'name' => ['Staging', 'Bar']}])
+    end
+  end
+
+  describe "#validate_unique_scoped_environment_variables" do
+    let(:stage_env) do
+      stage.assign_attributes(scoped_environment_variables_attributes: env_attributes)
+      stage
+    end
+
+    it "is valid with unique env vars" do
+      assert_valid stage_env
+    end
+
+    it "is invalid with duplicate environment_variables" do
+      stage_env.scoped_environment_variables.build(
+        name: "A", value: "A1", parent_id: project.id, parent_type: 'Project'
+      )
+      refute_valid stage_env
+      stage_env.errors.full_messages.must_equal ["Non-Unique environment variables found for: A"]
+    end
+  end
+end

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -75,6 +75,17 @@ describe SamsonEnv do
         end
       end
 
+      describe "with stage env" do
+        before do
+          stage.scoped_environment_variables.create!(name: "STAGE", value: "xyz", parent: project)
+        end
+
+        it "writes to .env" do
+          fire
+          File.read(".env.pod-100").must_include "STAGE=\"xyz\""
+        end
+      end
+
       describe "with deploy groups" do
         it "deletes the base file" do
           fire

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -32,6 +32,17 @@ describe SamsonEnv do
     end
   end
 
+  describe :project_allowed_includes do
+    it "allowed includes" do
+      Samson::Hooks.fire(:project_allowed_includes).must_include(
+        [
+          :environment_variable_groups,
+          :environment_variables_with_scope,
+        ]
+      )
+    end
+  end
+
   describe :after_deploy_setup do
     def fire
       job = stub(deploy: deploy, project: project)

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -526,8 +526,14 @@ describe Kubernetes::TemplateFiller do
       end
 
       it "adds env from deploy_group_env hook" do
-        Samson::Hooks.with_callback(:deploy_group_env, ->(p, dg, _) { {FromEnv: "#{p.name}-#{dg.name}"} }) do
+        Samson::Hooks.with_callback(:deploy_group_env, ->(p, dg, _, _) { {FromEnv: "#{p.name}-#{dg.name}"} }) do
           container.fetch(:env).must_include(name: 'FromEnv', value: 'Foo-Pod1')
+        end
+      end
+
+      it "adds stages env from deploy_group_env hook" do
+        Samson::Hooks.with_callback(:deploy_group_env, ->(_, _, stage, _) { {FromEnv: stage.name.to_s} }) do
+          container.fetch(:env).must_include(name: 'FromEnv', value: 'Staging')
         end
       end
 

--- a/test/models/concerns/group_scope_test.rb
+++ b/test/models/concerns/group_scope_test.rb
@@ -7,6 +7,7 @@ describe GroupScope do
   let(:deploy_group) { deploy_groups(:pod100) }
   let(:environment) { deploy_group.environment }
   let(:project) { projects(:test) }
+  let(:stage) { stages(:test_staging) }
   let(:deploy_group_scope_type_and_id) { "DeployGroup-#{deploy_group.id}" }
   let(:environment_variable) { EnvironmentVariable.new(name: "NAME", parent: project) } # TODO: don't use a plugin model
 
@@ -18,7 +19,7 @@ describe GroupScope do
     end
 
     it "is invalid with wrong type" do
-      environment_variable.scope_type_and_id = "Stage-#{project.id}"
+      environment_variable.scope_type_and_id = "Deploy-#{project.id}"
       refute_valid environment_variable
     end
   end
@@ -43,19 +44,23 @@ describe GroupScope do
     end
 
     it "is higher with project" do
-      EnvironmentVariable.new(parent_type: 'Project').priority.must_equal [0, 2]
+      EnvironmentVariable.new(parent_type: 'Project').priority.must_equal [0, 3]
     end
 
     it "is lower without project" do
-      EnvironmentVariable.new.priority.must_equal [1, 2]
+      EnvironmentVariable.new.priority.must_equal [1, 3]
     end
 
-    it "is higher with deploy group" do
-      EnvironmentVariable.new(scope_type: 'DeployGroup').priority.must_equal [1, 0]
+    it "is lower with deploy group" do
+      EnvironmentVariable.new(scope_type: 'DeployGroup').priority.must_equal [1, 1]
     end
 
     it "is lower with environment" do
-      EnvironmentVariable.new(scope_type: 'Environment').priority.must_equal [1, 1]
+      EnvironmentVariable.new(scope_type: 'Environment').priority.must_equal [1, 2]
+    end
+
+    it "is higher with stage" do
+      EnvironmentVariable.new(scope_type: 'Stage').priority.must_equal [1, 0]
     end
   end
 
@@ -81,6 +86,10 @@ describe GroupScope do
 
     it "matches environment" do
       assert EnvironmentVariable.new(scope: deploy_group.environment).matches_scope?(deploy_group)
+    end
+
+    it "matches stage" do
+      assert EnvironmentVariable.new(scope: stage).matches_scope?(deploy_group, stage)
     end
 
     it "does not matche other" do

--- a/test/models/environment_test.rb
+++ b/test/models/environment_test.rb
@@ -29,9 +29,10 @@ describe Environment do
       all.must_equal(
         [
           ["All", nil],
+          ["--- Environments ---", "disabled"],
           ["Production", "Environment-X"],
           ["Staging", "Environment-X"],
-          ["----", "disabled"],
+          ["--- Deploy Groups ---", "disabled"],
           ["Pod1", "DeployGroup-X"],
           ["Pod2", "DeployGroup-X"],
           ["Pod 100", "DeployGroup-X"]
@@ -39,8 +40,51 @@ describe Environment do
       )
     end
 
+    it "does not includes environments" do
+      Environment.stubs(:all).returns []
+      Environment.env_deploy_group_array.wont_include ["--- Environments ---", "disabled"]
+    end
+
+    it "does not includes deploy_groups" do
+      DeployGroup.stubs(:all).returns []
+      Environment.env_deploy_group_array.wont_include ["--- Deploy Groups ---", "disabled"]
+    end
+
     it "does not includes All when requested" do
       Environment.env_deploy_group_array(include_all: false).wont_include ["All", nil]
+    end
+  end
+
+  describe ".env_stage_deploy_group_array" do
+    let(:project) { projects(:test) }
+
+    it "includes project stages and All" do
+      all = Environment.env_stage_deploy_group_array(project: project)
+      all.map! { |name, value| [name, value&.sub(/-\d+/, '-X')] }
+      all.must_equal(
+        [
+          ["All", nil],
+          ["--- Environments ---", "disabled"],
+          ["Production", "Environment-X"],
+          ["Staging", "Environment-X"],
+          ["--- Deploy Groups ---", "disabled"],
+          ["Pod1", "DeployGroup-X"],
+          ["Pod2", "DeployGroup-X"],
+          ["Pod 100", "DeployGroup-X"],
+          ["--- Stages ---", "disabled"],
+          ["Staging", "Stage-X"],
+          ["Production", "Stage-X"],
+          ["Production Pod", "Stage-X"]
+        ]
+      )
+    end
+
+    it "does not includes All when requested" do
+      Environment.env_stage_deploy_group_array(project: project, include_all: false).wont_include ["All", nil]
+    end
+
+    it "does not includes project stages" do
+      Environment.env_stage_deploy_group_array.wont_include ["--- Stages ---", "disabled"]
     end
   end
 


### PR DESCRIPTION
User can add environment variables specific to each stage in project, This allows multiple configurations for the same deploy group.
Stage environment-variables can add both in projects and stages edit pages.

**Projects Edit Page**

<img width="1075" alt="Screen Shot 2019-03-11 at 11 20 18 PM" src="https://user-images.githubusercontent.com/1404500/54178921-81f88400-4454-11e9-9a14-274ce14f2727.png">

**Stages Edit Page**

<img width="1151" alt="Screen Shot 2019-03-11 at 11 21 41 PM" src="https://user-images.githubusercontent.com/1404500/54178935-87ee6500-4454-11e9-8026-44609cf7c093.png">


/cc @zendesk/samson
