### PR TITLE
fix ValidatingWebhookConfiguration not being deployable because it do…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -5,10 +5,33 @@ module Kubernetes
     # not perfect since the actual rules are stricter
     VALID_LABEL_VALUE = /\A[a-zA-Z0-9]([-a-zA-Z0-9.]*[a-zA-Z0-9])?\z/.freeze # also used in js ... cannot use /i
 
+    # TODO: lookup dynamically
     NAMESPACELESS_KINDS = [
-      'APIService', 'ClusterRoleBinding', 'ClusterRole', 'CustomResourceDefinition', 'Namespace', 'PodSecurityPolicy',
+      'ComponentStatus',
+      'Namespace',
+      'Node',
+      'PersistentVolume',
+      'MutatingWebhookConfiguration',
+      'ValidatingWebhookConfiguration',
+      'CustomResourceDefinition',
+      'APIService',
+      'TokenReview',
+      'SelfSubjectAccessReview',
+      'SelfSubjectRulesReview',
+      'SubjectAccessReview',
+      'CertificateSigningRequest',
+      'PodSecurityPolicy',
+      'NodeMetrics',
+      'PodSecurityPolicy',
+      'ClusterRoleBinding',
+      'ClusterRole',
+      'PriorityClass',
+      'StorageClass',
+      'VolumeAttachment',
       'ValidatingWebhookConfiguration'
     ].freeze
+
+    # for non-namespace deployments: names that should not be changed since they will break dependencies
     IMMUTABLE_NAME_KINDS = [
       'APIService', 'CustomResourceDefinition', 'ConfigMap', 'Role', 'ClusterRole', 'Namespace', 'PodSecurityPolicy',
       'ClusterRoleBinding'

--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -6,7 +6,8 @@ module Kubernetes
     VALID_LABEL_VALUE = /\A[a-zA-Z0-9]([-a-zA-Z0-9.]*[a-zA-Z0-9])?\z/.freeze # also used in js ... cannot use /i
 
     NAMESPACELESS_KINDS = [
-      'APIService', 'ClusterRoleBinding', 'ClusterRole', 'CustomResourceDefinition', 'Namespace', 'PodSecurityPolicy'
+      'APIService', 'ClusterRoleBinding', 'ClusterRole', 'CustomResourceDefinition', 'Namespace', 'PodSecurityPolicy',
+      'ValidatingWebhookConfiguration'
     ].freeze
     IMMUTABLE_NAME_KINDS = [
       'APIService', 'CustomResourceDefinition', 'ConfigMap', 'Role', 'ClusterRole', 'Namespace', 'PodSecurityPolicy',


### PR DESCRIPTION
…es not have a namespace

longterm fix is to stop keeping a list an actually checking against the api :/

```
[15:49:08] JobExecution failed: Kubernetes error foo bar the server could not find the requested resource

```

@zendesk/compute 