### PR TITLE
CC user email in access request mailer

### DIFF
--- a/app/mailers/access_request_mailer.rb
+++ b/app/mailers/access_request_mailer.rb
@@ -18,7 +18,7 @@ class AccessRequestMailer < ApplicationMailer
   end
 
   def build_cc
-    ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'].present? ? @manager_email : nil
+    (ENV['REQUEST_ACCESS_EMAIL_ADDRESS_LIST'].present? ? [@manager_email] : []) << @user.email
   end
 
   def build_subject

--- a/test/controllers/access_requests_controller_test.rb
+++ b/test/controllers/access_requests_controller_test.rb
@@ -98,7 +98,7 @@ describe AccessRequestsController do
               post :create, params: request_params
             end
             access_request_email = ActionMailer::Base.deliveries.last
-            access_request_email.cc.must_equal [manager_email]
+            access_request_email.cc.must_equal [manager_email, user.email]
             access_request_email.body.to_s.must_match /#{reason}/
             access_request_email.body.to_s.must_match /#{role.display_name}/
             Project.all.each { |project| access_request_email.body.to_s.must_match /#{project.name}/ }

--- a/test/mailers/access_request_mailer_test.rb
+++ b/test/mailers/access_request_mailer_test.rb
@@ -39,7 +39,7 @@ describe AccessRequestMailer do
       it 'has correct sender and recipients' do
         subject.from.must_equal [user.email]
         subject.to.must_equal address_list.split
-        subject.cc.must_equal [manager_email]
+        subject.cc.must_equal [manager_email, user.email]
       end
 
       it 'has a correct subject' do
@@ -67,7 +67,7 @@ describe AccessRequestMailer do
         let(:address_list) { 'jira@example.com' }
         it 'handles single email address configured' do
           subject.to.must_equal [address_list]
-          subject.cc.must_equal [manager_email]
+          subject.cc.must_equal [manager_email, user.email]
         end
       end
 
@@ -75,7 +75,7 @@ describe AccessRequestMailer do
         let(:address_list) { nil }
         it 'handles no configured email address' do
           subject.to.must_equal [manager_email]
-          subject.cc.must_be_empty
+          subject.cc.must_equal [user.email]
         end
       end
     end


### PR DESCRIPTION
Added user email in access request email so that user can track the approval request status if it is not creating any JIRA ticket.

/cc @zendesk/samson
