### PR TITLE
Added pagination links for JSON api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   include CurrentUser # must be after protect_from_forgery, so that authenticate! is called
   include JsonExceptions
   include JsonRenderer
+  include JsonPagination
   include Pagy::Backend
 
   # show error details to users and do not bother ExceptionNotifier

--- a/app/controllers/concerns/json_pagination.rb
+++ b/app/controllers/concerns/json_pagination.rb
@@ -2,12 +2,12 @@
 module JsonPagination
   private
 
-  def add_pagination_links(json, pagy)
+  def add_json_pagination_links(json, pagy)
     # add custom headers to the response
-    add_headers(pagy)
+    add_json_pagination_headers(pagy)
 
     # Insert links at beginning
-    links = links(pagy)
+    links = json_pagination_links(pagy)
     if links.present?
       json_d = json.clone
       json.clear
@@ -16,7 +16,7 @@ module JsonPagination
     end
   end
 
-  def pages(pagy)
+  def json_pagination_pages(pagy)
     paging = {}
     paging[:first] = 1          unless pagy.page == 1
     paging[:last] = pagy.pages  unless pagy.page == pagy.pages
@@ -26,19 +26,19 @@ module JsonPagination
     paging
   end
 
-  def links(pagy)
+  def json_pagination_links(pagy)
     links = {}
     uri = request.env["PATH_INFO"]
 
     # Build pagination links
-    pages(pagy).each do |key, value|
+    json_pagination_pages(pagy).each do |key, value|
       query_params = request.query_parameters.merge(page: value)
       links[key] = "#{uri}?#{query_params.to_param}"
     end
     links
   end
 
-  def add_headers(pagy)
+  def add_json_pagination_headers(pagy)
     headers['X-PER-PAGE']      = pagy.offset
     headers["X-CURRENT-PAGE"]  = pagy.page
     headers["X-TOTAL-PAGES"]   = pagy.pages

--- a/app/controllers/concerns/json_pagination.rb
+++ b/app/controllers/concerns/json_pagination.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+module JsonPagination
+  private
+
+  def add_pagination_links(json, pagy)
+    # add custom headers to the response
+    add_headers(pagy)
+
+    # Insert links at beginning
+    links = links(pagy)
+    if links.present?
+      json_d = json.clone
+      json.clear
+      json["links"] = links
+      json.merge! json_d
+    end
+  end
+
+  def pages(pagy)
+    paging = {}
+    paging[:first] = 1          unless pagy.page == 1
+    paging[:last] = pagy.pages  unless pagy.page == pagy.pages
+
+    paging[:prev] = pagy.prev   unless pagy.prev.nil?
+    paging[:next] = pagy.next   unless pagy.next.nil?
+    paging
+  end
+
+  def links(pagy)
+    links = {}
+    uri = request.env["PATH_INFO"]
+
+    # Build pagination links
+    pages(pagy).each do |key, value|
+      query_params = request.query_parameters.merge(page: value)
+      links[key] = "#{uri}?#{query_params.to_param}"
+    end
+    links
+  end
+
+  def add_headers(pagy)
+    headers['X-PER-PAGE']      = pagy.offset
+    headers["X-CURRENT-PAGE"]  = pagy.page
+    headers["X-TOTAL-PAGES"]   = pagy.pages
+    headers["X-TOTAL-RECORDS"] = pagy.count
+  end
+end

--- a/app/controllers/concerns/json_pagination.rb
+++ b/app/controllers/concerns/json_pagination.rb
@@ -2,12 +2,12 @@
 module JsonPagination
   private
 
-  def add_json_pagination_links(json, pagy)
+  def add_json_pagination(json, pagy)
     # add custom headers to the response
     add_json_pagination_headers(pagy)
 
     # Insert links at beginning
-    links = json_pagination_links(pagy)
+    links = add_json_pagination_links(pagy)
     if links.present?
       json_d = json.clone
       json.clear
@@ -26,7 +26,7 @@ module JsonPagination
     paging
   end
 
-  def json_pagination_links(pagy)
+  def add_json_pagination_links(pagy)
     links = {}
     uri = request.env["PATH_INFO"]
 

--- a/app/controllers/concerns/json_pagination.rb
+++ b/app/controllers/concerns/json_pagination.rb
@@ -6,13 +6,12 @@ module JsonPagination
     # add custom headers to the response
     add_json_pagination_headers(pagy)
 
-    # Insert links at beginning
     links = add_json_pagination_links(pagy)
     if links.present?
-      json_d = json.clone
-      json.clear
-      json["links"] = links
-      json.merge! json_d
+      # Pagination links are appened at the first place in JSON results.
+      # because it will be more hard to find links in large JSON.
+      json.delete("links")
+      json.replace({links: links}.merge(json))
     end
   end
 

--- a/app/controllers/concerns/json_renderer.rb
+++ b/app/controllers/concerns/json_renderer.rb
@@ -40,7 +40,7 @@ module JsonRenderer
 
   private
 
-  def render_as_json(namespace, resource, status: :ok, allowed_includes: [], pagy: nil)
+  def render_as_json(namespace, resource, pagy, status: :ok, allowed_includes: [])
     # validate includes
     requested_includes = permit_requested(:includes, allowed_includes)
 
@@ -64,7 +64,7 @@ module JsonRenderer
 
     # build reply
     json = {namespace => resource_json}
-    add_pagination_links(json, pagy) if pagy
+    add_json_pagination_links(json, pagy) if pagy
     JsonRenderer.add_includes(json, resource_list, requested_includes)
 
     yield json if block_given?

--- a/app/controllers/concerns/json_renderer.rb
+++ b/app/controllers/concerns/json_renderer.rb
@@ -40,7 +40,7 @@ module JsonRenderer
 
   private
 
-  def render_as_json(namespace, resource, status: :ok, allowed_includes: [])
+  def render_as_json(namespace, resource, status: :ok, allowed_includes: [], pagy: nil)
     # validate includes
     requested_includes = permit_requested(:includes, allowed_includes)
 
@@ -64,6 +64,7 @@ module JsonRenderer
 
     # build reply
     json = {namespace => resource_json}
+    add_pagination_links(json, pagy) if pagy
     JsonRenderer.add_includes(json, resource_list, requested_includes)
 
     yield json if block_given?

--- a/app/controllers/concerns/json_renderer.rb
+++ b/app/controllers/concerns/json_renderer.rb
@@ -64,7 +64,7 @@ module JsonRenderer
 
     # build reply
     json = {namespace => resource_json}
-    add_json_pagination_links(json, pagy) if pagy
+    add_json_pagination(json, pagy) if pagy
     JsonRenderer.add_includes(json, resource_list, requested_includes)
 
     yield json if block_given?

--- a/app/controllers/deploy_groups_controller.rb
+++ b/app/controllers/deploy_groups_controller.rb
@@ -14,7 +14,12 @@ class DeployGroupsController < ResourceController
     respond_to do |format|
       format.html
       format.json do
-        render_as_json(:deploy_groups, @deploy_groups, allowed_includes: Samson::Hooks.fire(:deploy_group_includes))
+        render_as_json(
+          :deploy_groups,
+          @deploy_groups,
+          nil,
+          allowed_includes: Samson::Hooks.fire(:deploy_group_includes)
+        )
       end
     end
   end

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -37,7 +37,7 @@ class DeploysController < ApplicationController
 
     respond_to do |format|
       format.json do
-        render_as_json :deploys, @deploys, allowed_includes: [:job, :project, :user, :stage]
+        render_as_json :deploys, @deploys, @pagy, allowed_includes: [:job, :project, :user, :stage]
       end
       format.csv do
         datetime = Time.now.strftime "%Y%m%d_%H%M"
@@ -96,7 +96,7 @@ class DeploysController < ApplicationController
           type: 'text/plain'
       end
       format.json do
-        render_as_json :deploy, @deploy, allowed_includes: [:job, :user, :project, :stage]
+        render_as_json :deploy, @deploy, nil, allowed_includes: [:job, :user, :project, :stage]
       end
     end
   end

--- a/app/controllers/outbound_webhooks_controller.rb
+++ b/app/controllers/outbound_webhooks_controller.rb
@@ -9,7 +9,7 @@ class OutboundWebhooksController < ResourceController
 
   def index
     respond_to do |format|
-      format.json { render_as_json :webhooks, @project.outbound_webhooks }
+      format.json { render_as_json :webhooks, @project.outbound_webhooks, nil }
     end
   end
 

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -20,7 +20,7 @@ class ResourceController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render_as_json resource_name.pluralize, @resources, allowed_includes: allowed_includes, pagy: @pagy
+        render_as_json resource_name.pluralize, @resources, @pagy, allowed_includes: allowed_includes
       end
       format.csv { render_as_csv @resources }
     end
@@ -142,7 +142,7 @@ class ResourceController < ApplicationController
   end
 
   def render_resource_as_json(**args)
-    render_as_json resource_name, @resource, **args, allowed_includes: allowed_includes
+    render_as_json resource_name, @resource, nil, **args, allowed_includes: allowed_includes
   end
 
   def set_resource

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -19,7 +19,9 @@ class ResourceController < ApplicationController
     )
     respond_to do |format|
       format.html
-      format.json { render_as_json resource_name.pluralize, @resources, allowed_includes: allowed_includes }
+      format.json do
+        render_as_json resource_name.pluralize, @resources, allowed_includes: allowed_includes, pagy: @pagy
+      end
       format.csv { render_as_csv @resources }
     end
   end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -20,7 +20,7 @@ class StagesController < ResourceController
         @pagy, @deploys = pagy(@stage.deploys, page: params[:page], items: 15)
       end
       format.json do
-        render_as_json :stage, @stage, allowed_includes: [
+        render_as_json :stage, @stage, nil, allowed_includes: [
           :last_deploy, :last_succeeded_deploy, :active_deploy, :lock
         ] do |reply|
           # deprecated way of inclusion, do not add more

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     @pagy, @users = pagy(User.search_by_criteria(params), page: params[:page], items: 25)
     respond_to do |format|
       format.html
-      format.json { render_as_json :users, @users, allowed_includes: [:user_project_roles] }
+      format.json { render_as_json :users, @users, @pagy, allowed_includes: [:user_project_roles] }
       format.csv do
         redirect_to(new_csv_export_path(format: :csv, type: :users))
       end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -9,7 +9,7 @@ class WebhooksController < ResourceController
   def index
     respond_to do |format|
       format.html
-      format.json { render_as_json :webhooks, @project.webhooks }
+      format.json { render_as_json :webhooks, @project.webhooks, nil }
     end
   end
 

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -8,7 +8,7 @@ class EnvironmentVariableGroupsController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render_as_json :environment_variable_groups, @groups, allowed_includes: [
+        render_as_json :environment_variable_groups, @groups, nil, allowed_includes: [
           :environment_variables,
         ]
       end

--- a/plugins/env/app/controllers/environment_variables_controller.rb
+++ b/plugins/env/app/controllers/environment_variables_controller.rb
@@ -4,12 +4,10 @@ class EnvironmentVariablesController < ApplicationController
 
   def index
     scope = EnvironmentVariable.where(search_params)
+    @pagy, @environment_variables = pagy(scope, page: params[:page], items: 30)
     respond_to do |format|
-      format.html do
-        @pagy, @environment_variables = pagy(scope, page: params[:page], items: 30)
-      end
       format.json do
-        render_as_json :environment_variables, scope
+        render_as_json :environment_variables, @environment_variables, @pagy
       end
     end
   end

--- a/plugins/env/app/controllers/environment_variables_controller.rb
+++ b/plugins/env/app/controllers/environment_variables_controller.rb
@@ -6,6 +6,7 @@ class EnvironmentVariablesController < ApplicationController
     scope = EnvironmentVariable.where(search_params)
     @pagy, @environment_variables = pagy(scope, page: params[:page], items: 30)
     respond_to do |format|
+      format.html
       format.json do
         render_as_json :environment_variables, @environment_variables, @pagy
       end

--- a/test/controllers/concerns/json_pagination_test.rb
+++ b/test/controllers/concerns/json_pagination_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe "JsonPagination Integration" do
+  describe ".add_pagination_links" do
+    let(:user) { users(:admin) }
+    let(:json) { JSON.parse(@response.body) }
+
+    before { stub_session_auth }
+
+    it "renders without links" do
+      get '/locks.json'
+      assert_response :success
+      json.keys.must_equal ['locks']
+    end
+
+    describe "with pagination" do
+      before do
+        Command.delete_all
+        7.times { |x| Command.create(command: "echo #{x}") }
+      end
+
+      it "renders with links" do
+        get '/commands.json', params: {per_page: 2}
+        json.keys.must_equal ['links', 'commands']
+        json['links']['last'].must_equal "/commands.json?page=4&per_page=2"
+        json['links']['next'].must_equal "/commands.json?page=2&per_page=2"
+      end
+
+      it "render with all links" do
+        get '/commands.json', params: {per_page: 2, page: 2}
+        json['links']['last'].must_equal "/commands.json?page=4&per_page=2"
+        json['links']['next'].must_equal "/commands.json?page=3&per_page=2"
+        json['links']['first'].must_equal "/commands.json?page=1&per_page=2"
+        json['links']['prev'].must_equal "/commands.json?page=1&per_page=2"
+      end
+
+      it "includes pagination headers" do
+        get '/commands.json', params: {per_page: 2, page: 2}
+        headers = @response.headers
+        headers["X-PER-PAGE"].must_equal 2
+        headers["X-CURRENT-PAGE"].must_equal 2
+        headers["X-TOTAL-PAGES"].must_equal 4
+        headers["X-TOTAL-RECORDS"].must_equal 7
+      end
+
+      it "includes links only if needed" do
+        get '/commands.json'
+        json.keys.must_equal ['commands']
+        headers = @response.headers
+        headers["X-TOTAL-PAGES"].must_equal 1
+      end
+    end
+  end
+end

--- a/test/controllers/concerns/json_renderer_test.rb
+++ b/test/controllers/concerns/json_renderer_test.rb
@@ -74,6 +74,12 @@ describe "JsonRenderer Integration" do
       )
     end
 
+    it "render with pagination links" do
+      get '/commands.json', params: {per_page: 1}
+      assert_response :success
+      json.keys.must_equal ['links', 'commands']
+    end
+
     describe '.allowed_inlines' do
       before do
         EnvironmentVariable.create!(name: 'FOO', value: 'bar', parent: projects(:test))


### PR DESCRIPTION
## Description
  We have pagination for Json API, but we don't have enough details in JSON API to perform pagination, along with this story, I have added addition details like `links` and `headers` for pagination.
<img width="553" alt="Screen Shot 2019-05-17 at 10 38 58 AM" src="https://user-images.githubusercontent.com/1404500/57947916-163bf880-7895-11e9-8b04-5919ebf98b3c.png">
<img width="554" alt="Screen Shot 2019-05-17 at 10 49 18 AM" src="https://user-images.githubusercontent.com/1404500/57947922-19cf7f80-7895-11e9-9461-5f28b821ce83.png">

### Risks
- Level: Low