### PR TITLE
PAAS-3303 allow configuring kubernetes rollout timeout per project

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_03_202316) do
+ActiveRecord::Schema.define(version: 2019_05_08_231523) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -404,6 +404,7 @@ ActiveRecord::Schema.define(version: 2019_04_03_202316) do
     t.boolean "kubernetes_allow_writing_to_root_filesystem", default: false, null: false
     t.boolean "jenkins_status_checker", default: false, null: false
     t.boolean "use_env_repo", default: false, null: false
+    t.integer "kubernetes_rollout_timeout"
     t.index ["build_command_id"], name: "index_projects_on_build_command_id"
     t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: 191
     t.index ["token"], name: "index_projects_on_token", unique: true, length: 191

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -8,8 +8,8 @@ module Kubernetes
     if ENV['KUBE_WAIT_FOR_LIVE'] && !ENV["KUBERNETES_WAIT_FOR_LIVE"]
       raise "Use KUBERNETES_WAIT_FOR_LIVE with seconds instead of KUBE_WAIT_FOR_LIVE" # uncovered
     end
-    WAIT_FOR_LIVE = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_LIVE', '600'))
-    WAIT_FOR_PREREQUISITES = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_PREREQUISITES', WAIT_FOR_LIVE))
+    DEFAULT_ROLLOUT_TIMEOUT = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_LIVE', '600'))
+    WAIT_FOR_PREREQUISITES = Integer(ENV.fetch('KUBERNETES_WAIT_FOR_PREREQUISITES', DEFAULT_ROLLOUT_TIMEOUT))
     STABILITY_CHECK_DURATION = Integer(ENV.fetch('KUBERNETES_STABILITY_CHECK_DURATION', 1.minute))
     TICK = Integer(ENV.fetch('KUBERNETES_STABILITY_CHECK_TICK', 10.seconds))
     RESTARTED = "Restarted"
@@ -44,7 +44,8 @@ module Kubernetes
       end
 
       if deploys.any?
-        return false unless deploy_and_watch(deploys, timeout: WAIT_FOR_LIVE)
+        timeout = @job.project.kubernetes_rollout_timeout || DEFAULT_ROLLOUT_TIMEOUT
+        return false unless deploy_and_watch(deploys, timeout: timeout)
       end
 
       true

--- a/plugins/kubernetes/app/views/samson_kubernetes/_project_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_project_form.html.erb
@@ -1,0 +1,4 @@
+<fieldset>
+  <legend>Kubernetes</legend>
+  <%= form.input :kubernetes_rollout_timeout, input_html: {placeholder: Kubernetes::DeployExecutor::DEFAULT_ROLLOUT_TIMEOUT}, label: "Rollout timeout (seconds)" %>
+</fieldset>

--- a/plugins/kubernetes/db/migrate/20190508231523_add_rollout_timeout_to_projects.rb
+++ b/plugins/kubernetes/db/migrate/20190508231523_add_rollout_timeout_to_projects.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddRolloutTimeoutToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :kubernetes_rollout_timeout, :integer
+  end
+end

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -22,6 +22,7 @@ module SamsonKubernetes
 end
 
 Samson::Hooks.view :project_tabs_view, 'samson_kubernetes/project_tab'
+Samson::Hooks.view :project_form, "samson_kubernetes/project_form"
 Samson::Hooks.view :manage_menu, 'samson_kubernetes/manage_menu'
 Samson::Hooks.view :stage_form, "samson_kubernetes/stage_form"
 Samson::Hooks.view :stage_show, "samson_kubernetes/stage_show"
@@ -43,6 +44,7 @@ Samson::Hooks.callback(:stage_permitted_params) do
   ]
 end
 Samson::Hooks.callback(:deploy_permitted_params) { [:kubernetes_rollback, :kubernetes_reuse_build] }
+Samson::Hooks.callback(:project_permitted_params) { [:kubernetes_rollout_timeout] }
 Samson::Hooks.callback(:link_parts_for_resource) do
   [
     "Kubernetes::Cluster",

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -222,6 +222,12 @@ describe Kubernetes::DeployExecutor do
       out.must_match /TIMEOUT.*\n\nDebug:/ # not showing missing pod statuses after deploy
     end
 
+    it "can use custom timeout" do
+      project.kubernetes_rollout_timeout = 123
+      executor.expects(:deploy_and_watch).with(anything, timeout: 123).returns(true)
+      assert execute, out
+    end
+
     describe "invalid configs" do
       before { build.delete } # build needs to be created -> assertion fails
       around { |test| refute_difference('Build.count') { refute_difference('Release.count', &test) } }

--- a/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
+++ b/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
@@ -5,6 +5,12 @@ require "kubeclient"
 SingleCov.covered!
 
 describe SamsonKubernetes do
+  describe :project_permitted_params do
+    it "adds ours" do
+      Samson::Hooks.fire(:project_permitted_params).flatten(1).must_include :kubernetes_rollout_timeout
+    end
+  end
+
   describe :stage_permitted_params do
     it "adds ours" do
       Samson::Hooks.fire(:stage_permitted_params).flatten(1).must_include :kubernetes


### PR DESCRIPTION
we have a few projects that take forever, so allow them to still deploy

@zendesk/compute @zendesk/bre @craig-day 

<img width="648" alt="Screen Shot 2019-05-08 at 4 37 03 PM" src="https://user-images.githubusercontent.com/11367/57415054-879dec00-71af-11e9-8a4b-66fed708111d.png">
