### PR TITLE
Tag images in parallel

### DIFF
--- a/plugins/gcloud/lib/samson_gcloud/image_tagger.rb
+++ b/plugins/gcloud/lib/samson_gcloud/image_tagger.rb
@@ -19,7 +19,7 @@ module SamsonGcloud
           next unless digest.match?(/(^|\/|\.)gcr.io\//) # gcr.io or https://gcr.io or region like asia.gcr.io
           base = digest.split('@').first
 
-          tags.each { |tag| tag_image(tag, base, digest, output) }
+          Samson::Parallelizer.map(tags) { |tag| tag_image(tag, base, digest, output) }
         end
       end
 


### PR DESCRIPTION
In e.g. [this deploy](https://samson.zende.sk/projects/help_center/deploys/693573#L504) we spend more than 20 seconds tagging images. This PR parallelizes that.

I can't get Samson to run locally, and I'm off on paternity in a week, but @grosser would you be able to take a look?

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### Risks
- Level: Med