### PR TITLE
keep file diff additions/deletions aligned even if we have long renames

### DIFF
--- a/app/views/changeset/_files.html.erb
+++ b/app/views/changeset/_files.html.erb
@@ -8,9 +8,11 @@
     <tbody>
     <% changeset.files.each do |file| %>
       <tr class="file-summary">
+        <td><%= file_status_label file.status %></td>
         <td>
-          <%= file_status_label file.status %> &nbsp;
-          <%= "#{file.previous_filename} → " if file.status == "renamed" %>
+          <% if file.status == "renamed" %>
+            <%= file.previous_filename %> → <br/>
+          <% end %>
           <%= file.filename %>
         </td>
         <td align="right">
@@ -19,7 +21,7 @@
         </td>
       </tr>
       <tr class="file-diff" style="display:none">
-        <td colspan="2"><pre><%= syntax_highlight file.patch, :diff %></pre></td>
+        <td colspan="3"><pre><%= syntax_highlight file.patch, :diff %></pre></td>
       </tr>
     <% end %>
     </tbody>


### PR DESCRIPTION
reproduce: deploy example-kubernetes 71f4147 then grosser/diff

before:
![image](https://user-images.githubusercontent.com/11367/58834416-32b39100-8608-11e9-9af5-0d354d6464b7.png)

after:
![Screen Shot 2019-06-03 at 1 59 47 PM](https://user-images.githubusercontent.com/11367/58834427-3810db80-8608-11e9-8334-5db9735192d4.png)

@zendesk/compute 