### PR TITLE
allow waiting for cluster resources then reset live timeout

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -4,7 +4,7 @@ module Kubernetes
     class Pod
       INIT_CONTAINER_KEY = :'pod.beta.kubernetes.io/init-containers'
       INGORED_AUTOSCALE_EVENT_REASONS = %w[FailedGetMetrics FailedRescale].freeze
-      WAITING_FOR_RESOURCES = ["FailedScheduling", "FailedCreatePodSandBox", "FailedAttachVolume"].freeze
+      WAITING_FOR_CAPACITY = ["FailedScheduling", "FailedCreatePodSandBox", "FailedAttachVolume"].freeze
 
       attr_writer :events
 
@@ -71,9 +71,9 @@ module Kubernetes
         events_indicating_failure.any?
       end
 
-      def waiting_for_resources?
+      def waiting_for_capacity?
         events = events_indicating_failure
-        events.any? && events_indicating_failure.all? { |e| WAITING_FOR_RESOURCES.include?(e[:reason]) }
+        events.any? && events_indicating_failure.all? { |e| WAITING_FOR_CAPACITY.include?(e[:reason]) }
       end
 
       private

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -85,7 +85,7 @@ module Kubernetes
         # us two time windows for timeouts instead of waiting for resources to become available and
         # ready within the WAIT_FOR_LIVE window. Primary goal is to allow node bootstrapping time
         # when using a cluster autoscaling mechanism.
-        if waiting_for_resources && pods.none?(&:waiting_for_resources?)
+        if waiting_for_resources && pods.none?(&:waiting_for_capacity?)
           waiting_for_resources = false
           wait_start_time = Time.now.to_i # reset wait start so the live check has reasonable time
         end

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -32,7 +32,7 @@ module Kubernetes
           @details = "Live"
           @live = true
           @finished = @pod.completed?
-        elsif (@pod.events = events(type: "Warning")) && @pod.waiting_for_resources?
+        elsif (@pod.events = events(type: "Warning")) && @pod.waiting_for_capacity?
           @details = "Waiting for resources (#{@pod.phase}, #{@pod.reason})"
         elsif @pod.events_indicate_failure?
           @details = "Error event"

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -314,37 +314,37 @@ describe Kubernetes::Api::Pod do
     end
   end
 
-  describe "#waiting_for_resources?" do
-    def waiting_for_resources?
+  describe "#waiting_for_capacity?" do
+    def waiting_for_capacity?
       pod_with_client.instance_variable_set(:@events, events)
-      pod_with_client.waiting_for_resources?
+      pod_with_client.waiting_for_capacity?
     end
 
     it "is not waiting when all is good" do
-      refute waiting_for_resources?
+      refute waiting_for_capacity?
     end
 
     it "is not waiting when bad" do
       event[:type] = "Warning"
-      refute waiting_for_resources?
+      refute waiting_for_capacity?
     end
 
     it "is not waiting when bad and FailedScheduling" do
       event[:type] = "Warning"
       events << event.dup.merge(reason: "FailedScheduling")
-      refute waiting_for_resources?
+      refute waiting_for_capacity?
     end
 
     it "is waiting when bad event is FailedScheduling" do
       event[:type] = "Warning"
       event[:reason] = "FailedScheduling"
-      assert waiting_for_resources?
+      assert waiting_for_capacity?
     end
 
     it "is waiting when bad event is FailedAttachVolume" do
       event[:type] = "Warning"
       event[:reason] = "FailedAttachVolume"
-      assert waiting_for_resources?
+      assert waiting_for_capacity?
     end
   end
 end


### PR DESCRIPTION
This starts an approach to changing how the live timeout check works during kubernetes deploys. 

For context, there might be a situation where a deployment happens and the kubernetes cluster doesn't have enough resources to schedule the workload. In our case, we have a cluster autoscaler in place to detect this and add nodes to the cluster. This process; however, takes about 5 minutes to get the new nodes ready to accept workloads. If we run with the default live timeout of 10 minutes, that means my deployment really only has 5 minutes to get ready after waiting for 5 minutes for the cluster to scale. 

This PR creates two timeout windows, both using the live timeout value. First, we assume we're going to wait on the cluster to provision more resources for us. Then, if none of the pods are waiting for those resources, meaning the workload has been scheduled, we reset our start time and the wait period. This should allow the actual full live timeout value for the pods to actually get live instead of waiting on the cluster to scale up. 

/cc @zendesk/samson

### Risks
- Level: Low. Deploys could take longer before timing out, or we would provide confusing messaging if we think we're waiting for resources but aren't. 