### PR TITLE
do not declare the check status pending when the suite was pending bu…

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -76,31 +76,34 @@ class CommitStatus
     preview_header = {Accept: 'application/vnd.github.antiope-preview+json'}
 
     check_suites = GITHUB.get("#{base_url}/check-suites", headers: preview_header).to_attrs.fetch(:check_suites)
-    checks = GITHUB.get("#{base_url}/check-runs", headers: preview_header).to_attrs
+    check_runs = GITHUB.get("#{base_url}/check-runs", headers: preview_header).to_attrs.fetch(:check_runs)
+
+    # ignore pending unimportant
+    check_suites.reject! do |s|
+      check_state(s[:conclusion]) == "pending" && IGNORE_PENDING_CHECKS.include?(s.dig(:app, :name))
+    end
 
     overall_state = check_suites.
-      map { |suite| check_state_equivalent(suite[:conclusion]) }.
+      map { |suite| check_state(suite[:conclusion]) }.
       max_by { |state| STATE_PRIORITY.index(state.to_sym) }
 
-    statuses = checks[:check_runs].map do |check_run|
+    statuses = check_runs.map do |check_run|
       {
-        state: check_state_equivalent(check_run[:conclusion]),
+        state: check_state(check_run[:conclusion]),
         description: ApplicationController.helpers.markdown(check_run[:output][:summary]),
         context: check_run[:name],
         target_url: check_run[:html_url],
         updated_at: check_run[:started_at]
       }
     end
-
-    statuses += pending_check_statuses(check_suites, checks)
+    statuses += missing_check_runs_as_status(check_suites, check_runs)
 
     {state: overall_state || 'pending', statuses: statuses}
   end
 
-  def pending_check_statuses(check_suites, checks)
-    reported = checks[:check_runs].map { |c| c.dig_fetch(:check_suite, :id) }
+  def missing_check_runs_as_status(check_suites, check_runs)
+    reported = check_runs.map { |c| c.dig_fetch(:check_suite, :id) }
     pending_suites = check_suites.reject { |s| reported.include?(s.fetch(:id)) }
-    pending_suites.reject! { |s| IGNORE_PENDING_CHECKS.include?(s.dig(:app, :name)) }
     pending_suites.map do |suite|
       name = suite.dig_fetch(:app, :name)
       {
@@ -130,7 +133,7 @@ class CommitStatus
     end
   end
 
-  def check_state_equivalent(check_conclusion)
+  def check_state(check_conclusion)
     case check_conclusion
     when *CHECK_STATE[:success] then 'success'
     when *CHECK_STATE[:error] then 'error'


### PR DESCRIPTION
…t the run was ignored

with the last PR https://github.com/zendesk/samson/pull/3377  we ignored the bad check-run, but the suite was still marked as pending and gave us an empty alert box popup ... fixing that by ignoring the pending suite and therefore not creating a pending run in the first place


@zendesk/compute
/cc @zendesk/samson
