### PR TITLE
do not auto-export all env vars to the stage env

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -204,8 +204,7 @@ class JobExecution
       PROJECT_REPOSITORY: @job.project.repository_url
     )
 
-    deploy = @job.deploy || Deploy.new(project: @job.project)
-    Samson::Hooks.fire(:deploy_env, deploy, nil).compact.inject(env, :merge!)
+    Samson::Hooks.fire(:deploy_execution_env, @job.deploy).compact.inject(env, :merge!) if @job.deploy
     base_commands(dir, env) + @job.commands
   end
 

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -50,6 +50,7 @@ module Samson
       :ensure_docker_image_has_no_vulnerabilities,
       :ignore_error,
       :deploy_env,
+      :deploy_execution_env,
       :link_parts_for_resource,
       :project_docker_build_method_options,
       :project_permitted_params,

--- a/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
+++ b/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
@@ -72,8 +72,7 @@ Samson::Hooks.callback :stage_permitted_params do
   ]
 end
 
-Samson::Hooks.callback :deploy_env do |deploy, _deploy_group, *|
-  next {} if deploy.stage&.aws_sts_iam_role_arn.blank?
-
+Samson::Hooks.callback :deploy_execution_env do |deploy|
+  next {} if deploy.stage.aws_sts_iam_role_arn.blank?
   SamsonAwsSts::Client.new(SamsonAwsSts.sts_client).deploy_env_vars(deploy)
 end

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -128,6 +128,11 @@ Samson::Hooks.callback :stage_permitted_params do
   AcceptsEnvironmentVariables::ASSIGNABLE_ATTRIBUTES
 end
 
+# TODO: remove this, just for backwards compatibility and broken since it does not check scope
+Samson::Hooks.callback :deploy_execution_env do |deploy|
+  deploy.stage.environment_variables.each_with_object({}) { |var, h| h[var.name] = var.value }
+end
+
 env_vars_flag = ENV["DEPLOY_ENV_VARS"]
 if env_vars_flag != "false" # uncovered
   if env_vars_flag != 'api_only' # uncovered

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -83,6 +83,17 @@ describe SamsonEnv do
     end
   end
 
+  describe :deploy_execution_env do
+    let(:deploy) { deploys(:succeeded_test) }
+
+    only_callbacks_for_plugin :deploy_execution_env
+
+    it "adds for stages" do
+      deploy.stage.environment_variables.create!(name: "WORLD", value: "hello")
+      Samson::Hooks.fire(:deploy_execution_env, deploy).must_equal [{"WORLD" => "hello"}]
+    end
+  end
+
   describe :deploy_env do
     let(:deploy) { deploys(:succeeded_test) }
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -147,7 +147,7 @@ describe JobExecution do
     freeze_time
     job.update(command: 'env | sort')
     Samson::Hooks.with_callback(
-      :deploy_env,
+      :deploy_execution_env,
       ->(*) { {ADDITIONAL_EXPORT1: "yes"} },
       ->(*) { {ADDITIONAL_EXPORT2: "yes"} }
     ) do


### PR DESCRIPTION
https://github.com/zendesk/samson/pull/3311 broken because we tried to resolve secrets from env vars
that did not have a "global" config since while generating env vars for the deploy we did not have
a deploy group and fell back to global ... changing direction to only have an explicit "deploy_execution_env"
for the 1-off usecase and not merge it into kubernetes ... which was an accident I hope

/cc users who used the "stage env" feature on a non-kubernetes stage @smedberg @fadimaali @irwingarry @hughobrien
```
es = EnvironmentVariable.where(parent_type: "Stage").all.select { |e| e.parent.project && !e.parent.kubernetes };nil
User.find(es.map { |e| e.audits.last.user_id }.uniq)
```