### PR TITLE
allow rollback when monitor is alerting after deploy

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -72,7 +72,7 @@ module DeploysHelper
       project_stage_deploys_path(
         @project,
         @deploy.stage,
-        deploy: Samson::RedeployParams.new(@deploy).to_hash
+        deploy: Samson::RedeployParams.new(@deploy, exact: false).to_hash
       ),
       html_options
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_21_145446) do
+ActiveRecord::Schema.define(version: 2019_06_21_175829) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2019_06_21_145446) do
   create_table "datadog_monitor_queries" do |t|
     t.string "query", null: false
     t.integer "stage_id", null: false
+    t.boolean "rollback_on_alert", default: false, null: false
     t.index ["stage_id"], name: "index_datadog_monitor_queries_on_stage_id"
   end
 

--- a/lib/samson/redeploy_params.rb
+++ b/lib/samson/redeploy_params.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 module Samson
   class RedeployParams
-    def initialize(deploy)
+    def initialize(deploy, exact:)
       @deploy = deploy
+      @exact = exact
     end
 
     # Applies different logic depending on the class of each of the deploy
     # parameters, so it supports nested parameters based on object relations
     def to_hash
-      DeploysController.deploy_permitted_params.each_with_object({}) do |param, collection|
+      hash = DeploysController.deploy_permitted_params.each_with_object({}) do |param, collection|
         case param
         when String, Symbol
           collection[param] = @deploy.public_send(param)
@@ -18,6 +19,8 @@ module Samson
           raise "Unsupported deploy param class: `#{param.class}` for `#{param}`."
         end
       end
+      hash[:reference] = @deploy.exact_reference if @exact
+      hash
     end
 
     private

--- a/plugins/datadog/app/decorators/deploy_decorator.rb
+++ b/plugins/datadog/app/decorators/deploy_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+Deploy.class_eval do
+  attr_accessor :datadog_monitors_for_rollback
+end

--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -51,6 +51,14 @@ class DatadogMonitor
     "https://#{SUBDOMAIN}.datadoghq.com/monitors/#{@id}"
   end
 
+  def reload
+    @response = nil
+  end
+
+  def alert?
+    state == "Alert"
+  end
+
   private
 
   def response

--- a/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
@@ -11,18 +11,29 @@
     <div class="form-group">
       <h3>Datadog monitors <%= additional_info "Monitors to show on the stage page" %></h3>
 
-      <div class="col-lg-6">
+      <div class="col-lg-12">
         <% @stage.datadog_monitors # trigger parallel preload %>
         <%= form.fields_for :datadog_monitor_queries, @stage.datadog_monitor_queries + [DatadogMonitorQuery.new] do |fields| %>
           <div class="form-group">
-            <div class="col-lg-6">
+            <div class="col-lg-4">
               <%= fields.text_field :query, class: "form-control", placeholder: "ID or comma separated tags" %>
             </div>
 
+            <div class="col-lg-3">
+              <% if fields.object.persisted? %>
+                <%= fields.object.monitors.first&.name %> <%= "+#{fields.object.monitors.size - 1}" if fields.object.monitors.size > 1 %>
+              <% end %>
+            </div>
+
+            <div class="col-lg-3 checkbox">
+              <%= fields.label :rollback_on_alert do %>
+                <%= fields.check_box :rollback_on_alert %>
+                Rollback on Alert
+                <%= additional_info "Rollback stage to last successful commit if monitors alert after the deploy, but did not alert before." %>
+              <% end %>
+            </div>
+
             <% if fields.object.persisted? %>
-              <div class="col-lg-5">
-                <%= fields.object.monitors.first&.name %> <%= "#{fields.object.monitors.size - 1} more" if fields.object.monitors.size > 1 %>
-              </div>
               <div class="col-lg-1 checkbox">
                 <%= fields.label :_destroy do %>
                   <%= fields.check_box :_destroy if fields.object.persisted? %>

--- a/plugins/datadog/db/migrate/20190621175829_add_rollback_to_datadog_monitors.rb
+++ b/plugins/datadog/db/migrate/20190621175829_add_rollback_to_datadog_monitors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddRollbackToDatadogMonitors < ActiveRecord::Migration[5.2]
+  def change
+    add_column :datadog_monitor_queries, :rollback_on_alert, :boolean, null: false, default: false
+  end
+end

--- a/plugins/datadog/lib/samson_datadog/samson_plugin.rb
+++ b/plugins/datadog/lib/samson_datadog/samson_plugin.rb
@@ -9,6 +9,42 @@ module SamsonDatadog
         DatadogNotification.new(deploy).deliver(**kwargs)
       end
     end
+
+    def store_rollback_monitors(deploy)
+      deploy.datadog_monitors_for_rollback =
+        deploy.stage.datadog_monitor_queries.
+          select(&:rollback_on_alert?).
+          flat_map(&:monitors).
+          reject(&:alert?)
+    end
+
+    def rollback_deploy(deploy, job_execution)
+      # not logging anything to reduce spam, since users did not enable datadog monitors
+      return if !deploy.succeeded? || !deploy.datadog_monitors_for_rollback&.any?
+
+      unless alerting = deploy.datadog_monitors_for_rollback.each(&:reload).select(&:alert?).presence
+        return job_execution.output.puts "No datadog monitors alerting"
+      end
+
+      job_execution.output.puts "Alert on datadog monitors:\n#{alerting.map { |m| "#{m.name} #{m.url}" }.join("\n")}"
+
+      unless previous_deploy = deploy.previous_succeeded_deploy
+        return job_execution.output.puts "No previous successful commit for rollback found"
+      end
+
+      if previous_deploy.commit == deploy.commit # prevents cascading/useless rollbacks when monitor is always broken
+        return job_execution.output.puts "No rollback to #{previous_deploy.exact_reference}, it is the same commit"
+      end
+
+      rollback = DeployService.new(deploy.user).redeploy(deploy)
+
+      if rollback.persisted?
+        job_execution.output.puts "Triggered rollback to previous commit #{rollback.exact_reference} #{rollback.url}"
+      else
+        errors = rollback.errors.full_messages.join(", ")
+        job_execution.output.puts "Error triggering rollback to previous commit #{rollback.exact_reference} #{errors}"
+      end
+    end
   end
 end
 
@@ -18,14 +54,16 @@ Samson::Hooks.view :stage_show, "samson_datadog"
 Samson::Hooks.callback :stage_permitted_params do
   [
     :datadog_tags,
-    {datadog_monitor_queries_attributes: [:query, :_destroy, :id]}
+    {datadog_monitor_queries_attributes: [:query, :rollback_on_alert, :_destroy, :id]}
   ]
 end
 
 Samson::Hooks.callback :before_deploy do |deploy, _|
   SamsonDatadog.send_notification(deploy, additional_tags: ['started'], now: true)
+  SamsonDatadog.store_rollback_monitors(deploy)
 end
 
-Samson::Hooks.callback :after_deploy do |deploy, _|
+Samson::Hooks.callback :after_deploy do |deploy, job_execution|
   SamsonDatadog.send_notification(deploy, additional_tags: ['finished'])
+  SamsonDatadog.rollback_deploy(deploy, job_execution)
 end

--- a/plugins/datadog/test/decorators/deploy_decorator_test.rb
+++ b/plugins/datadog/test/decorators/deploy_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe Deploy do
+  let(:deploy) { Deploy.new }
+
+  it "can assign datadog_monitors_for_rollback" do
+    deploy.datadog_monitors_for_rollback = 1
+    deploy.datadog_monitors_for_rollback.must_equal 1
+  end
+end

--- a/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
+++ b/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
@@ -23,6 +23,121 @@ describe SamsonDatadog do
     end
   end
 
+  describe ".store_rollback_monitors" do
+    def store(state: "OK")
+      stub_request(:get, "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey").
+        to_return(body: {id: 123, overall_state: state}.to_json)
+      SamsonDatadog.store_rollback_monitors(deploy)
+      deploy.datadog_monitors_for_rollback
+    end
+
+    before do
+      deploy.stage.datadog_monitor_queries.build(rollback_on_alert: true, query: "123")
+    end
+
+    it "stores good monitors" do
+      store.size.must_equal 1
+    end
+
+    it "stores nothing when not enabled" do
+      deploy.stage.datadog_monitor_queries.clear
+      store.size.must_equal 0
+    end
+
+    it "stores nothing when not rolling back" do
+      deploy.stage.datadog_monitor_queries.first.rollback_on_alert = false
+      store.size.must_equal 0
+    end
+
+    it "stores nothing when alerting" do
+      store(state: "Alert").size.must_equal 0
+    end
+  end
+
+  describe ".rollback_deploy" do
+    def rollback(state: "Alert")
+      stub_request(:get, "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey").
+        to_return(body: {id: 123, overall_state: state, name: "Foo is down"}.to_json)
+      SamsonDatadog.rollback_deploy(deploy, stub("Ex", output: out))
+    end
+
+    let(:out) { StringIO.new }
+    let(:previous_deploy) { deploys(:succeeded_test) }
+    let(:rollback_deploy) { deploys(:succeeded_production_test) }
+    let(:deploy) do
+      project = previous_deploy.project
+      job = Job.create!(status: "succeeded", user: previous_deploy.user, project: project, command: "ls")
+      Deploy.create!(
+        stage: previous_deploy.stage,
+        project: project,
+        reference: "master",
+        job: job
+      )
+    end
+
+    before do
+      deploy.job.commit = "a" * 40
+      deploy.datadog_monitors_for_rollback = [DatadogMonitor.new(123, overall_state: "OK")]
+    end
+
+    it "rolls back when monitor was triggered" do
+      DeployService.any_instance.expects(:deploy).returns(rollback_deploy)
+      rollback
+      out.string.must_equal <<~LOG
+        Alert on datadog monitors:
+        Foo is down https://app.datadoghq.com/monitors/123
+        Triggered rollback to previous commit v1.0 http://www.test-url.com/projects/foo/deploys/#{rollback_deploy.id}
+      LOG
+    end
+
+    it "does not roll back when no monitors were captured" do
+      DeployService.any_instance.expects(:deploy).never
+      deploy.datadog_monitors_for_rollback.clear
+      rollback
+      out.string.must_equal ""
+    end
+
+    it "does not roll back when all monitors are still ok" do
+      DeployService.any_instance.expects(:deploy).never
+      rollback state: "OK"
+      out.string.must_equal "No datadog monitors alerting\n"
+    end
+
+    it "does not roll back when there is no previous deploy" do
+      DeployService.any_instance.expects(:deploy).never
+      previous_deploy.destroy
+      rollback
+      out.string.must_equal <<~LOG
+        Alert on datadog monitors:
+        Foo is down https://app.datadoghq.com/monitors/123
+        No previous successful commit for rollback found
+      LOG
+    end
+
+    it "does not roll back when previous deploy was the same commit" do
+      DeployService.any_instance.expects(:deploy).never
+      previous_deploy.job.update_column(:commit, deploy.commit)
+      rollback
+      out.string.must_equal <<~LOG
+        Alert on datadog monitors:
+        Foo is down https://app.datadoghq.com/monitors/123
+        No rollback to aaaaaaa, it is the same commit
+      LOG
+    end
+
+    it "shows errors when rollback failed" do
+      rollback_deploy.stubs(persisted?: false)
+      rollback_deploy.errors.add :base, "Foo"
+      DeployService.any_instance.expects(:deploy).returns(rollback_deploy)
+      rollback
+      out.string.must_equal <<~LOG
+        Alert on datadog monitors:
+        Foo is down https://app.datadoghq.com/monitors/123
+        Error triggering rollback to previous commit v1.0 Foo
+      LOG
+    end
+  end
+
   describe :stage_permitted_params do
     it 'lists extra keys' do
       Samson::Hooks.fire(:stage_permitted_params).flatten(1).must_include :datadog_tags

--- a/test/lib/samson/redeploy_params_test.rb
+++ b/test/lib/samson/redeploy_params_test.rb
@@ -7,12 +7,18 @@ describe Samson::RedeployParams do
   let(:deploy) { deploys(:succeeded_test) }
 
   describe "#to_hash" do
-    let(:redeploy_params_array) { Samson::RedeployParams.new(deploy).to_hash.to_a }
+    def redeploy_params_array(exact: false)
+      Samson::RedeployParams.new(deploy, exact: exact).to_hash.to_a
+    end
 
     it "returns default deploy params" do
       redeploy_params_array.must_include(
         [:reference, "staging"]
       )
+    end
+
+    it "can return exact reference" do
+      redeploy_params_array(exact: true).must_include [:reference, "abcabca"]
     end
 
     context "when a plugin includes extra permitted params" do


### PR DESCRIPTION
barebones for now, will need grace period etc later on

![Screen Shot 2019-06-21 at 11 50 16 AM](https://user-images.githubusercontent.com/11367/59953339-6a0da480-9434-11e9-89cc-3d1cd8187a21.png)


```
[21:10:07] READY, starting stability test
[21:10:10] Testing for stability: 7s
[21:10:13] Testing for stability: 4s
[21:10:16] Testing for stability: 1s
[21:10:19] Testing for stability: 0s
[21:10:19] SUCCESS
[21:10:20] Alert on datadog monitors:
[21:10:20] Etcd not reporting to datadog🔒 https://datadoghq.com/monitors/123
[21:10:20] Triggered rollback to previous commit 8797f17 http://localhost:3000/projects/example-kubernetes/deploys/539
```

@zendesk/compute @zendesk/samson @zendesk/sre 
/cc @jonmoter 

local testing with:

```Ruby
ALERTS = [false, true]
  def alert?
    ALERTS.shift # state == "Alert"
  end
```

locally it can fail with `ActiveRecord::StatementInvalid: Mysql2::Error: Incorrect string value: '\xF0\x9F\x94\x92 h...` when mysql is not correctly configured to handle multibyte