### PR TITLE
request only Warning events to request less stuff from kubernetes

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -81,7 +81,6 @@ module Kubernetes
       def events_indicating_failure
         @events_indicating_failure ||= begin
           bad = @events.dup
-          bad.reject! { |e| e.fetch(:type) == 'Normal' }
           bad.reject! { |e| ignorable_hpa_event?(e) }
           bad.reject! do |e|
             e[:reason] == "Unhealthy" && e[:message] =~ /\A\S+ness probe failed/ && !probe_failed_to_often?(e)

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -245,18 +245,13 @@ describe Kubernetes::Api::Pod do
       pod_with_client.events_indicate_failure?
     end
 
+    it "is true" do
+      assert events_indicate_failure?
+    end
+
     it "is false when there are no events" do
       events.clear
       refute events_indicate_failure?
-    end
-
-    it "is false when there are Normal events" do
-      refute events_indicate_failure?
-    end
-
-    it "is true with bad events" do
-      event[:type] = "Warning"
-      assert events_indicate_failure?
     end
 
     describe "probe failures" do


### PR DESCRIPTION
we do a lot of event requests, so the faster this gets to more responsive the deploy will be
docs say "Type of this event (Normal, Warning), new types could be added in the future"
so should be good for now and we still print all when something fails

@zendesk/compute 

```
kubectl get events --field-selector 'type=Warning' -v8
GET api/v1/namespaces/podx/events?fieldSelector=type%3DWarning&limit=500
```