### PR TITLE
fix LoadBalancer check, it is a service type and not a standalone res…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -108,7 +108,7 @@ module Kubernetes
       allowed = ENV["KUBERNETES_ALLOWED_LOAD_BALANCER_NAMESPACES"].to_s.split(",")
       return if allowed.empty?
       bad = @elements.map do |e|
-        next unless e[:kind] == "LoadBalancer"
+        next unless e[:kind] == "Service" && e.dig(:spec, :type) == "LoadBalancer"
         namespace = e.dig(:metadata, :namespace) || "unset"
         namespace unless allowed.include?(namespace)
       end.compact

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -586,10 +586,7 @@ describe Kubernetes::RoleValidator do
     end
 
     describe "#validate_load_balancer" do
-      before do
-        role[0][:kind] = "LoadBalancer"
-        role[0][:metadata][:namespace] = "foo"
-      end
+      before { role[1][:metadata][:namespace] = "foo" }
 
       it "allows when not configured" do
         errors.must_be_nil


### PR DESCRIPTION
…ource

fixup for https://github.com/zendesk/samson/pull/3367

checked existing with:

```ruby
roles = Kubernetes::Role.where(autoscaled: true).all.to_a; nil

ignored_groups = DeployGroup.where(name: []).pluck(:id)
roles.select!(&:project); nil
roles.each do |role|
  groups_ids = Kubernetes::ReleaseDoc.where(kubernetes_role: role).pluck(:deploy_group_id).uniq - ignored_groups

  DeployGroup.where(id: groups_ids).all.each do |group|
    next unless doc = Kubernetes::ReleaseDoc.where(kubernetes_role: role, deploy_group: group).last
    doc.resources.each do |r|
      puts "FOUND #{role.project.url} #{role.name} #{r.template.dig(:metadata, :namespace)}" if r.kind == "Service" && r.template.dig(:spec, :type) == "LoadBalancer"
    end
  end
end; nil

```
@zendesk/compute 