### PR TITLE
Pull allowed request origins from ENV

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Samson::Application.configure do
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  config.action_cable.allowed_request_origins = ENV['RAILS_ALLOWED_REQUEST_ORIGINS'].split(',').map(&:strip)
 
   # Set to :debug to see everything in the log.
   config.log_level = :info

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,9 @@ Samson::Application.configure do
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
-  config.action_cable.allowed_request_origins = ENV['RAILS_ALLOWED_REQUEST_ORIGINS'].split(',').map(&:strip)
+  if origins = ENV['RAILS_ALLOWED_REQUEST_ORIGINS'].to_s.split(',').map(&:strip).presence
+    config.action_cable.allowed_request_origins = origins
+  end
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
Unless I'm much mistaken, Samson uses action cable now to tail your deploy log. We ran into this issue while upgrading today that was solved by setting the allowed action cable request origins in production.rb. It would be nice to be able to set them via the ENV.