### PR TITLE
 try debugging api foobar

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -211,7 +211,8 @@ module Kubernetes
               client.send(method, *args)
             else
 
-              puts $last_kubeclient_fetch.inspect
+              sleep 0.1
+              puts "NOW #{method} -- #{client.respond_to? method}"
 
               raise(
                 Samson::Hooks::UserError,

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -210,6 +210,9 @@ module Kubernetes
             if client.respond_to? method
               client.send(method, *args)
             else
+
+              puts $last_kubeclient_fetch.inspect
+
               raise(
                 Samson::Hooks::UserError,
                 "apiVersion #{@template.fetch(:apiVersion)} does not support #{kind}. " \

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -174,3 +174,13 @@ class ActiveSupport::TestCase
     stub_request(:get, 'http://foobar.server/version').to_return(body: '{"gitVersion": "v1.5.0"}')
   end
 end
+
+Kubeclient::Client.class_eval do
+  def fetch_entities
+    x = super
+    puts ">>>>> fetch_entities #{x}"
+    puts caller
+    puts "<<<<<"
+    x
+  end
+end

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -178,9 +178,12 @@ end
 Kubeclient::Client.class_eval do
   def fetch_entities
     x = super
-    puts ">>>>> fetch_entities #{x}"
-    puts caller
-    puts "<<<<<"
+    if @api_version == "extensions/v1beta1" && x["resources"].none? { |r| r["name"] == "deployments" }
+      puts ">>>>> fetch_entities #{@api_version} #{x}"
+      puts caller
+      puts "<<<<<"
+      raise
+    end
     x
   end
 end

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -174,11 +174,3 @@ class ActiveSupport::TestCase
     stub_request(:get, 'http://foobar.server/version').to_return(body: '{"gitVersion": "v1.5.0"}')
   end
 end
-
-$last_kubeclient_fetch = {}
-
-Kubeclient::Client.class_eval do
-  def fetch_entities
-    $last_kubeclient_fetch[@api_version] = super
-  end
-end

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -175,15 +175,10 @@ class ActiveSupport::TestCase
   end
 end
 
+$last_kubeclient_fetch = {}
+
 Kubeclient::Client.class_eval do
   def fetch_entities
-    x = super
-    if @api_version == "extensions/v1beta1" && x["resources"].none? { |r| r["name"] == "deployments" }
-      puts ">>>>> fetch_entities #{@api_version} #{x}"
-      puts caller
-      puts "<<<<<"
-      raise
-    end
-    x
+    $last_kubeclient_fetch[@api_version] = super
   end
 end


### PR DESCRIPTION
we see these a lot ...

theories are:
 - fetch_entities returns bad result
 - defining the methods blows up
 - methods get removed

```
Kubernetes::DeployExecutor::#execute::an autoscaled role#test_0001_only requires one pod to go live when a role is autoscaled:
Samson::Hooks::UserError: apiVersion extensions/v1beta1 does not support Deployment. Check kubernetes docs for correct apiVersion
    plugins/kubernetes/app/models/kubernetes/resource.rb:213:in `block in request'
    lib/samson/retry.rb:9:in `with_retries'
    plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb:20:in `retry_on_connection_errors'
    plugins/kubernetes/app/models/kubernetes/resource.rb:207:in `request'
    plugins/kubernetes/app/models/kubernetes/resource.rb:186:in `block in fetch_resource'
    plugins/kubernetes/app/models/kubernetes/resource.rb:251:in `ignore_404'
    plugins/kubernetes/app/models/kubernetes/resource.rb:185:in `fetch_resource'
    plugins/kubernetes/app/models/kubernetes/resource.rb:78:in `resource'
    plugins/kubernetes/app/models/kubernetes/release_doc.rb:23:in `map'
    plugins/kubernetes/app/models/kubernetes/release_doc.rb:23:in `deploy'
    lib/samson/parallelizer.rb:10:in `block (2 levels) in map'
    lib/samson/parallelizer.rb:10:in `block in map'
bin/rails test plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb:557
```