### PR TITLE
enforce 2-space indent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -189,3 +189,15 @@ Style/IfInsideElse:
 # Enable this once https://github.com/rubocop-hq/rubocop/issues/6410 is fixed
 Layout/AlignHash:
   Enabled: false
+
+# Opt-in
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+# Opt-in
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+# Opt-in
+Layout/FirstMethodParameterLineBreak:
+  Enabled: true

--- a/app/models/csv_export.rb
+++ b/app/models/csv_export.rb
@@ -12,8 +12,10 @@ class CsvExport < ActiveRecord::Base
   scope :old, -> {
     end_date = Rails.application.config.samson.export_job.downloaded_age.seconds.ago
     timeout_date = Rails.application.config.samson.export_job.max_age.seconds.ago
-    where("(status = 'downloaded' AND updated_at <= :end_date) OR created_at <= :timeout_date",
-      end_date: end_date, timeout_date: timeout_date)
+    where(
+      "(status = 'downloaded' AND updated_at <= :end_date) OR created_at <= :timeout_date",
+      end_date: end_date, timeout_date: timeout_date
+    )
   }
 
   def status?(state)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -59,9 +59,11 @@ class Release < ActiveRecord::Base
   rescue Octokit::NotFound
     false
   rescue Octokit::Error => e
-    ErrorNotifier.notify(e, parameters: {
-      repository_path: project.repository_path, commit: commit, other_commit: other_commit
-    })
+    ErrorNotifier.notify(
+      e, parameters: {
+        repository_path: project.repository_path, commit: commit, other_commit: other_commit
+      }
+    )
     false # Err on side of caution and cause a new release to be created.
   end
 

--- a/bin/cap
+++ b/bin/cap
@@ -8,8 +8,7 @@
 #
 
 require 'pathname'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile", Pathname.new(__FILE__).realpath)
 
 require 'rubygems'
 require 'bundler/setup'

--- a/plugins/airbrake_hook/test/samson_airbrake_hook/samson_plugin_test.rb
+++ b/plugins/airbrake_hook/test/samson_airbrake_hook/samson_plugin_test.rb
@@ -19,17 +19,19 @@ describe SamsonAirbrakeHook::Engine do
     end
 
     it "sends a notification" do
-      assert_request(:post, "https://api.airbrake.io/deploys.txt", with: {
-        body: {
-          "api_key" => "MY-SECRET",
-          "deploy" => {
-            "rails_env" => "staging",
-            "scm_revision" => "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1",
-            "local_username" => "Super Admin",
-            "scm_repository" => "https://example.com/bar/foo",
+      assert_request(
+        :post, "https://api.airbrake.io/deploys.txt", with: {
+          body: {
+            "api_key" => "MY-SECRET",
+            "deploy" => {
+              "rails_env" => "staging",
+              "scm_revision" => "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1",
+              "local_username" => "Super Admin",
+              "scm_repository" => "https://example.com/bar/foo",
+            }
           }
         }
-      }) { notify }
+      ) { notify }
     end
 
     it "does not send notifications when deploy groups are disabled" do

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -65,8 +65,10 @@ describe EnvironmentVariable do
           "repos/organization/repo_name/contents/generated/foo/pod100.env",
           "FROM_REPO_VAR_ONE=one\nVAR_TWO=two\n"
         )
-        expected_result = {"FROM_REPO_VAR_ONE" => "one", "VAR_TWO" => "two",
-                           "PROJECT" => "PROJECT", "Z" => "A", "X" => "Y", "Y" => "Z"}
+        expected_result = {
+          "FROM_REPO_VAR_ONE" => "one", "VAR_TWO" => "two",
+          "PROJECT" => "PROJECT", "Z" => "A", "X" => "Y", "Y" => "Z"
+        }
         EnvironmentVariable.env(project, deploy_group).must_equal expected_result
       end
 
@@ -79,8 +81,10 @@ describe EnvironmentVariable do
           "repos/organization/repo_name/contents/generated/foo/pod100.env",
           "FROM_REPO_VAR_ONE=one\nVAR_TWO=two\nPROJECT=NOT_PROJECT"
         )
-        expected_result = {"FROM_REPO_VAR_ONE" => "one", "VAR_TWO" => "db_two",
-                           "PROJECT" => "DEPLOY", "Z" => "A", "X" => "Y", "Y" => "Z"}
+        expected_result = {
+          "FROM_REPO_VAR_ONE" => "one", "VAR_TWO" => "db_two",
+          "PROJECT" => "DEPLOY", "Z" => "A", "X" => "Y", "Y" => "Z"
+        }
         EnvironmentVariable.env(project, deploy_group).must_equal expected_result
       end
 

--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -57,9 +57,11 @@ module Samson
     end
 
     def jenkins_job_config
-      conf = Rails.cache.fetch(jenkins_job_cache_key,
+      conf = Rails.cache.fetch(
+        jenkins_job_cache_key,
         expires_in: JENKINS_JOB_CACHE_TIME,
-        race_condition_ttl: 5.minute) do
+        race_condition_ttl: 5.minute
+      ) do
         client.job.get_config(job_name)
       end
       Nokogiri::XML(conf)

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -393,8 +393,10 @@ module Kubernetes
     def set_docker_image_for_containers(builds, containers)
       containers.each_with_index do |container, i|
         next unless build_selector = build_selector_for_container(container, first: i == 0, scan: false)
-        build = Samson::BuildFinder.detect_build_by_selector!(builds, *build_selector,
-          fail: true, project: project)
+        build = Samson::BuildFinder.detect_build_by_selector!(
+          builds, *build_selector,
+          fail: true, project: project
+        )
         container[:image] = build.docker_repo_digest
         container[:imagePullPolicy] = 'IfNotPresent' if container[:imagePullPolicy] == 'Always'
       end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -755,9 +755,11 @@ describe Kubernetes::DeployExecutor do
       )
       other.release_docs = release.release_docs.map do |doc|
         copy = Kubernetes::ReleaseDoc.new(doc.attributes.except('resource_template'))
-        copy.send(:resource_template=, doc.resource_template.map do |t|
-          t.deep_merge(metadata: {name: t.dig(:metadata, :name).sub("-blue", "-green")})
-        end)
+        copy.send(
+          :resource_template=,
+          doc.resource_template.
+            map { |t| t.deep_merge(metadata: {name: t.dig(:metadata, :name).sub("-blue", "-green")}) }
+        )
         copy.kubernetes_release = other
         copy
       end

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -34,8 +34,10 @@ describe DeploysController do
       "/projects/1/stages/2/deploys/new",
       controller: "deploys", action: "new", project_id: "1", stage_id: "2"
     )
-    assert_routing({method: "post", path: "/projects/1/stages/2/deploys"},
-      controller: "deploys", action: "create", project_id: "1", stage_id: "2")
+    assert_routing(
+      {method: "post", path: "/projects/1/stages/2/deploys"},
+      controller: "deploys", action: "create", project_id: "1", stage_id: "2"
+    )
   end
 
   as_a :viewer do

--- a/test/models/csv_export_test.rb
+++ b/test/models/csv_export_test.rb
@@ -18,8 +18,11 @@ describe CsvExport do
     end
 
     it "returns old downloaded" do
-      @old_export.update_attributes(updated_at: Time.now - 13.hours, created_at: Time.now - 14.hours,
-                                    status: 'downloaded')
+      @old_export.update_attributes(
+        updated_at: Time.now - 13.hours,
+        created_at: Time.now - 14.hours,
+        status: 'downloaded'
+      )
       assert_equal(1, CsvExport.old.size)
     end
 

--- a/test/models/webhook_recorder_test.rb
+++ b/test/models/webhook_recorder_test.rb
@@ -5,14 +5,16 @@ SingleCov.covered!
 
 describe WebhookRecorder do
   let(:request) do
-    request = ActionController::TestRequest.new({
-      "FOO" => "bar",
-      "rack.foo" => "bar",
-      "RAW_POST_DATA" => +"BODY",
-      "rack.input" => {"foo" => "bar"},
-      "QUERY_STRING" => "action=good&password=secret",
-      "action_dispatch.parameter_filter" => Rails.application.config.filter_parameters
-    }, {}, {})
+    request = ActionController::TestRequest.new(
+      {
+        "FOO" => "bar",
+        "rack.foo" => "bar",
+        "RAW_POST_DATA" => +"BODY",
+        "rack.input" => {"foo" => "bar"},
+        "QUERY_STRING" => "action=good&password=secret",
+        "action_dispatch.parameter_filter" => Rails.application.config.filter_parameters
+      }, {}, {}
+    )
     request.stubs(:params).returns("action" => "create") # making sure nobody calls this (includes controller action)
     request
   end


### PR DESCRIPTION
bad: (wasted whitespace + breaks code-flow + needs to be kept aligned with method length)
```Ruby
puts(foo: :bar,
     bar: :baz)
```

good:
```Ruby
puts(
  foo: :bar,
  bar: :baz
)
```

@zendesk/bre 
/fyi @zendesk/compute 

found via https://github.com/rubocop-hq/rubocop/issues/1744