### PR TITLE
report time as time to datadog instead of histogram

### DIFF
--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -295,7 +295,8 @@ describe JobExecution do
   end
 
   it "reports to statsd" do
-    Samson.statsd.expects(:histogram).
+    Samson.statsd.stubs(:timing)
+    Samson.statsd.expects(:timing).
       with('execute_shell.time', anything, tags: ['project:duck', 'stage:stage4', 'production:false'])
     assert execute_job("master")
   end


### PR DESCRIPTION
afaik timing is a special case of histogram so let's use it https://docs.datadoghq.com/developers/dogstatsd/data_types/#timers "Timers in DogStatsD are an implementation of Histograms"
(also unifying how duration is calculated)

@zendesk/bre 
/cc @zendesk/compute 