### PR TITLE
Support customizable GitHub deploy comment

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -549,6 +549,7 @@ ActiveRecord::Schema.define(version: 2019_04_03_202316) do
     t.string "aws_sts_iam_role_arn"
     t.integer "aws_sts_iam_role_session_duration"
     t.boolean "allow_redeploy_previous_when_failed", default: false, null: false
+    t.string "github_pull_request_comment"
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end

--- a/lib/samson/form_builder.rb
+++ b/lib/samson/form_builder.rb
@@ -36,7 +36,12 @@ module Samson
           end
         else
           input_html[:class] ||= "form-control"
-          content = label(attribute, label, class: "col-lg-2 control-label")
+          content = if label.present?
+            label(attribute, label, class: 'col-lg-2 control-label')
+          else
+            # Spacer with no label, useful for subfields or fields that are already under a different header
+            content_tag(:div, '', class: 'col-lg-2 control-label')
+          end
           content << content_tag(:div, class: 'col-lg-4', &block)
           content << help
         end

--- a/plugins/github/app/decorators/stage_decorator.rb
+++ b/plugins/github/app/decorators/stage_decorator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+Stage.class_eval do
+  validate :validate_github_pull_request_comment_variables
+
+  private
+
+  def validate_github_pull_request_comment_variables
+    if comment = github_pull_request_comment.presence
+      comment % Hash[GithubNotification::SUPPORTED_KEYS.map { |k| [k, ''] }] # Validate no extra keys are supplied
+    end
+  rescue KeyError => e
+    errors.add(:github_pull_request_comment, e.message)
+  end
+end

--- a/plugins/github/app/models/github_notification.rb
+++ b/plugins/github/app/models/github_notification.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 class GithubNotification
+  SUPPORTED_KEYS = [:stage_name, :reference].freeze
+  DEFAULT_MESSAGE = "This PR was deployed to %{stage_name}. Reference: %{reference}"
+
   def initialize(deploy)
     @deploy = deploy
     @stage = @deploy.stage
@@ -22,7 +25,10 @@ class GithubNotification
   def body
     url = Rails.application.routes.url_helpers.project_deploy_url(@project, @deploy)
     short_reference_link = "<a href='#{url}' target='_blank'>#{@deploy.short_reference}</a>"
-    "This PR was deployed to #{@stage.name}. Reference: #{short_reference_link}"
+
+    message = @stage.github_pull_request_comment.presence || DEFAULT_MESSAGE
+
+    message % {stage_name: @stage.name, reference: short_reference_link}
   end
 
   def in_multiple_threads(data)

--- a/plugins/github/app/views/samson_github/_fields.html.erb
+++ b/plugins/github/app/views/samson_github/_fields.html.erb
@@ -1,5 +1,14 @@
 <fieldset>
   <legend>GitHub</legend>
-  <%= form.input :update_github_pull_requests, as: :check_box, label: "Comment on Pull Requests after deployment" %>
-  <%= form.input :use_github_deployment_api, as: :check_box, label: "Use GitHub Deployment API" %>
+  <%= form.input :update_github_pull_requests,
+        as: :check_box,
+        label: 'Comment on Pull Requests after deployment'
+  %>
+  <%= form.input :github_pull_request_comment,
+        as: :text_area,
+        label: '',
+        help: 'Customize comment message. Supports replacement of <code>%{stage_name}</code> and <code>%{reference}</code>'.html_safe,
+        input_html: { placeholder: "Default: #{GithubNotification::DEFAULT_MESSAGE}" }
+  %>
+  <%= form.input :use_github_deployment_api, as: :check_box, label: 'Use GitHub Deployment API' %>
 </fieldset>

--- a/plugins/github/db/migrate/20190403185409_add_git_hub_pull_request_comment_to_stages.rb
+++ b/plugins/github/db/migrate/20190403185409_add_git_hub_pull_request_comment_to_stages.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddGitHubPullRequestCommentToStages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stages, :github_pull_request_comment, :string
+  end
+end

--- a/plugins/github/lib/samson_github/samson_plugin.rb
+++ b/plugins/github/lib/samson_github/samson_plugin.rb
@@ -14,7 +14,8 @@ Samson::Hooks.view :stage_form, "samson_github/fields"
 Samson::Hooks.callback :stage_permitted_params do
   [
     :update_github_pull_requests,
-    :use_github_deployment_api
+    :use_github_deployment_api,
+    :github_pull_request_comment
   ]
 end
 

--- a/plugins/github/test/decorators/stage_decorator_test.rb
+++ b/plugins/github/test/decorators/stage_decorator_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe Stage do
+  let(:stage) { Stage.new }
+
+  it('allows supported keys') do
+    stage.github_pull_request_comment = 'This %{stage_name} has this ref: %{reference}'
+
+    stage.save
+
+    stage.errors.messages[:github_pull_request_comment].must_be_empty
+  end
+
+  it('throws validation error if unsupported keys are used') do
+    stage.github_pull_request_comment = 'This is %{unsupported}'
+
+    stage.save
+
+    stage.errors.messages[:github_pull_request_comment].must_equal ['key{unsupported} not found']
+  end
+
+  it('handles no github_pull_request_comment') do
+    stage.github_pull_request_comment = nil
+
+    stage.save
+
+    stage.errors.messages[:github_pull_request_comment].must_be_empty
+  end
+end

--- a/plugins/github/test/models/github_notification_test.rb
+++ b/plugins/github/test/models/github_notification_test.rb
@@ -4,20 +4,41 @@ require_relative '../test_helper'
 SingleCov.covered! uncovered: 1
 
 describe GithubNotification do
+  let(:pull_requests) { stub(number: 9) }
   let(:project) { stub(name: "Glitter", repository_path: "glitter/glitter", to_param: "3-glitter") }
-  let(:stage) { stub(name: "staging", project: project) }
+  let(:stage) { stub(name: "staging", project: project, github_pull_request_comment: "") }
   let(:changeset) { stub_everything(commits: [], files: [], pull_requests: [pull_requests]) }
-  let(:deploy) { stub(changeset: changeset, short_reference: "7e6c415", id: 18, stage: stage) }
+  let(:deploy) { stub(changeset: changeset, short_reference: "7e6c415", id: 18, stage: stage, to_param: "18") }
   let(:notification) { GithubNotification.new(deploy) }
   let(:endpoint) { "https://api.github.com/repos/glitter/glitter/issues/9/comments" }
 
   describe 'when there are pull requests' do
-    let(:pull_requests) { stub(number: 9) }
-
     it "adds a comment" do
       assert_request(:post, endpoint) do
         notification.deliver
       end
+    end
+  end
+
+  describe '#body' do
+    it 'uses the correct default message' do
+      body = notification.send(:body)
+
+      body.must_equal <<~TEXT.squish
+        This PR was deployed to staging.
+        Reference: <a href='http://www.test-url.com/projects/3-glitter/deploys/18' target='_blank'>7e6c415</a>
+      TEXT
+    end
+
+    it 'uses the user supplied message' do
+      stage.stubs(github_pull_request_comment: "Deployed to %{stage_name}, ref: %{reference}")
+
+      body = notification.send(:body)
+
+      body.must_equal <<~TEXT.squish
+        Deployed to staging,
+        ref: <a href='http://www.test-url.com/projects/3-glitter/deploys/18' target='_blank'>7e6c415</a>
+      TEXT
     end
   end
 end

--- a/plugins/github/test/samson_github/samson_plugin_test.rb
+++ b/plugins/github/test/samson_github/samson_plugin_test.rb
@@ -10,7 +10,7 @@ describe SamsonDatadog do
   describe :stage_permitted_params do
     it "lists extra keys" do
       Samson::Hooks.fire(:stage_permitted_params).must_include(
-        [:update_github_pull_requests, :use_github_deployment_api]
+        [:update_github_pull_requests, :use_github_deployment_api, :github_pull_request_comment]
       )
     end
   end

--- a/test/lib/samson/form_builder_test.rb
+++ b/test/lib/samson/form_builder_test.rb
@@ -31,6 +31,10 @@ describe Samson::FormBuilder do
       builder.input(:name, label: "Ho Ho").must_include 'for="user_name">Ho Ho</label>'
     end
 
+    it "can handle a blank label" do
+      builder.input(:name, label: '').must_include '<div class="col-lg-2 control-label"></div>'
+    end
+
     it "can change field type" do
       builder.input(:name, as: :text_area).must_include '<textarea '
     end


### PR DESCRIPTION
Adds the ability to customize the comment left by Samson on PRs which have been deployed. This is helpful for public repositories, where I would still want to give an indication that a PR has been deployed, but not show a restricted link back to Samson. 

/cc @zendesk/samson

### Tasks
 - [x] :+1: from team

### Risks
- Level: Changes the GitHub commenting on deploy functionality