### PR TITLE
PAAS-3493 enforce requests/limits on all containers that samson is not filling …

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -379,6 +379,7 @@ module Kubernetes
       end
     end
 
+    # keep in sync with RoleValidator#validate_container_resources
     def set_resource_usage
       containers.first[:resources] = {
         requests: {cpu: @doc.requests_cpu.to_f, memory: "#{@doc.requests_memory}M"},


### PR DESCRIPTION
…out to avoid swap/oomkill etc issues

this will fail a few deploys, so I'll search for them first and try to fix them before merging

@zendesk/compute @zendesk/samson 

```ruby
bad = []
Kubernetes::Role.find_each do |role|
  next unless project = role.project
  next if role.config_file.blank?
  puts "#{project.permalink} #{role.config_file}"
  begin
    # NOTE: this might be out of date since we cannot trigger pulls from the console
    next unless content = project.repository.file_content(role.config_file, "master", pull: false)
    elements = Array.wrap(Kubernetes::Util.parse_file(content, role.config_file)).compact.map(&:deep_symbolize_keys)
    elements.each do |e|
      templates = [e, e.dig(:spec, :template), e.dig(:spec, :jobTemplate, :spec, :template)].compact
      containers = templates.flat_map do |t|
        all = ((t.dig(:spec, :containers) || [])[1..-1] || []) + (t.dig(:spec, :initContainers) || [])
        if json = t.dig(:metadata, :annotations, :"pod.beta.kubernetes.io/init-containers")
          all += JSON.parse(json, symbolize_names: true)
        end
        all
      end.flatten

      containers.each do |c|
        [
          [:resources, :requests, :cpu],
          [:resources, :requests, :memory],
          [:resources, :limits, :cpu],
          [:resources, :limits, :memory],
        ].each do |path|
          next if c.dig(*path)
          name = c[:name] || c[:image] || "unknown"
          bad << [role, c]
          puts "BAD #{project.permalink} #{role.config_file} #{name} is missing #{path.join(".")}"
        end
      end
    end
  rescue => e
    puts "Error #{e}"
    bad << [role]
  end
end
```