### PR TITLE
PAAS-2636 start production console in sandbox mode by default

### DIFF
--- a/.irbrc.rb
+++ b/.irbrc.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# loaded by marco-polo gem, marking sandbox mode
+if Rails.application.sandbox
+  [:PROMPT_I, :PROMPT_N].each { |p| IRB.conf[:PROMPT][:RAILS_ENV][p].sub!("(", "(sandbox ") }
+end

--- a/bin/rails
+++ b/bin/rails
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-# we don't want rails overhead when booting the server and behave like the real app server
+
+# avoid rails overhead when booting the server and behave like the real app server
 if ["s", "server"].include?(ARGV[0])
   require 'json'
   raise "No options supported, use puma directly" unless ARGV.size == 1
@@ -8,6 +9,11 @@ if ["s", "server"].include?(ARGV[0])
   ENV["RAILS_LOG_TO_STDOUT"] ||= "1"
   ENV["PORT"] ||= "3000"
   exec *JSON.parse(File.read("Dockerfile")[/^CMD (.*)/, 1])
+end
+
+# start production console in sandbox mode, disable with --no-sandbox
+if ENV["RAILS_ENV"] == "production" && ["c", "console"].include?(ARGV[0]) && !ARGV.include?("--no-sandbox")
+  ARGV.push "--sandbox"
 end
 
 APP_PATH = File.expand_path('../config/application', __dir__)

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -2,7 +2,9 @@
 Rails.application.console do
   Rails::ConsoleMethods.send(:prepend, Samson::ConsoleExtensions)
   puts "Samson version: #{SAMSON_VERSION.first(7)}" if SAMSON_VERSION
+
   ActiveRecord::Base.logger = Rails.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
   Rails.logger.level = :info if ENV['PROFILE']
+
   Audited.store[:audited_user] = "rails console #{ENV.fetch("USER")}"
 end


### PR DESCRIPTION
prompt will then be `samson(sandbox prod)>` to indicate it
can disable with --no-sandbox

@zendesk/bre @zendesk/compute 