### PR TITLE
Alter index length for secret sharing grants table

### DIFF
--- a/db/migrate/20190514215712_alter_secret_sharing_grants_indexes.rb
+++ b/db/migrate/20190514215712_alter_secret_sharing_grants_indexes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AlterSecretSharingGrantsIndexes < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :secret_sharing_grants, :key
+    remove_index :secret_sharing_grants, [:project_id, :key]
+    # https://dev.mysql.com/doc/refman/8.0/en/innodb-restrictions.html
+    # Safe allowed column prefix index length is 191
+    add_index :secret_sharing_grants, [:key], length: {key: 191}
+    add_index :secret_sharing_grants, [:project_id, :key], unique: true, length: {key: 160}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_10_213218) do
+ActiveRecord::Schema.define(version: 2019_05_14_215712) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -455,8 +455,8 @@ ActiveRecord::Schema.define(version: 2019_05_10_213218) do
     t.integer "project_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_secret_sharing_grants_on_key", length: 50
-    t.index ["project_id", "key"], name: "index_secret_sharing_grants_on_project_id_and_key", unique: true, length: { key: 50 }
+    t.index ["key"], name: "index_secret_sharing_grants_on_key", length: 191
+    t.index ["project_id", "key"], name: "index_secret_sharing_grants_on_project_id_and_key", unique: true, length: { key: 160 }
   end
 
   create_table "secrets", id: false do |t|


### PR DESCRIPTION
We have failures in sharing global secrets, because of the limit in **index prefix length** and unique index constraint on **secret_sharing_grants** tables, increasing the index prefix length would resolve the problem.

JIRA: https://zendesk.atlassian.net/browse/BRE-1639