### PR TITLE
we need multiple ClusterRoleBinding per role, so they cannot have the…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -9,7 +9,7 @@ module Kubernetes
       'APIService', 'ClusterRoleBinding', 'ClusterRole', 'CustomResourceDefinition', 'Namespace'
     ].freeze
     IMMUTABLE_NAME_KINDS = [
-      'APIService', 'CustomResourceDefinition', 'ConfigMap', 'Role', 'ClusterRole', 'Namespace'
+      'APIService', 'CustomResourceDefinition', 'ConfigMap', 'Role', 'ClusterRole', 'Namespace', 'ClusterRoleBinding'
     ].freeze
 
     # we either generate multiple names or allow custom names


### PR DESCRIPTION
… same name

### Risks
 - high: existing role-bindings get renamed and we end up with duplicates, need to check that first

@zendesk/compute 