### PR TITLE
report sum of times for each deploy

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -146,7 +146,7 @@ class JobExecution
       production: stage&.production?
     }
 
-    ActiveSupport::Notifications.instrument("execute_job.samson", payload) do
+    Samson::TimeSum.instrument "execute_job.samson", payload do
       payload[:success] =
         if kubernetes?
           @executor = Kubernetes::DeployExecutor.new(@job, @output)
@@ -155,8 +155,6 @@ class JobExecution
           @executor.execute(*cmds)
         end
     end
-
-    payload[:success]
   end
 
   # ideally the plugin should handle this, but that was even hackier

--- a/lib/samson/time_sum.rb
+++ b/lib/samson/time_sum.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# summarize activesupport notification duration into user defined buckets
+module Samson
+  module TimeSum
+    BASE = {
+      "execute.command_executor.samson" => :shell,
+      "execute.terminal_executor.samson" => :shell,
+      "request.rest_client.samson" => :kubeclient,
+      "request.vault.samson" => :vault,
+      "request.faraday.samson" => :http,
+      "sql.active_record" => :db
+    }.freeze
+
+    def self.record(metrics = BASE, &block)
+      sum = metrics.each_value.each_with_object({}) { |key, h| h[key] = 0.0 }
+      summarize = ->(metric, start, finish, *) { sum[metrics[metric]] += 1000 * (finish - start) }
+      metrics.each_key.inject(block) do |inner, name|
+        -> { ActiveSupport::Notifications.subscribed(summarize, name, &inner) }
+      end.call
+      sum
+    end
+
+    def self.instrument(notification, payload)
+      ActiveSupport::Notifications.instrument(notification, payload) do
+        result = nil
+        payload[:parts] = record(BASE) { result = yield }
+        result
+      end
+    end
+  end
+end

--- a/test/lib/samson/time_sum_test.rb
+++ b/test/lib/samson/time_sum_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Samson::TimeSum do
+  describe ".record" do
+    it "records empty" do
+      calls = []
+      Samson::TimeSum.record({}) { calls << 1 }.keys.must_equal []
+      calls.must_equal [1]
+    end
+
+    it "records single" do
+      result = Samson::TimeSum.record("sql.active_record" => :db) { User.first }
+      result.keys.must_equal [:db]
+      assert result[:db].between?(0, 5), result
+    end
+
+    it "records 0 when nothing happened" do
+      calls = []
+      Samson::TimeSum.record("sql.active_record" => :db) { calls << 1 }[:db].must_equal 0
+      calls.must_equal [1]
+    end
+  end
+
+  describe ".instrument" do
+    it "logs" do
+      Rails.logger.expects(:info).with do |payload|
+        payload[:message].must_equal "Job execution finished"
+        assert payload[:parts][:db].between?(0, 5)
+        true
+      end
+      result = Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", production: false) do
+        User.first
+      end
+      result.must_equal User.first
+    end
+
+    it "does not log parts when crashing" do
+      Rails.logger.expects(:info).with do |payload|
+        payload[:message].must_equal "Job execution finished"
+        refute payload[:parts]
+        true
+      end
+      assert_raises ArgumentError do
+        Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", production: false) do
+          raise ArgumentError
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
will help figure out what is taking so long by splitting it into buckets and consistently reporting

```
{:stage=>"Master", :project=>"Example-kubernetes", :production=>false, :success=>true, :parts=>{:shell=>1208.431, :kubeclient=>1066.569, :vault=>0.0, :http=>539.927, :db=>473.9900000000001}, :total=>73107.15299999999, :message=>"Job execution finished"}
```

@zendesk/compute @zendesk/bre 