### PR TITLE
render yaml flat as kubernetes does it / our config files do it

### DIFF
--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_tab_body.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_tab_body.html.erb
@@ -8,7 +8,7 @@
       <% release.release_docs.sort_by { |rd| DeployGroup.with_deleted{ rd.deploy_group&.name_sortable }}.each do |release_doc| %>
         <div>
           <h3><%= release_doc.deploy_group.name %> - <%= link_to release_doc.kubernetes_role.name, [@project, release_doc.kubernetes_role] %></h3>
-          <pre><%= release_doc.resource_template.map(&:deep_stringify_keys).to_yaml %></pre>
+          <pre><%= release_doc.resource_template.map(&:deep_stringify_keys).map(&:to_yaml).join("\n") %></pre>
         </div>
       <% end %>
     <% else %>


### PR DESCRIPTION
@zendesk/compute 

<img width="514" alt="Screen Shot 2019-05-30 at 8 50 51 AM" src="https://user-images.githubusercontent.com/11367/58645408-29e55700-82b8-11e9-84ec-1e35cd2c9344.png">
