### PR TITLE
slightly bumping up open timout to avoid slow api servers blocking de…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -51,7 +51,7 @@ module Kubernetes
           type,
           ssl_options: ssl_options,
           auth_options: auth_options,
-          timeouts: {open: 2, read: 10},
+          timeouts: {open: 3, read: 10},
           as: :parsed_symbolized
         )
       end


### PR DESCRIPTION
we saw requests that go up to 2 seconds, so bumping this to 3 to avoid blocking deploys.

@zendesk/compute 