### PR TITLE
make secret-sharing-grants cacheable

### DIFF
--- a/lib/samson/secrets/key_resolver.rb
+++ b/lib/samson/secrets/key_resolver.rb
@@ -139,7 +139,7 @@ module Samson
 
       def key_granted?(key_parts)
         if Samson::Secrets::Manager.sharing_grants? && key_parts.fetch(:project_permalink) == "global"
-          @shared_keys ||= SecretSharingGrant.where(project: @project).pluck(:key)
+          @shared_keys ||= @project.secret_sharing_grants.map(&:key)
           @shared_keys.include?(key_parts.fetch(:key))
         else
           true

--- a/test/lib/samson/secrets/key_resolver_test.rb
+++ b/test/lib/samson/secrets/key_resolver_test.rb
@@ -16,6 +16,15 @@ describe Samson::Secrets::KeyResolver do
       resolver.expand('ABC', 'bar').must_equal [["ABC", "global/global/global/bar"]]
     end
 
+    it "reuses project grants" do
+      # pretend everything is preloaded
+      resolver
+      project.secret_sharing_grants
+      deploy_group.environment
+
+      assert_sql_queries(0) { resolver.expand('ABC', 'bar') }
+    end
+
     it "expands symbols" do
       resolver.expand(:ABC, 'bar').must_equal [["ABC", "global/global/global/bar"]]
     end


### PR DESCRIPTION
during a deploy I noticed that we fetched these grants once per role

@zendesk/compute 