### PR TITLE
better error messages and set_via_env fix

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -102,7 +102,8 @@ module Kubernetes
         rescue KeyError, JSON::ParserError => e
           raise(
             Samson::Hooks::UserError,
-            "Unable to set path #{path.join(".")} for #{template[:kind]} in role #{@doc.kubernetes_role.name}: #{e.class} #{e.message}"
+            "Unable to set path #{path.join(".")} for #{template[:kind]} in role #{@doc.kubernetes_role.name}: " \
+            "#{e.class} #{e.message}"
           )
         end
       end

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -100,7 +100,10 @@ module Kubernetes
         begin
           template.dig_set(path, JSON.parse(static_env.fetch(v), symbolize_names: true))
         rescue KeyError, JSON::ParserError => e
-          raise Samson::Hooks::UserError, "Unable to set path #{path.join(".")}: #{e.class} #{e.message}"
+          raise(
+            Samson::Hooks::UserError,
+            "Unable to set path #{path.join(".")} for #{template[:kind]} in role #{@doc.kubernetes_role.name}: #{e.class} #{e.message}"
+          )
         end
       end
     end

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -171,6 +171,18 @@ describe Kubernetes::ReleaseDoc do
         create!.resource_template[2][:metadata][:labels][:project].must_equal 'foo'
       end
 
+      it "does not copy random annotations like secrets/set_via_env etc" do
+        template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '30%'}
+        create!.resource_template[2][:metadata][:annotations].keys.sort.must_equal [
+          :"samson/deploy_url", :"samson/updateTimestamp"
+        ]
+      end
+
+      it "copies keep-name so name stays in sync with the deployment" do
+        template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '30%', "samson/keep_name": 'true'}
+        assert create!.resource_template[2][:metadata][:annotations].key?(:"samson/keep_name")
+      end
+
       it "deletes when set to 0" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '0'}
         create!.resource_template[2][:delete].must_equal true

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -965,14 +965,17 @@ describe Kubernetes::TemplateFiller do
         environment.update_column(:value, 'foo')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
         e.message.must_equal(
-          "Unable to set path spec.foo for Deployment in role app-server: JSON::ParserError 765: unexpected token at 'foo'"
+          "Unable to set path spec.foo for Deployment in role app-server: " \
+          "JSON::ParserError 765: unexpected token at 'foo'"
         )
       end
 
       it "fails nicely with env is missing" do
         environment.update_column(:name, 'BAR')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
-        e.message.must_equal "Unable to set path spec.foo for Deployment in role app-server: KeyError key not found: \"FOO\""
+        e.message.must_equal(
+          "Unable to set path spec.foo for Deployment in role app-server: KeyError key not found: \"FOO\""
+        )
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -957,7 +957,7 @@ describe Kubernetes::TemplateFiller do
         }
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
         e.message.must_equal(
-          "Unable to set path foo.bar.foo: KeyError key not found: [:foo, :bar]"
+          "Unable to set path foo.bar.foo for Deployment in role app-server: KeyError key not found: [:foo, :bar]"
         )
       end
 
@@ -965,14 +965,14 @@ describe Kubernetes::TemplateFiller do
         environment.update_column(:value, 'foo')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
         e.message.must_equal(
-          "Unable to set path spec.foo: JSON::ParserError 765: unexpected token at 'foo'"
+          "Unable to set path spec.foo for Deployment in role app-server: JSON::ParserError 765: unexpected token at 'foo'"
         )
       end
 
       it "fails nicely with env is missing" do
         environment.update_column(:name, 'BAR')
         e = assert_raises(Samson::Hooks::UserError) { template.to_hash }
-        e.message.must_equal "Unable to set path spec.foo: KeyError key not found: \"FOO\""
+        e.message.must_equal "Unable to set path spec.foo for Deployment in role app-server: KeyError key not found: \"FOO\""
       end
     end
 


### PR DESCRIPTION
... also avoids duplicated secret lookups and all other kinds of useless annotation copy

@zendesk/compute 
/cc @craig-day 