### PR TITLE
ignore silenced alerts to be consistent with datadog UI

### DIFF
--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -51,7 +51,7 @@ class DatadogMonitor
     return unless response[:overall_state] # show fallback as warning
 
     if match_source.present?
-      return "OK" unless alerting = alerting_tags.presence # be lazy
+      return "OK" unless alerting = alerting_tags.presence
       deployed = deploy_groups.map { |dg| "#{match_target}:#{match_value(dg)}" }
       (deployed & alerting).any? ? "Alert" : "OK"
     else
@@ -73,19 +73,10 @@ class DatadogMonitor
 
   private
 
-  # alerting scopes, but ignore when it completely matches a silenced scope
   # @return [Array<String>]
   def alerting_tags
-    alerting = tags_from_response(:state, :groups)
-    silenced = tags_from_response(:options, :silenced)
-    alerting.reject! { |scope| silenced.any? { |s| (s & scope) == s } }
-    alerting.flatten(1)
-  end
-
-  # @return [Array<Array<String>>]
-  def tags_from_response(*path)
-    hash = response.dig(*path) || {}
-    hash.keys.map { |k| k.to_s.split(",").sort }
+    groups = response.dig(:state, :groups) || {}
+    groups.keys.flat_map { |k| k.to_s.split(",") }
   end
 
   def match_value(deploy_group)

--- a/plugins/datadog/test/models/datadog_monitor_test.rb
+++ b/plugins/datadog/test/models/datadog_monitor_test.rb
@@ -69,25 +69,6 @@ describe DatadogMonitor do
       end
     end
 
-    it "shows OK when alerting groups are silenced" do
-      assert_datadog alerting_groups.merge(options: {silenced: {"pod:pod1": 123}}) do
-        monitor.state(groups).must_equal "OK"
-      end
-    end
-
-    it "shows Alert when alerting groups did not match silence" do
-      assert_datadog alerting_groups.merge(options: {silenced: {"pod:pod1,foo:bar": 123}}) do
-        monitor.state(groups).must_equal "Alert"
-      end
-    end
-
-    it "shows OK when alerting groups matches complex silence" do
-      response = {state: {groups: {"pod:pod1,foo:bar": {}}}, options: {silenced: {"foo:bar,pod:pod1": 123}}}
-      assert_datadog response do
-        monitor.state(groups).must_equal "OK"
-      end
-    end
-
     it "shows OK when other groups are alerting" do
       assert_datadog(state: {groups: {"pod:pod3": {}}}) do
         monitor.state(groups).must_equal "OK"


### PR DESCRIPTION
for the "fail deploy" feature it mostly does not matter since we ignore monitors that were alerting before the deploy and the UI will now be more consistent with what datadog shows

@zendesk/compute 