### PR TITLE
add project permalink to webhook urls so we can quickly see where the…

### DIFF
--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -14,6 +14,7 @@
 
     <dl>
       <% Samson::Integration::SOURCES.each do |source| %>
+        <% token_args = [@project.token, {project: @project.permalink}] %>
         <dt>
           <% if source == 'generic' %>
             <details>
@@ -22,7 +23,7 @@
               <pre><%= <<~TEXT
                 curl -H 'Content-Type: application/json' \\
                   -d '{"deploy":{"branch":"master","commit":{"sha":"abc","message":"hi"}}}' \\
-                  #{integrations_generic_deploy_url(@project.token)}
+                  #{integrations_generic_deploy_url(*token_args)}
                TEXT
               %></pre>
             </details>
@@ -31,11 +32,12 @@
           <% end %>
         </dt>
         <dd>
-          <%= send("integrations_#{source}_deploy_url", @project.token) %>
-          <% if source == 'github' && token = Integrations::GithubController.secret_token %>
+          <%= public_send "integrations_#{source}_deploy_url", *token_args %>
+          <% if source == 'github' && secret_token = Integrations::GithubController.secret_token %>
             <br/>
             <% if current_user.admin_for?(@project) %>
-              (Set <%= link_to "secret token", "javascript:prompt('Copy this token', '#{token}')" %> in <%= link_to 'hook settings', "https://github.com/#{@project.repository_path}/settings/hooks" %>)
+              (Set <%= link_to "secret token", "javascript:prompt('Copy this token', '#{secret_token}')" %> in
+              <%= link_to 'hook settings', "https://github.com/#{@project.repository_path}/settings/hooks" %>)
             <% else %>
               (Secret token required, ask a project admin)
             <% end %>

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -154,6 +154,18 @@ describe Integrations::BaseController do
       @controller.request.env["PATH_INFO"].must_equal "/test/hidden-project-not-found-token"
     end
 
+    describe "project tokens" do
+      it "creates with project scoped token" do
+        post :create, params: {test_route: true, token: token, project: project.permalink}
+        assert_response :success
+      end
+
+      it "fails with incorrectly project scoped token" do
+        post :create, params: {test_route: true, token: token, project: "wut"}
+        assert_response :unauthorized
+      end
+    end
+
     describe "when deploy hooks are setup" do
       let(:deploy1) { deploys(:succeeded_test) }
       let(:deploy2) { deploys(:succeeded_production_test) }


### PR DESCRIPTION
…y go

decided against:
 - not being backwards compatible
 - duplicating all integration urls in projects scope
 - changing the token format to project-token since I want a readable permalink and all possible separators can be in the permalink too

<img width="742" alt="Screen Shot 2019-05-15 at 2 27 51 PM" src="https://user-images.githubusercontent.com/11367/57810949-e9190a00-771d-11e9-9a07-0780747697ab.png">

@zendesk/samson @zendesk/compute