### PR TITLE
unify event fetching logic

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -11,6 +11,7 @@ module Kubernetes
     class Base
       TICK = 2 # seconds
       UNSETTABLE_METADATA = [:selfLink, :uid, :resourceVersion, :generation, :creationTimestamp].freeze
+      attr_reader :template
 
       def initialize(template, deploy_group, autoscaled:, delete_resource:)
         @template = template

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+# TODO: merge plugins/kubernetes/app/models/kubernetes/api/pod.rb into here
+module Kubernetes
+  class ResourceStatus
+    attr_reader :resource, :role, :deploy_group, :kind, :details, :live, :finished, :pod
+    attr_writer :details
+
+    def initialize(resource:, role: nil, deploy_group:, prerequisite: false, start:, kind: resource.fetch(:kind))
+      @resource = resource
+      @kind = kind
+      @role = role
+      @deploy_group = deploy_group
+      @start = start
+      @prerequisite = prerequisite
+      @client = deploy_group.kubernetes_cluster.client('v1')
+    end
+
+    def check
+      if kind == "Pod"
+        @pod = Kubernetes::Api::Pod.new(@resource, client: @client) if @resource
+
+        if !@resource
+          @details = "Missing"
+        elsif @pod.restarted?
+          @details = "Restarted"
+          @finished = true
+        elsif @pod.failed?
+          @details = "Failed"
+          @finished = true
+        elsif @prerequisite ? @pod.completed? : @pod.live?
+          @details = "Live"
+          @live = true
+          @finished = @pod.completed?
+        elsif (@pod.events = events) && @pod.waiting_for_resources?
+          @details = "Waiting for resources (#{@pod.phase}, #{@pod.reason})"
+        elsif @pod.events_indicate_failure?
+          @details = "Error event"
+          @finished = true
+        else
+          @details = "Waiting (#{@pod.phase}, #{@pod.reason})"
+        end
+      end
+    end
+
+    def events
+      # do not rely on uid, when creation fails we don't get one
+      SamsonKubernetes.retry_on_connection_errors do
+        events = @client.get_events(
+          namespace: @resource.dig_fetch(:metadata, :namespace),
+          field_selector: "involvedObject.name=#{@resource.dig_fetch(:metadata, :name)},involvedObject.kind=#{@kind}"
+        ).fetch(:items)
+
+        # ignore events from before the deploy, comparing strings for speed
+        events.select! { |e| e.dig(:metadata, :creationTimestamp) >= @start }
+
+        # https://github.com/kubernetes/kubernetes/issues/29838
+        events.sort_by! { |e| e.dig(:metadata, :creationTimestamp) }
+
+        events
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Kubernetes::ResourceStatus do
+  let(:status) do
+    Kubernetes::ResourceStatus.new(
+      deploy_group: deploy_groups(:pod1),
+      role: kubernetes_roles(:app_server),
+      resource: resource,
+      kind: resource.fetch(:kind),
+      start: Time.now.iso8601
+    )
+  end
+  let(:resource) { {kind: 'Pod', metadata: {name: 'foo', namespace: 'default'}, status: {phase: "Running"}} }
+  let(:events) { [{metadata: {creationTimestamp: 30.seconds.from_now.utc.iso8601}}] }
+
+  describe "#check" do
+    let(:details) do
+      status.check
+      status.details
+    end
+
+    it "does not provide details for non-pods" do
+      resource[:kind] = "Service"
+      details.must_be_nil
+    end
+
+    it "is missing without resource" do
+      status.instance_variable_set(:@resource, nil)
+      details.must_equal "Missing"
+    end
+
+    it "is restarted when pod is restarted" do
+      resource[:status][:containerStatuses] = [{restartCount: 1}]
+      details.must_equal "Restarted"
+    end
+
+    it "is failed when pod is failed" do
+      resource[:status][:phase] = "Failed"
+      details.must_equal "Failed"
+    end
+
+    it "is live when live" do
+      resource[:status][:phase] = "Succeeded"
+      details.must_equal "Live"
+    end
+
+    it "is live when complete and prerequisite" do
+      resource[:status][:phase] = "Succeeded"
+      status.instance_variable_set(:@prerequisite, true)
+      details.must_equal "Live"
+    end
+
+    it "is waiting" do
+      assert_request :get, /events/, to_return: {body: {items: []}.to_json} do
+        details.must_equal "Waiting (Running, Unknown)"
+      end
+    end
+
+    it "waits when resources are missing" do
+      events[0].merge!(type: "Warning", reason: "FailedScheduling")
+      assert_request :get, /events/, to_return: {body: {items: events}.to_json} do
+        details.must_equal "Waiting for resources (Running, Unknown)"
+      end
+    end
+
+    it "errors when bad events happen" do
+      events[0].merge!(type: "Warning", reason: "Boom")
+      assert_request :get, /events/, to_return: {body: {items: events}.to_json} do
+        details.must_equal "Error event"
+      end
+    end
+  end
+
+  describe "#events" do
+    let(:result) do
+      assert_request :get, /events/, to_return: {body: {items: events}.to_json} do
+        status.events
+      end
+    end
+
+    it "finds events" do
+      result.size.must_equal 1
+    end
+
+    it "ignores previous events" do
+      events.first[:metadata][:creationTimestamp] = 30.seconds.ago.utc.iso8601
+      result.size.must_equal 0
+    end
+
+    it "sorts" do
+      new = 60.seconds.from_now.utc.iso8601
+      events.unshift metadata: {creationTimestamp: new}
+      events.push metadata: {creationTimestamp: new}
+      result.first.must_equal events[1]
+    end
+  end
+end

--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -19,9 +19,10 @@ ActiveSupport::TestCase.class_eval do
     assert_args = [request, assertion_options]
 
     if block_given?
-      yield
+      result = yield
       assert_requested(*assert_args)
       remove_request_stub(request)
+      result
     else
       raise "use assert_requests in the describe block" unless @assert_requests
       @assert_requests << assert_args


### PR DESCRIPTION
 - de-spaghetti deploy-executor
 - show all pod events even if the pod restarted
 - move logic from pod.rb -> resource_status so it can get killed someday
 - move autoscaling pod logic into a single place

breaking out improvements from https://github.com/zendesk/samson/pull/3258 which was getting too large

@zendesk/compute 