### PR TITLE
Do not allow using a Deployment without spec.selector which would fal…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -104,6 +104,7 @@ module Kubernetes
 
     # template_filler.rb sets name for everything except for IMMUTABLE_NAME_KINDS, keep_name, and Service
     # we make sure users dont use the same name on the same kind twice, to avoid them overwriting each other
+    # if they run in the default namespace
     def validate_name_kinds_are_unique
       # do not validate on global since we hope to be on namespace soon
       return if !@project || !@project.override_resource_names?
@@ -140,7 +141,7 @@ module Kubernetes
         kind = resource[:kind]
 
         label_paths = metadata_paths(resource).map { |p| p + [:labels] } +
-          if resource.dig(:spec, :selector, :matchLabels)
+          if resource.dig(:spec, :selector, :matchLabels) || resource[:kind] == "Deployment"
             [[:spec, :selector, :matchLabels]]
           elsif resource.dig(:spec, :selector) && !allow_selector_cross_match?(resource)
             [[:spec, :selector]]

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -509,6 +509,14 @@ describe Kubernetes::RoleValidator do
         role.last[:spec][:selector][:project] = 'other'
         errors.must_include error_message
       end
+
+      it "reports deployments without selector, which would default to all labels (like team)" do
+        role.first[:spec].delete :selector
+        errors.must_equal [
+          "Missing project or role for Deployment spec.selector.matchLabels",
+          error_message
+        ]
+      end
     end
 
     describe "#validate_host_volume_paths" do


### PR DESCRIPTION
…l back to all metadata.labels

could be changing labels like team etc that would make re-deploys fail

@zendesk/compute 