### PR TITLE
rename misleading kubernetes_roles

### DIFF
--- a/plugins/kubernetes/app/decorators/stage_decorator.rb
+++ b/plugins/kubernetes/app/decorators/stage_decorator.rb
@@ -6,8 +6,8 @@ Stage.class_eval do
   after_create :seed_kubernetes_roles
   validate :validate_not_using_non_kubernetes_rollback, if: :kubernetes?
 
-  has_many :kubernetes_roles, class_name: "Kubernetes::StageRole", dependent: :destroy
-  accepts_nested_attributes_for :kubernetes_roles,
+  has_many :kubernetes_stage_roles, class_name: "Kubernetes::StageRole", dependent: :destroy
+  accepts_nested_attributes_for :kubernetes_stage_roles,
     allow_destroy: true,
     reject_if: ->(a) { a[:kubernetes_role_id].blank? }
 

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -315,7 +315,7 @@ module Kubernetes
 
     def grouped_deploy_group_roles
       @grouped_deploy_group_roles ||= begin
-        ignored_role_ids = @job.deploy.stage.kubernetes_roles.where(ignored: true).pluck(:kubernetes_role_id)
+        ignored_role_ids = @job.deploy.stage.kubernetes_stage_roles.where(ignored: true).pluck(:kubernetes_role_id)
         deploy_group_roles = Kubernetes::DeployGroupRole.where(
           project_id: @job.project_id,
           deploy_group: @job.deploy.stage.deploy_groups.map(&:id)

--- a/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
@@ -25,7 +25,7 @@ module Kubernetes
 
     # The matrix is a list of deploy group and its roles + deploy-group-roles
     def self.matrix(stage)
-      ignored_role_ids = stage.kubernetes_roles.where(ignored: true).pluck(:kubernetes_role_id)
+      ignored_role_ids = stage.kubernetes_stage_roles.where(ignored: true).pluck(:kubernetes_role_id)
       project_dg_roles = Kubernetes::DeployGroupRole.where(
         project_id: stage.project_id,
         deploy_group_id: stage.deploy_groups.map(&:id)

--- a/plugins/kubernetes/app/models/kubernetes/stage_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/stage_role.rb
@@ -5,6 +5,6 @@ module Kubernetes
     self.table_name = 'kubernetes_stage_roles'
 
     belongs_to :kubernetes_role, class_name: 'Kubernetes::Role', inverse_of: :stage_roles
-    belongs_to :stage, inverse_of: :kubernetes_roles
+    belongs_to :stage, inverse_of: :kubernetes_stage_roles
   end
 end

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
@@ -3,9 +3,9 @@
   <%= form.input :kubernetes, as: :check_box, label: "Deploy via kubernetes / ignore commands" %>
 
   <h3>Role config</h3>
-  <% @stage.kubernetes_roles.build %>
+  <% @stage.kubernetes_stage_roles.build %>
   <% roles = @project.kubernetes_roles.not_deleted.pluck(:name, :id).unshift ["", nil] %>
-  <%= form.fields_for :kubernetes_roles, @stage.kubernetes_roles do |fields| %>
+  <%= form.fields_for :kubernetes_stage_roles, @stage.kubernetes_stage_roles do |fields| %>
     <div class="form-group">
       <div class="col-lg-3">
         <%= fields.select :kubernetes_role_id, roles, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -39,7 +39,7 @@ end
 Samson::Hooks.callback(:stage_permitted_params) do
   [
     :kubernetes,
-    {kubernetes_roles_attributes: [:kubernetes_role_id, :ignored, :_destroy, :id]}
+    {kubernetes_stage_roles_attributes: [:kubernetes_role_id, :ignored, :_destroy, :id]}
   ]
 end
 Samson::Hooks.callback(:deploy_permitted_params) { [:kubernetes_rollback, :kubernetes_reuse_build] }

--- a/plugins/kubernetes/test/decorators/stage_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/stage_decorator_test.rb
@@ -36,19 +36,19 @@ describe Stage do
     end
   end
 
-  describe "#kubernetes_roles" do
+  describe "#kubernetes_stage_roles" do
     it "accepts attributes" do
       stage = Stage.new(
-        kubernetes_roles_attributes: {0 => {kubernetes_role_id: kubernetes_roles(:app_server).id, ignored: true}}
+        kubernetes_stage_roles_attributes: {0 => {kubernetes_role_id: kubernetes_roles(:app_server).id, ignored: true}}
       )
-      stage.kubernetes_roles.size.must_equal 1
+      stage.kubernetes_stage_roles.size.must_equal 1
     end
 
     it "ignores blank attributes" do
       stage = Stage.new(
-        kubernetes_roles_attributes: {0 => {kubernetes_role_id: "", ignored: true}}
+        kubernetes_stage_roles_attributes: {0 => {kubernetes_role_id: "", ignored: true}}
       )
-      stage.kubernetes_roles.size.must_equal 0
+      stage.kubernetes_stage_roles.size.must_equal 0
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -305,7 +305,7 @@ describe Kubernetes::DeployExecutor do
         end
 
         it "passes when ignored" do
-          stage.kubernetes_roles.create!(kubernetes_role: worker_role.kubernetes_role, ignored: true)
+          stage.kubernetes_stage_roles.create!(kubernetes_role: worker_role.kubernetes_role, ignored: true)
           execute
           out.must_include "SUCCESS"
         end

--- a/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_group_role_test.rb
@@ -101,7 +101,7 @@ describe Kubernetes::DeployGroupRole do
     end
 
     it "ignores stage-roles that are ignored" do
-      stage.kubernetes_roles.create!(kubernetes_role: kubernetes_roles(:resque_worker), ignored: true)
+      stage.kubernetes_stage_roles.create!(kubernetes_role: kubernetes_roles(:resque_worker), ignored: true)
       Kubernetes::DeployGroupRole.matrix(stage).must_equal(
         [[
           stage.deploy_groups.first,


### PR DESCRIPTION
they are not "roles" but just a join-table called "StageRole"
followup to https://github.com/zendesk/samson/pull/3115

@zendesk/compute 