### PR TITLE
PAAS-3105 allow environment variables to be set via api

### DIFF
--- a/plugins/env/README.md
+++ b/plugins/env/README.md
@@ -10,6 +10,7 @@ Can be used to have 1-off settings that differ from the project.
 
 Can be used to have generic stages to run one-off jobs or other tasks that need to be parameterized on each run.
 Since these pose a compliance problem, they can be disabled with the samson environment variable `DEPLOY_ENV_VARS=false`.
+Alternatively, only allow it via the API by using `DEPLOY_ENV_VARS=api_only`.
 
 ## API
 

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -128,10 +128,13 @@ Samson::Hooks.callback :stage_permitted_params do
   AcceptsEnvironmentVariables::ASSIGNABLE_ATTRIBUTES
 end
 
-if ENV["DEPLOY_ENV_VARS"] != "false" # uncovered
-  # Adds the deploy env vars view to the deploy form in order to add
-  # specific environment vars per deploy
-  Samson::Hooks.view :deploy_form, 'samson_env/deploy_form'
+env_vars_flag = ENV["DEPLOY_ENV_VARS"]
+if env_vars_flag != "false" # uncovered
+  if env_vars_flag != 'api_only' # uncovered
+    # Adds the deploy env vars view to the deploy form in order to add
+    # specific environment vars per deploy
+    Samson::Hooks.view :deploy_form, 'samson_env/deploy_form'
+  end
 
   # Allows environment vars as valid parameters for the deploy model
   Samson::Hooks.callback :deploy_permitted_params do


### PR DESCRIPTION
cannot merge because compliance. compliance requires to show the diff before something is deployed. will address this in a separate PR, just parking this here for now.