### PR TITLE
do not return read-only column as json so writing objects back does n…

### DIFF
--- a/app/models/deploy_group.rb
+++ b/app/models/deploy_group.rb
@@ -40,6 +40,10 @@ class DeployGroup < ActiveRecord::Base
     super || (lock.resource_type == "Environment" && lock.resource_equal?(environment))
   end
 
+  def as_json(options = {})
+    super({except: [:name_sortable]}.merge(options))
+  end
+
   private
 
   def generated_name_sortable

--- a/test/models/deploy_group_test.rb
+++ b/test/models/deploy_group_test.rb
@@ -196,4 +196,10 @@ describe DeployGroup do
       refute deploy_group.locked_by?(Lock.new(resource: environments(:staging)))
     end
   end
+
+  describe "#as_json" do
+    it "does not render internal read-only column" do
+      deploy_group.as_json.keys.wont_include "name_sortable"
+    end
+  end
 end


### PR DESCRIPTION
…ot fail on permitted params

fixes https://github.com/zendesk/samson/issues/3269
fallout from https://github.com/zendesk/samson/pull/3231

... ideally we'd verify all models as_jjson against their permitted params, but that will be a bigger PR

@zendesk/bre @danihodovic