### PR TITLE
Skipped Pagination for Locks index

### DIFF
--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -4,6 +4,10 @@ class LocksController < ResourceController
   before_action :set_resource, only: [:create, :destroy]
   before_action :authorize_resource!
 
+  def index
+    super(paginate: false) if request.format.json?
+  end
+
   def create
     respond_to do |format|
       format.html do

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -115,7 +115,7 @@ class ResourceController < ApplicationController
   end
 
   def search_resources
-    resource_class
+    resource_class.all
   end
 
   # hook

--- a/test/controllers/locks_controller_test.rb
+++ b/test/controllers/locks_controller_test.rb
@@ -57,6 +57,21 @@ describe LocksController do
   as_a :project_deployer do
     unauthorized :post, :create, lock: {description: 'xyz'}
 
+    describe '#index' do
+      it "doesn't paginate" do
+        2.times { create_lock stage }
+        get :index, format: :json, params: {per_page: 1}
+        json = JSON.parse(response.body)
+        json['locks'].count.must_equal 2
+      end
+
+      it "refuses to render html" do
+        assert_raises ActionController::UnknownFormat do
+          get :index
+        end
+      end
+    end
+
     describe "with global lock" do
       before { global_lock }
       unauthorized :delete, :destroy, resource_id: "", resource_type: ""


### PR DESCRIPTION
> Skip's pagination for the rendering Locks controller index method in JSON format.
> Limited to render only JSON format


### Risks
- Level: Low
