### PR TITLE
say that tagged images are unsupported and stop requesting them from …

### DIFF
--- a/plugins/gcloud/lib/samson_gcloud/image_scanner.rb
+++ b/plugins/gcloud/lib/samson_gcloud/image_scanner.rb
@@ -5,8 +5,9 @@ module SamsonGcloud
     SUCCESS = 1
     FOUND = 2
     ERROR = 3
+    UNSUPPORTED = 4
 
-    FINISHED = [SUCCESS, FOUND].freeze
+    FINISHED = [SUCCESS, FOUND, UNSUPPORTED].freeze
 
     class << self
       # found by inspecting
@@ -22,25 +23,28 @@ module SamsonGcloud
       end
 
       def result_url(image)
-        return unless image && digest_base = image.split(SamsonGcloud.project, 2)[1]
+        return unless digest_base = digest_base(image)
         "https://console.cloud.google.com/gcr/images/#{SamsonGcloud.project}/GLOBAL#{digest_base}/details/vulnz"
       end
 
       def status(id)
         case id
-        when WAITING
-          "Waiting for Vulnerability scan"
-        when SUCCESS
-          "No vulnerabilities found"
-        when FOUND
-          "Vulnerabilities found"
-        when ERROR
-          "Error retrieving vulnerabilities"
-        else raise
+        when WAITING then "Waiting for Vulnerability scan"
+        when SUCCESS then "No vulnerabilities found"
+        when FOUND then "Vulnerabilities found"
+        when ERROR then "Error retrieving vulnerabilities"
+        when UNSUPPORTED then "Only full gcr repos with shas are supported for scanning"
+        else raise "Unknown id #{id}"
         end
       end
 
       private
+
+      def digest_base(image)
+        return unless image
+        return unless image.include? "@" # only scanning shas is supported, not tags
+        image.split(SamsonGcloud.project, 2)[1]
+      end
 
       # gcr only offers one endpoint that returns both "scan is finished" events (discovery) and
       # "vulnerability found" events (package vulnerability).
@@ -49,7 +53,7 @@ module SamsonGcloud
       # NOTE: If we could guarantee ordering we could make a single request for
       # "(kind=\"DISCOVERY\" OR kind=\"PACKAGE_VULNERABILITY\")"
       def uncached_scan(image)
-        return ERROR unless image.include? SamsonGcloud.project
+        return UNSUPPORTED unless digest_base(image)
         return ERROR unless result = request(image, "occurrences", "kind=\"DISCOVERY\"")
 
         status = result.dig("occurrences", 0, "discovered", "discovered", "analysisStatus")

--- a/plugins/gcloud/lib/samson_gcloud/samson_plugin.rb
+++ b/plugins/gcloud/lib/samson_gcloud/samson_plugin.rb
@@ -26,7 +26,9 @@ module SamsonGcloud
 
       success = (status == SamsonGcloud::ImageScanner::SUCCESS)
       message = SamsonGcloud::ImageScanner.status(status)
-      message += ", see #{SamsonGcloud::ImageScanner.result_url(build.docker_repo_digest)}" unless success
+      if !success && url = SamsonGcloud::ImageScanner.result_url(build.docker_repo_digest)
+        message += ", see #{url}"
+      end
       output.puts message
 
       success || scan_optional
@@ -37,13 +39,13 @@ module SamsonGcloud
 
       status = SamsonGcloud::ImageScanner.scan(image)
       return if status == SamsonGcloud::ImageScanner::SUCCESS
+      result = SamsonGcloud::ImageScanner.status(status)
 
       message =
         if url = SamsonGcloud::ImageScanner.result_url(image)
-          result = SamsonGcloud::ImageScanner.status(status)
           "GCR scan result: #{result} for #{url}"
         else
-          "Image needs to be hosted on GCR to be scanned for vulnerabilities: #{image}."
+          "#{result}: #{image}"
         end
 
       raise Samson::Hooks::UserError, message

--- a/plugins/gcloud/test/samson_gcloud/image_scanner_test.rb
+++ b/plugins/gcloud/test/samson_gcloud/image_scanner_test.rb
@@ -6,7 +6,7 @@ SingleCov.covered!
 describe SamsonGcloud::ImageScanner do
   with_env GCLOUD_ACCOUNT: 'acc', GCLOUD_PROJECT: 'proj'
 
-  let(:image) { 'foo.com/proj/image' }
+  let(:image) { 'foo.com/proj/image@sha256:abcdef' }
 
   describe ".scan" do
     def assert_done(status = "FINISHED_SUCCESS")
@@ -75,9 +75,14 @@ describe SamsonGcloud::ImageScanner do
       SamsonGcloud::ImageScanner.scan("https://#{image}").must_equal SamsonGcloud::ImageScanner::WAITING
     end
 
-    it "shows error when image is not scannable" do
+    it "shows unsupported when image is not scannable because it is from another project" do
       Samson::CommandExecutor.unstub(:execute)
-      SamsonGcloud::ImageScanner.scan('foo_image').must_equal SamsonGcloud::ImageScanner::ERROR
+      SamsonGcloud::ImageScanner.scan('foo_image').must_equal SamsonGcloud::ImageScanner::UNSUPPORTED
+    end
+
+    it "shows unsupported when image is not scannable because it is not a sha" do
+      Samson::CommandExecutor.unstub(:execute)
+      SamsonGcloud::ImageScanner.scan(image.split('@').first).must_equal SamsonGcloud::ImageScanner::UNSUPPORTED
     end
 
     it "caches final results" do
@@ -107,7 +112,7 @@ describe SamsonGcloud::ImageScanner do
     end
 
     it "can scan images that include gcloud projects twice" do
-      SamsonGcloud::ImageScanner.result_url("#{image}/proj/bar").must_include "GLOBAL/image/proj/bar/details"
+      SamsonGcloud::ImageScanner.result_url("#{image}/proj/bar").must_include ":abcdef/proj/bar/details/"
     end
   end
 
@@ -117,6 +122,7 @@ describe SamsonGcloud::ImageScanner do
       SamsonGcloud::ImageScanner.status(1).must_equal "No vulnerabilities found"
       SamsonGcloud::ImageScanner.status(2).must_equal "Vulnerabilities found"
       SamsonGcloud::ImageScanner.status(3).must_equal "Error retrieving vulnerabilities"
+      SamsonGcloud::ImageScanner.status(4).must_equal "Only full gcr repos with shas are supported for scanning"
     end
 
     it "raises on invalid status" do


### PR DESCRIPTION
…the api

sadly there is no nice api to resolve tags to shas, so for now let's declare them unresolvable instead of making futile requests and throwing errors

```
JobExecution failed: GCR scan result: Error retrieving vulnerabilities for <URL>
```

now it fails with
```
JobExecution failed: GCR scan result: Only full gcr repos with shas are supported for scanning for 
```

@zendesk/samson @zendesk/compute 