### PR TITLE
Update GitHub status API

### DIFF
--- a/plugins/github/test/samson_github/samson_plugin_test.rb
+++ b/plugins/github/test/samson_github/samson_plugin_test.rb
@@ -73,18 +73,18 @@ describe SamsonDatadog do
       Samson::Hooks.fire(:repo_provider_status)
     end
 
-    let(:status_url) { "#{SamsonGithub::STATUS_URL}/api/status.json" }
+    let(:status_url) { "#{SamsonGithub::STATUS_URL}/api/v2/status.json" }
 
     around { |t| Samson::Hooks.only_callbacks_for_plugin('github', :repo_provider_status, &t) }
 
     it "reports good response" do
-      assert_request(:get, status_url, to_return: {body: {status: 'good'}.to_json}) do
+      assert_request(:get, status_url, to_return: {body: {status: {indicator: 'none'}}.to_json}) do
         fire.must_equal [nil]
       end
     end
 
     it "reports bad response" do
-      assert_request(:get, status_url, to_return: {body: {status: 'bad'}.to_json}) do
+      assert_request(:get, status_url, to_return: {body: {status: {indicator: 'critical'}}.to_json}) do
         fire.to_s.must_include "GitHub may be having problems"
       end
     end

--- a/test/lib/samson/periodical_test.rb
+++ b/test/lib/samson/periodical_test.rb
@@ -214,7 +214,7 @@ describe Samson::Periodical do
   end
 
   it "runs everything" do
-    stub_request(:get, "https://status.github.com/api/status.json")
+    stub_request(:get, "https://www.githubstatus.com/api/v2/status.json")
     Samson::Periodical.send(:registered).each_key do |task|
       Samson::Periodical.run_once task
     end


### PR DESCRIPTION
GitHub deprecated its old status page API and probably moved to Atlassian product. New status API is here: 
https://www.githubstatus.com/api#status

/cc @zendesk/samson @kiranprakash154 @ben @lennardseah 

### Tasks
 - Update the default URL and status check field

### Risks
- Level: Low