### PR TITLE
make role validation errors unique and readable

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
@@ -13,7 +13,7 @@ class Kubernetes::RolesController < ResourceController
     begin
       Kubernetes::Role.seed!(@project, params[:ref].presence || DEFAULT_BRANCH)
     rescue Samson::Hooks::UserError
-      flash[:error] = $!.message
+      flash[:error] = helpers.simple_format($!.message)
     end
     redirect_to action: :index
   end

--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -44,7 +44,7 @@ module Kubernetes
       end
 
       if errors = Kubernetes::RoleValidator.new(@elements).validate
-        raise Samson::Hooks::UserError, "Error found when parsing #{path}\n#{errors.join("\n")}"
+        raise Samson::Hooks::UserError, "Error found when validating #{path}\n#{errors.join("\n")}"
       end
     end
 

--- a/plugins/kubernetes/test/controllers/kubernetes/role_verifications_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/role_verifications_controller_test.rb
@@ -28,7 +28,7 @@ describe Kubernetes::RoleVerificationsController do
 
       it "fails nicely with borked template" do
         post :create, params: {role: "---"}
-        assigns[:errors].must_include "Error found when parsing test.yml"
+        assigns[:errors].must_include "Error found when validating test.yml"
       end
 
       it "reports invalid json" do


### PR DESCRIPTION
before:
![Screen Shot 2019-04-29 at 1 56 26 PM](https://user-images.githubusercontent.com/11367/56926515-c2ed3c00-6a86-11e9-86d1-179008b00974.png)

after:
![Screen Shot 2019-04-29 at 1 56 22 PM](https://user-images.githubusercontent.com/11367/56926520-c41e6900-6a86-11e9-97fa-370d4b10e431.png)

@zendesk/compute 