### PR TITLE
PAAS-3264 fill namespace from project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,7 +512,7 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.11.0)
-    single_cov (1.3.0)
+    single_cov (1.3.2)
     slop (3.6.0)
     socksify (1.7.1)
     soft_deletion (1.3.1)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -280,7 +280,7 @@ ActiveRecord::Schema.define(version: 2019_05_14_231932) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.string "resource_name", null: false
+    t.string "resource_name"
     t.boolean "autoscaled", default: false, null: false
     t.boolean "blue_green", default: false, null: false
     t.index ["project_id"], name: "index_kubernetes_roles_on_project_id"

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -198,7 +198,7 @@ For namespace-less resources, set `metadata.namespace:` (which will result in `n
 
 ### Using custom resource names
 
-Samson overrides each resource name in a particular role with the resource and service name set in the UI to prevent
+When not using project namespaces samson overrides each resource name in a particular role with the resource and service name set in the UI to prevent
 collision between resources in the same namespace from different projects unintentionally.
 
 To make Samson leave your resource name alone, set `metadata.annotations.samson/keep_name: 'true'`

--- a/plugins/kubernetes/app/controllers/kubernetes/role_verifications_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/role_verifications_controller.rb
@@ -7,7 +7,7 @@ class Kubernetes::RoleVerificationsController < ApplicationController
     input = params[:role].presence || '{}'
     filename = (input.start_with?('{', '[') ? 'test.json' : 'test.yml')
     begin
-      Kubernetes::RoleConfigFile.new(input, filename, namespace: nil)
+      Kubernetes::RoleConfigFile.new(input, filename, project: nil)
     rescue Samson::Hooks::UserError
       @errors = $!.message
     else

--- a/plugins/kubernetes/app/decorators/project_decorator.rb
+++ b/plugins/kubernetes/app/decorators/project_decorator.rb
@@ -10,4 +10,8 @@ Project.class_eval do
     class_name: 'Kubernetes::Namespace', dependent: nil, inverse_of: :projects, optional: true
 
   scope :with_kubernetes_roles, -> { where(id: Kubernetes::Role.not_deleted.pluck(Arel.sql('distinct project_id'))) }
+
+  def override_resource_names?
+    !kubernetes_namespace_id?
+  end
 end

--- a/plugins/kubernetes/app/models/kubernetes/namespace.rb
+++ b/plugins/kubernetes/app/models/kubernetes/namespace.rb
@@ -12,6 +12,7 @@ module Kubernetes
     has_many :projects, dependent: nil, foreign_key: :kubernetes_namespace_id, inverse_of: :kubernetes_namespace
 
     validates :name, presence: true, uniqueness: true, format: NAME_PATTERN
+    after_save :remove_configured_resource_names
     before_destroy :ensure_unused
 
     private
@@ -20,6 +21,16 @@ module Kubernetes
       return if projects.none?
       errors.add :base, 'Can only delete when not used by any project.'
       throw :abort
+    end
+
+    # we will no longer use these, so clean the DB up and leave audits behind
+    def remove_configured_resource_names
+      roles = Kubernetes::Role.
+        where(project_id: projects.map(&:id)).
+        where("resource_name IS NOT NULL OR service_name IS NOT NULL")
+      roles.find_each do |role|
+        role.update_attributes!(resource_name: nil, service_name: nil, manual_deletion_acknowledged: true)
+      end
     end
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -90,26 +90,14 @@ module Kubernetes
 
     def add_pod_disruption_budget
       return unless deployment = raw_template.detect { |r| ["Deployment", "StatefulSet"].include? r[:kind] }
+      return unless target = disruption_budget_target(deployment)
 
-      min_available = deployment.dig(:metadata, :annotations, :"samson/minAvailable")
-      return if min_available == "disabled"
-
-      # NOTE: this is a bit of overhead for 0 or 1 replica deployments, but we don't know if a bad budget existed before
-      min_available ||= ENV["KUBERNETES_AUTO_MIN_AVAILABLE"]
-      return unless min_available
-
-      target = if percent = min_available.to_s[/\A(\d+)\s*%\z/, 1] # "30%" -> 30 / "30 %" -> 30
-        percent = Integer(percent)
-        if percent >= 100
-          raise Samson::Hooks::UserError, "minAvailable of >= 100% would result in eviction deadlock, pick lower"
+      name =
+        if kubernetes_release.project.override_resource_names?
+          kubernetes_role.resource_name
         else
-          [((replica_target.to_f / 100) * percent).ceil, replica_target - 1].min
+          deployment.dig(:metadata, :name)
         end
-      else
-        [replica_target - 1, Integer(min_available)].min
-      end
-      target = 0 if target < 0
-
       annotations = (deployment.dig(:metadata, :annotations) || {}).dup
       annotations[:"samson/updateTimestamp"] = Time.now.utc.iso8601
 
@@ -117,7 +105,7 @@ module Kubernetes
         apiVersion: "policy/v1beta1",
         kind: "PodDisruptionBudget",
         metadata: {
-          name: kubernetes_role.resource_name,
+          name: name,
           labels: deployment.dig_fetch(:metadata, :labels).dup,
           annotations: annotations
         },
@@ -133,6 +121,28 @@ module Kubernetes
       raw_template << budget
     end
 
+    def disruption_budget_target(deployment)
+      min_available = deployment.dig(:metadata, :annotations, :"samson/minAvailable")
+      return if min_available == "disabled"
+
+      # NOTE: overhead for 0 or 1 replica deployments, but we don't know if a bad budget existed before
+      min_available ||= ENV["KUBERNETES_AUTO_MIN_AVAILABLE"]
+      return unless min_available
+
+      target = if percent = min_available.to_s[/\A(\d+)\s*%\z/, 1] # "30%" -> 30 / "30 %" -> 30
+        percent = Integer(percent)
+        if percent >= 100
+          raise Samson::Hooks::UserError, "minAvailable of >= 100% would result in eviction deadlock, pick lower"
+        else
+          [((replica_target.to_f / 100) * percent).ceil, replica_target - 1].min
+        end
+      else
+        [replica_target - 1, Integer(min_available)].min
+      end
+      target = 0 if target < 0
+      target
+    end
+
     def validate_config_file
       return unless kubernetes_role
       raw_template # trigger RoleConfigFile validations
@@ -144,7 +154,7 @@ module Kubernetes
       @raw_template ||= begin
         file = kubernetes_role.config_file
         content = kubernetes_release.project.repository.file_content(file, kubernetes_release.git_sha)
-        RoleConfigFile.new(content, file, namespace: kubernetes_release.project.kubernetes_namespace&.name).elements
+        RoleConfigFile.new(content, file, project: kubernetes_release.project).elements
       end
     end
   end

--- a/plugins/kubernetes/app/views/kubernetes/namespaces/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/namespaces/_form.html.erb
@@ -8,7 +8,7 @@
       <%= form.input :name, required: true, pattern: Kubernetes::Namespace::NAME_PATTERN, input_html: {disabled: form.object.persisted?} %>
       <%= form.input :comment, as: :text_area %>
 
-      <%= form.input :project_ids, label: 'Projects' do %>
+      <%= form.input :project_ids, label: 'Projects', help: "Adding a projects will remove it's kubernetes roles resource and service names AND move it from it's current namespace" do %>
         <%= form.select :project_ids, Project.pluck(:name, :id), {}, multiple: true, **Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
       <% end %>
     </fieldset>

--- a/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
@@ -5,11 +5,13 @@
   <fieldset>
     <%= form.input :name %>
     <%= form.input :config_file %>
-    <%= form.input :service_name, help: "Override service name with this name. Uses name from yml file if it starts with this name." %>
-    <%= form.input :resource_name,
-        pattern: Kubernetes::RoleValidator::VALID_LABEL_VALUE,
-        help: "Name for the resource this role will create (service/job), a-Z 0-9 and -"
-    %>
+    <% if @project.override_resource_names? %>
+      <%= form.input :service_name, help: "Override service name with this name. Uses name from yml file if it starts with this name." %>
+      <%= form.input :resource_name,
+          pattern: Kubernetes::RoleValidator::VALID_LABEL_VALUE,
+          help: "Name for the resource this role will create (service/job), a-Z 0-9 and -"
+      %>
+    <% end %>
     <% if @kubernetes_role.manual_deletion_required? %>
       <div class="alert-danger">
         <%= form.input :manual_deletion_acknowledged, as: :check_box, label: "I will manually delete the changed resource/service from all deploy groups before deploying (this will cause a short outage, deleting after deploying will result in undefined behavior with 2 copies running)" %>

--- a/plugins/kubernetes/app/views/kubernetes/roles/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/index.html.erb
@@ -13,8 +13,10 @@
         <tr>
           <th>Name</th>
           <th>Config</th>
-          <th>Service Name</th>
-          <th>Resource</th>
+          <% if @project.override_resource_names? %>
+            <th>Service Name</th>
+            <th>Resource</th>
+          <% end %>
           <th></th>
         </tr>
 
@@ -22,8 +24,10 @@
           <tr>
             <td><%= link_to role.name, [@project, role] %></td>
             <td><%= role.config_file %></td>
-            <td><%= role.service_name %></td>
-            <td><%= role.resource_name %></td>
+            <% if @project.override_resource_names? %>
+              <td><%= role.service_name %></td>
+              <td><%= role.resource_name %></td>
+            <% end %>
             <td>
               <%= link_to 'Edit', [@project, role] if current_user.admin_for?(role.project) %>
             </td>

--- a/plugins/kubernetes/db/migrate/20190514231932_allow_nil_kubernetes_roles_resource_name.rb
+++ b/plugins/kubernetes/db/migrate/20190514231932_allow_nil_kubernetes_roles_resource_name.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AllowNilKubernetesRolesResourceName < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :kubernetes_roles, :resource_name, true
+  end
+end

--- a/plugins/kubernetes/test/controllers/kubernetes/roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/roles_controller_test.rb
@@ -57,7 +57,7 @@ describe Kubernetes::RolesController do
 
         # verify that the template is valid
         template = response.body[/<pre>(.*)<\/pre>/m, 1]
-        Kubernetes::RoleConfigFile.new(template, 'app-server.yml', namespace: nil)
+        Kubernetes::RoleConfigFile.new(template, 'app-server.yml', project: nil)
       end
     end
   end

--- a/plugins/kubernetes/test/decorators/project_decorator_test.rb
+++ b/plugins/kubernetes/test/decorators/project_decorator_test.rb
@@ -36,6 +36,14 @@ describe Project do
     end
   end
 
+  describe "#override_resource_names?" do
+    it "is disabled when namespace is used" do
+      assert project.override_resource_names?
+      project.create_kubernetes_namespace!(name: "bar")
+      refute project.override_resource_names?
+    end
+  end
+
   describe ".with_kubernetes_roles" do
     it "shows projects with kubernetes roles" do
       Project.with_kubernetes_roles.must_equal([projects(:test)])

--- a/plugins/kubernetes/test/fixtures/kubernetes/roles.yml
+++ b/plugins/kubernetes/test/fixtures/kubernetes/roles.yml
@@ -1,4 +1,3 @@
----
 app_server:
   project: test
   name: app-server

--- a/plugins/kubernetes/test/models/kubernetes/namespace_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/namespace_test.rb
@@ -5,6 +5,7 @@ SingleCov.covered!
 
 describe Kubernetes::Namespace do
   let(:namespace) { kubernetes_namespaces(:test) }
+  let(:project) { projects(:test) }
 
   describe "validations" do
     it "is valid" do
@@ -25,6 +26,24 @@ describe Kubernetes::Namespace do
     it "does not allow deletion when used" do
       namespace.projects << projects(:test)
       refute namespace.destroy
+    end
+  end
+
+  describe "#remove_configured_resource_names" do
+    it "clean existing roles" do
+      assert_difference "Audited::Audit.count", 3 do
+        namespace.update_attributes!(project_ids: [project.id]) # do what controller does
+      end
+      role = kubernetes_roles(:app_server)
+      role.resource_name.must_be_nil
+      role.service_name.must_be_nil
+    end
+
+    it "skips clean roles" do
+      Kubernetes::Role.update_all(resource_name: nil, service_name: nil)
+      assert_difference "Audited::Audit.count", 1 do
+        project.create_kubernetes_namespace!(name: "bar")
+      end
     end
   end
 end

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -158,6 +158,12 @@ describe Kubernetes::ReleaseDoc do
         create!.resource_template[2][:metadata][:namespace].must_equal 'default'
       end
 
+      it "keeps name when using custom namespace" do
+        doc.kubernetes_release.project.create_kubernetes_namespace!(name: "foo")
+        template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '30%'}
+        create!.resource_template[2][:metadata][:name].must_equal 'some-project-rc'
+      end
+
       it "supports multiproject" do
         metadata = template.dig(0, :metadata)
         metadata[:annotations] = {"samson/minAvailable": '30%', "samson/override_project_label": "true"}

--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -5,19 +5,19 @@ SingleCov.covered!
 
 describe Kubernetes::RoleConfigFile do
   let(:content) { read_kubernetes_sample_file('kubernetes_deployment.yml') }
-  let(:config_file) { Kubernetes::RoleConfigFile.new(content, 'some-file.yml', namespace: nil) }
+  let(:config_file) { Kubernetes::RoleConfigFile.new(content, 'some-file.yml', project: projects(:test)) }
 
   describe "#initialize" do
     it "fails with a message that points to the broken file" do
       e = assert_raises Samson::Hooks::UserError do
-        Kubernetes::RoleConfigFile.new(content, 'some-file.json', namespace: nil)
+        Kubernetes::RoleConfigFile.new(content, 'some-file.json', project: nil)
       end
       e.message.must_include 'some-file.json'
     end
 
     it "fails when empty" do
       e = assert_raises Samson::Hooks::UserError do
-        Kubernetes::RoleConfigFile.new("", 'some-file.json', namespace: nil)
+        Kubernetes::RoleConfigFile.new("", 'some-file.json', project: nil)
       end
       e.message.must_include 'some-file.json'
     end

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -239,6 +239,14 @@ describe Kubernetes::Role do
       names = Kubernetes::Role.all.map(&:service_name)
       names.last.must_match /#{existing_name}-change-me-\d+/
     end
+
+    it "does not see service or resource when using manual naming" do
+      project.create_kubernetes_namespace!(name: "foo")
+      write_config 'kubernetes/a.json', config_content.to_json
+      Kubernetes::Role.seed! project, 'HEAD'
+      project.kubernetes_roles.map(&:resource_name).must_equal [nil]
+      project.kubernetes_roles.map(&:service_name).must_equal [nil]
+    end
   end
 
   describe '.configured_for_project' do

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -41,7 +41,7 @@ class ActiveSupport::TestCase
     role = Kubernetes::RoleConfigFile.new(
       read_kubernetes_sample_file('kubernetes_deployment.yml'),
       'config/app_server.yml',
-      namespace: nil
+      project: nil
     )
     Kubernetes::ReleaseDoc.any_instance.stubs(raw_template: role.elements)
   end


### PR DESCRIPTION
stop setting resource names and service names when using namespace feature (since there should be no collisions)

@zendesk/compute @zendesk/samson 

<img width="996" alt="Screen Shot 2019-05-15 at 10 53 30 AM" src="https://user-images.githubusercontent.com/11367/57797639-b6f8af80-76ff-11e9-80ee-13c5f08a7531.png">
<img width="634" alt="Screen Shot 2019-05-15 at 10 53 16 AM" src="https://user-images.githubusercontent.com/11367/57797640-b6f8af80-76ff-11e9-9a5b-11a57a2e2023.png">

<img width="809" alt="Screen Shot 2019-05-15 at 10 50 05 AM" src="https://user-images.githubusercontent.com/11367/57797573-96c8f080-76ff-11e9-9950-898ab653f5df.png">
