### PR TITLE
allow user to decide whether to rollback or fail when monitor is aler…

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_163916) do
+ActiveRecord::Schema.define(version: 2019_06_27_154835) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -77,9 +77,9 @@ ActiveRecord::Schema.define(version: 2019_06_26_163916) do
   create_table "datadog_monitor_queries" do |t|
     t.string "query", null: false
     t.integer "stage_id", null: false
-    t.boolean "fail_deploy_on_alert", default: false, null: false
     t.string "match_target"
     t.string "match_source"
+    t.string "failure_behavior"
     t.index ["stage_id"], name: "index_datadog_monitor_queries_on_stage_id"
   end
 

--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -8,7 +8,7 @@ class DatadogMonitor
   BASE_URL = ENV["DATADOG_URL"] || "https://#{SUBDOMAIN}.datadoghq.com"
 
   attr_reader :id
-  attr_accessor :match_target, :match_source
+  attr_accessor :match_target, :match_source, :failure_behavior
 
   class << self
     # returns raw data
@@ -67,7 +67,7 @@ class DatadogMonitor
     "#{BASE_URL}/monitors/#{@id}"
   end
 
-  def reload
+  def reload_from_api
     @response = nil
   end
 

--- a/plugins/datadog/app/models/datadog_monitor_query.rb
+++ b/plugins/datadog/app/models/datadog_monitor_query.rb
@@ -10,9 +10,16 @@ class DatadogMonitorQuery < ActiveRecord::Base
     "Cluster Permalink" => "kubernetes_cluster.permalink"
   }.freeze
 
+  # add new handling code to samson_plugin.rb when adding
+  FAILURE_BEHAVIORS = {
+    "Redeploy previous" => "redeploy_previous",
+    "Fail deploy" => "fail_deploy"
+  }.freeze
+
   belongs_to :stage, inverse_of: :datadog_monitor_queries
   validates :query, format: /\A\d+\z|\A[a-z:,\d_-]+\z/
   validates :match_source, inclusion: MATCH_SOURCES.values, allow_blank: true
+  validates :failure_behavior, inclusion: FAILURE_BEHAVIORS.values, allow_blank: true
   validate :validate_query_works, if: :query_changed?
   validate :validate_source_and_target
 
@@ -23,8 +30,10 @@ class DatadogMonitorQuery < ActiveRecord::Base
       else
         DatadogMonitor.list(query)
       end.each do |m|
+        # TODO: pass the whole query object
         m.match_target = match_target
         m.match_source = match_source
+        m.failure_behavior = failure_behavior
       end
     end
   end

--- a/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
@@ -39,16 +39,13 @@
             </div>
 
             <div class="form-group checkbox-disable">
-              <div class="col-lg-3 checkbox">
-                <%= fields.label :fail_deploy_on_alert do %>
-                  <%= fields.check_box :fail_deploy_on_alert %>
-                  Fail Deploy on Alert
-                  <%= additional_info "Fail deploy if monitors alerts after the deploy, but did not alert before." %>
-                <% end %>
+              <div class="col-lg-3">
+                On Alert <%= fields.select :failure_behavior, options_for_select(DatadogMonitorQuery::FAILURE_BEHAVIORS, fields.object.failure_behavior), include_blank: true %>
+                <%= additional_info "Action to take when monitors alerts after a deploy, but did not alert before." %>
               </div>
               <div class="col-lg-9 checkbox-disabled">
                 Match
-                <%= fields.select :match_source, options_for_select(DatadogMonitorQuery::MATCH_SOURCES, fields.object.match_source), include_blank: true, class: "form-control", style: "display: inline; width: auto" %>
+                <%= fields.select :match_source, options_for_select(DatadogMonitorQuery::MATCH_SOURCES, fields.object.match_source), include_blank: true %>
                 to
                 <%= fields.text_field :match_target, placeholder: "tag" %>
               </div>

--- a/plugins/datadog/db/migrate/20190627154835_add_failure_options_to_datadog.rb
+++ b/plugins/datadog/db/migrate/20190627154835_add_failure_options_to_datadog.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddFailureOptionsToDatadog < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :datadog_monitor_queries, :fail_deploy_on_alert
+    add_column :datadog_monitor_queries, :failure_behavior, :string
+  end
+end

--- a/plugins/datadog/test/models/datadog_monitor_query_test.rb
+++ b/plugins/datadog/test/models/datadog_monitor_query_test.rb
@@ -73,7 +73,6 @@ describe DatadogMonitorQuery do
 
     it "does not allow source without target" do
       assert_id_request do
-        query.fail_deploy_on_alert = true
         query.match_target = "foo"
         refute_valid query
       end

--- a/plugins/datadog/test/models/datadog_monitor_test.rb
+++ b/plugins/datadog/test/models/datadog_monitor_test.rb
@@ -190,7 +190,7 @@ describe DatadogMonitor do
     it "expires the cache when reloaded" do
       assert_datadog(overall_state: "OK", times: 2) do
         monitor.name
-        monitor.reload
+        monitor.reload_from_api
         monitor.name
       end
     end


### PR DESCRIPTION
…ting

not all users want to "deploy previous on every failure", so adding this option, reuses the existing rollback behavior

![Screen Shot 2019-06-27 at 9 16 16 AM](https://user-images.githubusercontent.com/11367/60283946-3791fa80-98bf-11e9-8d2c-9a6676cd0e57.png)

```
[16:35:50] Alert on datadog monitors:
[16:35:50]  alarm🔒 https://zendesk.datadoghq.com/monitors/123
[16:35:50] Trying to redeploy previous succeeded deploy
[16:35:50] Deploy failed, attempting redeploy of previous succeeded deploy ...
[16:35:50] Previous succeeded deploy is the same reference 123
```

@zendesk/compute 