### PR TITLE
wip: git cmd timeout from ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,8 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 
 # RELEASE_TAG_IN_REPO_RETRIES=10 # how often to retry finding a tag after it is released to github
 
+# GIT_CMD_TIMEOUT=1800 # how long to wait on git commands, default to 10 minutes.
+
 # IGNORE_PENDING_COMMIT_CHECKS=Foo,Bar # commit status
 
 ## Plugin: NewRelic

--- a/test/models/git_repository_test.rb
+++ b/test/models/git_repository_test.rb
@@ -437,4 +437,24 @@ describe GitRepository do
       c.must_equal 1
     end
   end
+
+  describe "#timeout" do
+    it "defaults to 600 seconds" do
+      TerminalExecutor.any_instance.expects(:execute).with(
+        "git -c core.askpass=true clone --mirror #{project.repository_url} #{repository.repo_cache_dir}",
+        timeout: 600
+      ).returns true
+      assert repository.send(:clone!)
+    end
+
+    it "uses GIT_CMD_TIMEOUT" do
+      with_env GIT_CMD_TIMEOUT: '1800' do
+        TerminalExecutor.any_instance.expects(:execute).with(
+          "git -c core.askpass=true clone --mirror #{project.repository_url} #{repository.repo_cache_dir}",
+          timeout: 1800
+        ).returns true
+        assert repository.send(:clone!)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Most of the git commands like clone, fetch, sync..etc has default 5 sec timeout, which is not enough to perform those operations.
Added ENV to customize the timeout limit for git cmds.
It was also triggers errors:
https://rollbar-us.zendesk.com/Zendesk/Samson/items/1326/
