### PR TITLE
PAAS-3357 add kritis breakglass option

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_14_231932) do
+ActiveRecord::Schema.define(version: 2019_05_28_173915) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -218,6 +218,7 @@ ActiveRecord::Schema.define(version: 2019_05_14_231932) do
     t.string "encrypted_client_key_iv"
     t.string "encryption_key_sha"
     t.boolean "verify_ssl", default: false, null: false
+    t.boolean "kritis_breakglass", default: false, null: false
   end
 
   create_table "kubernetes_deploy_group_roles", id: :integer do |t|

--- a/plugins/kubernetes/app/controllers/kubernetes/clusters_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/clusters_controller.rb
@@ -40,6 +40,7 @@ class Kubernetes::ClustersController < ResourceController
     params = super.permit(
       :name, :config_filepath, :config_context, :description, :ip_prefix,
       :auth_method, :api_endpoint, :verify_ssl, :client_cert, :client_key,
+      :kritis_breakglass,
       deploy_group_ids: []
     )
     params.delete_if { |_, v| v == HIDDEN }

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -53,6 +53,7 @@ module Kubernetes
           set_image_pull_secrets
           set_resource_blue_green if blue_green_color
           set_init_containers
+          set_kritis_breakglass
         elsif kind == 'PodDisruptionBudget'
           set_name
           set_match_labels_blue_green if blue_green_color
@@ -405,6 +406,12 @@ module Kubernetes
 
     def project
       @project ||= @doc.kubernetes_release.project
+    end
+
+    def set_kritis_breakglass
+      return unless @doc.deploy_group.kubernetes_cluster.kritis_breakglass
+      template.dig_fetch(:metadata, :labels)[:"kritis.grafeas.io/tutorial"] = ""
+      template.dig_fetch(:metadata, :annotations)[:"kritis.grafeas.io/breakglass"] = "true"
     end
 
     # custom annotation we support here and in kucodiff

--- a/plugins/kubernetes/app/views/kubernetes/clusters/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/_form.html.erb
@@ -13,6 +13,8 @@
           help: "First 1 to 3 sections of an IPv4 address to replace Service clusterIP, for example 123.231"
       %>
 
+      <%= form.input :kritis_breakglass, as: :check_box, help: "Make all resources skip kritis" %>
+
       <%= form.input :auth_method do %>
         <%= form.select :auth_method, ["context", "database"] %>
       <% end %>

--- a/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
@@ -22,6 +22,15 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <label class="col-lg-2 control-label">
+      Kritis Breakglass
+    </label>
+    <div class="col-lg-4">
+      <p class="form-control-static"><%= @kubernetes_cluster.kritis_breakglass ? "YES" : "NO" %></p>
+    </div>
+  </div>
+
   <% case @kubernetes_cluster.auth_method %>
   <% when "context" %>
     <div class="form-group">

--- a/plugins/kubernetes/db/migrate/20190528173915_add_kritis_breakglass.rb
+++ b/plugins/kubernetes/db/migrate/20190528173915_add_kritis_breakglass.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddKritisBreakglass < ActiveRecord::Migration[5.2]
+  def change
+    add_column :kubernetes_clusters, :kritis_breakglass, :boolean, default: false, null: false
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -244,7 +244,7 @@ describe Kubernetes::Cluster do
       cluster.as_json.keys.must_equal(
         [
           "id", "name", "description", "config_filepath", "config_context", "created_at", "updated_at", "ip_prefix",
-          "auth_method", "api_endpoint", "verify_ssl"
+          "auth_method", "api_endpoint", "verify_ssl", "kritis_breakglass"
         ]
       )
     end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -965,6 +965,25 @@ describe Kubernetes::TemplateFiller do
         e.message.must_equal "Unable to set key samson/set_via_env_json-spec.foo: KeyError key not found: \"FOO\""
       end
     end
+
+    describe "set_kritis_breakglass" do
+      it "does not add by default" do
+        template.to_hash[:metadata][:labels].keys.must_equal [:project, :role]
+      end
+
+      describe "when requested" do
+        before { doc.deploy_group.kubernetes_cluster.update_column(:kritis_breakglass, true) }
+
+        it "adds when requested" do
+          template.to_hash[:metadata][:labels].keys.must_equal [:project, :role, :"kritis.grafeas.io/tutorial"]
+        end
+
+        it "does not add to non-runnables" do
+          raw_template[:kind] = "Service"
+          template.to_hash[:metadata][:labels].keys.must_equal [:project, :role]
+        end
+      end
+    end
   end
 
   describe "#verify" do


### PR DESCRIPTION

![Screen Shot 2019-05-28 at 10 55 12 AM](https://user-images.githubusercontent.com/11367/58500625-6473b600-8137-11e9-8799-a4fe1071e5fe.png)
![Screen Shot 2019-05-28 at 10 52 13 AM](https://user-images.githubusercontent.com/11367/58500627-6473b600-8137-11e9-8786-ae3e2f554573.png)


```
- apiVersion: extensions/v1beta1
  kind: Deployment
  metadata:
    name: example-server
    labels:
      project: example
      role: server
      team: foo
      kritis.grafeas.io/tutorial: ''
    namespace: sdfsfsfs
    annotations:
      samson/deploy_url: http://localhost:3000/projects/example-kubernetes/deploys/515
      kritis.grafeas.io/breakglass: 'true'
```

@zendesk/compute 
/cc @zendesk/samson 