### PR TITLE
treat replica target as min for autoscaled roles, to avoid declaring …

### DIFF
--- a/plugins/kubernetes/app/helpers/deploy_group_roles_helper.rb
+++ b/plugins/kubernetes/app/helpers/deploy_group_roles_helper.rb
@@ -8,7 +8,11 @@ module DeployGroupRolesHelper
       html = "".html_safe
       html << dgr.replicas.to_s
       if role.autoscaled?
-        html << icon_tag(:scale, title: "Replicas managed externally, actual count might not match this")
+        html << " "
+        html << icon_tag(
+          :scale,
+          title: "Replicas managed externally, minimum replicas needed for deployment, actual count might be higher."
+        )
       end
       html
     end

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -90,7 +90,7 @@ module Kubernetes
         if @delete_resource
           0
         else
-          replica_source.dig(:spec, :replicas) || (RoleConfigFile.primary?(@template) ? 1 : 0)
+          @template.dig(:spec, :replicas) || (RoleConfigFile.primary?(@template) ? 1 : 0)
         end
       end
 
@@ -98,11 +98,6 @@ module Kubernetes
 
       def error_location
         "#{name} #{namespace} #{@deploy_group.name}"
-      end
-
-      # when autoscaling we expect as many pods as we currently have
-      def replica_source
-        (@autoscaled && resource) || @template
       end
 
       def backoff_wait(backoff, reason)
@@ -165,6 +160,7 @@ module Kubernetes
         # when autoscaling on a resource with replicas we should keep replicas constant
         # (not setting replicas will make it use the default of 1)
         path = [:spec, :replicas]
+        replica_source = (@autoscaled && resource) || @template
         copy.dig_set(path, replica_source.dig(*path)) if @template.dig(*path)
 
         # copy fields

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
@@ -27,7 +27,7 @@
     <% end %>
 
     <% [
-         [:replicas, "Replicas"],
+         [:replicas, @kubernetes_deploy_group_role.kubernetes_role&.autoscaled? ? "Min Replicas" : "Replicas"],
          [:requests_cpu, 'Requests CPU Cores'],
          [:requests_memory, 'Requests Memory in MB'],
          [:limits_cpu, 'Limits CPU Cores'],

--- a/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
@@ -18,8 +18,10 @@
       </div>
     <% end %>
 
-    <%= form.input :autoscaled, label: "Replicas managed externally", as: :check_box, help: "Deploying will not change replicas count. Use this when autoscaling deployments." %>
-    <%= form.input :blue_green, as: :check_box, label: "Blue/Green Deployment", help: "Starts a new isolated deployment shifting between blue and green sufixes, switching service selectors if successfully deployed and deleting previous resources, all active resources must be deleted manually when switching this" %>
+    <%= form.input :autoscaled, label: "Replicas managed externally", as: :check_box,
+          help: "<ul><li>Deploying will not change replica counts</li><li>Replica counts are used as the minimum number of replicas that need to be live</li><li>Use when autoscaling Deployments</li></ul>".html_safe %>
+    <%= form.input :blue_green, as: :check_box, label: "Blue/Green Deployment",
+          help: "Starts a new isolated deployment shifting between blue and green suffixes, switching service selectors if successfully deployed and deleting previous resources, all active resources must be deleted manually when switching this" %>
 
     <div class="form-group">
       <div class="col-lg-offset-2 col-lg-10">

--- a/plugins/kubernetes/test/helpers/deploy_group_roles_helper_test.rb
+++ b/plugins/kubernetes/test/helpers/deploy_group_roles_helper_test.rb
@@ -16,7 +16,7 @@ describe DeployGroupRolesHelper do
 
     it "shows autoscaled" do
       role.autoscaled = true
-      kubernetes_deploy_group_role_replica(role, dgr).must_include "3<i title=\"Replicas managed"
+      kubernetes_deploy_group_role_replica(role, dgr).must_include "3 <i title=\"Replicas managed"
     end
 
     it "shows deleted" do

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -296,20 +296,6 @@ describe Kubernetes::Resource do
         resource.desired_pod_count.must_equal 3
       end
 
-      it "expects a constant number of pods when using autoscaling" do
-        assert_request(:get, url, to_return: {body: {spec: {replicas: 4}}.to_json}) do
-          autoscaled!
-          resource.desired_pod_count.must_equal 4
-        end
-      end
-
-      it "uses template amount when creating with autoscaling" do
-        assert_request(:get, url, to_return: {status: 404}) do
-          autoscaled!
-          resource.desired_pod_count.must_equal 2
-        end
-      end
-
       it "is 1 when not set for primary" do
         template[:spec].delete :replicas
         resource.desired_pod_count.must_equal 1


### PR DESCRIPTION
…deploy success too easily

```Ruby
# check hpa min matches replicas (also allow hpa to be deployed in a different role)
roles = Kubernetes::Role.where(autoscaled: true).all.to_a; nil
ignored_groups = DeployGroup.where(name: []).pluck(:id)
roles.select!(&:project); nil
roles.each do |role|
  groups_ids = Kubernetes::ReleaseDoc.where(kubernetes_role: role).pluck(:deploy_group_id).uniq - ignored_groups

  DeployGroup.where(id: groups_ids).all.each do |group|
    next unless dgr = Kubernetes::DeployGroupRole.where(kubernetes_role: role, deploy_group: group, delete_resource: false).last

    doc = Kubernetes::ReleaseDoc.where(kubernetes_role: role, deploy_group: group).last
    docs = Kubernetes::ReleaseDoc.where(kubernetes_release_id: doc.kubernetes_release_id)

    hpas = docs.flat_map(&:resources).select do |r|
      next unless r.kind == "HorizontalPodAutoscaler"
      ref = r.template.dig(:spec, :scaleTargetRef).values_at(:kind, :name)
      doc.resources.map { |r| [r.kind, r.name] }.include?(ref)
    end

    puts "MULTIPLE" if hpas.size > 1

    hpa_count = hpas.first&.template&.dig(:spec, :minReplicas) || -1

    good = (hpa_count >= dgr.replicas)
    puts "#{good ? "GOOD" : "BAD"} #{role.project.url} #{role.name} #{group.name} #{hpa_count} vs #{dgr.replicas}"
  end
end; nil
```

# Risks
 - Med: roles that have configured a replica count above the minimum will be fail their deploy because of missing pods

3 when there are 2 replicas live
```
[21:58:06] Deploy status:
[21:58:06]   GroupK server Pod: Live
[21:58:06]   GroupK server Pod: Live
[21:58:06]   GroupK server Pod: Missing
```

1 when there are 2 replicas live
```
[21:59:54] Deploy status:
[21:59:54]   GroupK server Pod: Waiting (Pending, Unknown)
```

@zendesk/compute @craig-day 