### PR TITLE
hide add-stage-command when not using commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache:
     - tmp/rubocop_cache
     - node_modules
 sudo: false
+services:
+- mysql
+- postgresql
 branches:
   only: master
 env:

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -205,7 +205,7 @@ class CommitStatus
   # optimized to sql instead of AR fanciness to make it go from 1s -> 0.01s on our worst case stage
   def last_deployed_references
     last_deployed = deploy_scope.pluck(Arel.sql('max(deploys.id)'))
-    Deploy.reorder(nil).where(id: last_deployed).pluck(Arel.sql('distinct reference'))
+    Deploy.reorder(id: :asc).where(id: last_deployed).pluck(Arel.sql('distinct reference, id')).map(&:first)
   end
 
   def deploy_scope

--- a/app/views/stages/_commands.html.erb
+++ b/app/views/stages/_commands.html.erb
@@ -28,16 +28,9 @@
     <% end %>
     <%= render 'new_command' %>
   </div>
+
+  <%= button_tag 'Add Stage Command', class: 'btn btn-primary stage-command-button', type: 'button' %>
 </fieldset>
-
-<hr/>
-
-<%= button_tag(
-      'Add Stage Command',
-      class: 'btn btn-primary stage-command-button',
-      type: 'button'
-    )
-%>
 
 <script>
   $(function() {


### PR DESCRIPTION
when nit using commands button is gone:
<img width="691" alt="Screen Shot 2019-06-12 at 8 50 03 AM" src="https://user-images.githubusercontent.com/11367/59366529-4c7f6300-8cef-11e9-8245-3d432e7e00a4.png">
when using commands button is there:
<img width="553" alt="Screen Shot 2019-06-12 at 8 50 37 AM" src="https://user-images.githubusercontent.com/11367/59366538-5012ea00-8cef-11e9-9389-2e954175f07b.png">

@zendesk/compute 