### PR TITLE
reduce N+1 during kubernetes deploy

### DIFF
--- a/config/initializers/backtrace_cleaner.rb
+++ b/config/initializers/backtrace_cleaner.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails/backtrace_cleaner'
+
+# by default backtrace from plugins are hidden in test output and production logs
+# to update: add a error into a file inside a plugin and run the test
+# backtrace should show the exact line of the error
+old = Rails::BacktraceCleaner::APP_DIRS_PATTERN
+Rails::BacktraceCleaner.send(:remove_const, :APP_DIRS_PATTERN)
+Rails::BacktraceCleaner::APP_DIRS_PATTERN = Regexp.union(old, %r{^/?plugin})
+
+# hide mapped_database_exceptions which wraps all AR calls but mostly does nothing
+Rails.backtrace_cleaner.add_silencer { |line| line.include?("lib/samson/mapped_database_exceptions.rb") }
+
+# hide test-support which lots of tests go through, especially needed for test/support/query_counter.rb
+# which shows query origin
+Rails.backtrace_cleaner.add_silencer { |line| line.include?("test/support/") }

--- a/config/initializers/show_plugin_backtrace.rb
+++ b/config/initializers/show_plugin_backtrace.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-# by default backtrace from plugins are hidden in test output and production logs
-# to update: add a error into a file inside a plugin and run the test
-# backtrace should show the exact line of the error
-require 'rails/backtrace_cleaner'
-old = Rails::BacktraceCleaner::APP_DIRS_PATTERN
-Rails::BacktraceCleaner.send(:remove_const, :APP_DIRS_PATTERN)
-Rails::BacktraceCleaner::APP_DIRS_PATTERN = Regexp.union(old, %r{^/?plugin})

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -466,8 +466,7 @@ module Kubernetes
         end
 
         # name of the cluster
-        kube_cluster_name = DeployGroup.find(metadata[:deploy_group_id]).kubernetes_cluster.name.to_s
-        env[:KUBERNETES_CLUSTER_NAME] = kube_cluster_name
+        env[:KUBERNETES_CLUSTER_NAME] = @doc.deploy_group.kubernetes_cluster.name.to_s
 
         # blue-green phase
         env[:BLUE_GREEN] = blue_green_color if blue_green_color

--- a/test/support/query_counter.rb
+++ b/test/support/query_counter.rb
@@ -5,7 +5,21 @@ class ActiveSupport::TestCase
     queries = []
     counter = ->(*, payload) do
       sql = payload.fetch(:sql)
-      queries << sql if !["CACHE", "SCHEMA"].include?(payload.fetch(:name)) && !sql.include?("SAVEPOINT")
+      next if ["CACHE", "SCHEMA"].include?(payload.fetch(:name))
+      next if sql.include?("SAVEPOINT")
+      next if sql.include?("INSERT INTO")
+
+      # resolve binds to make queries less generic (parent_type = ? -> parent_type = 'Project')
+      # needed for sqlite which uses `?` and postgres which uses `$1,$2,...`
+      # ideally find a builtin way of resolving binds
+      payload[:type_casted_binds].each do |v|
+        sql = sql.dup.sub!(/\?|\$\d+/, v.inspect) || raise("Unable to find placeholder for #{v.inspect}")
+      end
+
+      # show caller for easy debugging
+      sql += " # from #{Rails.backtrace_cleaner.filter(caller).first(5).join(' / ')}"
+
+      queries << sql
     end
 
     ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &block)
@@ -20,5 +34,16 @@ class ActiveSupport::TestCase
       "Expected #{expected} queries, but found #{queries.count}:\n#{queries.join("\n")}"
     )
     queries
+  end
+
+  def assert_nplus1_queries(expected, &block)
+    queries = sql_queries(&block)
+    queries = queries.group_by { |q| q.gsub(/\d+/, "DIGIT").split(" #").first }.select { |_, v| v.size > 1 }
+    actual = queries.values.map { |v| v.size - 1 }.sum
+    list = queries.map { |q, v| "#{q}:\n#{v.map { |x| "  #{x}" }.join("\n")}" }.join("\n")
+    actual.must_equal(
+      expected,
+      "Expected #{expected} nplus1 queries, but found #{queries.count}:\n#{list}"
+    )
   end
 end


### PR DESCRIPTION
first stab at making deploy faster

 - making backtrace filter better
 - adding nplus helper

@zendesk/compute 