### PR TITLE
use lastTimestamp to find relevant events

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -51,10 +51,10 @@ module Kubernetes
         ).fetch(:items)
 
         # ignore events from before the deploy, comparing strings for speed
-        events.select! { |e| e.dig(:metadata, :creationTimestamp) >= @start }
+        events.select! { |e| e.dig(:lastTimestamp) >= @start }
 
         # https://github.com/kubernetes/kubernetes/issues/29838
-        events.sort_by! { |e| e.dig(:metadata, :creationTimestamp) }
+        events.sort_by! { |e| e.dig(:lastTimestamp) }
 
         events
       end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -407,7 +407,7 @@ describe Kubernetes::DeployExecutor do
                 type: 'Warning',
                 reason: 'Unhealthy',
                 message: "kubelet, ip-12-34-56-78 Liveness probe failed: Get http://12.34.56.78/ping",
-                metadata: {creationTimestamp: 1.minute.from_now.iso8601}
+                lastTimestamp: 1.minute.from_now.iso8601
               }
             ]
           }.to_json
@@ -432,7 +432,7 @@ describe Kubernetes::DeployExecutor do
                 type: 'Warning',
                 reason: 'FailedScheduling',
                 message: "0/20 nodes are available: 17 Insufficient cpu, 3 Insufficient memory.",
-                metadata: {creationTimestamp: 1.minute.from_now.iso8601}
+                lastTimestamp: 1.minute.from_now.iso8601
               }
             ]
           }.to_json
@@ -611,14 +611,14 @@ describe Kubernetes::DeployExecutor do
                   type: 'Warning',
                   message: "fit failure on node (ip-1-2-3-4)\nfit failure on node (ip-2-3-4-5)",
                   count: 4,
-                  metadata: {creationTimestamp: 1.hour.from_now.utc.iso8601}
+                  lastTimestamp: 1.hour.from_now.utc.iso8601
                 },
                 {
                   reason: 'FailedScheduling',
                   type: 'Warning',
                   message: "fit failure on node (ip-2-3-4-5)\nfit failure on node (ip-1-2-3-4)",
                   count: 1,
-                  metadata: {creationTimestamp: 1.hour.from_now.utc.iso8601}
+                  lastTimestamp: 1.hour.from_now.utc.iso8601
                 }
               ]
             }.to_json
@@ -649,13 +649,13 @@ describe Kubernetes::DeployExecutor do
                   reason: 'Foobar',
                   type: 'Warning',
                   count: 1,
-                  metadata: {creationTimestamp: 1.hour.from_now.utc.iso8601}
+                  lastTimestamp: 1.hour.from_now.utc.iso8601
                 },
                 {
                   reason: 'Foobar',
                   type: 'Warning',
                   count: 1,
-                  metadata: {creationTimestamp: 1.hour.from_now.utc.iso8601}
+                  lastTimestamp: 1.hour.from_now.utc.iso8601
                 }
               ]
             }.to_json
@@ -676,7 +676,7 @@ describe Kubernetes::DeployExecutor do
                   type: 'Warning',
                   message: 'Foobar',
                   count: 1,
-                  metadata: {creationTimestamp: 1.hour.ago.utc.iso8601}
+                  lastTimestamp: 1.hour.ago.utc.iso8601
                 }
               ]
             }.to_json

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -14,7 +14,7 @@ describe Kubernetes::ResourceStatus do
     )
   end
   let(:resource) { {kind: 'Pod', metadata: {name: 'foo', namespace: 'default'}, status: {phase: "Running"}} }
-  let(:events) { [{metadata: {creationTimestamp: 30.seconds.from_now.utc.iso8601}}] }
+  let(:events) { [{lastTimestamp: 30.seconds.from_now.utc.iso8601}] }
 
   describe "#check" do
     let(:details) do
@@ -86,14 +86,14 @@ describe Kubernetes::ResourceStatus do
     end
 
     it "ignores previous events" do
-      events.first[:metadata][:creationTimestamp] = 30.seconds.ago.utc.iso8601
+      events.first[:lastTimestamp] = 30.seconds.ago.utc.iso8601
       result.size.must_equal 0
     end
 
     it "sorts" do
       new = 60.seconds.from_now.utc.iso8601
-      events.unshift metadata: {creationTimestamp: new}
-      events.push metadata: {creationTimestamp: new}
+      events.unshift lastTimestamp: new
+      events.push lastTimestamp: new
       result.first.must_equal events[1]
     end
   end


### PR DESCRIPTION
important for things that are only updated like deployents/named pods, so we do not show previous events

lastTimestamp = last time it happened
firstTimestamp=metadata.creationTimestamp = first time it happened

@zendesk/compute 