### PR TITLE
Send "Deploy Metrics Report" in chunks

### DIFF
--- a/app/presenters/deploy_metrics_csv_presenter.rb
+++ b/app/presenters/deploy_metrics_csv_presenter.rb
@@ -4,14 +4,13 @@ require 'csv'
 class DeployMetricsCsvPresenter
   class << self
     def to_csv
-      CSV.generate do |csv|
-        csv << csv_header
+      Enumerator.new do |yielder|
+        yielder << CSV.generate_line(csv_header)
 
-        # deploy metrics only applicable to succeeded production deployment
         production_stages = Stage.select(&:production?)
         deploys = Deploy.succeeded.where(stage: production_stages).includes(:job, stage: :project)
         deploys.each do |deploy|
-          csv << csv_line(deploy)
+          yielder << CSV.generate_line(csv_line(deploy))
         end
       end
     end

--- a/app/views/csv_exports/new_deploy_metrics.erb
+++ b/app/views/csv_exports/new_deploy_metrics.erb
@@ -4,12 +4,7 @@
   <div class="csv-users-filters clearfix">
     <%= form_tag new_csv_export_path(format: :csv, type: :deploy_metrics), method: :get, class: "form-horizontal" do %>
       <%= hidden_field_tag :type, "deploy_metrics" %>
-
-      <div class="form-group">
-        <div class="col-lg-offset-2 col-lg-10">
-          <%= submit_tag "Download Deploy Metrics Report", class: 'btn btn-default' %>
-        </div>
-      </div>
+      <%= submit_tag "Download Deploy Metrics Report", class: 'btn btn-default' %>
     <% end %>
   </div>
 </section>

--- a/test/controllers/csv_exports_controller_test.rb
+++ b/test/controllers/csv_exports_controller_test.rb
@@ -142,6 +142,11 @@ describe CsvExportsController do
         describe "deploy_metrics type" do
           it "returns csv" do
             get :new, params: {format: :csv, type: "deploy_metrics"}
+            @response.headers.key?("Content-Length").must_equal false
+            @response.headers["Cache-Control"].must_equal "no-cache"
+            @response.headers["Content-Type"].must_equal "text/csv"
+            @response.headers["Content-Disposition"].must_include "DeployMetrics"
+            @response.headers["X-Accel-Buffering"].must_equal "no"
             assert_response :success
           end
         end

--- a/test/presenters/deploy_metrics_csv_presenter_test.rb
+++ b/test/presenters/deploy_metrics_csv_presenter_test.rb
@@ -11,7 +11,7 @@ describe DeployMetricsCsvPresenter do
       production_stages = Stage.select(&:production?)
       deploys = Deploy.succeeded.where(stage: production_stages).includes(:job, stage: :project)
       expected_csv_rows += deploys.size
-      DeployMetricsCsvPresenter.to_csv.split("\n").size.must_equal expected_csv_rows
+      DeployMetricsCsvPresenter.to_csv.count.must_equal expected_csv_rows
     end
   end
 


### PR DESCRIPTION
Send the Deploy Metrics CSV in chunks instead since we might get timeout if the dataset is too big

/cc @zendesk/samson
