### PR TITLE
Added monospace font to secret value entry list and views

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,7 +50,8 @@ a.btn.disabled[title] {
   pointer-events: auto;
 }
 
-#command_command {
+#command_command,
+.form-control.monospace {
   font-family: monospace;
 }
 

--- a/app/views/secrets/_row.html.erb
+++ b/app/views/secrets/_row.html.erb
@@ -12,10 +12,15 @@
     <% end %>
   </td>
   <td><%= parts.fetch(:deploy_group_permalink) %></td>
-  <td title="<%= id %>"><%= parts.fetch(:key) %></td>
+  <td title="<%= id %>">
+    <code><%= parts.fetch(:key) %></code>
+  </td>
   <td>
-    <%= link_to "Edit", secret_path(id) %> |
-    <%= link_to_delete(secret_path(id), remove_container: 'tr', question: "Delete #{id} ?") %> |
+    <span class="ui-buttonset">
+      <%= link_to "Edit", secret_path(id) %> |
+      <%= link_to_delete(secret_path(id), remove_container: 'tr', question: "Delete #{id} ?") %>
+    </span>
+
     <%= content_tag :span, icon_tag("eye-open"), title: "Visible" if secret_stub.fetch(:visible) %>
     <%= if deprecated_at = secret_stub[:deprecated_at]
           content_tag :span, icon_tag("warning-sign"), title: "Deprecated #{deprecated_at}"

--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -36,7 +36,7 @@
           {include_blank: true}, class: "form-control", required: true, disabled: !!id %>
       <% end %>
 
-      <%= form.input :key, input_html: {disabled: !!id}, required: true %>
+      <%= form.input :key, input_html: {class: "form-control monospace", disabled: !!id}, required: true %>
 
       <%= form.input :comment, as: :text_area %>
 
@@ -54,7 +54,7 @@
 
       <% needs_value = @duplicate_secret_error || !id %>
       <%= form.input :value do %>
-        <%= form.text_area :value, class: "form-control", rows: 10, placeholder: ('-- hidden --' if !needs_value), required: needs_value %>
+        <%= form.text_area :value, class: "form-control monospace", rows: 10, placeholder: ('-- hidden --' if !needs_value), required: needs_value %>
         <div id="value_json_warning" class="alert-danger"></div>
       <% end %>
 


### PR DESCRIPTION
When adding secrets, the names and values are better rendered in a fixed width (monospace) font.

This PR addresses this on the secrets list and new/edit pages. It also removes the final pipe (`|`) after the `Delete` link on the secrets list page view that's always annoyed me.

## Screenshots
### List view old style/new style
![Screen Shot 2019-07-05 at 5 07 21 pm](https://user-images.githubusercontent.com/1818757/60704317-6d7e5100-9f47-11e9-952d-ad58f797176e.png)

### Edit view new style
![Screen Shot 2019-07-05 at 5 02 09 pm](https://user-images.githubusercontent.com/1818757/60704030-a669f600-9f46-11e9-8ddb-3f2adbb4cf1c.png)

### Risks
Low: display/UI changes.
