### PR TITLE
Allow including locks when fetching stage json

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -21,7 +21,7 @@ class StagesController < ResourceController
       end
       format.json do
         render_as_json :stage, @stage, allowed_includes: [
-          :last_deploy, :last_succeeded_deploy, :active_deploy
+          :last_deploy, :last_succeeded_deploy, :active_deploy, :lock
         ] do |reply|
           # deprecated way of inclusion, do not add more
           if params[:include] == "kubernetes_matrix"


### PR DESCRIPTION
In scooter, we'd want to not delete resources if the stage backing them
is locked.

ref: QA-1777

/cc @zendesk/samson

Risks: Low, not user facing