### PR TITLE
release author is always a use, so it does not need a type column

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -4,8 +4,9 @@ class Release < ActiveRecord::Base
   VERSION_REGEX = /\Av(#{Samson::RELEASE_NUMBER})\z/.freeze
 
   belongs_to :project, touch: true, inverse_of: :releases
-  belongs_to :author, polymorphic: true
+  belongs_to :author, class_name: "User", inverse_of: nil
 
+  before_validation :assign_author_type
   before_validation :assign_release_number
   before_validation :covert_ref_to_sha
 
@@ -42,6 +43,10 @@ class Release < ActiveRecord::Base
 
   def version
     "v#{number}"
+  end
+
+  def assign_author_type
+    self.author_type = "User"
   end
 
   def assign_release_number

--- a/test/fixtures/releases.yml
+++ b/test/fixtures/releases.yml
@@ -2,4 +2,5 @@ test:
   project: test
   commit: abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd
   number: "123"
-  author: deployer (User)
+  author: deployer
+  author_type: User


### PR DESCRIPTION
reduces complexity and might make some queries cache more

next PR will drop the column (already check it is always User)

@zendesk/bre 