### PR TITLE
PAAS-3057 calculate allowed errors per role

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -230,9 +230,9 @@ metadata.annotations.samson-set-via-env-json-metadata.labels.custom: SOME_ENV_VA
 ```
 Then configure an ENV var with that same name and a value that is valid JSON.
 
-### Allow randomly not-ready pods during redines check
+### Allow randomly not-ready pods during readiness check
 
-Set `KUBERNETES_ALLOW_NOT_READY_PERCENT=10` to allow up to 10% of pods being not-ready,
+Set `KUBERNETES_ALLOW_NOT_READY_PERCENT=10` to allow up to 10% of pods per role being not-ready,
 this is useful when dealing with large deployments that have some random failures.
 
 ### Disabling service selector validation

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 # TODO: merge plugins/kubernetes/app/models/kubernetes/api/pod.rb into here
+# TODO: rename live to ready to be more consistent with deploy_executor
 module Kubernetes
   class ResourceStatus
     attr_reader :resource, :role, :deploy_group, :kind, :details, :live, :finished, :pod

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -392,7 +392,7 @@ describe Kubernetes::DeployExecutor do
     it "fails when release has errors" do
       Kubernetes::Release.any_instance.expects(:persisted?).at_least_once.returns(false)
       e = assert_raises(Samson::Hooks::UserError) { execute }
-      e.message.must_equal "Failed to create release: []" # inspected errros
+      e.message.must_equal "Failed to create release: []" # inspected errors
     end
 
     it "shows status of each individual pod when there is more than 1 per deploy group" do
@@ -439,6 +439,13 @@ describe Kubernetes::DeployExecutor do
 
       out.must_include "resque-worker Pod: Failed\n"
       out.must_include "UNSTABLE"
+    end
+
+    it "ignores allowed percentage of failures" do
+      with_env KUBERNETES_ALLOW_NOT_READY_PERCENT: "34" do # 1/3 allowed to fail
+        pod_status[:phase] = "Failed"
+        assert execute
+      end
     end
 
     it "stops when detecting a failure via events" do


### PR DESCRIPTION
if a role has a single pod and it fails, consider it a failure
if a role has 10 pods and 1 of them fails, consider it ok

@zendesk/compute 