### PR TITLE
make env vars reviewable

### DIFF
--- a/app/models/concerns/group_scope.rb
+++ b/app/models/concerns/group_scope.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 module GroupScope
+  GROUP_SCOPE_TYPE_PRIORITY = ["DeployGroup", "Environment", nil].freeze
+
   def self.included(base)
-    base.validates :scope_type, inclusion: ["Environment", "DeployGroup", nil]
+    base.validates :scope_type, inclusion: GROUP_SCOPE_TYPE_PRIORITY
     base.belongs_to :scope, polymorphic: true, optional: true
   end
 
@@ -31,14 +33,6 @@ module GroupScope
   end
 
   def priority
-    [
-      (project? ? 0 : 1),
-      case scope_type
-      when nil then 2
-      when "Environment" then 1
-      when "DeployGroup" then 0
-      else raise "Unsupported scope #{scope_type}"
-      end
-    ]
+    GROUP_SCOPE_TYPE_PRIORITY.index(scope_type) || raise("Unsupported scope #{scope_type}")
   end
 end

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -204,7 +204,8 @@ class JobExecution
       PROJECT_REPOSITORY: @job.project.repository_url
     )
 
-    Samson::Hooks.fire(:deploy_env, @job.deploy).compact.inject(env, :merge!) if @job.deploy
+    deploy = @job.deploy || Deploy.new(project: @job.project)
+    Samson::Hooks.fire(:deploy_env, deploy, nil).compact.inject(env, :merge!)
     base_commands(dir, env) + @job.commands
   end
 

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -42,7 +42,6 @@ module Samson
       :build_permitted_params,
       :buildkite_release_params,
       :can,
-      :deploy_group_env,
       :deploy_group_includes,
       :deploy_group_permitted_params,
       :deploy_permitted_params,

--- a/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
+++ b/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
@@ -72,8 +72,8 @@ Samson::Hooks.callback :stage_permitted_params do
   ]
 end
 
-Samson::Hooks.callback :deploy_env do |deploy|
-  next {} if deploy.stage.aws_sts_iam_role_arn.blank?
+Samson::Hooks.callback :deploy_env do |deploy, _deploy_group, *|
+  next {} if deploy.stage&.aws_sts_iam_role_arn.blank?
 
   SamsonAwsSts::Client.new(SamsonAwsSts.sts_client).deploy_env_vars(deploy)
 end

--- a/plugins/aws_sts/test/samson_aws_sts/samson_plugin_test.rb
+++ b/plugins/aws_sts/test/samson_aws_sts/samson_plugin_test.rb
@@ -66,7 +66,7 @@ describe SamsonAwsSts do
     end
   end
 
-  describe 'deploy_env_vars callback' do
+  describe :deploy_env do
     it 'calls SamsonAwsSts.deploy_env_vars' do
       stage.aws_sts_iam_role_arn = "some_arn"
 

--- a/plugins/env/app/controllers/env/environment_controller.rb
+++ b/plugins/env/app/controllers/env/environment_controller.rb
@@ -6,7 +6,7 @@ module Env
 
     def show
       deploy_group = DeployGroup.find_by_permalink!(params.require(:deploy_group))
-      env = EnvironmentVariable.env(current_project, deploy_group, preview: true)
+      env = EnvironmentVariable.env(Deploy.new(project: current_project), deploy_group, preview: true)
       if unexpanded = unexpanded_secrets(env).presence
         render plain: "Unexpanded secrets found: #{unexpanded.join(', ')}", status: :unprocessable_entity
       else

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -54,7 +54,7 @@ class EnvironmentVariableGroupsController < ApplicationController
       @project = Project.find(params[:project_id])
     end
 
-    @groups = SamsonEnv.env_groups(@project, deploy_groups, preview: true)
+    @groups = SamsonEnv.env_groups(Deploy.new(project: @project), deploy_groups, preview: true)
 
     respond_to do |format|
       format.html

--- a/plugins/env/app/decorators/deploy_decorator.rb
+++ b/plugins/env/app/decorators/deploy_decorator.rb
@@ -12,7 +12,7 @@ Deploy.class_eval do
   private
 
   def serialized_environment_variables
-    if groups = SamsonEnv.env_groups(project, stage.deploy_groups, preview: true, resolve_secrets: false)
+    if groups = SamsonEnv.env_groups(self, stage.deploy_groups, preview: true, resolve_secrets: false)
       groups.map do |name, data|
         name = name.empty? ? '' : "# #{name.delete('.').titleize}\n"
         "#{name}#{SamsonEnv.generate_dotenv(data)}"

--- a/plugins/env/app/decorators/project_decorator.rb
+++ b/plugins/env/app/decorators/project_decorator.rb
@@ -20,9 +20,12 @@ Project.class_eval do
   end
 
   def serialized_environment_variables
-    variables = EnvironmentVariable.nested_variables(self)
     @env_scopes ||= Environment.env_deploy_group_array # cache since each save needs them twice
-    EnvironmentVariable.serialize(variables, @env_scopes)
+    EnvironmentVariable.serialize(nested_environment_variables, @env_scopes)
+  end
+
+  def nested_environment_variables
+    [self, *environment_variable_groups].flat_map(&:environment_variables)
   end
 
   private

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -3,6 +3,7 @@ require 'validates_lengths_from_database'
 
 class EnvironmentVariable < ActiveRecord::Base
   FAILED_LOOKUP_MARK = ' X' # SpaceX
+  PARENT_PRIORITY = ["Deploy", "Stage", "Project"].freeze
 
   include GroupScope
   extend Inlinable
@@ -22,24 +23,22 @@ class EnvironmentVariable < ActiveRecord::Base
     # preview parameter can be used to not raise an error,
     # but return a value with a helpful message
     # also used by an external plugin
-    def env(project, deploy_group, preview: false, resolve_secrets: true)
+    def env(deploy, deploy_group, preview: false, resolve_secrets: true)
       env = {}
-      if (env_repo_name = ENV["DEPLOYMENT_ENV_REPO"]) && project.use_env_repo
-        env = env_vars_from_repo(env_repo_name, project, deploy_group)
+      if deploy_group && (env_repo_name = ENV["DEPLOYMENT_ENV_REPO"]) && deploy.project.use_env_repo
+        env.merge! env_vars_from_repo(env_repo_name, deploy.project, deploy_group)
       end
-      env.merge!(env_vars_from_db(project, deploy_group))
+      env.merge! env_vars_from_db(deploy, deploy_group)
+
       resolve_dollar_variables(env)
-      resolve_secrets(project, deploy_group, env, preview: preview) if resolve_secrets
+      resolve_secrets(deploy.project, deploy_group, env, preview: preview) if resolve_secrets
+
       env
     end
 
     # scopes is given as argument since it needs to be cached
     def sort_by_scopes(variables, scopes)
       variables.sort_by { |x| [x.name, scopes.index { |_, s| s == x.scope_type_and_id } || 999] }
-    end
-
-    def nested_variables(project)
-      project.environment_variables + project.environment_variable_groups.flat_map(&:environment_variables)
     end
 
     # env_scopes is given as argument since it needs to be cached
@@ -50,8 +49,13 @@ class EnvironmentVariable < ActiveRecord::Base
       end.join("\n")
     end
 
-    def env_vars_from_db(project, deploy_group)
-      variables = nested_variables(project)
+    private
+
+    def env_vars_from_db(deploy, deploy_group)
+      variables =
+        deploy.environment_variables +
+        (deploy.stage&.environment_variables || []) +
+        deploy.project.nested_environment_variables
       variables.sort_by!(&:priority)
       variables.each_with_object({}) do |ev, all|
         all[ev.name] = ev.value if !all[ev.name] && ev.matches_scope?(deploy_group)
@@ -65,8 +69,6 @@ class EnvironmentVariable < ActiveRecord::Base
     rescue StandardError => e
       raise Samson::Hooks::UserError, "Cannot download env file #{path} from #{env_repo_name} (#{e.message})"
     end
-
-    private
 
     def resolve_dollar_variables(env)
       env.each do |k, value|
@@ -92,13 +94,13 @@ class EnvironmentVariable < ActiveRecord::Base
     end
   end
 
-  # used by `priority` from GroupScope
-  def project?
-    parent_type == "Project"
+  def priority
+    [PARENT_PRIORITY.index(parent_type) || 999, super]
   end
 
   private
 
+  # callback for audited
   def auditing_enabled
     parent_type != "Deploy" && super
   end

--- a/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
@@ -1,5 +1,4 @@
-<% environment_variables << EnvironmentVariable.new %>
-<%= form.fields_for :environment_variables, environment_variables do |fields| %>
+<%= form.fields_for :environment_variables, environment_variables + [EnvironmentVariable.new] do |fields| %>
   <div class="form-group">
     <div class="col-lg-3">
       <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -468,8 +468,8 @@ module Kubernetes
         env[:BLUE_GREEN] = blue_green_color if blue_green_color
 
         # env from plugins
-        plugin_envs = Samson::Hooks.fire(:deploy_group_env, project, @doc.deploy_group, resolve_secrets: false)
-        plugin_envs += Samson::Hooks.fire(:deploy_env, @doc.kubernetes_release.deploy) if @doc.kubernetes_release.deploy
+        deploy = @doc.kubernetes_release.deploy || Deploy.new(project: project)
+        plugin_envs = Samson::Hooks.fire(:deploy_env, deploy, @doc.deploy_group, resolve_secrets: false)
         plugin_envs.compact.inject(env, :merge!)
       end
     end

--- a/plugins/kubernetes/app/models/kubernetes/usage_limit.rb
+++ b/plugins/kubernetes/app/models/kubernetes/usage_limit.rb
@@ -15,12 +15,11 @@ class Kubernetes::UsageLimit < ActiveRecord::Base
     all.sort_by(&:priority).detect { |l| l.send(:matches?, project, deploy_group) }
   end
 
-  private
-
-  # used by `priority` from GroupScope
-  def project?
-    project_id
+  def priority
+    [project_id ? 0 : 1, super]
   end
+
+  private
 
   def matches?(project, deploy_group)
     (!project_id || project_id == project.id) && matches_scope?(deploy_group)

--- a/plugins/kubernetes/test/models/kubernetes/usage_limit_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/usage_limit_test.rb
@@ -79,4 +79,17 @@ describe Kubernetes::UsageLimit do
       Kubernetes::UsageLimit.most_specific(project, deploy_group).must_equal found
     end
   end
+
+  describe "#priority" do
+    let(:limit) { create_limit(scope: environments(:staging)) }
+
+    it "is high with project" do
+      limit.priority.must_equal [0, 1]
+    end
+
+    it "is low when global" do
+      limit.project = nil
+      limit.priority.must_equal [1, 1]
+    end
+  end
 end

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -435,7 +435,7 @@ describe DeploysController do
         end
 
         it "creates a deploy" do
-          deploy_called.each { |c| c[1] = c[1].to_h }
+          deploy_called.each { |c| c[1] = c[1].to_h.except(:project) }
           assert_equal [[stage, {"reference" => "master"}]], deploy_called
         end
 
@@ -456,7 +456,7 @@ describe DeploysController do
         end
 
         it "creates a deploy" do
-          deploy_called.each { |c| c[1] = c[1].to_h }
+          deploy_called.each { |c| c[1] = c[1].to_h.except(:project) }
           assert_equal [[stage, {"reference" => "master"}]], deploy_called
         end
 

--- a/test/models/concerns/group_scope_test.rb
+++ b/test/models/concerns/group_scope_test.rb
@@ -43,19 +43,19 @@ describe GroupScope do
     end
 
     it "is higher with project" do
-      EnvironmentVariable.new(parent_type: 'Project').priority.must_equal [0, 2]
+      EnvironmentVariable.new(parent_type: 'Project').priority.must_equal [2, 2]
     end
 
     it "is lower without project" do
-      EnvironmentVariable.new.priority.must_equal [1, 2]
+      EnvironmentVariable.new.priority.must_equal [999, 2]
     end
 
     it "is higher with deploy group" do
-      EnvironmentVariable.new(scope_type: 'DeployGroup').priority.must_equal [1, 0]
+      EnvironmentVariable.new(scope_type: 'DeployGroup').priority.must_equal [999, 0]
     end
 
     it "is lower with environment" do
-      EnvironmentVariable.new(scope_type: 'Environment').priority.must_equal [1, 1]
+      EnvironmentVariable.new(scope_type: 'Environment').priority.must_equal [999, 1]
     end
   end
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -148,8 +148,8 @@ describe JobExecution do
     job.update(command: 'env | sort')
     Samson::Hooks.with_callback(
       :deploy_env,
-      ->(_job) { {ADDITIONAL_EXPORT1: "yes"} },
-      ->(_job) { {ADDITIONAL_EXPORT2: "yes"} }
+      ->(*) { {ADDITIONAL_EXPORT1: "yes"} },
+      ->(*) { {ADDITIONAL_EXPORT2: "yes"} }
     ) do
       execute_job
       lines = job.output.split "\n"


### PR DESCRIPTION
problem: when a user enters per-deploy environment variables they did not show up in buddy review window (neither did stage var changes)

@zendesk/compute @zendesk/bre 

![Screen Shot 2019-04-04 at 4 02 41 PM](https://user-images.githubusercontent.com/11367/55594704-7b78c780-56f5-11e9-958f-d984183e360c.png)

also:
 - rework priority to be additive instead of callback based
 - make deploy review and confirm consistent (not removing trailing space)
 - allow any params in deploy/new
 - sort env vars correctly by deploy/stage/project/env/deploy-group

### Risks
 - medium: project-wide env vars are now directly in the job executors environment which could lead to surprises
 - low: previously all deploy/stage env vars were injected into all deploys no matter if they matched the scope