### PR TITLE
remove padding hack that makes spacing uneven

### DIFF
--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -16,7 +16,7 @@
 
   <%= search_select :key, @keys, live: true %>
 
-  <div class="col-sm-2" style="padding-left: 0;">
+  <div class="col-sm-2">
     <% if duplicate = params.dig(:search, :value_from) %>
       <%= label_tag "Duplicates of" %>
       <%= text_field_tag 'search[value_from]', duplicate, class: "form-control" %>


### PR DESCRIPTION
before:
![Screen Shot 2019-06-18 at 9 13 57 AM](https://user-images.githubusercontent.com/11367/59700987-70d4b700-91a9-11e9-8fec-19dc75cf72cd.png)


after:
![Screen Shot 2019-06-18 at 9 13 40 AM](https://user-images.githubusercontent.com/11367/59700975-6a463f80-91a9-11e9-8cb3-69bf8d155103.png)
