### PR TITLE
kubernetes executor is not a drop-in-replacement for TerminalExecutor

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -149,8 +149,7 @@ class JobExecution
     Samson::TimeSum.instrument "execute_job.samson", payload do
       payload[:success] =
         if kubernetes?
-          @executor = Kubernetes::DeployExecutor.new(@job, @output)
-          @executor.execute
+          Kubernetes::DeployExecutor.new(@job, @output).execute
         else
           @executor.execute(*cmds)
         end

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -20,17 +20,6 @@ module Kubernetes
       @reference = job.deploy.reference
     end
 
-    # restart_signal_handler.rb calls this to show details about all running job-executions
-    # and show something that identifies the deploy
-    # TODO: change to .details and call that from restart_signal_handler and job_execution
-    def pid
-      "Kubernetes-deploy-#{object_id}"
-    end
-
-    def pgid
-      pid
-    end
-
     def execute(*)
       verify_kubernetes_templates!
       @release = create_release

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -24,20 +24,6 @@ describe Kubernetes::DeployExecutor do
     deploy.update_column :kubernetes, true
   end
 
-  describe "#pid" do
-    it "returns a fake pid" do
-      Kubernetes::DeployExecutor.any_instance.stubs(:build_selectors).returns([])
-      executor.pid.must_include "Kubernetes"
-    end
-  end
-
-  describe "#pgid" do
-    it "returns a fake pid" do
-      Kubernetes::DeployExecutor.any_instance.stubs(:build_selectors).returns([])
-      executor.pgid.must_include "Kubernetes"
-    end
-  end
-
   describe "#execute" do
     def execute
       stub_request(:get, %r{http://foobar.server/api/v1/namespaces/staging/pods\?}).


### PR DESCRIPTION
also still exposes the pid of the underlying executor so we can kill it if git or some other shell hangs

@zendesk/compute 

# Risks
 - Med: deploy / restarts / cancelling breaking