### PR TITLE
Fix random travis error / listener thread dead-lock

### DIFF
--- a/app/models/output_buffer.rb
+++ b/app/models/output_buffer.rb
@@ -88,7 +88,7 @@ class OutputBuffer
       yield chunk
     end
   ensure
-    @listeners.delete(queue)
+    @mutex.synchronize { @listeners.delete(queue) }
   end
 
   private


### PR DESCRIPTION
random travis failure let us to investigate this
 https://travis-ci.org/zendesk/samson/jobs/526180157

if a listener is removed while close is iterating, it will not close all listeners

Found this with:
```
it "allows writing chunks of data to multiple listeners" do
...
rescue Timeout::Error
  puts "DEBUG #{buffer.instance_variable_get(:@listeners).map(&:closed?)}"
  # DEBUG [false]
  raise
end
```

@zendesk/compute @zendesk/bre 