### PR TITLE
Use a popover to display detected problems

### DIFF
--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -17,12 +17,13 @@
 
       <div class="form-group">
         <%= form.label :reference, "Reference", class: "col-lg-2 control-label" %>
+        <div class="col-lg-4">
         <% if @stage.no_reference_selection %>
           <%= form.object.reference = @stage.default_reference.presence || 'master' %>
           <%= form.hidden_field :reference, id: 'disable_js_hooks' %>
           <%= additional_info "Reference selection is disabled for this stage." %>
         <% else %>
-          <div id="scrollable-dropdown-menu" class="col-lg-4">
+          <div id="scrollable-dropdown-menu">
             <%= form.text_field :reference,
                 class: "form-control",
                 autofocus: true,
@@ -32,12 +33,18 @@
             %>
           </div>
         <% end %>
-      </div>
+        </div>
+        <div class="col-lg-6">
+          <div id="ref-problem-warning" class="col-lg-10 popover show right alert alert-warning hidden" style="max-width: 100%">
+            <div class="arrow" style="top: 20px"></div>
 
-      <div class="form-group">
-        <div id="ref-problem-warning" class="col-lg-5 col-lg-offset-2 alert alert-warning hidden">
-          <p>Problems detected:</p>
-          <ul id="ref-problem-list"></ul>
+            <h3 class="popover-title">Problems detected:
+              <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+            </h3>
+            <div class="popover-content">
+              <ul id="ref-problem-list"></ul>
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Use a popover to display detected problems - no more pushing down the deploy button when you're about to click as the problems UI loads.

![Screen Shot 2019-05-07 at 1 26 13 pm](https://user-images.githubusercontent.com/153219/57330816-f6a21480-70cb-11e9-8ba4-d6fefa44f3cd.png)

/cc @zendesk/samson @zendesk/compute @grosser 

### Tasks
 - [ ] :+1: from team

### References
 - Jira link:

### Risks
- Level: Low - UI change
