### PR TITLE
LoadBalancer blocker

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -243,3 +243,7 @@ this is useful when dealing with large deployments that have some random failure
 To debug services or to create resources that needs to reference a selector that doesn't include team/role (like a Gateway), you can disable selector validation with:
 
 `metadata.annotations.samson/service_selector_across_roles: "true"`
+
+### Blocking LoadBalancer usage
+
+Set `KUBERNETES_ALLOWED_LOAD_BALANCER_NAMESPACES=foo,bar` to block all other namespaces from using them.

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -584,6 +584,29 @@ describe Kubernetes::RoleValidator do
         errors.must_equal ["Team names change, do not select or match on them"]
       end
     end
+
+    describe "#validate_load_balancer" do
+      before do
+        role[0][:kind] = "LoadBalancer"
+        role[0][:metadata][:namespace] = "foo"
+      end
+
+      it "allows when not configured" do
+        errors.must_be_nil
+      end
+
+      it "allows when namespace is allowed" do
+        with_env KUBERNETES_ALLOWED_LOAD_BALANCER_NAMESPACES: "foo" do
+          errors.must_be_nil
+        end
+      end
+
+      it "does not allow when namespace is not allowed" do
+        with_env KUBERNETES_ALLOWED_LOAD_BALANCER_NAMESPACES: "bar" do
+          errors.must_equal ["LoadBalancer is not allowed in foo namespace"]
+        end
+      end
+    end
   end
 
   describe '.map_attributes' do


### PR DESCRIPTION
nobody using it atm, so we are good 🤷‍♂ 

```ruby
roles = Kubernetes::Role.where(autoscaled: true).all.to_a; nil
ignored_groups = DeployGroup.where(name: []).pluck(:id)
roles.select!(&:project); nil
roles.each do |role|
  groups_ids = Kubernetes::ReleaseDoc.where(kubernetes_role: role).pluck(:deploy_group_id).uniq - ignored_groups

  DeployGroup.where(id: groups_ids).all.each do |group|
    next unless doc = Kubernetes::ReleaseDoc.where(kubernetes_role: role, deploy_group: group).last
    doc.resources.each do |r|
      puts "FOUND #{role.project.url} #{role.name} #{r.template.dig(:metadata, :namespace)}" if r.kind == "LoadBalancer"
    end
  end
end; nil

```