### PR TITLE
fix random error with simpler sleep

### DIFF
--- a/test/models/output_buffer_test.rb
+++ b/test/models/output_buffer_test.rb
@@ -4,8 +4,6 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe OutputBuffer do
-  include OutputBufferSupport
-
   let(:buffer) { OutputBuffer.new }
 
   before { freeze_time }
@@ -16,7 +14,7 @@ describe OutputBuffer do
     listener1 = build_listener
     listener2 = build_listener
 
-    wait_for_listeners(buffer, 2)
+    sleep 0.1
 
     buffer.write("hello")
     buffer.write("world")
@@ -31,7 +29,7 @@ describe OutputBuffer do
 
     listener = build_listener
 
-    wait_for_listeners(buffer)
+    sleep 0.1
 
     buffer.close
 

--- a/test/support/output_buffer_support.rb
+++ b/test/support/output_buffer_support.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-module OutputBufferSupport
-  def wait_for_listeners(buffer, size = 1)
-    sleep(0.1) until buffer.listeners.size == size && buffer.listeners.all? { |l| l.num_waiting == 1 }
-  end
-end


### PR DESCRIPTION
https://travis-ci.org/zendesk/samson/jobs/524120631

```
------ >>> test/models/output_buffer_test.rb 
Run options: --seed 36140
# Running:
......E
Error:
OutputBuffer#test_0001_allows writing chunks of data to multiple listeners:
Maxitest::Timeout::TestCaseTimeout: Test took too long to finish, aborting. To use a debugger, def maxitest_timeout;false;end in the test file.
    test/models/output_buffer_test.rb:25:in `value'
    test/models/output_buffer_test.rb:25:in `block (2 levels) in <top (required)>'
Error:
OutputBuffer#test_0001_allows writing chunks of data to multiple listeners:
RuntimeError: Test left 1 extra threads ([#<Thread:0x00000000087daa70@/home/travis/build/zendesk/samson/test/models/output_buffer_test.rb:133 sleep_forever>])
    
bin/rails test test/models/output_buffer_test.rb:13

```

@zendesk/bre @zendesk/compute 