### PR TITLE
do not print roll-name twice in pod status line

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -185,8 +185,11 @@ module Kubernetes
     end
 
     def resource_identifier(status, exact: true)
-      name = (exact ? (status.resource&.dig(:metadata, :name) || status.role.name) : status.role.name)
-      "#{status.deploy_group.name} #{status.role.name} #{status.kind} #{name}"
+      id = "#{status.deploy_group.name} #{status.role.name} #{status.kind}"
+      if exact && name = status.resource&.dig(:metadata, :name)
+        id += " #{name}"
+      end
+      id
     end
 
     # show why container failed to boot


### PR DESCRIPTION
`[21:25:44]   pod 105 stats Pod stats: Live`

@zendesk/compute 