### PR TITLE
fix coverage randomly being bad because cache was filled before first…

### DIFF
--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -362,7 +362,7 @@ describe ApplicationHelper do
   end
 
   describe "#audited_classes" do
-    after { ApplicationHelper.class_variable_set(:@@audited_classes, nil) }
+    before_and_after { ApplicationHelper.class_variable_set(:@@audited_classes, nil) }
 
     # we know this reaches inside because of coverage is 100%
     it "works when in test" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -219,6 +219,11 @@ ActiveSupport::TestCase.class_eval do
     plugin_name = caller(1..1).first[/\/plugins\/([^\/]+)/, 1] || raise("not called from a plugin")
     around { |t| Samson::Hooks.only_callbacks_for_plugin(plugin_name, callback, &t) }
   end
+
+  def self.before_and_after(&block)
+    before(&block)
+    after(&block)
+  end
 end
 
 # Helpers for controller tests


### PR DESCRIPTION
… run

```
ruby test/helpers/application_helper_test.rb -s 14004
Lines missing coverage:
app/helpers/application_helper.rb:117:7-124:10
```

@zendesk/bre @zendesk/compute 