### PR TITLE
allow checking datadog monitors for user-defined duration after deploy

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_27_154835) do
+ActiveRecord::Schema.define(version: 2019_06_27_175546) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2019_06_27_154835) do
     t.string "match_target"
     t.string "match_source"
     t.string "failure_behavior"
+    t.integer "check_duration"
     t.index ["stage_id"], name: "index_datadog_monitor_queries_on_stage_id"
   end
 

--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -8,7 +8,7 @@ class DatadogMonitor
   BASE_URL = ENV["DATADOG_URL"] || "https://#{SUBDOMAIN}.datadoghq.com"
 
   attr_reader :id
-  attr_accessor :match_target, :match_source, :failure_behavior
+  attr_accessor :match_target, :match_source, :failure_behavior, :check_duration
 
   class << self
     # returns raw data

--- a/plugins/datadog/app/models/datadog_monitor_query.rb
+++ b/plugins/datadog/app/models/datadog_monitor_query.rb
@@ -22,6 +22,7 @@ class DatadogMonitorQuery < ActiveRecord::Base
   validates :failure_behavior, inclusion: FAILURE_BEHAVIORS.values, allow_blank: true
   validate :validate_query_works, if: :query_changed?
   validate :validate_source_and_target
+  validate :validate_duration_used_with_failure
 
   def monitors
     @monitors ||= begin
@@ -34,6 +35,7 @@ class DatadogMonitorQuery < ActiveRecord::Base
         m.match_target = match_target
         m.match_source = match_source
         m.failure_behavior = failure_behavior
+        m.check_duration = check_duration
       end
     end
   end
@@ -48,6 +50,10 @@ class DatadogMonitorQuery < ActiveRecord::Base
   end
 
   private
+
+  def validate_duration_used_with_failure
+    errors.add :check_duration, "only set when also using 'On Alert'." if check_duration? && !failure_behavior?
+  end
 
   def validate_source_and_target
     errors.add :match_source, "cannot be set when target is not set." if match_source? ^ match_target?

--- a/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_form.html.erb
@@ -15,17 +15,34 @@
         <% @stage.datadog_monitors # trigger parallel preload %>
         <%= form.fields_for :datadog_monitor_queries, @stage.datadog_monitor_queries + [DatadogMonitorQuery.new] do |fields| %>
           <div>
+            <% if fields.object.persisted? && example = fields.object.monitors.first %>
+              <% name = truncate(example.name, to: 30) %>
+              <% name += "+#{fields.object.monitors.size - 1}" if fields.object.monitors.size > 1 %>
+              <h3><%= link_to name, fields.object.url %></h3>
+            <% end %>
+
             <div class="form-group">
-              <div class="col-lg-4">
+              <div class="col-lg-5">
                 <%= fields.text_field :query, class: "form-control", placeholder: "ID or comma separated tags" %>
               </div>
 
+              <div class="col-lg-4">
+                On Alert <%= fields.select :failure_behavior, options_for_select(DatadogMonitorQuery::FAILURE_BEHAVIORS, fields.object.failure_behavior), include_blank: true %>
+                <%= additional_info "Action to take when monitors alerts after a deploy, but did not alert before." %>
+              </div>
+
               <div class="col-lg-3">
-                <% if fields.object.persisted? && example = fields.object.monitors.first %>
-                  <% name = truncate(example.name, to: 30) %>
-                  <% name += "+#{fields.object.monitors.size - 1}" if fields.object.monitors.size > 1 %>
-                  <%= link_to name, fields.object.url %>
-                <% end %>
+                Check for <%= fields.select :check_duration, options_for_select([1, 5, 15, 30].map { |m| ["#{m} Min", m.minutes] }), include_blank: true %>
+                <%= additional_info "How long to check the monitor after the deploy is done." %>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <div class="col-lg-9">
+                Match
+                <%= fields.select :match_source, options_for_select(DatadogMonitorQuery::MATCH_SOURCES, fields.object.match_source), include_blank: true %>
+                to
+                <%= fields.text_field :match_target, placeholder: "tag" %>
               </div>
 
               <% if fields.object.persisted? %>
@@ -36,19 +53,6 @@
                   <% end %>
                 </div>
               <% end %>
-            </div>
-
-            <div class="form-group checkbox-disable">
-              <div class="col-lg-3">
-                On Alert <%= fields.select :failure_behavior, options_for_select(DatadogMonitorQuery::FAILURE_BEHAVIORS, fields.object.failure_behavior), include_blank: true %>
-                <%= additional_info "Action to take when monitors alerts after a deploy, but did not alert before." %>
-              </div>
-              <div class="col-lg-9 checkbox-disabled">
-                Match
-                <%= fields.select :match_source, options_for_select(DatadogMonitorQuery::MATCH_SOURCES, fields.object.match_source), include_blank: true %>
-                to
-                <%= fields.text_field :match_target, placeholder: "tag" %>
-              </div>
             </div>
             <hr/>
           </div>

--- a/plugins/datadog/db/migrate/20190627175546_add_datadog_check_duration_min.rb
+++ b/plugins/datadog/db/migrate/20190627175546_add_datadog_check_duration_min.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddDatadogCheckDurationMin < ActiveRecord::Migration[5.2]
+  def change
+    add_column :datadog_monitor_queries, :check_duration, :integer
+  end
+end

--- a/plugins/datadog/test/models/datadog_monitor_query_test.rb
+++ b/plugins/datadog/test/models/datadog_monitor_query_test.rb
@@ -77,6 +77,23 @@ describe DatadogMonitorQuery do
         refute_valid query
       end
     end
+
+    describe "#validate_duration_used_with_failure" do
+      it "does not allow setting duration without failure" do
+        assert_id_request do
+          query.check_duration = 60
+          refute_valid query
+        end
+      end
+
+      it "allows duration with failure" do
+        assert_id_request do
+          query.check_duration = 60
+          query.failure_behavior = "fail_deploy"
+          assert_valid query
+        end
+      end
+    end
   end
 
   describe "#monitors" do


### PR DESCRIPTION
![Screen Shot 2019-06-27 at 11 03 52 AM](https://user-images.githubusercontent.com/11367/60291868-c6f3d980-98d0-11e9-8ab4-171b6605a762.png)

@zendesk/compute 

```
No datadog monitors alerting 3 min remaining
No datadog monitors alerting 2 min remaining
Alert on datadog monitors:
Foo is down https://app.datadoghq.com/monitors/123
```