### PR TITLE
fix randomly failing test

### DIFF
--- a/test/lib/samson/console_extensions_test.rb
+++ b/test/lib/samson/console_extensions_test.rb
@@ -80,7 +80,7 @@ describe Samson::ConsoleExtensions do
   describe "#flamegraph" do
     it "can graph" do
       capture_stdout do
-        flamegraph(name: "foo") { sleep 0.1 }
+        flamegraph(name: "foo") { 15.times { sleep 0.1 } }
       end
       assert File.exist?("foo.js")
     ensure


### PR DESCRIPTION
```
Samson::ConsoleExtensions::#flamegraph#test_0001_can graph:
RuntimeError: profile does not include raw samples (add `raw: true` to collecting StackProf.run)
    lib/samson/console_extensions.rb:44:in `block in flamegraph'
    lib/samson/console_extensions.rb:44:in `open'
    lib/samson/console_extensions.rb:44:in `flamegraph'
    test/lib/samson/console_extensions_test.rb:83:in `block (4 levels) in <top (required)>'
    test/test_helper.rb:92:in `capture_stdout'
    test/lib/samson/console_extensions_test.rb:82:in `block (3 levels) in <top (required)>'
bin/rails test test/lib/samson/console_extensions_test.rb:81
```

@zendesk/bre 