### PR TITLE
stop deploys when bad events happen directly on the deployed resource

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -49,11 +49,13 @@ module Kubernetes
         reasons.reject(&:blank?).uniq.join("/").presence || "Unknown"
       end
 
+      # TODO: move into resource_status.rb
       def container_names
         (@pod.dig(:spec, :containers) + self.class.init_containers(@pod)).map { |c| c.fetch(:name) }.uniq
       end
 
       # tries to get logs from current or previous pod depending on if it restarted
+      # TODO: move into resource_status.rb
       def logs(container, end_time)
         fetch_logs(container, end_time, previous: restarted?)
       rescue *SamsonKubernetes.connection_errors # not found or pod is initializing

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -6,7 +6,7 @@ require 'vault'
 module Kubernetes
   class DeployExecutor
     if ENV['KUBE_WAIT_FOR_LIVE'] && !ENV["KUBERNETES_WAIT_FOR_LIVE"]
-      raise "Use KUBERNETES_WAIT_FOR_LIVE with seconds instead of KUBE_WAIT_FOR_LIVE"
+      raise "Use KUBERNETES_WAIT_FOR_LIVE with seconds instead of KUBE_WAIT_FOR_LIVE" # uncovered
     end
     WAIT_FOR_LIVE = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_LIVE', '600'))
     WAIT_FOR_PREREQUISITES = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_PREREQUISITES', WAIT_FOR_LIVE))
@@ -61,16 +61,16 @@ module Kubernetes
       )
     end
 
-    # check all pods and see if they are running
-    # once they are running check if they are stable (for apps only, since jobs are finished and will not change)
+    # check all resources and see if they are working
+    # once they are working check if they are stable (for apps only, since jobs are finished and will not change)
     def wait_for_resources_to_complete(release_docs, timeout)
       waiting_for_ready = true
       wait_start_time = Time.now.to_i
-      @output.puts "Waiting for pods to be created"
+      @output.puts "Waiting for resources to come up" unless release_docs.all?(&:delete_resource)
 
       loop do
-        statuses = pod_statuses(release_docs)
-        if statuses.none?
+        statuses = resource_statuses(release_docs)
+        if statuses.select { |s| s.kind == "Pod" }.none?
           @output.puts "No pods were created"
           return success, statuses
         end
@@ -82,9 +82,9 @@ module Kubernetes
           print_statuses(statuses)
           if too_many_not_ready
             if stopped = not_ready_statuses.select(&:finished).presence
-              unstable!('one or more pods stopped', stopped)
+              unstable!("resources failed", stopped)
               return false, statuses
-            elsif (Time.now.to_i - wait_start_time) > timeout
+            elsif time_left(wait_start_time, timeout) == 0
               @output.puts "TIMEOUT, pods took too long to get live"
               return false, statuses
             end
@@ -98,12 +98,12 @@ module Kubernetes
         else
           if too_many_not_ready
             print_statuses(statuses)
-            unstable!('one or more pods are not live', not_ready_statuses)
+            unstable!("resources not ready", not_ready_statuses)
             return false, statuses
           else
-            remaining = [wait_start_time + STABILITY_CHECK_DURATION - Time.now.to_i, 0].max
+            remaining = time_left(wait_start_time, STABILITY_CHECK_DURATION)
             @output.puts "Testing for stability: #{remaining}s"
-            return success, statuses if stable?(remaining)
+            return success, statuses if remaining == 0
           end
         end
 
@@ -112,13 +112,31 @@ module Kubernetes
     end
 
     # test hook
-    def stable?(remaining)
-      remaining == 0
+    def time_left(start, timeout)
+      [start + timeout - Time.now.to_i, 0].max
     end
 
-    def pod_statuses(release_docs)
+    def resource_statuses(release_docs)
+      non_pod_statuses = release_docs.flat_map do |doc|
+        # do not report on the status when we are about to delete
+        next [] if doc.delete_resource
+
+        # ignore pods since we report on them via pod_statuses
+        resources = doc.resources.reject { |r| r.is_a?(Kubernetes::Resource::Pod) }
+
+        resources.map! do |resource|
+          ResourceStatus.new(
+            resource: resource.template, # avoid extra fetches and show events when create failed
+            kind: resource.kind,
+            role: doc.kubernetes_role,
+            deploy_group: doc.deploy_group,
+            start: @deploy_start_time
+          )
+        end.each(&:check)
+      end
+
       pods = fetch_pods
-      release_docs.flat_map { |release_doc| release_statuses(pods, release_doc) }
+      non_pod_statuses + release_docs.flat_map { |release_doc| pod_statuses(pods, release_doc) }
     end
 
     # efficient pod fetching by querying once per cluster instead of once per deploy group
@@ -130,87 +148,64 @@ module Kubernetes
 
     def show_logs_on_deploy_if_requested(statuses)
       statuses = statuses.select do |s|
-        s.resource&.dig(:metadata, :annotations, :'samson/show_logs_on_deploy') == 'true'
+        s.resource&.dig(:metadata, :annotations, :'samson/show_logs_on_deploy') == 'true' && s.kind == "Pod"
       end
       log_end = Time.now # here to be consistent for all pods
-      statuses.each { |status| print_pod_details(status, log_end, events: false) }
+      statuses.each { |status| print_logs(status, log_end) }
     rescue StandardError
       info = ErrorNotifier.notify($!, sync: true)
-      @output.puts "Error showing logs: #{info}"
+      @output.puts "  Error showing logs: #{info || "See samson logs for details"}"
     end
 
-    def show_failure_cause(release_docs, statuses)
-      release_docs.each { |doc| print_resource_events(doc) }
+    def show_failure_cause(statuses)
+      pod_statuses, non_pod_statuses = statuses.partition { |s| s.kind == "Pod" }
+
+      # print events for non-resources
+      non_pod_statuses.each { |s| print_events(s) }
+
+      # print logs for 1 pod per role
       log_end_time = Integer(ENV['KUBERNETES_LOG_TIMEOUT'] || '20').seconds.from_now
-      debug_statuses = statuses.reject(&:live).select(&:resource).group_by(&:role).each_value.map(&:first)
-      debug_statuses.each do |status|
-        print_pod_details(status, log_end_time, events: true)
+      sample_pod_statuses = pod_statuses.reject(&:live).select(&:resource).group_by(&:role).each_value.map(&:first)
+      sample_pod_statuses.each do |status|
+        print_events(status)
+        print_logs(status, log_end_time)
       end
     rescue
       info = ErrorNotifier.notify($!, sync: true)
       @output.puts "Error showing failure cause: #{info}"
     ensure
       @output.puts(
-        "Debug: disable 'Rollback on failure' when deploying and use 'kubectl describe pod <name>' on failed pods"
+        "\nDebug: disable 'Rollback on failure' when deploying and use 'kubectl describe pod <name>' on failed pods"
       )
     end
 
-    def print_pod_details(status, log_end_time, events:)
-      @output.puts "\n#{pod_identifier(status)}:"
-      if events
-        print_pod_events(status)
-        @output.puts
-      end
-      print_pod_logs(status.pod, log_end_time)
-      @output.puts "\n------------------------------------------\n"
-    end
-
-    def pod_identifier(status)
-      name = status.resource&.dig(:metadata, :name)
-      "#{status.deploy_group.name} #{status.kind} #{name}"
+    def resource_identifier(status, exact: true)
+      name = (exact ? (status.resource&.dig(:metadata, :name) || status.role.name) : status.role.name)
+      "#{status.deploy_group.name} #{status.role.name} #{status.kind} #{name}"
     end
 
     # show why container failed to boot
-    def print_pod_logs(pod, end_time)
-      @output.puts "LOGS:"
+    def print_logs(status, end_time)
+      @output.puts "\n#{resource_identifier(status)} logs:"
 
-      containers_names = pod.container_names
+      containers_names = status.pod.container_names
       containers_names.each do |container_name|
         @output.puts "Container #{container_name}" if containers_names.size > 1
 
         # Display the first and last n_lines of the log
         max = Integer(ENV['KUBERNETES_LOG_LINES'] || '50')
-        lines = (pod.logs(container_name, end_time) || "No logs found").split("\n")
+        lines = (status.pod.logs(container_name, end_time) || "No logs found").split("\n")
         lines = lines.first(max / 2) + ['...'] + lines.last(max / 2) if lines.size > max
         lines.each { |line| @output.puts "  #{line}" }
       end
     end
 
-    def print_resource_events(doc)
-      # ignores pods since we print their events already
-      resources = doc.resources.reject { |r| r.is_a?(Kubernetes::Resource::Pod) }
-
-      resources.each do |resource|
-        status = ResourceStatus.new(
-          # does not use resource.resource to also see events for failed creation
-          deploy_group: doc.deploy_group, resource: resource.template, start: @deploy_start_time
-        )
-        events = status.events
-        next if events.none?
-
-        @output.puts "RESOURCE EVENTS #{pod_identifier(status)}:"
-        print_events(events)
-      end
-    end
-
     # show what happened in kubernetes internally since we might not have any logs
     # reloading the events so we see things added during+after pod restart
-    def print_pod_events(status)
-      @output.puts "POD EVENTS:"
-      print_events(status.events)
-    end
+    def print_events(status)
+      return unless events = status.events.presence
+      @output.puts "\n#{resource_identifier(status)} events:"
 
-    def print_events(events)
       groups = events.group_by { |e| [e[:type], e[:reason], (e[:message] || "").split("\n").sort] }
       groups.each do |_, event_group|
         count = event_group.sum { |e| e[:count] }
@@ -220,14 +215,14 @@ module Kubernetes
       end
     end
 
-    def unstable!(reason, bad_release_statuses)
-      @output.puts "UNSTABLE: #{reason}"
+    def unstable!(message, bad_release_statuses)
+      @output.puts "UNSTABLE: #{message}"
       bad_release_statuses.select(&:resource).each do |status|
-        @output.puts "  #{pod_identifier(status)}: #{status.details}"
+        @output.puts "  #{resource_identifier(status)}: #{status.details}"
       end
     end
 
-    def release_statuses(pods, release_doc)
+    def pod_statuses(pods, release_doc)
       group = release_doc.deploy_group
       role = release_doc.kubernetes_role
 
@@ -263,15 +258,17 @@ module Kubernetes
       statuses
     end
 
-    def print_statuses(status_groups)
+    def print_statuses(statuses)
       return if @last_status_output && @last_status_output > 10.seconds.ago
-
       @last_status_output = Time.now
+
       @output.puts "Deploy status:"
-      status_groups.group_by(&:deploy_group).each do |deploy_group, statuses|
-        statuses.each do |status|
-          @output.puts "  #{deploy_group.name} #{status.role.name}: #{status.details}"
-        end
+
+      # ignore boring things that rarely fail
+      statuses = statuses.select { |s| s.kind == "Pod" || !s.live }
+
+      statuses.each do |status|
+        @output.puts "  #{resource_identifier(status, exact: false)}: #{status.details}"
       end
     end
 
@@ -328,10 +325,8 @@ module Kubernetes
         roles_present_in_repo = Kubernetes::Role.configured_for_project(@job.project, @job.commit).
           reject { |role| ignored_role_ids.include?(role.id) }
 
-        # check that all roles have a matching deploy_group_role
-        # and all roles are configured
-        errors = []
-        groups = @job.deploy.stage.deploy_groups.map do |deploy_group|
+        # check that all roles have a matching deploy_group_role and all roles are configured
+        @job.deploy.stage.deploy_groups.map do |deploy_group|
           group_roles = deploy_group_roles.select { |dgr| dgr.deploy_group_id == deploy_group.id }
 
           # safe some sql queries during release creation
@@ -360,9 +355,6 @@ module Kubernetes
 
           group_roles
         end
-
-        raise Samson::Hooks::UserError, errors.join("\n") if errors.any?
-        groups
       end
     end
 
@@ -392,7 +384,7 @@ module Kubernetes
         show_logs_on_deploy_if_requested(statuses)
         true
       else
-        show_failure_cause(release_docs, statuses)
+        show_failure_cause(statuses)
         rollback(release_docs) if @job.deploy.kubernetes_rollback
         @output.puts "DONE"
         false


### PR DESCRIPTION
clean replacement for https://github.com/zendesk/samson/pull/3258 now that refactoring was merged

jira had daemonset as an example, but that was on a pod too
I found adding runAsUser to replicaset/daemonset works :)

```
[22:25:01] RESOURCE EVENTS pod 105 ReplicaSet kube-stats:
[22:25:01]   Warning FailedCreate: Error creating: pods "foo-2b297" is forbidden: SecurityContext.RunAsUser is forbidden
```

@zendesk/compute 