### PR TITLE
do not return nil for tags that could not be stripped

### DIFF
--- a/plugins/datadog/app/decorators/stage_decorator.rb
+++ b/plugins/datadog/app/decorators/stage_decorator.rb
@@ -4,7 +4,7 @@ Stage.class_eval do
   accepts_nested_attributes_for :datadog_monitor_queries, allow_destroy: true, reject_if: ->(a) { a[:query].blank? }
 
   def datadog_tags_as_array
-    datadog_tags.to_s.split(";").map(&:strip!)
+    datadog_tags.to_s.split(";").each(&:strip!)
   end
 
   # also preloading the monitors in parallel for speed

--- a/plugins/datadog/test/decorators/stage_decorator_test.rb
+++ b/plugins/datadog/test/decorators/stage_decorator_test.rb
@@ -22,6 +22,11 @@ describe Stage do
       stage.datadog_tags_as_array.must_equal []
     end
 
+    it "works when not stripping" do
+      stage.datadog_tags = " foo;bar;baz"
+      stage.datadog_tags_as_array.must_equal ["foo", "bar", "baz"]
+    end
+
     it "returns an array of the tags" do
       stage.datadog_tags = " foo; bar; baz "
       stage.datadog_tags_as_array.must_equal ["foo", "bar", "baz"]


### PR DESCRIPTION
fixup for https://github.com/zendesk/samson/pull/3407 which made tags without spaces return nil :(