### PR TITLE
adding imagesecuritypolicy as a non-namespaced resource

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -27,7 +27,8 @@ module Kubernetes
       'ClusterRole',
       'PriorityClass',
       'StorageClass',
-      'VolumeAttachment'
+      'VolumeAttachment',
+      'ImageSecurityPolicy'
     ].freeze
 
     # for non-namespace deployments: names that should not be changed since they will break dependencies


### PR DESCRIPTION
* ImageSecurityPolicy is a Custom Resource Definition that should be scoped at the cluster level instead of the namespace. This change allows the CRD deploy via Samson without a namespace. Currently getting a 404.

/cc @zendesk/compute