### PR TITLE
Send code version to airbrake/rollbar

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 Rails.application.console do
   Rails::ConsoleMethods.send(:prepend, Samson::ConsoleExtensions)
-  puts "Samson version: #{Rails.application.config.samson.version&.first(7)}"
+  puts "Samson version: #{SAMSON_VERSION.first(7)}"
   ActiveRecord::Base.logger = Rails.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
   Rails.logger.level = :info if ENV['PROFILE']
   Audited.store[:audited_user] = "rails console #{ENV.fetch("USER")}"

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 # sha or tag samson is currently running truncated to 7 characters in the UI, so need to be unique/exact
 file = Rails.root.join('REVISION')
-version =
+SAMSON_VERSION =
   ENV['TAG'] ||
   ENV['HEROKU_SLUG_COMMIT'] || # heroku labs:enable runtime-dyno-metadata
   (File.exist?(file) && File.read(file).chomp) || # local file
-  `git describe --tags --exact-match HEAD 2>/dev/null`.chomp.presence # local git
+  `git describe --tags --exact-match HEAD 2>/dev/null`.chomp.presence || # local git
+  "unknown" # fallback
 
-Rails.application.config.samson.version = version
+ActiveSupport.run_load_hooks(:samson_version, SAMSON_VERSION)

--- a/plugins/airbrake/config/initializers/airbrake.rb
+++ b/plugins/airbrake/config/initializers/airbrake.rb
@@ -1,34 +1,36 @@
 # frozen_string_literal: true
 
 if key = ENV['AIRBRAKE_API_KEY']
-  Airbrake.user_information_placeholder = ErrorNotifier::USER_INFORMATION_PLACEHOLDER
-  Airbrake.user_information = # replaces replaces user_information_placeholder on 500 pages
-    "<br/><br/>Error number: <a href='https://airbrake.io/locate/{{error_id}}'>{{error_id}}</a>" +
-      ((link = ENV['HELP_LINK']) ? "<br/><br/>#{link}" : "")
+  ActiveSupport.on_load(:samson_version) do |version|
+    Airbrake.user_information_placeholder = ErrorNotifier::USER_INFORMATION_PLACEHOLDER
+    Airbrake.user_information = # replaces replaces user_information_placeholder on 500 pages
+      "<br/><br/>Error number: <a href='https://airbrake.io/locate/{{error_id}}'>{{error_id}}</a>" +
+        ((link = ENV['HELP_LINK']) ? "<br/><br/>#{link}" : "")
 
-  Airbrake.configure do |config|
-    config.project_id = ENV.fetch('AIRBRAKE_PROJECT_ID')
-    config.project_key = key
+    Airbrake.configure do |config|
+      config.project_id = ENV.fetch('AIRBRAKE_PROJECT_ID')
+      config.project_key = key
 
-    config.app_version = Rails.application.config.samson.version&.first(7)
-    raise 'This must run after config/initializers/ ' if Rails.application.config.filter_parameters.empty?
-    config.blacklist_keys = Rails.application.config.filter_parameters
+      config.app_version = version.first(7)
+      raise 'This must run after config/initializers/ ' if Rails.application.config.filter_parameters.empty?
+      config.blacklist_keys = Rails.application.config.filter_parameters
 
-    # send correct errors even when something blows up during initialization
-    config.environment = Rails.env
-    config.ignore_environments = [:test, :development]
+      # send correct errors even when something blows up during initialization
+      config.environment = Rails.env
+      config.ignore_environments = [:test, :development]
 
-    # report in development:
-    # - add AIRBRAKE_API_KEY to ENV
-    # - add AIRBRAKE_PROJECT_ID to ENV
-    # - set consider_all_requests_local = false in development.rb
-    # - comment out add_filter below
-    # - uncomment
-    # config.ignore_environments = [:test]
-  end
+      # report in development:
+      # - add AIRBRAKE_API_KEY to ENV
+      # - add AIRBRAKE_PROJECT_ID to ENV
+      # - set consider_all_requests_local = false in development.rb
+      # - comment out add_filter below
+      # - uncomment
+      # config.ignore_environments = [:test]
+    end
 
-  # Ignore errors based on result of hook, so other parts of the code can interact with errors
-  Airbrake.add_filter do |notice|
-    notice.ignore! if notice[:errors].any? { |e| Samson::Hooks.fire(:ignore_error, e[:type]).any? }
+    # Ignore errors based on result of hook, so other parts of the code can interact with errors
+    Airbrake.add_filter do |notice|
+      notice.ignore! if notice[:errors].any? { |e| Samson::Hooks.fire(:ignore_error, e[:type]).any? }
+    end
   end
 end

--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -1,31 +1,33 @@
 # frozen_string_literal: true
 
 if token = ENV['ROLLBAR_ACCESS_TOKEN']
-  Rollbar.configure do |config|
-    config.access_token = token
-    config.environment = Rails.env
-    if url = ENV['ROLLBAR_URL']
-      config.endpoint = url + '/api/1/item/'
-    end
-    if web_base = ENV['ROLLBAR_WEB_BASE'] || url
-      config.web_base = web_base
-    end
-    config.use_thread # use threads for async notifications (waits for them at_exit)
-    config.code_version = Rails.application.config.samson.version&.first(7)
-    config.populate_empty_backtraces = true
-    config.logger = Rails.logger
+  ActiveSupport.on_load(:samson_version) do |version|
+    Rollbar.configure do |config|
+      config.access_token = token
+      config.environment = Rails.env
+      if url = ENV['ROLLBAR_URL']
+        config.endpoint = url + '/api/1/item/'
+      end
+      if web_base = ENV['ROLLBAR_WEB_BASE'] || url
+        config.web_base = web_base
+      end
+      config.use_thread # use threads for async notifications (waits for them at_exit)
+      config.code_version = version.first(7)
+      config.populate_empty_backtraces = true
+      config.logger = Rails.logger
 
-    # ignore errors we do not want to send to Rollbar
-    config.before_process << proc do |options|
-      "ignored" if Samson::Hooks.fire(:ignore_error, options[:exception].class.name).any?
-    end
+      # ignore errors we do not want to send to Rollbar
+      config.before_process << proc do |options|
+        "ignored" if Samson::Hooks.fire(:ignore_error, options[:exception].class.name).any?
+      end
 
-    Rollbar::UserInformer.user_information_placeholder = ErrorNotifier::USER_INFORMATION_PLACEHOLDER
-    Rollbar::UserInformer.user_information = <<~HTML
-      <br/><br/>
-      <a href="#{Rollbar.notifier.configuration.web_base}/instance/uuid?uuid={{error_uuid}}">
-        View error {{error_uuid}} on Rollbar
-      </a>
-    HTML
+      Rollbar::UserInformer.user_information_placeholder = ErrorNotifier::USER_INFORMATION_PLACEHOLDER
+      Rollbar::UserInformer.user_information = <<~HTML
+        <br/><br/>
+        <a href="#{Rollbar.notifier.configuration.web_base}/instance/uuid?uuid={{error_uuid}}">
+          View error {{error_uuid}} on Rollbar
+        </a>
+      HTML
+    end
   end
 end


### PR DESCRIPTION
since the last refactor we did not send the version since it was nil because of initializer ordering and using rails config object which does not raise on nils
(review without whitespace for sanity)

@zendesk/bre @zendesk/compute 