### PR TITLE
PAAS-3246 show pending checks when previewing deploys

### DIFF
--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -21,7 +21,7 @@ describe ReleasesController do
         }
       ]
     }
-    check_suite_response = {check_suites: [{conclusion: 'success'}]}
+    check_suite_response = {check_suites: [{conclusion: 'success', id: 1}]}
     check_run_response = {
       check_runs: [
         {
@@ -30,6 +30,7 @@ describe ReleasesController do
           name: 'Travis CI',
           html_url: 'https://coolbeans.com',
           started_at: Time.now.iso8601,
+          check_suite: {id: 1}
         }
       ]
     }


### PR DESCRIPTION
before: checks api returns a check without a run and a state of "pending", this results in the js UI showing pending but no status since no check run got converted into a status

<img width="625" alt="Screen Shot 2019-04-26 at 3 47 00 PM" src="https://user-images.githubusercontent.com/11367/56840121-ad83d200-683a-11e9-8c22-af63860096d2.png">
<img width="647" alt="Screen Shot 2019-04-26 at 2 30 01 PM" src="https://user-images.githubusercontent.com/11367/56840122-afe62c00-683a-11e9-91f4-c5bea0708b3f.png">

after: for each missing check run we add a fake "pending" run that then shows in the UI
<img width="551" alt="Screen Shot 2019-04-26 at 3 04 54 PM" src="https://user-images.githubusercontent.com/11367/56840135-beccde80-683a-11e9-842d-65153a626a3f.png">

@zendesk/compute @zendesk/bre 