### PR TITLE
Resolve Omniauth CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-ldap'
 gem 'omniauth-gitlab'
 gem 'omniauth-bitbucket'
+gem 'omniauth-rails_csrf_protection' # remove once https://github.com/omniauth/omniauth/pull/809 is resolved
 gem 'octokit'
 gem 'faraday'
 gem 'faraday-http-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,6 +399,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     pagy (0.12.0)
     parallel (1.14.0)
     parallel_tests (2.21.1)
@@ -605,6 +608,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-ldap
   omniauth-oauth2
+  omniauth-rails_csrf_protection
   pagy
   parallel
   parallel_tests

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,8 @@ end
 
 desc 'Scan for gem vulnerabilities'
 task :bundle_audit do
-  sh "bundle-audit check --update"
+  # TODO: remove CVE-2015-9284 once https://github.com/omniauth/omniauth/pull/809 is resolved
+  sh "bundle-audit check --update --ignore CVE-2015-9284"
 end
 
 desc "Run rubocop"

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,7 +9,7 @@
     <% else %>
       <% ['Github', 'Google', 'LDAP', 'Gitlab', 'Bitbucket'].each do |provider| %>
         <% if Rails.application.config.samson.auth.public_send(provider.downcase) %>
-          <%= link_to omniauth_path(provider.downcase.to_sym), class: "action #{provider.downcase}" do %>
+          <%= link_to omniauth_path(provider.downcase.to_sym), class: "action #{provider.downcase}", method: :post do %>
             <%= image_tag image_url("#{provider.downcase}.png") %> Login with <%= provider %>
           <% end %>
         <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ Bundler.require(:assets) if Rails.env.development? || ENV["PRECOMPILE"]
 
 ###
 # Railties need to be loaded before the application is initialized
+require 'omniauth'
+require 'omniauth/rails_csrf_protection'
+
 if ['development', 'staging'].include?(Rails.env) && ENV["SERVER_MODE"]
   require 'rack-mini-profiler' # side effect: removes expires headers
   Rack::MiniProfiler.config.authorization_mode = :allow_all

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require 'omniauth'
-
 OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use OmniAuth::Builder do


### PR DESCRIPTION
allows picking a provider of choice when signing up, only exploitable when multiple providers are enabled

see https://github.com/omniauth/omniauth/pull/809

testing: making a get request (removing the `method: :post` from the link) fails with 404

@zendesk/compute @uthark 🎉 