### PR TITLE
use a progress deadline for deployment timeouts instead of manual timer

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -8,7 +8,6 @@ module Kubernetes
     if ENV['KUBE_WAIT_FOR_LIVE'] && !ENV["KUBERNETES_WAIT_FOR_LIVE"]
       raise "Use KUBERNETES_WAIT_FOR_LIVE with seconds instead of KUBE_WAIT_FOR_LIVE" # uncovered
     end
-    WAIT_FOR_LIVE = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_LIVE', '600'))
     WAIT_FOR_PREREQUISITES = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_PREREQUISITES', WAIT_FOR_LIVE))
     STABILITY_CHECK_DURATION = Integer(ENV.fetch('KUBERNETES_STABILITY_CHECK_DURATION', 1.minute))
     TICK = Integer(ENV.fetch('KUBERNETES_STABILITY_CHECK_TICK', 10.seconds))
@@ -44,7 +43,7 @@ module Kubernetes
       end
 
       if deploys.any?
-        return false unless deploy_and_watch(deploys, timeout: WAIT_FOR_LIVE)
+        return false unless deploy_and_watch(deploys)
       end
 
       true
@@ -83,9 +82,6 @@ module Kubernetes
           if too_many_not_ready?(statuses)
             if stopped = not_ready_statuses.select(&:finished).presence
               print_statuses("UNSTABLE, resources failed:", stopped, exact: true)
-              return false, statuses
-            elsif time_left(wait_start_time, timeout) == 0
-              @output.puts "TIMEOUT, pods took too long to get live"
               return false, statuses
             end
           elsif ready_statuses.all?(&:finished)

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -810,6 +810,19 @@ describe Kubernetes::TemplateFiller do
       end
     end
 
+    describe "progressDeadlineSeconds" do
+      around { |t| stub_const Kubernetes::TemplateFiller, :WAIT_FOR_LIVE, '10', &t }
+
+      it "sets a default value" do
+        template.to_hash.dig_fetch(:spec, :progressDeadlineSeconds).must_equal('10')
+      end
+
+      it "does not overwrite" do
+        raw_template[:spec][:progressDeadlineSeconds] = '1000'
+        template.to_hash.dig_fetch(:spec, :progressDeadlineSeconds).must_equal('1000')
+      end
+    end
+
     describe "HorizontalPodAutoscaler" do
       before do
         raw_template[:kind] = "HorizontalPodAutoscaler"


### PR DESCRIPTION
Instead of having Samson watch the pods and manage the timeout, I propose that we use the [Progressing Deployment](https://v1-12.docs.kubernetes.io/docs/concepts/workloads/controllers/deployment/#progressing-deployment) mechanisms provided by Kubernetes. This will allow deployments to set their own timeouts, but keeps the safety mechanism of setting a default timeout so deploys don't sit around forever. 

/cc @zendesk/samson

### Risks
- Level: Med