### PR TITLE
allow ignoring checks that never report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,8 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 
 # RELEASE_TAG_IN_REPO_RETRIES=10 # how often to retry finding a tag after it is released to github
 
+# IGNORE_PENDING_COMMIT_CHECKS=Foo,Bar # commit status
+
 ## Plugin: NewRelic
 # report performance stats see https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration
 # NEW_RELIC_LICENSE_KEY=

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -23,6 +23,7 @@ class CommitStatus
       }
     ]
   }.freeze
+  IGNORE_PENDING_CHECKS = ENV["IGNORE_PENDING_COMMIT_CHECKS"].to_s.split(",").freeze
 
   def initialize(project, reference, stage: nil)
     @project = project
@@ -99,6 +100,7 @@ class CommitStatus
   def pending_check_statuses(check_suites, checks)
     reported = checks[:check_runs].map { |c| c.dig_fetch(:check_suite, :id) }
     pending_suites = check_suites.reject { |s| reported.include?(s.fetch(:id)) }
+    pending_suites.reject! { |s| IGNORE_PENDING_CHECKS.include?(s.dig(:app, :name)) }
     pending_suites.map do |suite|
       name = suite.dig_fetch(:app, :name)
       {

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -389,6 +389,13 @@ describe CommitStatus do
         )
       end
 
+      it "does not show pending suites that are unreliable/unimportant" do
+        stub_const CommitStatus, :IGNORE_PENDING_CHECKS, ["My App"] do
+          stub_github_api(check_run_url, check_runs: [])
+          status.statuses.map { |s| s[:description].first(22) }.must_equal ["No status was reported"]
+        end
+      end
+
       it 'shows pending suites without PRs' do
         stub_github_api(
           check_suite_url, check_suites: [{


### PR DESCRIPTION
every deploy shows this error `pending: Check "Codecov" has not reported yet`
because codecov registered their check for all repos and they did not respond within ~3 weeks with a solution ... so ignoring them when it's pending since even if the status will come later it is not important enough to block a deploy and we finally get some nice green deploy statuses ... instead of alert fatigue

@zendesk/compute 
/cc @zendesk/samson 