### PR TITLE
set requests and limits so secret-puller does not get oomkkilled

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -262,7 +262,11 @@ module Kubernetes
           {name: "VAULT_TLS_VERIFY", value: vault_client.options.fetch(:ssl_verify).to_s},
           {name: "VAULT_MOUNT", value: Samson::Secrets::VaultClientManager::MOUNT},
           {name: "VAULT_PREFIX", value: Samson::Secrets::VaultClientManager::PREFIX}
-        ]
+        ],
+        resources: {
+          requests: {cpu: "100m", memory: "100M"},
+          limits: {cpu: "500m", memory: "256M"}
+        }
       }
       init_containers.unshift container
 


### PR DESCRIPTION
@zendesk/compute 
100 was too little and 200 was enough

```
    lastState:
      terminated:
        exitCode: 137
        reason: OOMKilled
    name: secret-puller
    ready: false
    restartCount: 2
```