### PR TITLE
PAAS-3025 debug-log shell/vault/kubernetes calls

### DIFF
--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Log github request timing so it is more obvious what we spent our time on
+# and any other backend that uses faraday
+require 'faraday'
+
+Faraday::Connection.prepend(Module.new do
+  def run_request(method, url, *)
+    ActiveSupport::Notifications.instrument("request.faraday.samson", method: method, url: url) { super }
+  end
+end)

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -38,11 +38,3 @@ Octokit.api_endpoint = Rails.application.config.samson.github.api_url
 Octokit.web_endpoint = Rails.application.config.samson.github.web_url
 
 GITHUB = Octokit::Client.new(access_token: token)
-
-# Log github request timing so it is more obvious what we spent our time on
-Sawyer::Response.prepend(Module.new do
-  def initialize(*)
-    super
-    Rails.logger.info("GITHUB #{@env.method.upcase} (#{timing}s) #{@env.url}")
-  end
-end)

--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# instrument all vault calls
+require 'vault'
+
+Vault::Client.prepend(Module.new do
+  def request(method, path, *)
+    ActiveSupport::Notifications.instrument("request.vault.samson", method: method, path: path) { super }
+  end
+end)

--- a/plugins/kubernetes/config/initializers/kubeclient.rb
+++ b/plugins/kubernetes/config/initializers/kubeclient.rb
@@ -9,3 +9,10 @@ Kubeclient::Client.prepend(Module.new do
     raise
   end
 end)
+
+# instrument all kube-client calls since that is the only thing using rest-client
+(class << RestClient::Request; self; end).prepend(Module.new do
+  def execute(args)
+    ActiveSupport::Notifications.instrument("request.rest_client.samson", args.slice(:method, :url)) { super }
+  end
+end)


### PR DESCRIPTION
we log AR calls that are usually fast, so lets log this stuff too since it can slow us down significantly

 - being careful not to log script with secrets
 - being careful not to log request payloads
 - replacing existing 1-off github instrumentation that is now captured by faraday instrumentation

@zendesk/bre @zendesk/compute 