### PR TITLE
avoid race conditions from defining methods on demand for kubeclient

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -26,7 +26,7 @@ module Kubernetes
     before_destroy :ensure_unused
 
     def client(type)
-      (@client ||= {})[type] ||= begin
+      (@client ||= {})[[Thread.current.object_id, type]] ||= begin
         case auth_method
         when "context"
           context = kubeconfig.context(config_context)

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -131,6 +131,10 @@ describe Kubernetes::Cluster do
       cluster.client('v1').object_id.must_equal cluster.client('v1').object_id
     end
 
+    it 'caches per thread to avoid race conditions of method definition' do
+      cluster.client('v1').object_id.wont_equal Thread.new { cluster.client('v1').object_id }.value
+    end
+
     it 'can build for other types' do
       cluster.client('policy/v1beta1').api_endpoint.to_s.must_equal 'http://foobar.server/apis'
     end


### PR DESCRIPTION
debug steps are in https://github.com/zendesk/samson/pull/3326

there might be other race conditions that this avoids too, like sending 2 requests at once

known issue cam from the call here https://github.com/zendesk/samson/blob/76901674fef7e429d650a20d7ba16f1eb005dce5/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb#L372

@zendesk/compute @zendesk/bre 