### PR TITLE
ignore a query mysql seems to do when running the first query

### DIFF
--- a/lib/samson/readonly_db.rb
+++ b/lib/samson/readonly_db.rb
@@ -4,7 +4,7 @@
 # NOTE: not perfect and can be circumvented with multiline sql statements or `;`
 module Samson
   module ReadonlyDb
-    ALLOWED = ["SELECT ", "SHOW ", "SET  @@SESSION.", "EXPLAIN ", "PRAGMA "].freeze
+    ALLOWED = ["SELECT ", "SHOW ", "SET  @@SESSION.", "SET NAMES", "EXPLAIN ", "PRAGMA "].freeze
     PROMPT_CHANGE = ["(", "(readonly "].freeze
     PROMPTS = [:PROMPT_I, :PROMPT_N].freeze
 


### PR DESCRIPTION
```
SET NAMES utf8,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 10
```

/cc @zendesk/samson
