### PR TITLE
mark deploys as failed when they trigger datadog monitors

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_21_175829) do
+ActiveRecord::Schema.define(version: 2019_06_26_012607) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 2019_06_21_175829) do
   create_table "datadog_monitor_queries" do |t|
     t.string "query", null: false
     t.integer "stage_id", null: false
-    t.boolean "rollback_on_alert", default: false, null: false
+    t.boolean "fail_deploy_on_alert", default: false, null: false
     t.index ["stage_id"], name: "index_datadog_monitor_queries_on_stage_id"
   end
 

--- a/lib/samson/error_notifier.rb
+++ b/lib/samson/error_notifier.rb
@@ -8,8 +8,7 @@ module Samson
       def notify(exception, options = {})
         debug_info = Samson::Hooks.fire(:error, exception, options).compact.detect { |result| result.is_a?(String) }
         if ::Rails.env.test?
-          message = "ErrorNotifier caught exception: #{exception.message}. Use ErrorNotifier.expects(:notify) to " \
-            "silence in tests"
+          message = "#{name} caught exception: #{exception.message}. Use #{name}.expects(:notify) to silence in tests"
           raise RuntimeError, message, exception.backtrace
         else
           # TODO: Don't spam logs twice if any exception plugin is enabled

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -63,7 +63,8 @@ module Samson
       :trace_scope,
       :asynchronous_performance_tracer,
       :repo_provider_status,
-      :changeset_api_request
+      :changeset_api_request,
+      :validate_deploy
     ].freeze
 
     # Hooks that are slow and we want performance info on

--- a/plugins/datadog/app/decorators/deploy_decorator.rb
+++ b/plugins/datadog/app/decorators/deploy_decorator.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 Deploy.class_eval do
-  attr_accessor :datadog_monitors_for_rollback
+  attr_accessor :datadog_monitors_for_validation
 end

--- a/plugins/datadog/app/models/datadog_notification.rb
+++ b/plugins/datadog/app/models/datadog_notification.rb
@@ -31,8 +31,8 @@ class DatadogNotification
       }.to_json
     end
 
-    unless response.success?
-      Rails.logger.info "Failed to send Datadog notification: #{response.status}"
-    end
+    raise "Failed to send Datadog notification: #{response.status}" unless response.success?
+  rescue StandardError => e
+    Samson::ErrorNotifier.notify(e)
   end
 end

--- a/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
@@ -26,10 +26,10 @@
             </div>
 
             <div class="col-lg-3 checkbox">
-              <%= fields.label :rollback_on_alert do %>
-                <%= fields.check_box :rollback_on_alert %>
-                Rollback on Alert
-                <%= additional_info "Rollback stage to last successful commit if monitors alert after the deploy, but did not alert before." %>
+              <%= fields.label :fail_deploy_on_alert do %>
+                <%= fields.check_box :fail_deploy_on_alert %>
+                Fail Deploy on Alert
+                <%= additional_info "Fail deploy if monitors alerts after the deploy, but did not alert before." %>
               <% end %>
             </div>
 

--- a/plugins/datadog/db/migrate/20190626012607_rename_rollback_on_failure.rb
+++ b/plugins/datadog/db/migrate/20190626012607_rename_rollback_on_failure.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class RenameRollbackOnFailure < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :datadog_monitor_queries, :rollback_on_alert, :fail_deploy_on_alert
+  end
+end

--- a/plugins/datadog/test/decorators/deploy_decorator_test.rb
+++ b/plugins/datadog/test/decorators/deploy_decorator_test.rb
@@ -7,7 +7,7 @@ describe Deploy do
   let(:deploy) { Deploy.new }
 
   it "can assign datadog_monitors_for_rollback" do
-    deploy.datadog_monitors_for_rollback = 1
-    deploy.datadog_monitors_for_rollback.must_equal 1
+    deploy.datadog_monitors_for_validation = 1
+    deploy.datadog_monitors_for_validation.must_equal 1
   end
 end

--- a/plugins/datadog/test/decorators/stage_decorator_test.rb
+++ b/plugins/datadog/test/decorators/stage_decorator_test.rb
@@ -12,6 +12,13 @@ describe Stage do
     end
 
     it "is returns monitors" do
+      stub_request(:get, "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey").
+        to_return(body: {name: 'x'}.to_json)
+      Stage.new(datadog_monitor_queries_attributes: {0 => {query: "123"}}).datadog_monitors.map(&:name).must_equal ['x']
+    end
+
+    it "is returns monitors when it fails" do
+      Samson::ErrorNotifier.expects(:notify)
       stub_request(:get, "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey")
       Stage.new(datadog_monitor_queries_attributes: {0 => {query: "123"}}).datadog_monitors.map(&:id).must_equal [123]
     end

--- a/plugins/datadog/test/models/datadog_monitor_test.rb
+++ b/plugins/datadog/test/models/datadog_monitor_test.rb
@@ -45,6 +45,7 @@ describe DatadogMonitor do
     end
 
     it "is error when request times out" do
+      Samson::ErrorNotifier.expects(:notify)
       assert_datadog_timeout do
         silence_stderr { monitor.name.must_equal "api error" }
       end
@@ -95,8 +96,16 @@ describe DatadogMonitor do
       end
     end
 
-    it "shows api error in the UI when it fails" do
+    it "shows api error in the UI when it times out" do
+      Samson::ErrorNotifier.expects(:notify)
       assert_request(:get, url, to_timeout: []) do
+        DatadogMonitor.list({}).map(&:name).must_equal ["api error"]
+      end
+    end
+
+    it "shows api error in the UI when it fails" do
+      Samson::ErrorNotifier.expects(:notify)
+      assert_request(:get, url, to_return: {status: 500}) do
         DatadogMonitor.list({}).map(&:name).must_equal ["api error"]
       end
     end

--- a/plugins/datadog/test/models/datadog_notification_test.rb
+++ b/plugins/datadog/test/models/datadog_notification_test.rb
@@ -80,8 +80,15 @@ describe DatadogNotification do
     end
 
     it 'logs failure message if status is not 202' do
-      Rails.logger.expects(:info).with('Failed to send Datadog notification: 400')
+      Samson::ErrorNotifier.expects(:notify)
       assert_request(:post, url, with: {body: expected_body}, to_return: {status: 400}) do
+        notification.deliver
+      end
+    end
+
+    it "notifies of errors but does not block deploys when datadog is unreachable" do
+      Samson::ErrorNotifier.expects(:notify)
+      assert_request(:post, url, with: {body: expected_body}, to_timeout: []) do
         notification.deliver
       end
     end

--- a/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
+++ b/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
@@ -23,16 +23,16 @@ describe SamsonDatadog do
     end
   end
 
-  describe ".store_rollback_monitors" do
+  describe ".store_validation_monitors" do
     def store(state: "OK")
       stub_request(:get, "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey").
         to_return(body: {id: 123, overall_state: state}.to_json)
-      SamsonDatadog.store_rollback_monitors(deploy)
-      deploy.datadog_monitors_for_rollback
+      SamsonDatadog.store_validation_monitors(deploy)
+      deploy.datadog_monitors_for_validation
     end
 
     before do
-      deploy.stage.datadog_monitor_queries.build(rollback_on_alert: true, query: "123")
+      deploy.stage.datadog_monitor_queries.build(fail_deploy_on_alert: true, query: "123")
     end
 
     it "stores good monitors" do
@@ -45,7 +45,7 @@ describe SamsonDatadog do
     end
 
     it "stores nothing when not rolling back" do
-      deploy.stage.datadog_monitor_queries.first.rollback_on_alert = false
+      deploy.stage.datadog_monitor_queries.first.fail_deploy_on_alert = false
       store.size.must_equal 0
     end
 
@@ -54,16 +54,16 @@ describe SamsonDatadog do
     end
   end
 
-  describe ".rollback_deploy" do
-    def rollback(state: "Alert")
+  describe ".validate_deploy" do
+    def validate(state: "Alert")
       stub_request(:get, "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey").
         to_return(body: {id: 123, overall_state: state, name: "Foo is down"}.to_json)
-      SamsonDatadog.rollback_deploy(deploy, stub("Ex", output: out))
+      SamsonDatadog.validate_deploy(deploy, stub("Ex", output: out))
     end
 
     let(:out) { StringIO.new }
     let(:previous_deploy) { deploys(:succeeded_test) }
-    let(:rollback_deploy) { deploys(:succeeded_production_test) }
+    let(:validate_deploy) { deploys(:succeeded_production_test) }
     let(:deploy) do
       project = previous_deploy.project
       job = Job.create!(status: "succeeded", user: previous_deploy.user, project: project, command: "ls")
@@ -77,64 +77,32 @@ describe SamsonDatadog do
 
     before do
       deploy.job.commit = "a" * 40
-      deploy.datadog_monitors_for_rollback = [DatadogMonitor.new(123, overall_state: "OK")]
+      deploy.datadog_monitors_for_validation = [DatadogMonitor.new(123, overall_state: "OK")]
     end
 
-    it "rolls back when monitor was triggered" do
-      DeployService.any_instance.expects(:deploy).returns(rollback_deploy)
-      rollback
+    it "fails when monitor was triggered" do
+      validate.must_equal false
       out.string.must_equal <<~LOG
         Alert on datadog monitors:
         Foo is down https://app.datadoghq.com/monitors/123
-        Triggered rollback to previous commit v1.0 http://www.test-url.com/projects/foo/deploys/#{rollback_deploy.id}
       LOG
     end
 
-    it "does not roll back when no monitors were captured" do
-      DeployService.any_instance.expects(:deploy).never
-      deploy.datadog_monitors_for_rollback.clear
-      rollback
+    it "does not add more noise when deploy is already failed" do
+      deploy.job.status = "failed"
+      validate.must_equal true
       out.string.must_equal ""
     end
 
-    it "does not roll back when all monitors are still ok" do
-      DeployService.any_instance.expects(:deploy).never
-      rollback state: "OK"
+    it "passes when no monitors were captured" do
+      deploy.datadog_monitors_for_validation.clear
+      validate.must_equal true
+      out.string.must_equal ""
+    end
+
+    it "passes when all monitors are still ok" do
+      validate(state: "OK").must_equal true
       out.string.must_equal "No datadog monitors alerting\n"
-    end
-
-    it "does not roll back when there is no previous deploy" do
-      DeployService.any_instance.expects(:deploy).never
-      previous_deploy.destroy
-      rollback
-      out.string.must_equal <<~LOG
-        Alert on datadog monitors:
-        Foo is down https://app.datadoghq.com/monitors/123
-        No previous successful commit for rollback found
-      LOG
-    end
-
-    it "does not roll back when previous deploy was the same commit" do
-      DeployService.any_instance.expects(:deploy).never
-      previous_deploy.job.update_column(:commit, deploy.commit)
-      rollback
-      out.string.must_equal <<~LOG
-        Alert on datadog monitors:
-        Foo is down https://app.datadoghq.com/monitors/123
-        No rollback to aaaaaaa, it is the same commit
-      LOG
-    end
-
-    it "shows errors when rollback failed" do
-      rollback_deploy.stubs(persisted?: false)
-      rollback_deploy.errors.add :base, "Foo"
-      DeployService.any_instance.expects(:deploy).returns(rollback_deploy)
-      rollback
-      out.string.must_equal <<~LOG
-        Alert on datadog monitors:
-        Foo is down https://app.datadoghq.com/monitors/123
-        Error triggering rollback to previous commit v1.0 Foo
-      LOG
     end
   end
 
@@ -160,6 +128,14 @@ describe SamsonDatadog do
       stage.stubs(:send_datadog_notifications?).returns(true)
       SamsonDatadog.expects(:send_notification).with(deploy, additional_tags: ['finished'])
       Samson::Hooks.fire(:after_deploy, deploy, stub(output: nil))
+    end
+  end
+
+  describe :validate_deploy do
+    only_callbacks_for_plugin :validate_deploy
+
+    it 'sends notification on after hook' do
+      Samson::Hooks.fire(:validate_deploy, deploy, stub(output: nil)).must_equal [true]
     end
   end
 end

--- a/test/lib/samson/error_notifier_test.rb
+++ b/test/lib/samson/error_notifier_test.rb
@@ -24,8 +24,8 @@ describe Samson::ErrorNotifier do
         Samson::ErrorNotifier.notify(exception)
       end
 
-      expected_message = "ErrorNotifier caught exception: motherofgod. Use ErrorNotifier.expects(:notify)" \
-        " to silence in tests"
+      expected_message = "Samson::ErrorNotifier caught exception: motherofgod." \
+        " Use Samson::ErrorNotifier.expects(:notify) to silence in tests"
       e.message.must_equal expected_message
       e.backtrace.must_equal ['neatbacktraceyougotthere']
     end

--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -291,6 +291,13 @@ describe DeployService do
       run_deploy
     end
 
+    it "fails a deploy when verification fails" do
+      Samson::Hooks.with_callback(:validate_deploy, ->(*) { false }) do
+        run_deploy
+      end
+      deploy.reload.status.must_equal "failed"
+    end
+
     describe "with redeploy_previous_when_failed" do
       def run_deploy(redeploy)
         service.deploy(stage, reference: reference)


### PR DESCRIPTION
reuse existing rollback on failure feature to roll them back

 - low: during deploy stage edit page will fail while old code is running

```
[03:23:48] Testing for stability: 1s
[03:23:51] Testing for stability: 0s
[03:23:51] SUCCESS
[03:23:52] Alert on datadog monitors:
[03:23:52] sitemap refreshes missing https://foo.datadoghq.com/monitors/1805
```

@zendesk/compute 

also: send datadog errors to notifier instead of log which nobody looks at / do not blow up the deploy when datadog is down