### PR TITLE
PAAS-3091 show all locks for a resource

### DIFF
--- a/app/helpers/locks_helper.rb
+++ b/app/helpers/locks_helper.rb
@@ -19,18 +19,18 @@ module LocksHelper
     icon_tag "warning-sign"
   end
 
-  def global_lock
-    return @global_lock if defined?(@global_lock)
-    @global_lock = Lock.global.first
+  def global_locks
+    return @global_locks if defined?(@global_locks)
+    @global_locks = Lock.global
   end
 
-  def render_lock(resource)
-    lock = (resource == :global ? global_lock : Lock.for_resource?(resource).first)
-    render '/locks/lock', lock: lock if lock
+  def render_locks(resource)
+    locks = (resource == :global ? global_locks : Lock.for_resource(resource))
+    render partial: '/locks/lock', collection: locks, as: :lock if locks.any?
   end
 
   def resource_lock_icon(resource)
-    return unless lock = Lock.for_resource?(resource).first
+    return unless lock = Lock.for_resource(resource).first
     text = (lock.warning? ? "#{warning_icon} Warning" : "#{lock_icon} Locked")
     content_tag :span, text.html_safe, class: "label label-warning", title: strip_tags(lock.summary)
   end

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -32,13 +32,13 @@ class Lock < ActiveRecord::Base
 
     # normally there are very few locks, so we grab them all and filter down to avoid lookups
     # sorted by priority(warning) and specificity(type)
-    def for_resource?(resource)
+    def for_resource(resource)
       matching_locks = all_cached.select { |l| resource.locked_by?(l) }
       matching_locks.sort_by! { |l| [l.warning? ? 1 : 0, RESOURCE_TYPES.index(l.resource_type)] }
     end
 
     def locked_for?(resource, user)
-      locks = for_resource?(resource)
+      locks = for_resource(resource)
       locks.any? { |l| !l.warning? && l.user.id != user&.id }
     end
 
@@ -81,7 +81,7 @@ class Lock < ActiveRecord::Base
   end
 
   def reason
-    description.blank? ? "Description not given" : description
+    description.presence || "Description not given"
   end
 
   # avoid loading resource if we do not have to, which is uncacheable since it is polymorphic

--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_title @deploy_group.name %>
 
-<%= render_lock @deploy_group %>
+<%= render_locks @deploy_group %>
 
 <section class="form-horizontal">
   <div class="form-group">

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= breadcrumb @project, @stage, "Deploy" %>
 
-<%= render_lock @stage %>
+<%= render_locks @stage %>
 
 <section>
   <% data = {

--- a/app/views/environments/show.html.erb
+++ b/app/views/environments/show.html.erb
@@ -1,6 +1,6 @@
 <%= page_title "#{@environment.new_record? ? 'New' : 'Edit'} Environment" %>
 
-<%= render_lock @environment %>
+<%= render_locks @environment %>
 
 <section>
   <%= form_for @environment, html: { class: "form-horizontal" } do |form| %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -13,7 +13,7 @@
 <div class="admin-actions">
   <% if current_user.admin? %>
     <div class="pull-right">
-      <%= render "locks/button", lock: global_lock, resource: nil, prefix: "Global " %>
+      <%= render partial: "locks/button", collection: global_locks, as: :lock, resource: nil, prefix: "Global " %>
       <%= link_to "New", new_project_path, class: "btn btn-default" %>
     </div>
   <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,6 +1,6 @@
 <% page_title @project.name %>
 
-<%= render_lock @project %>
+<%= render_locks @project %>
 
 <%= render 'projects/header', project: @project, tab: "stages" %>
 

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= breadcrumb @project, @stage %>
 
-<%= render_lock @stage %>
+<%= render_locks @stage %>
 
 <h1>
   <%= @stage.name %>

--- a/test/helpers/locks_helper_test.rb
+++ b/test/helpers/locks_helper_test.rb
@@ -59,14 +59,14 @@ describe LocksHelper do
   describe "#global_lock" do
     it "caches nil" do
       Lock.expects(:global).returns []
-      global_lock.must_be_nil
-      global_lock.must_be_nil
+      global_locks.must_equal []
+      global_locks.must_equal []
     end
 
     it "caches values" do
       Lock.expects(:global).returns [1]
-      global_lock.must_equal 1
-      global_lock.must_equal 1
+      global_locks.must_equal [1]
+      global_locks.must_equal [1]
     end
   end
 
@@ -77,19 +77,19 @@ describe LocksHelper do
 
     it "can render global" do
       Lock.create!(user: users(:admin))
-      global_lock # caches
+      global_locks # caches
       assert_sql_queries 1 do # loads user to render the lock
-        render_lock(:global).must_include "ALL STAGES"
+        render_locks(:global).must_include "ALL STAGES"
       end
     end
 
     it "can render specific locks" do
       Lock.create!(user: users(:admin), resource: stage)
-      render_lock(stage).must_include "Deployments to stage were locked"
+      render_locks(stage).must_include "Deployments to stage were locked"
     end
 
     it "does not render when there is no locks" do
-      render_lock(stage).must_be_nil
+      render_locks(stage).must_be_nil
     end
   end
 

--- a/test/models/lock_test.rb
+++ b/test/models/lock_test.rb
@@ -206,7 +206,7 @@ describe Lock do
       stage # trigger find
       Lock.send :all_cached
       assert_sql_queries 0 do
-        Lock.for_resource?(stage).must_equal []
+        Lock.for_resource(stage).must_equal []
       end
     end
 
@@ -215,7 +215,7 @@ describe Lock do
       lock = Lock.create!(user: user)
       Lock.send :all_cached
       assert_sql_queries 0 do
-        Lock.for_resource?(stage).must_equal [lock]
+        Lock.for_resource(stage).must_equal [lock]
       end
     end
 
@@ -224,12 +224,12 @@ describe Lock do
       before { lock } # trigger create
 
       it "combines locks" do
-        Lock.for_resource?(stage).must_equal [lock, global]
+        Lock.for_resource(stage).must_equal [lock, global]
       end
 
       it "sorts locks for display, so .first will be the highest priority" do
         lock.update_column(:warning, true)
-        Lock.for_resource?(stage).must_equal [global, lock]
+        Lock.for_resource(stage).must_equal [global, lock]
       end
     end
   end


### PR DESCRIPTION
via API or global+local a single resource can have multiple locks/warnings ... we should always show all of them so the deployer knows all ongoing issues

@zendesk/bre @zendesk/compute 

<img width="663" alt="Screen Shot 2019-04-15 at 7 49 28 AM" src="https://user-images.githubusercontent.com/11367/56100417-6a308600-5f53-11e9-9f33-160192b93c3c.png">
