### PR TITLE
fix resource events being shown from previous deploys

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -94,6 +94,7 @@ module Kubernetes
       def events(reload: false)
         @events = nil if reload
         @events ||= raw_events.select do |event|
+          # ignore events from old pods if this is a statefulset pod / static pod
           # compare strings to avoid parsing time '2017-03-31T22:56:20Z'
           event.dig(:metadata, :creationTimestamp) >= @pod.dig(:status, :startTime).to_s
         end
@@ -125,7 +126,7 @@ module Kubernetes
         SamsonKubernetes.retry_on_connection_errors do
           @client.get_events(
             namespace: namespace,
-            field_selector: "involvedObject.name=#{name}"
+            field_selector: "involvedObject.name=#{name},involvedObject.kind=Pod"
           ).fetch(:items)
         end
       end

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -81,6 +81,10 @@ module Kubernetes
         resource&.dig_fetch(:metadata, :uid)
       end
 
+      def kind
+        @template.fetch(:kind)
+      end
+
       def desired_pod_count
         if @delete_resource
           0
@@ -201,13 +205,13 @@ module Kubernetes
       def request(verb, *args)
         SamsonKubernetes.retry_on_connection_errors do
           begin
-            method = "#{verb}_#{Kubeclient::ClientMixin.underscore_entity(@template.fetch(:kind))}"
+            method = "#{verb}_#{Kubeclient::ClientMixin.underscore_entity(kind)}"
             if client.respond_to? method
               client.send(method, *args)
             else
               raise(
                 Samson::Hooks::UserError,
-                "apiVersion #{@template.fetch(:apiVersion)} does not support #{@template.fetch(:kind)}. " \
+                "apiVersion #{@template.fetch(:apiVersion)} does not support #{kind}. " \
                 "Check kubernetes docs for correct apiVersion"
               )
             end

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -40,7 +40,7 @@ describe Kubernetes::Api::Pod do
   end
   let(:start_time) { "2017-03-31T22:56:20Z" }
   let(:events_url) do
-    "http://foobar.server/api/v1/namespaces/the-namespace/events?fieldSelector=involvedObject.name=test_name"
+    "http://foobar.server/api/v1/namespaces/the-namespace/events?fieldSelector=involvedObject.name=test_name,involvedObject.kind=Pod"
   end
   let(:event) { {metadata: {creationTimestamp: start_time}, type: 'Normal'} }
   let(:events) { [event] }


### PR DESCRIPTION
also benchmarked using `involvedObject.uid` but it's the same speed, so no reason for this complexity

extracting bits from https://github.com/zendesk/samson/pull/3258 which was getting too large

@zendesk/compute 