### PR TITLE
migrate/improve datadog monitoring UI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -98,6 +98,7 @@ task :flay do
     'app/views/secrets/index.html.erb', # simple html
     'plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb', # similar but slightly different validations
     'plugins/flowdock/app/views/samson_flowdock/_fields.html.erb', # simple html
+    'plugins/datadog/app/views/samson_datadog/_stage_form.html.erb', # simple html
   ]
   flay = Flay.run([*files, '--mass', '25']) # mass threshold is shown mass / occurrences
   abort "Code duplication found" if flay.report.any?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_27_160620) do
+ActiveRecord::Schema.define(version: 2019_06_20_184209) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -72,6 +72,12 @@ ActiveRecord::Schema.define(version: 2019_05_27_160620) do
     t.datetime "updated_at", null: false
     t.string "filters", default: "{}", null: false
     t.string "status", default: "pending", null: false
+  end
+
+  create_table "datadog_monitor_queries" do |t|
+    t.string "query", null: false
+    t.integer "stage_id", null: false
+    t.index ["stage_id"], name: "index_datadog_monitor_queries_on_stage_id"
   end
 
   create_table "deploy_groups", id: :integer do |t|

--- a/plugins/datadog/app/decorators/stage_decorator.rb
+++ b/plugins/datadog/app/decorators/stage_decorator.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 Stage.class_eval do
+  has_many :datadog_monitor_queries, dependent: :destroy
+  accepts_nested_attributes_for :datadog_monitor_queries, allow_destroy: true, reject_if: ->(a) { a[:query].blank? }
+
   def datadog_tags_as_array
     datadog_tags.to_s.split(";").map(&:strip!)
   end
 
   def datadog_monitors
-    datadog_monitor_ids.to_s.split(/, ?/).grep(/\A\d+\z/).map { |id| DatadogMonitor.new(id) }
+    datadog_monitor_queries.flat_map(&:monitors)
   end
 end

--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -8,6 +8,18 @@ class DatadogMonitor
 
   attr_reader :id
 
+  def self.get(id)
+    begin
+      url = "https://api.datadoghq.com/api/v1/monitor/#{id}?api_key=#{API_KEY}&application_key=#{APP_KEY}"
+      response = Faraday.new(request: {open_timeout: 2, timeout: 4}).get(url)
+      raise "Bad response #{response.status}" unless response.success?
+      JSON.parse(response.body, symbolize_names: true)
+    rescue StandardError => e
+      Rails.logger.error("Datadog error #{e}")
+      {}
+    end
+  end
+
   def initialize(id)
     @id = Integer(id)
   end
@@ -21,20 +33,12 @@ class DatadogMonitor
   end
 
   def url
-    "https://#{SUBDOMAIN}.datadoghq.com/monitors/#{id}"
+    "https://#{SUBDOMAIN}.datadoghq.com/monitors/#{@id}"
   end
 
   private
 
   def response
-    @response ||=
-      begin
-        url = "https://api.datadoghq.com/api/v1/monitor/#{@id}?api_key=#{API_KEY}&application_key=#{APP_KEY}"
-        body = Faraday.new(request: {open_timeout: 2, timeout: 4}).get(url).body
-        JSON.parse(body, symbolize_names: true)
-      rescue StandardError => e
-        Rails.logger.error("Datadog error #{e}")
-        {}
-      end
+    @response ||= self.class.get(@id)
   end
 end

--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -30,7 +30,8 @@ class DatadogMonitor
     @response ||=
       begin
         url = "https://api.datadoghq.com/api/v1/monitor/#{@id}?api_key=#{API_KEY}&application_key=#{APP_KEY}"
-        JSON.parse(Faraday.get(url).body, symbolize_names: true)
+        body = Faraday.new(request: {open_timeout: 2, timeout: 4}).get(url).body
+        JSON.parse(body, symbolize_names: true)
       rescue StandardError => e
         Rails.logger.error("Datadog error #{e}")
         {}

--- a/plugins/datadog/app/models/datadog_monitor_query.rb
+++ b/plugins/datadog/app/models/datadog_monitor_query.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class DatadogMonitorQuery < ActiveRecord::Base
+  belongs_to :stage, inverse_of: :datadog_monitor_queries
+  validates :query, format: /\A\d+\z/
+  validate :validate_query_works, if: :query_changed?
+
+  def monitors
+    [DatadogMonitor.new(query)]
+  end
+
+  private
+
+  def validate_query_works
+    errors.add :query, "#{query} did not find a monitor" if errors[:query].empty? && DatadogMonitor.get(query).empty?
+  end
+end

--- a/plugins/datadog/app/models/datadog_notification.rb
+++ b/plugins/datadog/app/models/datadog_notification.rb
@@ -19,7 +19,8 @@ class DatadogNotification
         "error"
       end
 
-    response = Faraday.post "https://api.datadoghq.com/api/v1/events?api_key=#{DatadogMonitor::API_KEY}" do |request|
+    url = "https://api.datadoghq.com/api/v1/events?api_key=#{DatadogMonitor::API_KEY}"
+    response = Faraday.new(request: {open_timeout: 2, timeout: 4}).post(url) do |request|
       request.body = {
         title: @deploy.summary,
         text: "#{@deploy.user.email} deployed #{@deploy.short_reference} to #{@stage.name}",

--- a/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
@@ -2,21 +2,36 @@
   <legend>Datadog</legend>
   <div class="col-lg-offset-2">
     <div class="form-group">
+      <h3>Deploy events with tags <%= additional_info "In addition to started/finished tags), separated by <code>;</code><br/>Leave empty to not send notifications.".html_safe %></h3>
       <div class="col-lg-6">
         <%= form.text_field :datadog_tags, class: "form-control", placeholder: "Datadog deploy event tags" %>
-        <span class="help-block">
-          Tags that should be used on deploy events (in addition to started/finished tags), separated by <code>;</code><br/>
-          Leave empty to not send notifications.
-        </span>
       </div>
     </div>
 
     <div class="form-group">
+      <h3>Datadog monitors <%= additional_info "Monitors to show on the stage page" %></h3>
+
       <div class="col-lg-6">
-        <%= form.text_field :datadog_monitor_ids, class: "form-control", placeholder: "Datadog Monitor Ids" %>
-        <span class="help-block">
-          Datadog monitor ids to show on the stage page (comma separated)
-        </span>
+        <%= form.fields_for :datadog_monitor_queries, @stage.datadog_monitor_queries + [DatadogMonitorQuery.new] do |fields| %>
+          <div class="form-group">
+            <div class="col-lg-3">
+              <%= fields.text_field :query, class: "form-control", placeholder: "ID" %>
+            </div>
+
+            <% if fields.object.persisted? %>
+              <div class="col-lg-6">
+                <%= fields.object.monitors.first&.name %>
+              </div>
+              <div class="col-lg-1 checkbox">
+                <%= fields.label :_destroy do %>
+                  <%= fields.check_box :_destroy if fields.object.persisted? %>
+                  Delete
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+        <%= link_to "Add row", "#", class: "duplicate_previous_row" %>
       </div>
     </div>
   </div>

--- a/plugins/datadog/db/migrate/20190620184209_migrate_datadog_monitors_to_table.rb
+++ b/plugins/datadog/db/migrate/20190620184209_migrate_datadog_monitors_to_table.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class MigrateDatadogMonitorsToTable < ActiveRecord::Migration[5.2]
+  class Stage < ActiveRecord::Base
+  end
+
+  class DatadogMonitorQuery < ActiveRecord::Base
+  end
+
+  def change
+    create_table :datadog_monitor_queries do |t|
+      t.string :query, null: false
+      t.integer :stage_id, null: false
+      t.index :stage_id
+    end
+
+    Stage.where("datadog_monitor_ids is NOT NULL AND datadog_monitor_ids != ''").each do |stage|
+      stage.datadog_monitor_ids.to_s.split(/, ?/).each do |id|
+        DatadogMonitorQuery.create!(query: id, stage_id: stage.id)
+      end
+    end
+  end
+end

--- a/plugins/datadog/lib/samson_datadog/samson_plugin.rb
+++ b/plugins/datadog/lib/samson_datadog/samson_plugin.rb
@@ -18,7 +18,7 @@ Samson::Hooks.view :stage_show, "samson_datadog"
 Samson::Hooks.callback :stage_permitted_params do
   [
     :datadog_tags,
-    :datadog_monitor_ids
+    {datadog_monitor_queries_attributes: [:query, :_destroy, :id]}
   ]
 end
 

--- a/plugins/datadog/test/decorators/stage_decorator_test.rb
+++ b/plugins/datadog/test/decorators/stage_decorator_test.rb
@@ -11,9 +11,8 @@ describe Stage do
       Stage.new.datadog_monitors.must_equal []
     end
 
-    it "splits multiple monitors" do
-      stage = Stage.new(datadog_monitor_ids: "1,2, 3")
-      stage.datadog_monitors.map(&:id).must_equal [1, 2, 3]
+    it "is returns monitors" do
+      Stage.new(datadog_monitor_queries_attributes: {0 => {query: "123"}}).datadog_monitors.map(&:id).must_equal [123]
     end
   end
 

--- a/plugins/datadog/test/models/datadog_monitor_query_test.rb
+++ b/plugins/datadog/test/models/datadog_monitor_query_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe DatadogMonitorQuery do
+  let(:query) { DatadogMonitorQuery.new(query: '123', stage: stages(:test_staging)) }
+
+  describe "validations" do
+    def assert_request(to_return: {body: '{"name":"foo"}'}, &block)
+      super(
+        :get,
+        "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey",
+        to_return: to_return,
+        &block
+      )
+    end
+
+    it "is valid" do
+      assert_request do
+        assert_valid query
+      end
+    end
+
+    it "is invalid with bad id" do
+      query.query = "hey"
+      refute_valid query
+    end
+
+    it "is invalid with bad monitor" do
+      assert_request to_return: {status: 404} do
+        refute_valid query
+      end
+    end
+
+    it "does not make q request when query did not change" do
+      assert_request do
+        query.save!
+        assert_valid query
+      end
+    end
+  end
+
+  describe "#monitors" do
+    it "returns ids as monitors" do
+      query.monitors.map(&:id).must_equal [123]
+    end
+  end
+end

--- a/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
+++ b/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
@@ -25,7 +25,7 @@ describe SamsonDatadog do
 
   describe :stage_permitted_params do
     it 'lists extra keys' do
-      Samson::Hooks.fire(:stage_permitted_params).must_include [:datadog_tags, :datadog_monitor_ids]
+      Samson::Hooks.fire(:stage_permitted_params).flatten(1).must_include :datadog_tags
     end
   end
 


### PR DESCRIPTION
 - not removing old columns for now so samson keeps running after migration is done but before it restarts
 - validating ids
 - validating monitors exist
 - showing monitors in edit UI

![Screen Shot 2019-06-20 at 2 33 50 PM](https://user-images.githubusercontent.com/11367/59883201-2863f780-9369-11e9-8906-9c363e82d6e4.png)
![Screen Shot 2019-06-20 at 2 30 31 PM](https://user-images.githubusercontent.com/11367/59883208-2ac65180-9369-11e9-974d-a78483fcf95a.png)

@zendesk/compute @zendesk/samson 