### PR TITLE
validate datadog tags match the selected monitors

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,3 +57,10 @@ a.btn.disabled[title] {
 .github-user-avatar {
   border-radius: .2em
 }
+
+// form elements not built by the form-builder have has-error divs directly around the form elements
+// color is same as `.has-error .form-control` from bootstrap
+.inline-errors .has-error {
+  border: 1px solid #a94442;
+  display: inline-block;
+}

--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -71,6 +71,10 @@ class DatadogMonitor
     @response = nil
   end
 
+  def response
+    @response ||= self.class.get(@id)
+  end
+
   private
 
   # @return [Array<String>]
@@ -88,9 +92,5 @@ class DatadogMonitor
       deploy_group.kubernetes_cluster ? deploy_group.kubernetes_cluster.name.tr(" ", "").downcase : "none"
     else raise ArgumentError, "Unsupported match_source #{query.match_source}"
     end
-  end
-
-  def response
-    @response ||= self.class.get(@id)
   end
 end

--- a/plugins/datadog/app/views/samson_datadog/_datadog_monitor_queries_fields.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_datadog_monitor_queries_fields.html.erb
@@ -16,18 +16,18 @@
             <%= fields.text_field :query, class: "form-control", placeholder: "ID or comma separated tags" %>
           </div>
 
-          <div class="col-lg-4">
+          <div class="col-lg-4 inline-errors">
             On Alert <%= fields.select :failure_behavior, options_for_select(DatadogMonitorQuery::FAILURE_BEHAVIORS, fields.object.failure_behavior), include_blank: true %>
             <%= additional_info "Action to take when monitors alerts after a deploy, but did not alert before." %>
           </div>
 
-          <div class="col-lg-3">
+          <div class="col-lg-3 inline-errors">
             Check for <%= fields.select :check_duration, options_for_select([1, 5, 15, 30].map { |m| ["#{m} Min", m.minutes] }), include_blank: true %>
             <%= additional_info "How long to check the monitor after the deploy is done." %>
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group inline-errors">
           <div class="col-lg-9">
             Match
             <%= fields.select :match_source, options_for_select(DatadogMonitorQuery::MATCH_SOURCES, fields.object.match_source), include_blank: true %>


### PR DESCRIPTION
otherwise the monitors will never alert since the tags will never appear in the group-state

still not perfect since the computed tag values could still not be in the queries, but a good step forward ...

this means all monitors selected by a query must have a common tag, which is usually good anyway ...

<img width="653" alt="Screen Shot 2019-06-28 at 9 18 09 PM" src="https://user-images.githubusercontent.com/11367/60379725-e2540700-99ec-11e9-99c5-8b15178eaff8.png">

also added alert borders so it's clear which fields are invalid
<img width="707" alt="Screen Shot 2019-06-28 at 9 30 12 PM" src="https://user-images.githubusercontent.com/11367/60379726-e6802480-99ec-11e9-8306-9d30276cf61d.png">


@zendesk/compute 