### PR TITLE
Deploy resources in kind order

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -367,7 +367,7 @@ module Kubernetes
           [release_doc]
         end
       end
-      Samson::Parallelizer.map(resources, db: true, &:deploy)
+      resources.map(&:deploy)
     end
 
     def deploy_and_watch(release_docs, timeout:)

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -43,12 +43,18 @@ module Kubernetes
     end
 
     def resources
-      @resources ||= resource_template.map do |t|
-        Kubernetes::Resource.build(
-          t, deploy_group,
-          autoscaled: kubernetes_role.autoscaled,
-          delete_resource: delete_resource
-        )
+      @resources ||= begin
+        resources = resource_template.map do |t|
+          Kubernetes::Resource.build(
+            t, deploy_group,
+            autoscaled: kubernetes_role.autoscaled,
+            delete_resource: delete_resource
+          )
+        end
+        resources.sort_by do |r|
+          Kubernetes::RoleConfigFile::DEPLOY_SORT_ORDER.index(r.kind) ||
+            Kubernetes::RoleConfigFile::DEPLOY_SORT_ORDER.size # default to maximum value
+        end
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -6,6 +6,37 @@ module Kubernetes
   class RoleConfigFile
     attr_reader :path, :elements
 
+    # from https://github.com/helm/helm/blob/release-2.13/pkg/tiller/kind_sorter.go#L29
+    DEPLOY_SORT_ORDER = [
+      "Namespace",
+      "ResourceQuota",
+      "LimitRange",
+      "PodSecurityPolicy",
+      "PodDisruptionBudget",
+      "Secret",
+      "ConfigMap",
+      "StorageClass",
+      "PersistentVolume",
+      "PersistentVolumeClaim",
+      "ServiceAccount",
+      "CustomResourceDefinition",
+      "ClusterRole",
+      "ClusterRoleBinding",
+      "Role",
+      "RoleBinding",
+      "Service",
+      "DaemonSet",
+      "Pod",
+      "ReplicationController",
+      "ReplicaSet",
+      "Deployment",
+      "StatefulSet",
+      "Job",
+      "CronJob",
+      "Ingress",
+      "APIService",
+    ].freeze
+
     DEPLOY_KINDS = ['Deployment', 'DaemonSet', 'StatefulSet'].freeze
     SERVICE_KINDS = ['Service'].freeze
     PREREQUISITE = [:metadata, :annotations, :'samson/prerequisite'].freeze

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -212,6 +212,31 @@ describe Kubernetes::ReleaseDoc do
       doc.instance_variable_get(:@previous_resources).must_equal([nil, nil]) # will not revert
     end
 
+    it "deploys resources in DEPLOY_SORT_ORDER order" do
+      configs = YAML.load_stream(read_kubernetes_sample_file('kubernetes_rbac.yml'))
+      configs.each { |c| c['metadata']['namespace'] = 'pod1' if c['metadata']['namespace'].present? }
+      doc.send(:resource_template=, doc.resource_template + configs)
+
+      expected_request_order = [:serviceaccounts, :clusterroles, :clusterrolebindings, :services, :deployments]
+      request_order = []
+      regex = %r{
+        http://foobar.server(:80)?/apis?/
+        (extensions/|rbac.authorization.k8s.io/)?
+        v1(beta\d)?/
+        (namespaces/pod1/)?
+        (\w+)
+      }x
+      stub_request(:get, %r{#{regex}/some-project.*}).to_raise(kube_404)
+      stub_request(:post, regex).to_return do |request|
+        request_order << regex.match(request.uri)[5].to_sym
+        {body: "{}"}
+      end
+
+      doc.deploy
+      doc.instance_variable_get(:@previous_resources).must_equal([nil, nil, nil, nil, nil]) # will not revert
+      request_order.must_equal expected_request_order
+    end
+
     it "remembers the previous deploy in case we have to revert" do
       # check service ... do nothing
       stub_request(:get, service_url).to_return(body: '{"SER":"VICE"}')
@@ -223,15 +248,18 @@ describe Kubernetes::ReleaseDoc do
       client.expects(:update_deployment).returns("Rest client resonse")
 
       doc.deploy
-      doc.instance_variable_get(:@previous_resources).must_equal([{DE: "PLOY"}, {SER: "VICE"}])
+      doc.instance_variable_get(:@previous_resources).must_equal([{SER: "VICE"}, {DE: "PLOY"}])
     end
   end
 
   describe '#revert' do
     it "reverts all resources" do
-      doc.instance_variable_set(:@previous_resources, [{DE: "PLOY"}, {SER: "VICE"}])
-      doc.send(:resources)[0].expects(:revert).with(DE: "PLOY")
-      doc.send(:resources)[1].expects(:revert).with(SER: "VICE")
+      doc.instance_variable_set(:@previous_resources, [{SER: "VICE"}, {DE: "PLOY"}])
+      resources = doc.send(:resources)
+      resources.detect { |r| r.is_a? Kubernetes::Resource::Deployment }.
+        expects(:revert).with(DE: "PLOY")
+      resources.detect { |r| r.is_a? Kubernetes::Resource::Service }.
+        expects(:revert).with(SER: "VICE")
       doc.revert
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -142,9 +142,14 @@ describe Kubernetes::Release do
 
     it "scoped statefulset for previous release since they do not update their labels when using patch" do
       resource = {spec: {template: {metadata: {labels: {release_id: 123}}}}}
-      Kubernetes::Resource.expects(:build).returns(stub(
-        is_a?: true, patch_replace?: true, resource: resource, namespace: 'pod1'
-      ))
+      resource_mock = mock(
+        is_a?: true,
+        patch_replace?: true,
+        resource: resource,
+        kind: "StatefulSet",
+        namespace: 'pod1'
+      )
+      Kubernetes::Resource.expects(:build).returns(resource_mock)
       release = kubernetes_releases(:test_release)
       release.clients[0][1].must_equal namespace: "pod1", label_selector: "release_id=123,deploy_group_id=431971589"
     end

--- a/plugins/kubernetes/test/samples/kubernetes_rbac.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_rbac.yml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: some-project-service-account
+  namespace: default
+  labels:
+    project: some-project
+    role: some-role
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: some-project-role
+  labels:
+    project: some-project
+    role: some-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: some-project-role-binding
+  labels:
+    project: some-project
+    role: some-role
+subjects:
+  - kind: ServiceAccount
+    name: some-project-service-account
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: some-project-role
+  apiGroup: rbac.authorization.k8s.io

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -162,6 +162,15 @@ class ActiveSupport::TestCase
       "resources" => [
         {"name" => "customresourcedefinitions", "namespaced" => true, "kind" => "CustomResourceDefinition"}
       ]
+    },
+    "rbac.authorization.k8s.io/v1" => {
+      "kind" => "APIResourceList",
+      "resources" => [
+        {"name" => "clusterrolebindings", "namespaced" => false, "kind" => "ClusterRoleBinding"},
+        {"name" => "clusterroles", "namespaced" => false, "kind" => "ClusterRole"},
+        {"name" => "rolebindings", "namespaced" => true, "kind" => "RoleBinding"},
+        {"name" => "roles", "namespaced" => true, "kind" => "Role"}
+      ]
     }
   }.freeze
 


### PR DESCRIPTION
Deploy resources in kind order specified by https://github.com/helm/helm/blob/release-2.13/pkg/tiller/kind_sorter.go#L29

/cc @zendesk/samson

### Tasks
 - [ ] :+1: from team

### References
 - Jira link: https://zendesk.atlassian.net/browse/PAAS-3365

### Risks
- Level: Low/Med/High
