### PR TITLE
stop deploys when bad events happen directly on the deployed resource

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -122,12 +122,7 @@ module Kubernetes
       end
 
       def raw_events
-        SamsonKubernetes.retry_on_connection_errors do
-          @client.get_events(
-            namespace: namespace,
-            field_selector: "involvedObject.name=#{name}"
-          ).fetch(:items)
-        end
+        Kubernetes::EventReader.events(@client, @pod)
       end
 
       # if the pod is still running we stream the logs until it times out to get as much info as possible

--- a/plugins/kubernetes/app/models/kubernetes/event_reader.rb
+++ b/plugins/kubernetes/app/models/kubernetes/event_reader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Kubernetes
+  module EventReader
+    class << self
+      def events(client, resource)
+        SamsonKubernetes.retry_on_connection_errors do
+          selector = ["involvedObject.name=#{resource.dig_fetch(:metadata, :name)}"]
+
+          # do not query for nil uid ... rather show events for old+new resource when creation failed
+          if uid = resource.dig_fetch(:metadata, :uid)
+            selector << "involvedObject.uid=#{uid}"
+          end
+
+          client.get_events(
+            namespace: resource.dig(:metadata, :namespace),
+            field_selector: selector.join(",")
+          ).fetch(:items)
+        end
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -378,7 +378,7 @@ describe Kubernetes::DeployExecutor do
 
     it "stops when detecting a restart and pod goes missing" do
       worker_is_unstable
-      Kubernetes::DeployExecutor::ReleaseStatus.any_instance.stubs(:pod)
+      Kubernetes::DeployExecutor::ResourceStatus.any_instance.stubs(:pod)
 
       refute execute
 


### PR DESCRIPTION
this works now, I just don't know any way how to create a bad event ... 
jira had daemonset as an example, but that was on a pod too ... and the others I found are on replicaset which requires another change to fetch the rs from each deployment :/
parking this here for now and extracting some parts into smaller PRs