### PR TITLE
Render environment variables as JSON

### DIFF
--- a/app/models/concerns/inlinable.rb
+++ b/app/models/concerns/inlinable.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Inlinable
+  def allow_inline(method)
+    (allowed_inlines << method).flatten!
+  end
+
+  def allowed_inlines
+    (@allowed_inlines ||= [])
+  end
+end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -219,8 +219,8 @@ class Deploy < ActiveRecord::Base
     ]
   end
 
-  def as_json
-    hash = super(methods: [:status, :url, :production, :commit])
+  def as_json(methods: [])
+    hash = super(methods: [:status, :url, :production, :commit] + methods)
     hash["summary"] = summary_for_timeline
     hash
   end

--- a/app/models/outbound_webhook.rb
+++ b/app/models/outbound_webhook.rb
@@ -43,7 +43,7 @@ class OutboundWebhook < ActiveRecord::Base
     )
   end
 
-  def as_json
+  def as_json(*)
     super(except: [:password])
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -201,13 +201,13 @@ class Project < ActiveRecord::Base
     )
   end
 
-  def as_json(options = {})
+  def as_json(methods: [], **options)
     super(
       {
         except: [:token, :deleted_at],
         methods: [
           :repository_path,
-        ]
+        ] + methods
       }.merge(options)
     )
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,4 @@
+
 # API
 
 Many endpoints offer a `.json` response, open PRs for missing ones.
@@ -17,3 +18,22 @@ To use a token via an api clients, send it as `Authorization: Bearer` header.
 
 If no OAuth application exists, create one under `/oauth/applications` and name it "Personal Access Tokens".
 Then users can click on their profile and "Access Tokens" to create tokens for use with API clients.
+
+### Render as JSON
+
+Many JSON endpoints have the option to append associated records or some custom inline data along with original JSON response, by requesting the endpoint with some extra parameter.
+
+#### ?includes
+
+The parameter `includes` will add requested associated record values and their associated ids along with the original JSON response.
+If you are requesting for many associated records, it should be separated by `comma's ,`
+
+`http://samson-example.com/projects/zendesk.json?includes=environment_variable_groups,environment_variables_with_scope`
+
+If the requested associated records are not permitted, then the response will raise an error with a message.
+
+#### ?inlines
+
+The parameter `inlines` will append additional allowed custom method values with original JSON response
+
+`http://samson-example.com/environment_variables.json?inlines=parent_name,scope_name`

--- a/plugins/env/app/controllers/environment_variables_controller.rb
+++ b/plugins/env/app/controllers/environment_variables_controller.rb
@@ -20,6 +20,8 @@ class EnvironmentVariablesController < ApplicationController
     head :ok
   end
 
+  private
+
   def search_params
     permitted = params.fetch(:search, {}).permit(:id, :name, :value, :parent_id, :parent_type, :scope_id, :scope_type)
     permitted.select { |_, v| v.present? }

--- a/plugins/env/app/controllers/environment_variables_controller.rb
+++ b/plugins/env/app/controllers/environment_variables_controller.rb
@@ -4,14 +4,24 @@ class EnvironmentVariablesController < ApplicationController
 
   def index
     scope = EnvironmentVariable
-    search = params[:search] || {}
-    scope = scope.where(name: search[:name]) if search[:name].present?
-    scope = scope.where(value: search[:value]) if search[:value].present?
-    @pagy, @environment_variables = pagy(scope, page: params[:page], items: 30)
+    scope = scope.where(search_params) if search_params.present?
+    respond_to do |format|
+      format.html do
+        @pagy, @environment_variables = pagy(scope, page: params[:page], items: 30)
+      end
+      format.json do
+        render_as_json :environment_variables, scope.all
+      end
+    end
   end
 
   def destroy
     EnvironmentVariable.find(params.require(:id)).destroy!
     head :ok
+  end
+
+  def search_params
+    permitted = params.fetch(:search, {}).permit(:id, :name, :value, :parent_id, :parent_type, :scope_id, :scope_type)
+    permitted.select { |_, v| v.present? }
   end
 end

--- a/plugins/env/app/controllers/environment_variables_controller.rb
+++ b/plugins/env/app/controllers/environment_variables_controller.rb
@@ -3,14 +3,13 @@ class EnvironmentVariablesController < ApplicationController
   before_action :authorize_admin!, except: [:index]
 
   def index
-    scope = EnvironmentVariable
-    scope = scope.where(search_params) if search_params.present?
+    scope = EnvironmentVariable.where(search_params)
     respond_to do |format|
       format.html do
         @pagy, @environment_variables = pagy(scope, page: params[:page], items: 30)
       end
       format.json do
-        render_as_json :environment_variables, scope.all
+        render_as_json :environment_variables, scope
       end
     end
   end

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -5,6 +5,7 @@ class EnvironmentVariable < ActiveRecord::Base
   FAILED_LOOKUP_MARK = ' X' # SpaceX
 
   include GroupScope
+  extend Inlinable
   audited
 
   belongs_to :parent, polymorphic: true # Resource they are set on
@@ -14,8 +15,8 @@ class EnvironmentVariable < ActiveRecord::Base
   include ValidatesLengthsFromDatabase
   validates_lengths_from_database only: :value
 
-  delegate :name, to: :parent, prefix: true, allow_nil: true
-  delegate :name, to: :scope, prefix: true, allow_nil: true
+  allow_inline delegate :name, to: :parent, prefix: true, allow_nil: true
+  allow_inline delegate :name, to: :scope, prefix: true, allow_nil: true
 
   class << self
     # preview parameter can be used to not raise an error,
@@ -94,10 +95,6 @@ class EnvironmentVariable < ActiveRecord::Base
   # used by `priority` from GroupScope
   def project?
     parent_type == "Project"
-  end
-
-  def as_json(options = {})
-    super({methods: [:parent_name, :scope_name]}.merge(options))
   end
 
   private

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -14,6 +14,9 @@ class EnvironmentVariable < ActiveRecord::Base
   include ValidatesLengthsFromDatabase
   validates_lengths_from_database only: :value
 
+  delegate :name, to: :parent, prefix: true, allow_nil: true
+  delegate :name, to: :scope, prefix: true, allow_nil: true
+
   class << self
     # preview parameter can be used to not raise an error,
     # but return a value with a helpful message
@@ -91,6 +94,10 @@ class EnvironmentVariable < ActiveRecord::Base
   # used by `priority` from GroupScope
   def project?
     parent_type == "Project"
+  end
+
+  def as_json(options = {})
+    super({methods: [:parent_name, :scope_name]}.merge(options))
   end
 
   private

--- a/plugins/env/app/models/environment_variable_group.rb
+++ b/plugins/env/app/models/environment_variable_group.rb
@@ -21,7 +21,7 @@ class EnvironmentVariableGroup < ActiveRecord::Base
     environment_variables.sort_by(&:id).map(&:name).uniq
   end
 
-  def as_json(options = {})
-    super({methods: [:variable_names]}.merge(options))
+  def as_json(methods: [], **options)
+    super({methods: [:variable_names] + methods}.merge(options))
   end
 end

--- a/plugins/env/test/controllers/environment_variables_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variables_controller_test.rb
@@ -18,6 +18,17 @@ describe EnvironmentVariablesController do
         assigns[:environment_variables].size.must_equal 2
       end
 
+      it "renders json" do
+        get :index, format: :json
+        assert_response :success
+        json_response = JSON.parse response.body
+        first_env = json_response['environment_variables'].first
+        first_env.keys.must_include "parent_name"
+        first_env.keys.must_include "scope_name"
+        first_env['name'].must_equal "FOO"
+        first_env['parent_name'].must_equal "Foo"
+      end
+
       it "can filter by name" do
         get :index, params: {search: {name: 'FOO'}}
         assert_response :success
@@ -28,6 +39,39 @@ describe EnvironmentVariablesController do
         get :index, params: {search: {value: 'bar'}}
         assert_response :success
         assigns[:environment_variables].size.must_equal 1
+      end
+
+      it "can filter by name and value" do
+        get :index, params: {search: {name: 'FOO', value: 'bar'}}
+        assert_response :success
+        assigns[:environment_variables].size.must_equal 1
+      end
+
+      it "can filter by parent_id and parent_type via json" do
+        get :index, params: {search: {parent_id: env_var.parent_id, parent_type: env_var.parent_type}}, format: "json"
+        assert_response :success
+        body = JSON.parse(response.body)
+        body["environment_variables"].size.must_equal 2
+      end
+
+      it "can filter by scope_id and scope_type via json" do
+        env_var.update_attributes!(scope_id: 1, scope_type: 'DeployGroup')
+        get :index, params: {search: {scope_id: env_var.scope_id, scope_type: env_var.scope_type}}, format: "json"
+        assert_response :success
+        body = JSON.parse(response.body)
+        body["environment_variables"].size.must_equal 1
+      end
+
+      it "skips filters without values" do
+        get :index, params: {search: {name: '', value: nil}}
+        assert_response :success
+        assigns[:environment_variables].size.must_equal 2
+      end
+
+      it "fails when filtering for unknown" do
+        assert_raises ActionController::UnpermittedParameters do
+          get :index, params: {search: {group: "xx"}}
+        end
       end
     end
   end

--- a/plugins/env/test/controllers/environment_variables_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variables_controller_test.rb
@@ -23,10 +23,27 @@ describe EnvironmentVariablesController do
         assert_response :success
         json_response = JSON.parse response.body
         first_env = json_response['environment_variables'].first
+        first_env['name'].must_equal "FOO"
+      end
+
+      it "renders json with inlines" do
+        get :index, params: {inlines: "parent_name,scope_name"}, format: :json
+        assert_response :success
+        json_response = JSON.parse response.body
+        first_env = json_response['environment_variables'].first
         first_env.keys.must_include "parent_name"
         first_env.keys.must_include "scope_name"
-        first_env['name'].must_equal "FOO"
         first_env['parent_name'].must_equal "Foo"
+      end
+
+      it "fails with invalid inlines" do
+        get :index, params: {inlines: "xyz"}, format: :json
+        json_response = JSON.parse response.body
+        assert_response :bad_request
+        json_response.must_equal(
+          "status" => 400,
+          "error" => "Forbidden inlines [xyz] found, allowed inlines are [parent_name, scope_name]"
+        )
       end
 
       it "can filter by name" do

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -258,15 +258,9 @@ describe EnvironmentVariable do
     end
   end
 
-  describe "#as_json" do
-    let(:variable) { environment_variable.as_json }
-
-    it "includes parent_name" do
-      variable.keys.must_include "parent_name"
-    end
-
-    it "includes scope_name" do
-      variable.keys.must_include "scope_name"
+  describe ".allowed_inlines" do
+    it "allows inline" do
+      EnvironmentVariable.allowed_inlines.count.must_equal 2
     end
   end
 

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -258,6 +258,18 @@ describe EnvironmentVariable do
     end
   end
 
+  describe "#as_json" do
+    let(:variable) { environment_variable.as_json }
+
+    it "includes parent_name" do
+      variable.keys.must_include "parent_name"
+    end
+
+    it "includes scope_name" do
+      variable.keys.must_include "scope_name"
+    end
+  end
+
   describe "#auditing_enabled" do
     it "creates audits for regular vars" do
       assert_difference "Audited::Audit.count", +1 do

--- a/test/controllers/concerns/json_renderer_test.rb
+++ b/test/controllers/concerns/json_renderer_test.rb
@@ -73,5 +73,33 @@ describe "JsonRenderer Integration" do
         "error" => "Forbidden includes [nope] found, allowed includes are [job, project, user, stage]"
       )
     end
+
+    describe '.allowed_inlines' do
+      before do
+        EnvironmentVariable.create!(name: 'FOO', value: 'bar', parent: projects(:test))
+      end
+
+      it "renders single inlines" do
+        get '/environment_variables.json', params: {inlines: "parent_name"}
+        assert_response :success
+        json.keys.must_equal ['environment_variables']
+        json['environment_variables'].first.keys.must_include "parent_name"
+        json['environment_variables'].first.keys.wont_include "scope_name"
+      end
+
+      it "renders multiple inlines" do
+        get '/environment_variables.json', params: {inlines: "parent_name,scope_name"}
+        assert_response :success
+        json.keys.must_equal ['environment_variables']
+        json['environment_variables'].first.keys.must_include "parent_name"
+        json['environment_variables'].first.keys.must_include "scope_name"
+      end
+
+      it "skips inlines with empty collection" do
+        get '/environment_variables.json', params: {inlines: "parent_name", search: {name: 'xyz'}}
+        assert_response :success
+        json['environment_variables'].must_be_empty
+      end
+    end
   end
 end

--- a/test/models/concerns/inlinable_test.rb
+++ b/test/models/concerns/inlinable_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Inlinable do
+  class Foo < ActiveRecord::Base
+    extend Inlinable
+
+    allow_inline def bar1
+      "bar1"
+    end
+
+    allow_inline def bar2
+      "bar2"
+    end
+  end
+
+  it "allows inline" do
+    Foo.allowed_inlines.count.must_equal 2
+  end
+end


### PR DESCRIPTION
Allow the user to render environment variables as JSON, As many projects depends on SAMSON project env, the option to export env in JSON format is required rather than looping over samson to fetch those.

/cc @zendesk/samson
