### PR TITLE
add readonly mode to production console

### DIFF
--- a/.irbrc.rb
+++ b/.irbrc.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# loaded by marco-polo, cannot be in console.rb
+if Rails.env.production?
+  puts "Running in readonly mode. Use Samson::ReadonlyDb.disable to switch to writable."
+  Samson::ReadonlyDb.enable
+end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 Rails.application.console do
   Rails::ConsoleMethods.send(:prepend, Samson::ConsoleExtensions)
+
   puts "Samson version: #{SAMSON_VERSION.first(7)}" if SAMSON_VERSION
+
   ActiveRecord::Base.logger = Rails.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
   Rails.logger.level = :info if ENV['PROFILE']
+
   Audited.store[:audited_user] = "rails console #{ENV.fetch("USER")}"
 end

--- a/lib/samson/readonly_db.rb
+++ b/lib/samson/readonly_db.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Make Activerecord readonly by blocking write requests
+# NOTE: not perfect and can be circumvented with multiline sql statements or `;`
+module Samson
+  module ReadonlyDb
+    ALLOWED = ["SELECT ", "SHOW ", "SET  @@SESSION.", "EXPLAIN ", "PRAGMA "].freeze
+    PROMPT_CHANGE = ["(", "(readonly "].freeze
+    PROMPTS = [:PROMPT_I, :PROMPT_N].freeze
+
+    class << self
+      def enable
+        return if @subscriber
+        @subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+          sql = payload.fetch(:sql)
+          next if sql.lstrip.start_with?(*ALLOWED)
+          raise ActiveRecord::ReadOnlyRecord, <<~MSG
+            Database is in readonly mode, cannot execute query
+            Switch off readonly with #{self}.#{method(:disable).name}
+            #{sql}
+          MSG
+        end
+        update_prompt
+      end
+
+      def disable
+        return unless @subscriber
+        ActiveSupport::Notifications.unsubscribe @subscriber
+        @subscriber = nil
+        update_prompt
+      end
+
+      private
+
+      # TODO: modify normal prompt when marco-polo is not enabled
+      # TODO: pry support
+      def update_prompt
+        return unless defined?(IRB) # uncovered
+        return unless prompt = IRB.conf.dig(:PROMPT, :RAILS_ENV)
+
+        PROMPTS.each do |prompt_key|
+          value = prompt.fetch(prompt_key) # change marco-polo prompt
+          change = (@subscriber ? PROMPT_CHANGE : PROMPT_CHANGE.reverse)
+          value.sub!(*change) || raise("Unable to change prompt #{prompt_key} #{value.inspect}")
+        end
+        nil
+      end
+    end
+  end
+end

--- a/test/lib/samson/readonly_db_test.rb
+++ b/test/lib/samson/readonly_db_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+require 'irb'
+
+SingleCov.covered!
+
+describe Samson::ReadonlyDb do
+  after { Samson::ReadonlyDb.disable }
+
+  describe "#enable" do
+    it "allows write queries when disabled" do
+      assert_difference("User.count", +1) { User.create!(name: "Foo") }
+    end
+
+    it "blocks write queries when enabled" do
+      Samson::ReadonlyDb.enable
+      assert_difference "User.count", 0 do
+        assert_raises(ActiveRecord::ReadOnlyRecord) { User.create!(name: "Foo") }
+      end
+    end
+
+    it "allows read queries when enable" do
+      Samson::ReadonlyDb.enable
+      User.first!
+    end
+
+    it "does not add 2 hooks when enabling twice" do
+      ActiveSupport::Notifications.expects(:subscribe).times(1).returns(1)
+      2.times { Samson::ReadonlyDb.enable }
+    end
+
+    it "changes the prompt by in-place modifying" do
+      i = +"a(b)"
+      n = +"b(c)"
+      IRB.conf[:PROMPT] = {RAILS_ENV: {PROMPT_I: i, PROMPT_N: n}}
+
+      Samson::ReadonlyDb.enable
+      i.must_equal "a(readonly b)"
+      n.must_equal "b(readonly c)"
+
+      Samson::ReadonlyDb.disable
+      i.must_equal "a(b)"
+      n.must_equal "b(c)"
+    ensure
+      IRB.conf[:PROMPT].clear
+    end
+  end
+
+  describe "#disable" do
+    before { Samson::ReadonlyDb.enable }
+
+    it "allows write queries when disabled" do
+      Samson::ReadonlyDb.disable
+      assert_difference("User.count", +1) { User.create!(name: "Foo") }
+    end
+
+    it "does not fail when disabling twice" do
+      2.times { Samson::ReadonlyDb.disable }
+    end
+  end
+end


### PR DESCRIPTION
Alternative for https://github.com/zendesk/samson/pull/3323 which can lock up the whole DB

```
rails c
Loading development environment (Rails 5.2.2.1)
Running in readonly mode. Use Samson::ReadonlyDb.disable to switch to writable.
samson(readonly dev)> Samson::ReadonlyDb.disable
samson(dev)>
```

@zendesk/compute @zendesk/bre 