### PR TITLE
show triggered deploys on triggering deploy

### DIFF
--- a/plugins/pipelines/app/views/samson_pipelines/_deploy_header.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_deploy_header.html.erb
@@ -1,5 +1,17 @@
 <% if triggering_deploy = deploy.triggering_deploy %>
   <div class="alert alert-info">
-    Triggered via <%= link_to "Deploy ##{triggering_deploy.id}", project_deploy_path(deploy.project, triggering_deploy) %>
+    Triggered via <%= link_to "#{triggering_deploy.short_reference} to #{triggering_deploy.stage&.name}", [@project, triggering_deploy] %>
+  </div>
+<% elsif triggered_deploys = Deploy.where(triggering_deploy_id: deploy).presence %>
+  <div class="alert alert-info">
+    Triggered deploys:
+    <ul>
+      <% triggered_deploys.each do |deploy| %>
+        <%= link_to [@project, deploy] do %>
+          <%= deploy.stage&.name %>
+          <%= status_badge deploy.status %>
+        <% end %>
+      <% end %>
+    </ul>
   </div>
 <% end %>

--- a/plugins/pipelines/test/samson_pipelines/samson_plugin_test.rb
+++ b/plugins/pipelines/test/samson_pipelines/samson_plugin_test.rb
@@ -92,6 +92,8 @@ describe SamsonPipelines do
         include Rails.application.routes.url_helpers
       end
 
+      view_context.instance_variable_set(:@project, Project.first)
+
       view_context
     end
 
@@ -107,8 +109,8 @@ describe SamsonPipelines do
         deploy.update_column(:triggering_deploy_id, other_deploy.id)
 
         html = render_view
-        html.must_match 'alert-info'
-        html.must_match "<a href=\"/projects/foo/deploys/#{other_deploy.id}"
+        html.must_include 'alert-info'
+        html.must_include "<a href=\"/projects/foo/deploys/#{other_deploy.id}"
       end
 
       it 'renders nothing if there is no triggering deploy' do


### PR DESCRIPTION
makes navigating pipelines a bit easier and shows triggered deploys status without having to open all the urls from the output log

adds 1 more query to the deploy page, but it's indexed so should be cheap

![Screen Shot 2019-04-25 at 1 39 46 PM](https://user-images.githubusercontent.com/11367/56767050-b2c01e80-675f-11e9-80c9-30086962dfc7.png)
![Screen Shot 2019-04-25 at 1 39 38 PM](https://user-images.githubusercontent.com/11367/56767051-b2c01e80-675f-11e9-9597-c0898e97dc62.png)

@zendesk/bre @zendesk/compute 