### PR TITLE
[CONFIG-430] samson_env: use S3 sdk to connect to config service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ PATH
   remote: plugins/env
   specs:
     samson_env (0.0.0)
+      aws-sdk-s3
       dotenv
 
 PATH
@@ -218,15 +219,25 @@ GEM
     autoprefixer-rails (9.4.8)
       execjs
     awesome_print (1.6.1)
-    aws-partitions (1.82.0)
-    aws-sdk-core (3.20.2)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.184.0)
+    aws-sdk-core (3.59.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
-      aws-sigv4 (~> 1.0)
+      aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
     aws-sdk-ecr (1.3.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sigv4 (1.0.2)
+    aws-sdk-kms (1.23.0)
+      aws-sdk-core (~> 3, >= 3.58.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.45.0)
+      aws-sdk-core (~> 3, >= 3.58.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
@@ -671,4 +682,4 @@ RUBY VERSION
    ruby 2.5.3
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/plugins/env/README.md
+++ b/plugins/env/README.md
@@ -19,8 +19,9 @@ for a project and deploy_group.
 
 ## Service to manage environment variables
 
-Set `CONFIG_SERVICE_URL` and make it return replies to samsons queries, details see `app/models/environment_variable.rb`
-Returned env variables will be merged with database config.
+To enable reading environment variables from an S3 bucket, set the variables `CONFIG_SERVICE_BUCKET` and `CONFIG_SERVICE_REGION`.  Returned env variables will be merged with database config.
+
+For details, see `app/models/environment_variable.rb`
 
 ## GitHub to manage environment variables
 

--- a/plugins/env/README.md
+++ b/plugins/env/README.md
@@ -19,7 +19,10 @@ for a project and deploy_group.
 
 ## Service to manage environment variables
 
-To enable reading environment variables from an S3 bucket, set the variables `CONFIG_SERVICE_BUCKET` and `CONFIG_SERVICE_REGION`.  Returned env variables will be merged with database config.
+Run a service that writes config to an s3 bucket, 1 folder per project and 1 file per deploy group.
+To enable reading environment variables from an S3 bucket, 
+set samson environment variables `CONFIG_SERVICE_BUCKET` and `CONFIG_SERVICE_REGION`.
+Database environment variable config will override returned env variables.
 
 For details, see `app/models/environment_variable.rb`
 

--- a/plugins/env/app/views/samson_env/_project_form.html.erb
+++ b/plugins/env/app/views/samson_env/_project_form.html.erb
@@ -15,11 +15,11 @@
     %>
   <% end %>
 
-  <% if defined?(EnvironmentVariable) && folder = EnvironmentVariable.config_service_folder(@project, required: false) %>
+  <% if defined?(EnvironmentVariable) && url = EnvironmentVariable.config_service_url(@project) %>
     <%= form.input(
         :config_service,
         label: "Use Config service",
-        help: "Use config service to manage deployment environment variables, base url is #{folder}"
+        help: "Use config service to manage deployment environment variables, S3 path is #{url}"
       )
     %>
   <% end %>

--- a/plugins/env/app/views/samson_env/_project_form.html.erb
+++ b/plugins/env/app/views/samson_env/_project_form.html.erb
@@ -15,11 +15,11 @@
     %>
   <% end %>
 
-  <% if defined?(EnvironmentVariable) && url = EnvironmentVariable.config_service_url(@project) %>
+  <% if @project.config_service? || url = EnvironmentVariable.config_service_location(@project, nil, display: true) %>
     <%= form.input(
         :config_service,
         label: "Use Config service",
-        help: "Use config service to manage deployment environment variables, S3 path is #{url}"
+        help: "Use config service to manage deployment environment variables, S3 folder is #{url}"
       )
     %>
   <% end %>

--- a/plugins/env/samson_env.gemspec
+++ b/plugins/env/samson_env.gemspec
@@ -8,5 +8,6 @@ Gem::Specification.new "samson_env", "0.0.0" do |s|
     ".env.deploy-group-name files are generated when there are deploy groups assigned to the stage"
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
+  s.add_runtime_dependency "aws-sdk-s3"
   s.add_runtime_dependency "dotenv"
 end

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -113,16 +113,12 @@ describe EnvironmentVariable do
     end
 
     describe "env vars from config service" do
-      let(:url) { "https://config.service/samson/foo/pod100.yml" }
-
-      with_env CONFIG_SERVICE_URL: "https://config.service"
-
       before { project.config_service = true }
 
       it "add to env hash" do
-        assert_request(:get, url, to_return: {body: {"FOO" => "one"}.to_yaml}) do
-          EnvironmentVariable.env(deploy, deploy_group).must_equal "FOO" => "one"
-        end
+        response = {"FOO" => "one"}.to_yaml
+        EnvironmentVariable.stubs(:config_service_read).with('samson/foo/pod100.yml').returns(response)
+        EnvironmentVariable.env(deploy, deploy_group).must_equal "FOO" => "one"
       end
 
       it "ignores without deploy group" do
@@ -130,23 +126,23 @@ describe EnvironmentVariable do
       end
 
       it "shows error when api failed" do
-        assert_request(:get, url, to_return: {status: 404}) do
-          assert_raises(Samson::Hooks::UserError) do
-            EnvironmentVariable.env(deploy, deploy_group)
-          end
+        error = Aws::S3::Errors::NoSuchKey.new({}, "The specified key does not exist.")
+        EnvironmentVariable.stubs(:s3_client).raises(error)
+        assert_raises(Samson::Hooks::UserError) do
+          EnvironmentVariable.env(deploy, deploy_group)
         end
       end
 
       it "shows error when api times out" do
-        assert_request(:get, url, to_timeout: [], times: 4) do
-          assert_raises(Samson::Hooks::UserError) do
-            EnvironmentVariable.env(deploy, deploy_group)
-          end
+        error = Aws::S3::Errors::ServiceError.new({}, "us-east-1 is at the bottom of the ocean.")
+        EnvironmentVariable.stubs(:s3_client).raises(error)
+        assert_raises(Samson::Hooks::UserError) do
+          EnvironmentVariable.env(deploy, deploy_group)
         end
       end
 
       it "refuses to deploy when configured but env var is missing" do
-        with_env CONFIG_SERVICE_URL: nil do
+        with_env CONFIG_SERVICE_BUCKET: nil do
           assert_raises(Samson::Hooks::UserError) do
             EnvironmentVariable.env(deploy, deploy_group)
           end
@@ -156,6 +152,46 @@ describe EnvironmentVariable do
       it "does not read env vars when project is not opted in" do
         project.config_service = false
         EnvironmentVariable.env(deploy, deploy_group)
+      end
+
+      it "returns the full bucket path for the project" do
+        with_env CONFIG_SERVICE_BUCKET: "da-bucket" do
+          expected = 's3://da-bucket/samson/foo'
+          EnvironmentVariable.config_service_url(project).must_equal expected
+        end
+      end
+
+      it "returns the relative path for the project if bucket not defined" do
+        with_env CONFIG_SERVICE_BUCKET: nil do
+          expected = 'samson/foo'
+          EnvironmentVariable.config_service_url(project).must_equal expected
+        end
+      end
+
+      it "creates a client using the CONFIG_SERVICE_REGION environment variable" do
+        Aws::S3::Client.expects(:new).once.with(region: 'us-east-1')
+        with_env CONFIG_SERVICE_REGION: "us-east-1" do
+          EnvironmentVariable.s3_client
+        end
+      end
+
+      it "issues a get_object request to the bucket specified in CONFIG_SERVICE_BUCKET" do
+        mock_client = stub(get_object: stub(body: stub(read: 'thus sayeth s3')))
+        Aws::S3::Client.stubs(:new).returns(mock_client)
+        with_env CONFIG_SERVICE_BUCKET: "da-bucket", CONFIG_SERVICE_REGION: 'us-east-1' do
+          EnvironmentVariable.config_service_read('the/key')
+        end
+      end
+
+      it "puts the key in an error if the key is not found" do
+        error = Aws::S3::Errors::NoSuchKey.new({}, "The specified key does not exist.")
+        EnvironmentVariable.stubs(:s3_client).raises(error)
+        with_env CONFIG_SERVICE_BUCKET: "da-bucket" do
+          e = assert_raises StandardError do
+            EnvironmentVariable.config_service_read('the/key')
+          end
+          e.message.must_include "the/key"
+        end
       end
     end
 


### PR DESCRIPTION
Security requires the bucket be private, so we are updating clients to
connect to the config service bucket using the SDK, instead of plain
'ol HTTP.

### References
- Jira link: https://zendesk.atlassian.net/browse/CONFIG-430

### Risks
- Low: if `CONFIG_SERVICE_REGION` and `CONFIG_SERVICE_BUCKET` are not configured, samson will throw an error for projects in which the config service integration is enabled.
