### PR TITLE
Add `{include_hidden: false}` option to reject first blank value

### DIFF
--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -9,7 +9,7 @@
     <%= form.input :manager_email, as: :email_field, required: true %>
     <%= form.input :reason, as: :text_area, required: true %>
     <%= form.input :project_ids, label: 'Projects', required: true do %>
-      <%= form.select :project_ids, @projects.pluck(:name, :id), {}, multiple: true, **Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
+      <%= form.select :project_ids, @projects.pluck(:name, :id), {include_hidden: false}, multiple: true, **Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
     <% end %>
     <%= form.input :role_id, required: true do %>
       <%= select_tag 'access_request[role_id]', options_from_collection_for_select(@roles, :id, :display_name),


### PR DESCRIPTION
## Fix https://samson.zende.sk/access_requests/new

Posting access_requests form fails, because the form generates a list empty first item in `project_ids` array.

### Reason

As https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/select says:

![image](https://user-images.githubusercontent.com/1061118/58535768-42566280-8221-11e9-91f5-93147b89c690.png)

### Before and After Change

**Before change:**

Params received before change:

```
{"utf8"=>"✓", "authenticity_token"=>"5ppTfqSZGb3QUc1uHE858wZlVVdHdBO9OFVlWcLF6Z2afoBF3HQNPtAJeqmjh8ZTlQ8Woj0+EicPZleYFnx/4A==", "redirect_to"=>"/profile", "access_request"=>{"manager_email"=>"munishapc@gmail.com", "reason"=>"some reason", "project_ids"=>["", "1"], "role_id"=>"1"}, "commit"=>"Save", "controller"=>"access_requests", "action"=>"create"}
```

Notice empty value in `project_ids`.

**After change:**

Params received after change:

```
{"utf8"=>"✓", "authenticity_token"=>"ewkeCZ2uQJHsRoD6CdQ84SPiKIpf/bM5jpaGdEPqVF8H7c0y5UNUEuweNz22HMNBsIhrfyW3sqO5pbS1l1PCIg==", "redirect_to"=>"/profile", "access_request"=>{"manager_email"=>"munishapc@gmail.com", "reason"=>"some reason", "project_ids"=>["1"], "role_id"=>"0"}, "commit"=>"Save", "controller"=>"access_requests", "action"=>"create"}
```

Notice `project_ids`

**What if no project is selected?**

You get validation error:

![image](https://user-images.githubusercontent.com/1061118/58536135-3f0fa680-8222-11e9-9aa7-b95db07960e6.png)

cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/BRE-1715

### Risks
- Level: Low: The request access might not still work
