### PR TITLE
print a sample of the statuses when there is too much to print

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -261,8 +261,14 @@ module Kubernetes
 
     def print_statuses(message, statuses, exact:)
       @output.puts message
-      statuses.each do |status|
-        @output.puts "  #{resource_identifier(status, exact: exact)}: #{status.details}"
+      lines = statuses.map do |status|
+        "  #{resource_identifier(status, exact: exact)}: #{status.details}"
+      end
+
+      # for big deploys, do not print all the identical pods
+      lines.group_by(&:itself).each_value do |group|
+        group = [group.first, "  ... #{group.size - 1} identical"] if lines.size >= 10 && group.size > 2
+        group.each { |l| @output.puts l }
       end
     end
 


### PR DESCRIPTION
the bigger our replica count gets the more this noise will be annoying, so let's fix it

@zendesk/compute 

```
[18:41:45] Deploy status:
[18:41:45]   GroupK server Pod: Waiting (Pending, ContainersNotReady/ContainerCreating)
[18:41:45]   GroupK server Pod: Missing
[18:41:45]   ... 8 identical
[18:41:55] Deploy status:
[18:41:55]   GroupK server Pod: Waiting (Pending, Unknown)
[18:41:55]   GroupK server Pod: Waiting (Pending, Unknown)
[18:41:55]   GroupK server Pod: Live
[18:41:55]   ... 2 identical
[18:41:55]   GroupK server Pod: Missing
[18:41:55]   ... 4 identical
[18:42:05] Deploy status:
[18:42:05]   GroupK server Pod: Live
[18:42:05]   ... 5 identical
[18:42:05]   GroupK server Pod: Waiting (Pending, Unknown)
[18:42:05]   GroupK server Pod: Waiting (Pending, ContainersNotReady/ContainerCreating)
[18:42:05]   GroupK server Pod: Missing
[18:42:05]   GroupK server Pod: Missing
[18:42:15] Deploy status:
[18:42:15]   GroupK server Pod: Live
[18:42:15]   ... 9 identical
[18:42:15] READY, starting stability test

```