### PR TITLE
PAAS-2961 report id errors when listing all ids

### DIFF
--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -159,6 +159,13 @@ describe Samson::Secrets::HashicorpVaultBackend do
         end
       end
     end
+
+    it "ignores invalid ids so a single bad key does not blow up secrets UI" do
+      ErrorNotifier.expects(:notify)
+      assert_vault_request :get, "?list=true", body: {data: {keys: ["oh-noes", "a/b/c/d"]}}.to_json do
+        backend.ids.must_equal ["a/b/c/d"]
+      end
+    end
   end
 
   describe "raises BackendError when a vault instance is down/unreachable" do


### PR DESCRIPTION
we do not want to break all of the secrets UI when a single bad secret is added to vault
this can happen by accident when some script goes wrong and writes into samsons namespace

@zendesk/compute 