### PR TITLE
PAAS-3552 allow setting values via env that exceed 64 char limit

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -219,15 +219,19 @@ This can be useful for Migrations (see above).
 
 ### Changing templates via ENV
 
-For custom things that need to be different between environments/deploy-groups.
+For things that need to be different between environments/deploy-groups.
 
 Use an annotation to configure what will to be replaced:
 ```
-metadata.annotations.samson/set_via_env_json-metadata.labels.custom: SOME_ENV_VAR
-or for paths failing dns name validations:
-metadata.annotations.samson-set-via-env-json-metadata.labels.custom: SOME_ENV_VAR
+metadata.annotations.samson/set_via_env_json: |
+  metadata.labels.custom: FOO_ENV_VAR
+  metadata.labels.other: BAR_ENV_VAR
 ```
+
 Then configure an ENV var with that same name and a value that is valid JSON.
+
+ - To set string values as env vars, use quotes, i.e. `"foo"`
+ - To set values inside of arrays use numbers as index `spec.containers.0.name`
 
 ### Allow randomly not-ready pods during readiness check
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -915,6 +915,13 @@ describe Kubernetes::TemplateFiller do
         template.to_hash[:spec][:foo].must_equal "bar"
       end
 
+      it "supports yaml for long names above 64 chars limit" do
+        raw_template[:metadata][:annotations] = {
+          "samson/set_via_env_json": "spec.foo: FOO"
+        }
+        template.to_hash[:spec][:foo].must_equal "bar"
+      end
+
       it "sets podless roles" do
         raw_template[:spec] = {}
         template.to_hash[:spec][:foo].must_equal "bar"
@@ -947,7 +954,7 @@ describe Kubernetes::TemplateFiller do
         }
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
         e.message.must_equal(
-          "Unable to set key samson/set_via_env_json-foo.bar.foo: KeyError key not found: [:foo, :bar]"
+          "Unable to set path foo.bar.foo: KeyError key not found: [:foo, :bar]"
         )
       end
 
@@ -955,14 +962,14 @@ describe Kubernetes::TemplateFiller do
         environment.update_column(:value, 'foo')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
         e.message.must_equal(
-          "Unable to set key samson/set_via_env_json-spec.foo: JSON::ParserError 765: unexpected token at 'foo'"
+          "Unable to set path spec.foo: JSON::ParserError 765: unexpected token at 'foo'"
         )
       end
 
       it "fails nicely with env is missing" do
         environment.update_column(:name, 'BAR')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
-        e.message.must_equal "Unable to set key samson/set_via_env_json-spec.foo: KeyError key not found: \"FOO\""
+        e.message.must_equal "Unable to set path spec.foo: KeyError key not found: \"FOO\""
       end
     end
 


### PR DESCRIPTION
```
samson/set_via_env_json-spec.metrics.0.external.metricSelector.matchLabels.kube_cluster": name part must be no more than 63 characters
```
keeping the old code but removing it from the docs so we only use 1 way going forward

@zendesk/compute 
/cc @nayena 