### PR TITLE
fix randomly slow ci breaking tests

### DIFF
--- a/test/lib/samson/time_sum_test.rb
+++ b/test/lib/samson/time_sum_test.rb
@@ -29,7 +29,7 @@ describe Samson::TimeSum do
     it "logs" do
       Rails.logger.expects(:info).with do |payload|
         payload[:message].must_equal "Job execution finished"
-        (0..5).must_include(payload[:parts][:db])
+        (0..10).must_include(payload[:parts][:db]) # ms
         true
       end
       result = Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", production: false) do


### PR DESCRIPTION
https://travis-ci.org/zendesk/samson/jobs/548451763
```
Failure:
Samson::TimeSum::.instrument#test_0001_logs [/home/travis/build/zendesk/samson/test/lib/samson/time_sum_test.rb:32]:
Expected 0..5 to include 5.004194.
bin/rails test test/lib/samson/time_sum_test.rb:29
```

@zendesk/compute 