### PR TITLE
use keyword args to avoid duping options hash

### DIFF
--- a/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
+++ b/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
@@ -15,10 +15,7 @@ module SamsonAirbrake
   end
 end
 
-Samson::Hooks.callback :error do |exception, options|
-  sync = options[:sync]
-  options = options.without(:sync)
-
+Samson::Hooks.callback :error do |exception, sync: false, **options|
   if sync
     SamsonAirbrake::Engine.exception_debug_info(Airbrake.notify_sync(exception, options))
   else

--- a/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
+++ b/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
@@ -8,9 +8,7 @@ module SamsonRollbar
   end
 end
 
-Samson::Hooks.callback :error do |exception, options|
-  sync = options[:sync]
-  options = options.without(:sync)
+Samson::Hooks.callback :error do |exception, sync: false, **options|
   data = Rollbar.error(exception, options)
 
   if sync


### PR DESCRIPTION
@zendesk/compute @zendesk/bre 