### PR TITLE
lazy load datadog monitors to make stage page fast

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,8 @@ end
 
 desc "'Run brakeman, use `bundle exec brakeman --add-engine-path 'plugins/*' -I` to add or remove obsolete ignores"
 task :brakeman do
-  sh "brakeman --no-pager --add-engine-path 'plugins/*' --ensure-latest"
+  system("brakeman --no-pager --add-engine-path 'plugins/*' --ensure-latest") ||
+    abort("Fix the found issues, or add new ignored with:\nbundle exec brakeman --add-engine-path 'plugins/*' -I")
 end
 
 desc 'Scan for gem vulnerabilities'

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,7 +1,37 @@
 {
   "ignored_warnings": [
-
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "fe634091bb6f66cef4c61121ee25a00cafcf81d9e3e92458ed2086b9ad824c0a",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "plugins/datadog/app/views/samson_datadog/_monitor_list.html.erb",
+      "line": 3,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to((Unresolved Model).new.name, (Unresolved Model).new.url, :class => (\"label label-#{({ \"OK\" => \"success\", \"Alert\" => \"danger\" }[(Unresolved Model).new.state(Stage.find(params.fetch(:id)).deploy_groups)] or \"warning\")}\"))",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Datadog::MonitorsController",
+          "method": "index",
+          "line": 6,
+          "file": "plugins/datadog/app/controllers/datadog/monitors_controller.rb",
+          "rendered": {
+            "name": "samson_datadog/_monitor_list",
+            "file": "plugins/datadog/app/views/samson_datadog/_monitor_list.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "samson_datadog/_monitor_list"
+      },
+      "user_input": "(Unresolved Model).new.url",
+      "confidence": "Weak",
+      "note": "DatadogMonitor points links to the external monitor url"
+    }
   ],
-  "updated": "2018-01-12 08:38:04 -0800",
-  "brakeman_version": "4.1.1"
+  "updated": "2019-06-30 15:32:56 -0700",
+  "brakeman_version": "4.5.1"
 }

--- a/plugins/datadog/app/controllers/datadog/monitors_controller.rb
+++ b/plugins/datadog/app/controllers/datadog/monitors_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Datadog::MonitorsController < ApplicationController
+  def index
+    @stage = Stage.find(params.fetch(:id))
+    render "samson_datadog/_monitor_list", layout: false
+  end
+end

--- a/plugins/datadog/app/decorators/stage_decorator.rb
+++ b/plugins/datadog/app/decorators/stage_decorator.rb
@@ -6,10 +6,22 @@ Stage.class_eval do
     datadog_tags.to_s.split(";").each(&:strip!)
   end
 
+  # check if there are monitors without triggering http requests
+  def datadog_monitors?
+    all_datadog_monitor_queries.any?
+  end
+
   # preloading the monitors in parallel for speed
+  # @return [Array<DatadogMonitor>]
   def datadog_monitors(with_failure_behavior: false)
-    queries = project.datadog_monitor_queries + datadog_monitor_queries
+    queries = all_datadog_monitor_queries
     queries.select!(&:failure_behavior?) if with_failure_behavior # avoid loading unnecessary monitors
     Samson::Parallelizer.map(queries) { |q| q.monitors.each(&:name) }.flatten(1)
+  end
+
+  private
+
+  def all_datadog_monitor_queries
+    project.datadog_monitor_queries + datadog_monitor_queries
   end
 end

--- a/plugins/datadog/app/views/samson_datadog/_monitor_list.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_monitor_list.html.erb
@@ -1,0 +1,4 @@
+<% @stage.datadog_monitors.each do |monitor| %>
+  <% label = {"OK" => "success", "Alert" => "danger"}[monitor.state(@stage.deploy_groups)] || "warning" %>
+  <%= link_to monitor.name, monitor.url, class: "label label-#{label}" %>
+<% end %>

--- a/plugins/datadog/app/views/samson_datadog/_stage_show.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_stage_show.html.erb
@@ -1,7 +1,6 @@
-<% if datadog_monitors = @stage.datadog_monitors.presence %>
+<% if @stage.datadog_monitors? %>
   <h2>Datadog Monitors</h2>
-  <% datadog_monitors.each do |monitor| %>
-    <% label = {"OK" => "success", "Alert" => "danger"}[monitor.state(@stage.deploy_groups)] || "warning" %>
-    <%= link_to monitor.name, monitor.url, class: "label label-#{label}" %>
-  <% end %>
+  <%# show monitors without blocking the page, leaving room for 1 row of monitors to pop in %>
+  <div class="lazy-load" style="min-height: 20px" data-url="<%= datadog_monitors_path(@stage.id) %>" data-delay="1000">
+  </div>
 <% end %>

--- a/plugins/datadog/config/routes.rb
+++ b/plugins/datadog/config/routes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Samson::Application.routes.draw do
+  namespace :datadog do
+    get "/monitors/:id", to: "monitors#index", as: :monitors
+  end
+end

--- a/plugins/datadog/test/controllers/datadog/monitors_controller_test.rb
+++ b/plugins/datadog/test/controllers/datadog/monitors_controller_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+SingleCov.covered!
+
+describe Datadog::MonitorsController do
+  as_a :viewer do
+    describe "#index" do
+      let(:stage) { stages(:test_staging) }
+
+      before do
+        url = "https://api.datadoghq.com/api/v1/monitor/123?api_key=dapikey&application_key=dappkey&group_states=alert"
+        stub_request(:get, url).to_return(body: {overall_state: "OK"}.to_json)
+        stage.datadog_monitor_queries.create!(query: 123)
+      end
+
+      it "renders without layout" do
+        get :index, params: {id: stage.id}
+        assert_response :success
+        response.body.must_include "monitors/123"
+        response.body.wont_include "<html"
+      end
+    end
+  end
+end

--- a/plugins/datadog/test/decorators/stage_decorator_test.rb
+++ b/plugins/datadog/test/decorators/stage_decorator_test.rb
@@ -4,11 +4,10 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe Stage do
-  let(:stage) { Stage.new }
+  let(:stage) { Stage.new(project: Project.new) }
 
   describe "#datadog_monitors" do
     let(:base_url) { "https://api.datadoghq.com/api/v1" }
-    let(:stage) { Stage.new(project: Project.new) }
 
     it "is empty" do
       stage.datadog_monitors.must_equal []
@@ -66,6 +65,17 @@ describe Stage do
     it "returns an empty array if no tags have been configured" do
       stage.datadog_tags = nil
       stage.datadog_tags_as_array.must_equal []
+    end
+  end
+
+  describe "#datadog_monitors?" do
+    it "is false when there are no monitors" do
+      refute stage.datadog_monitors?
+    end
+
+    it "is true when there are monitors" do
+      stage.datadog_monitor_queries.build
+      assert stage.datadog_monitors?
     end
   end
 end


### PR DESCRIPTION
also prevents lets us deploy when datadog has a bad day ...

<del>stealing</del> reusing @ragurney rollbar widget lazyload setup

@zendesk/compute 