### PR TITLE
do not fail on randomly long query times

### DIFF
--- a/test/lib/samson/time_sum_test.rb
+++ b/test/lib/samson/time_sum_test.rb
@@ -15,7 +15,7 @@ describe Samson::TimeSum do
     it "records single" do
       result = Samson::TimeSum.record("sql.active_record" => :db) { User.first }
       result.keys.must_equal [:db]
-      assert result[:db].between?(0, 5), result
+      assert result[:db].between?(0, 10), result
     end
 
     it "records 0 when nothing happened" do


### PR DESCRIPTION
saw 2 of these already, time to bump ... 
```
test/lib/samson/time_sum_test.rb 
Run options: --seed 14429
# Running:
F
Failure:
Samson::TimeSum::.record#test_0002_records single [/home/travis/build/zendesk/samson/test/lib/samson/time_sum_test.rb:18]:
{:db=>5.3148800000000005}
bin/rails test test/lib/samson/time_sum_test.rb:15
```