### PR TITLE
PAAS-2926 stop overriding namespaces the users picked

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -190,12 +190,11 @@ Set `KUBERNETES_NO_CPU_LIMIT_ALLOWED=1`, see [#2820](https://github.com/zendesk/
 Knowing which team owns each component is useful, set `KUBERNETES_ENFORCE_TEAMS=true`
 to make all kubernetes deploys that do not use a `metadata.labels.team` / `spec.template.metadata.labels.team` fail.
 
-### Using custom namespace
+### Resources without namespace
 
-Samson overrides each resources namespace with to the deploygroups `kubernetes_namespace`.
+Samson sets namespaces to the deploygroups `kubernetes_namespace` if no `metadata.namespace` is set in the resource.
 
-To make Samson not override the namespace, set `metadata.annotations.samson/keep_namespace: 'true'`
-(or `metadata.labels.kubernetes.io/cluster-service: 'true'`)
+For namespace-less resources, set `metadata.namespace:` (which will result in `nil`)
 
 ### Using custom resource names
 

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -118,7 +118,6 @@ module Kubernetes
         kind: "PodDisruptionBudget",
         metadata: {
           name: kubernetes_role.resource_name,
-          namespace: deployment.dig(:metadata, :namespace),
           labels: deployment.dig_fetch(:metadata, :labels).dup,
           annotations: annotations
         },
@@ -127,6 +126,9 @@ module Kubernetes
           selector: {matchLabels: deployment.dig_fetch(:spec, :selector, :matchLabels).dup}
         }
       }
+      if deployment[:metadata].key? :namespace
+        budget[:metadata][:namespace] = deployment.dig(:metadata, :namespace)
+      end
       budget[:delete] = true if target == 0
       raw_template << budget
     end

--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -26,7 +26,6 @@ module Kubernetes
       return ["Only hashes supported"] unless @elements.all? { |e| e.is_a?(Hash) }
       validate_name
       validate_name_kinds_are_unique
-      validate_namespace
       validate_single_primary_kind
       validate_api_version
       validate_containers
@@ -79,13 +78,6 @@ module Kubernetes
 
     def validate_name
       @errors << "Needs a metadata.name" unless map_attributes([:metadata, :name]).all?
-    end
-
-    def validate_namespace
-      elements = @elements.reject { |e| NAMESPACELESS_KINDS.include? e[:kind] }
-      return if elements.empty?
-      namespaces = map_attributes([:metadata, :namespace], elements: elements)
-      @errors << "Namespaces need to be unique" if namespaces.uniq.size != 1
     end
 
     # multiple pods in a single role will make validations misbehave (recommend they all have the same role etc)

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -194,8 +194,7 @@ module Kubernetes
     end
 
     def set_namespace
-      return if template.dig(:metadata, :labels, :'kubernetes.io/cluster-service') == 'true'
-      return if template.dig(:metadata, :annotations, :'samson/keep_namespace') == 'true'
+      return if template[:metadata].key?(:namespace)
       template[:metadata][:namespace] = @doc.deploy_group.kubernetes_namespace
     end
 

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_group_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_group_form.html.erb
@@ -4,5 +4,5 @@
     <%= cluster_form.collection_select(:kubernetes_cluster_id, Kubernetes::Cluster.all, :id, :name, { include_blank: true }, { class: 'form-control' }) %>
   <% end %>
 
-  <%= cluster_form.input :namespace, label: "Kubernetes Namespace" %>
+  <%= cluster_form.input :namespace, label: "Kubernetes Namespace", help: "Used when metadata.namespace is not set" %>
 <% end %>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_group_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_group_show.html.erb
@@ -12,7 +12,10 @@
 </div>
 
 <div class="form-group">
-  <label class="col-lg-2 control-label">Kubernetes Namespace</label>
+  <label class="col-lg-2 control-label">
+    Kubernetes Namespace
+    <%= additional_info "Used when metadata.namespace is not set" %>
+  </label>
   <div class="col-lg-4">
     <p class="form-control-static"><%= @deploy_group.kubernetes_namespace %></p>
   </div>

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -252,18 +252,6 @@ describe Kubernetes::RoleValidator do
       errors.must_include "Needs apiVersion specified"
     end
 
-    describe "#validate_namespace" do
-      it "reports non-unique namespaces since that would break pod fetching" do
-        role.first[:metadata][:namespace] = "default"
-        errors.to_s.must_include "Namespaces need to be unique"
-      end
-
-      it "allows only namespace-less resources" do
-        role.each { |r| r[:kind] = "ClusterRole" }
-        errors.must_be_nil
-      end
-    end
-
     describe "#validate_name_kinds_are_unique" do
       before { role.each { |r| r[:kind] = "foo" } }
 


### PR DESCRIPTION
Verified nobody does it wrong by using:

```Ruby
bad = []
Kubernetes::Role.find_each do |role|
  next unless project = role.project
  next if role.config_file.blank?
  puts "#{project.permalink} #{role.config_file}"
  begin
    # NOTE: this might be out of date since we cannot trigger pulls from the console
    next unless content = project.repository.file_content(role.config_file, "master", pull: false)
    elements = Array.wrap(Kubernetes::Util.parse_file(content, role.config_file)).compact.map(&:deep_symbolize_keys)
    elements.each do |e|
      next if e[:metadata].key?(:namespace) && (
        e.dig(:metadata, :annotations, :"samson/keep_namespace") == "true" ||
        e.dig(:metadata, :labels, :"kubernetes.io/cluster-service") == "true"
      )
      next if !e[:metadata].key?(:namespace) && (
        e.dig(:metadata, :annotations, :"samson/keep_namespace") != "true" &&
        e.dig(:metadata, :labels, :"kubernetes.io/cluster-service") != "true"
      )
      bad << [role, e]
      puts "BAD #{project.permalink} #{role.config_file} #{e[:kind]} #{e.dig(:metadata, :name)}"
    end
  rescue => e
    puts "Error #{e}"
    bad << [role]
  end
end
```

@zendesk/compute @zendesk/samson 