### PR TITLE
cleanup deletion logic and make it harder to accidentally press for important resources

### DIFF
--- a/app/assets/javascripts/type_to_delete.js
+++ b/app/assets/javascripts/type_to_delete.js
@@ -1,0 +1,13 @@
+// make the user type the param of the resource to be deleted to make sure they pay attention
+$(function(){
+  $("a[data-type-to-delete]").click(function(e){
+    var message = $(this).data("type-to-delete");
+    var parts = $(this).attr("href").split("/");
+    var text = parts[parts.length - 1];
+    var answer = prompt(message + " Type '" + text + "'");
+    if(answer != text) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  })
+});

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -134,7 +134,9 @@ module ApplicationHelper
     content_tag :i, '', options.merge(class: css_classes)
   end
 
-  def link_to_delete(path, text: 'Delete', question: nil, remove_container: false, disabled: false, **options)
+  def link_to_delete(
+    path, text: 'Delete', question: nil, type_to_delete: false, remove_container: false, disabled: false, **options
+  )
     if disabled
       content_tag :span, text, title: disabled, class: 'mouseover'
     else
@@ -150,7 +152,12 @@ module ApplicationHelper
         else
           "Really delete ?"
         end
-      options[:data] = {confirm: message, method: :delete}
+      options[:data] = {method: :delete}
+      if type_to_delete
+        options[:data][:type_to_delete] = message
+      else
+        options[:data][:confirm] = message
+      end
       if remove_container
         options[:data][:remove_container] = remove_container
         options[:data][:remote] = true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -124,7 +124,7 @@ module ApplicationHelper
     end
   end
 
-  def icon_tag(type, options = {})
+  def icon_tag(type, **options)
     css_classes = "glyphicon glyphicon-#{type}"
 
     if klass = options[:class]
@@ -134,33 +134,30 @@ module ApplicationHelper
     content_tag :i, '', options.merge(class: css_classes)
   end
 
-  def link_to_delete(path, options = {})
-    text = options[:text] || 'Delete'
-    disabled_reason = options[:disabled]
-    if disabled_reason
-      content_tag :span, text, title: disabled_reason, class: 'mouseover'
+  def link_to_delete(path, text: 'Delete', question: nil, remove_container: false, disabled: false, **options)
+    if disabled
+      content_tag :span, text, title: disabled, class: 'mouseover'
     else
-      resource = Array(path).last
       message =
-        if question = options.delete(:question)
+        if question
           question
-        elsif resource.is_a?(ActiveRecord::Base)
+        elsif path.is_a?(ActiveRecord::Base)
+          resource = path
+          name, path = link_parts_for_resource(resource)
+          "Delete #{resource.class.name.split("::").last} #{name} ?"
+        elsif (resource = Array(path).last) && resource.is_a?(ActiveRecord::Base)
           "Delete this #{resource.class.name.split("::").last} ?"
         else
-          "Are you sure ?"
+          "Really delete ?"
         end
       options[:data] = {confirm: message, method: :delete}
-      if container = options[:remove_container]
-        options[:data][:remove_container] = container
+      if remove_container
+        options[:data][:remove_container] = remove_container
         options[:data][:remote] = true
         options[:class] = "remove_container"
       end
       link_to text, path, options
     end
-  end
-
-  def link_to_delete_button(path, options = {})
-    link_to_delete(path, options.merge(text: icon_tag('remove') + ' Delete', class: 'btn btn-danger'))
   end
 
   # Flash type -> Bootstrap alert class

--- a/app/views/deploy_groups/edit.html.erb
+++ b/app/views/deploy_groups/edit.html.erb
@@ -12,6 +12,6 @@
 
     <hr>
 
-    <%= form.actions(delete: true, history: true) %>
+    <%= form.actions(delete: :type, history: true) %>
   <% end %>
 </section>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -28,6 +28,6 @@
 
     <%= Samson::Hooks.render_views(:project_form, self, form: form) %>
 
-    <%= form.actions delete: current_user.admin_for?(@project) %>
+    <%= form.actions delete: can?(:write, :projects, @project) %>
   </fieldset>
 <% end %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -28,6 +28,6 @@
 
     <%= Samson::Hooks.render_views(:project_form, self, form: form) %>
 
-    <%= form.actions delete: can?(:write, :projects, @project) %>
+    <%= form.actions delete: (:type if can?(:write, :projects, @project)) %>
   </fieldset>
 <% end %>

--- a/app/views/stages/_form.html.erb
+++ b/app/views/stages/_form.html.erb
@@ -7,5 +7,5 @@
 
   <hr>
 
-  <%= form.actions delete: can?(:write, :stages, @project) %>
+  <%= form.actions delete: (:type if can?(:write, :stages, @project)) %>
 <% end %>

--- a/app/views/stages/_form.html.erb
+++ b/app/views/stages/_form.html.erb
@@ -7,5 +7,5 @@
 
   <hr>
 
-  <%= form.actions %>
+  <%= form.actions delete: can?(:write, :stages, @project) %>
 <% end %>

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -18,7 +18,6 @@
 
     <% if admin_for_project? %>
       <%= link_to "Edit", edit_project_stage_path(@project, @stage), class: "btn btn-default" %>
-      <%= link_to_delete_button([@project, @stage]) %>
     <% end %>
 
     <div class="pull-right">

--- a/lib/samson/form_builder.rb
+++ b/lib/samson/form_builder.rb
@@ -52,9 +52,9 @@ module Samson
       content_tag :div, class: "form-group" do
         content_tag :div, class: "col-lg-offset-2 col-lg-10" do
           content = submit label, class: "btn btn-primary"
-          resource = (delete.is_a?(Array) ? delete : object)
+          resource = (delete.is_a?(Array) ? delete : object) # TODO: remove array support
           if object.persisted?
-            content << SPACER << @template.link_to_delete(resource) if delete
+            content << SPACER << @template.link_to_delete(resource, type_to_delete: (delete == :type)) if delete
             content << (delete ? SEPARATOR : SPACER) << @template.link_to_history(resource) if history
           end
           content << @template.capture(&block) if block

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,7 +2,7 @@
 # rubocop:disable Metrics/LineLength
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered!
 
 describe ApplicationHelper do
   include LocksHelper
@@ -257,14 +257,22 @@ describe ApplicationHelper do
     end
 
     it "shows common message for paths" do
-      link_to_delete("/foo").must_include "Are you sure ?"
+      link_to_delete("/foo").must_include "Really delete ?"
     end
 
-    it "shows detailed message for resource" do
-      link_to_delete([projects(:test), stages(:test_staging)]).must_include "Delete this Stage ?"
+    it "shows detailed message for resource given as array" do
+      link = link_to_delete([projects(:test), stages(:test_staging)])
+      link.must_include "Delete this Stage ?"
+      link.must_include "/projects/foo/stages/staging"
     end
 
-    it "builds a hint for when disabled" do
+    it "can link directly to a resource" do
+      link = link_to_delete(stages(:test_staging))
+      link.must_include "Delete Stage Staging ?"
+      link.must_include "/projects/foo/stages/staging"
+    end
+
+    it "builds a hint when disabled" do
       link_to_delete("/foo", disabled: "Foo").must_equal(
         "<span title=\"Foo\" class=\"mouseover\">Delete</span>"
       )
@@ -281,14 +289,6 @@ describe ApplicationHelper do
       link_to_delete("/foo", question: "Foo?").must_equal(
         "<a data-confirm=\"Foo?\" data-method=\"delete\" href=\"/foo\">Delete</a>"
       )
-    end
-  end
-
-  describe "#link_to_delete_button" do
-    it "builds a button" do
-      result = link_to_delete_button("/foo")
-      result.must_include "Delete"
-      result.must_include "Delete"
     end
   end
 
@@ -352,6 +352,21 @@ describe ApplicationHelper do
       projects(:test).soft_delete!(validate: false)
       stage = stages(:test_staging)
       link_to_resource(stage).must_equal "Staging"
+    end
+  end
+
+  describe "#audited_classes" do
+    after { ApplicationHelper.class_variable_set(:@@audited_classes, nil) }
+
+    # we know this reaches inside because of coverage is 100%
+    it "works when in test" do
+      audited_classes
+    end
+
+    it "works when not in test" do
+      Rails.env.stubs(:test?).returns(false)
+      Rails.application.config.stubs(:eager_load).returns(true)
+      audited_classes
     end
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -287,7 +287,13 @@ describe ApplicationHelper do
 
     it "can ask a question" do
       link_to_delete("/foo", question: "Foo?").must_equal(
-        "<a data-confirm=\"Foo?\" data-method=\"delete\" href=\"/foo\">Delete</a>"
+        "<a data-method=\"delete\" data-confirm=\"Foo?\" href=\"/foo\">Delete</a>"
+      )
+    end
+
+    it "can ask to type" do
+      link_to_delete("/foo", type_to_delete: true).must_equal(
+        "<a data-method=\"delete\" data-type-to-delete=\"Really delete ?\" href=\"/foo\">Delete</a>"
       )
     end
   end

--- a/test/lib/samson/form_builder_test.rb
+++ b/test/lib/samson/form_builder_test.rb
@@ -140,6 +140,11 @@ describe Samson::FormBuilder do
       builder.actions(delete: [:admin, commands(:echo)]).must_include "Delete"
     end
 
+    it "can include type_to_delete link" do
+      template.expects(:url_for).with(builder.object).returns('/xxx')
+      builder.actions(delete: :type).must_include "type-to-delete"
+    end
+
     it "does not include history link for new object" do
       builder.object.stubs(persisted?: false)
       builder.actions(history: true).wont_include "History"


### PR DESCRIPTION
@zendesk/bre @zendesk/compute 

<img width="449" alt="Screen Shot 2019-04-16 at 12 30 39 PM" src="https://user-images.githubusercontent.com/11367/56180852-0b980480-6046-11e9-8aa7-ac52e13cf42a.png">


/cc @mhratson let's do the same for cerebro