### PR TITLE
add monitor linking and reuse faraday

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
   remote: plugins/datadog
   specs:
     samson_datadog (0.0.0)
-      dogapi (~> 1.9)
+      faraday
 
 PATH
   remote: plugins/env
@@ -250,8 +250,6 @@ GEM
     ddtrace (0.14.2)
       msgpack
     diffy (3.2.0)
-    dogapi (1.21.0)
-      multi_json
     dogstatsd-ruby (3.0.0)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)

--- a/app/models/outbound_webhook.rb
+++ b/app/models/outbound_webhook.rb
@@ -21,7 +21,7 @@ class OutboundWebhook < ActiveRecord::Base
   def deliver(deploy)
     Rails.logger.info "Sending webhook notification to #{url}. Deploy: #{deploy.id}"
 
-    response = connection.post do |req|
+    response = connection.post url do |req|
       req.headers['Content-Type'] = 'application/json'
       req.body = self.class.deploy_as_json(deploy).to_json
     end
@@ -50,7 +50,7 @@ class OutboundWebhook < ActiveRecord::Base
   private
 
   def connection
-    Faraday.new(url: url) do |faraday|
+    Faraday.new do |faraday|
       faraday.request  :url_encoded
       faraday.adapter  Faraday.default_adapter
       faraday.basic_auth(username, password) if username.present?

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -4,7 +4,9 @@
 require 'faraday'
 
 Faraday::Connection.prepend(Module.new do
-  def run_request(method, url, *)
-    ActiveSupport::Notifications.instrument("request.faraday.samson", method: method, url: url) { super }
+  def run_request(method, url, *args)
+    raise "Missing url for logging, do not use `do |request| request.url = ` pattern" unless url
+    log_url = url.sub(/key=\w+/, "key=redacted") # ignore datadog credentials and maybe others
+    ActiveSupport::Notifications.instrument("request.faraday.samson", method: method, url: log_url) { super }
   end
 end)

--- a/plugins/datadog/README.md
+++ b/plugins/datadog/README.md
@@ -1,1 +1,8 @@
-Datadog monitoring and deploy tracking
+Datadog monitoring and before/after-deploy events.
+
+Env vars to set:
+```
+DATADOG_API_KEY
+DATADOG_APPLICATION_KEY
+DATADOG_SUBDOMAIN
+```

--- a/plugins/datadog/app/decorators/stage_decorator.rb
+++ b/plugins/datadog/app/decorators/stage_decorator.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 Stage.class_eval do
   def datadog_tags_as_array
-    datadog_tags.to_s.split(";").map(&:strip)
-  end
-
-  def send_datadog_notifications?
-    datadog_tags_as_array.any?
+    datadog_tags.to_s.split(";").map(&:strip!)
   end
 
   def datadog_monitors
-    datadog_monitor_ids.to_s.split(/, ?/).map { |id| DatadogMonitor.new(id) }
+    datadog_monitor_ids.to_s.split(/, ?/).grep(/\A\d+\z/).map { |id| DatadogMonitor.new(id) }
   end
 end

--- a/plugins/datadog/app/models/datadog_notification.rb
+++ b/plugins/datadog/app/models/datadog_notification.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-require 'dogapi'
+require 'faraday'
 require 'digest/md5'
 
+# Note: might be able to replace this with Samson.statsd.event
 class DatadogNotification
   def initialize(deploy)
     @deploy = deploy
@@ -9,8 +10,6 @@ class DatadogNotification
   end
 
   def deliver(additional_tags: [], now: false)
-    Rails.logger.info "Sending Datadog notification..."
-
     status =
       if @deploy.active?
         "info"
@@ -20,34 +19,19 @@ class DatadogNotification
         "error"
       end
 
-    event = Dogapi::Event.new(
-      body,
-      msg_title: @deploy.summary,
-      event_type: "deploy",
-      event_object: Digest::MD5.hexdigest("#{Time.new}|#{rand}"),
-      alert_type: status,
-      source_type_name: "samson",
-      date_happened: now ? Time.now : @deploy.updated_at,
-      tags: @stage.datadog_tags_as_array + ["deploy", *additional_tags]
-    )
-
-    client = Dogapi::Client.new(api_key, nil, "")
-    status = client.emit_event(event)[0]
-
-    if status == "202"
-      Rails.logger.info "Sent Datadog notification"
-    else
-      Rails.logger.info "Failed to send Datadog notification: #{status}"
+    response = Faraday.post "https://api.datadoghq.com/api/v1/events?api_key=#{DatadogMonitor::API_KEY}" do |request|
+      request.body = {
+        title: @deploy.summary,
+        text: "#{@deploy.user.email} deployed #{@deploy.short_reference} to #{@stage.name}",
+        alert_type: status,
+        source_type_name: "samson",
+        date_happened: now ? Time.now.to_i : @deploy.updated_at.to_i,
+        tags: @stage.datadog_tags_as_array + ["deploy", *additional_tags]
+      }.to_json
     end
-  end
 
-  private
-
-  def body
-    "#{@deploy.user.email} deployed #{@deploy.short_reference} to #{@stage.name}"
-  end
-
-  def api_key
-    ENV["DATADOG_API_KEY"]
+    unless response.success?
+      Rails.logger.info "Failed to send Datadog notification: #{response.status}"
+    end
   end
 end

--- a/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
@@ -3,9 +3,9 @@
   <div class="col-lg-offset-2">
     <div class="form-group">
       <div class="col-lg-6">
-        <%= form.text_field :datadog_tags, class: "form-control", placeholder: "Datadog tags" %>
+        <%= form.text_field :datadog_tags, class: "form-control", placeholder: "Datadog deploy event tags" %>
         <span class="help-block">
-          Tags that should be used on deploy events, separated by <code>;</code><br/>
+          Tags that should be used on deploy events (in addition to started/finished tags), separated by <code>;</code><br/>
           Leave empty to not send notifications.
         </span>
       </div>
@@ -15,7 +15,7 @@
       <div class="col-lg-6">
         <%= form.text_field :datadog_monitor_ids, class: "form-control", placeholder: "Datadog Monitor Ids" %>
         <span class="help-block">
-          Datadog monitor ids (comma separated)
+          Datadog monitor ids to show on the stage page (comma separated)
         </span>
       </div>
     </div>

--- a/plugins/datadog/app/views/samson_datadog/_stage_show.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_show.html.erb
@@ -1,7 +1,7 @@
 <% if datadog_monitors = @stage.datadog_monitors.presence %>
   <h2>Datadog Monitors</h2>
   <% datadog_monitors.each do |monitor| %>
-    <% label = {pass: "success", fail: "danger"}[monitor.status] || "warning" %>
-    <span class="label label-<%= label %>"><%= monitor.name %></span>
+    <% label = {"OK" => "success", "Alert" => "danger"}[monitor.state] || "warning" %>
+    <%= link_to monitor.name, monitor.url, class: "label label-#{label}" %>
   <% end %>
 <% end %>

--- a/plugins/datadog/lib/samson_datadog/samson_plugin.rb
+++ b/plugins/datadog/lib/samson_datadog/samson_plugin.rb
@@ -5,7 +5,7 @@ module SamsonDatadog
 
   class << self
     def send_notification(deploy, **kwargs)
-      if deploy.stage.send_datadog_notifications?
+      if deploy.stage.datadog_tags.present?
         DatadogNotification.new(deploy).deliver(**kwargs)
       end
     end

--- a/plugins/datadog/samson_datadog.gemspec
+++ b/plugins/datadog/samson_datadog.gemspec
@@ -3,5 +3,5 @@ Gem::Specification.new "samson_datadog", "0.0.0" do |s|
   s.summary = "Samson Datadog integration"
   s.authors = ["Michael Grosser"]
   s.email = "mgrosser@zendesk.com"
-  s.add_runtime_dependency 'dogapi', '~> 1.9'
+  s.add_runtime_dependency 'faraday'
 end

--- a/plugins/datadog/test/decorators/stage_decorator_test.rb
+++ b/plugins/datadog/test/decorators/stage_decorator_test.rb
@@ -37,14 +37,4 @@ describe Stage do
       stage.datadog_tags_as_array.must_equal []
     end
   end
-
-  describe "#send_datadog_notifications?" do
-    it "is false when there are no tags" do
-      Stage.new.send_datadog_notifications?.must_equal false
-    end
-
-    it "is true when there are tags" do
-      Stage.new(datadog_tags: "a").send_datadog_notifications?.must_equal true
-    end
-  end
 end

--- a/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
+++ b/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
@@ -9,7 +9,7 @@ describe SamsonDatadog do
 
   describe '.send_notification' do
     it 'sends notification' do
-      stage.stubs(:send_datadog_notifications?).returns(true)
+      stage.datadog_tags = "foo"
       dd_notification_mock = mock
       dd_notification_mock.expects(:deliver).with(additional_tags: ['started'])
       DatadogNotification.expects(:new).with(deploy).returns(dd_notification_mock)

--- a/plugins/ledger/lib/samson_ledger/client.rb
+++ b/plugins/ledger/lib/samson_ledger/client.rb
@@ -74,8 +74,7 @@ module SamsonLedger
       end
 
       def post(data)
-        connection = Faraday.new(url: ledger_base_url + LEDGER_PATH)
-        connection.post do |request|
+        Faraday.post ledger_base_url + LEDGER_PATH do |request|
           request.headers['Content-Type'] = "application/json"
           request.headers['Authorization'] = "Token token=#{ledger_token}"
           request.body = data.to_json

--- a/plugins/slack_app/app/models/slack_message.rb
+++ b/plugins/slack_app/app/models/slack_message.rb
@@ -8,9 +8,9 @@ class SlackMessage
     # Only deploys triggered by the slash-command will have a DeployResponseUrl,
     # but we'll get to this point after every deploy completes.
     url = DeployResponseUrl.find_by(deploy_id: @deploy.id)&.response_url
-    return unless url.present?
+    return if url.blank?
 
-    Faraday.new(url).post do |request|
+    Faraday.post url do |request|
       request.headers['Content-Type'] = 'application/json'
       request.body = JSON.unparse message_body
     end

--- a/test/models/outbound_webhook_test.rb
+++ b/test/models/outbound_webhook_test.rb
@@ -76,8 +76,6 @@ describe OutboundWebhook do
     before do
       @webhook = OutboundWebhook.create!(selected_webhook)
       @connection = @webhook.send(:connection)
-
-      assert_equal selected_webhook[:url], @connection.url_prefix.to_s
     end
 
     describe "with no authorization" do


### PR DESCRIPTION
in preparation for adding more monitor logic ... I want 1 less abstraction layer and have logging for all http requests

@zendesk/compute @zendesk/samson 

<img width="666" alt="Screen Shot 2019-06-19 at 7 10 05 PM" src="https://user-images.githubusercontent.com/11367/59813340-eb92f480-92c5-11e9-8ae3-b614c13b3a7c.png">
