### PR TITLE
Added monospace font to environment variables section

### DIFF
--- a/plugins/env/app/views/environment_variable_groups/form.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/form.html.erb
@@ -20,6 +20,7 @@
       edit it.
     </div>
   <% end %>
+
   <%= form_for @group, html: { class: "form-horizontal" } do |form| %>
     <fieldset <%= disabled %>>
       <%= form.input :name %>
@@ -38,6 +39,7 @@
         Environment variables
         <%= additional_info SamsonEnv::HELP_TEXT %>
       </legend>
+
       <%= render "samson_env/environment_variables", form: form %> |
       <%= link_to "Preview", preview_environment_variable_groups_path(group_id: @group.id) %>
       <hr>

--- a/plugins/env/app/views/environment_variable_groups/index.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/index.html.erb
@@ -30,7 +30,7 @@
         <td>
           <%= link_to group.name, group %>
           <%= unordered_list(sorted_vars, display_limit: max_display_variables, show_more_tag: link_to("+ #{sorted_vars.count - max_display_variables} More", group)) do |name| %>
-            <%= name %>
+            <code><%= name %></code>
           <% end %>
         </td>
         <td><%= render 'projects', group: group, display_limit: max_display_projects %></td>

--- a/plugins/env/app/views/environment_variables/index.html.erb
+++ b/plugins/env/app/views/environment_variables/index.html.erb
@@ -27,8 +27,8 @@
     </thead>
     <% @environment_variables.each do |variable| %>
       <tr>
-        <td><%= variable.name %></td>
-        <td><%= variable.value %></td>
+        <td><code><%= variable.name %></code></td>
+        <td><pre><%= variable.value %></pre></td>
         <td><%= variable.scope_type ? (variable.scope&.name || "Deleted #{variable.scope_type} ##{variable.scope_id}") : 'All' %></td>
         <td>
           <% if parent = variable.parent %>

--- a/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
+++ b/plugins/env/app/views/samson_env/_environment_variables_fields.html.erb
@@ -1,12 +1,12 @@
 <%= form.fields_for :environment_variables, environment_variables + [EnvironmentVariable.new] do |fields| %>
   <div class="form-group">
     <div class="col-lg-3">
-      <%= fields.text_field :name, class: "form-control", placeholder: "Name" %>
+      <%= fields.text_field :name, class: "form-control monospace", placeholder: "Name" %>
     </div>
 
     <div class="col-lg-5">
       <%# using a text area so users can resize them with browser controls %>
-      <%= fields.text_area :value, class: "form-control", placeholder: "Value", rows: 1 %>
+      <%= fields.text_area :value, class: "form-control monospace", rows: 1, placeholder: "Value" %>
     </div>
 
     <% if DeployGroup.enabled? && defined?(scopes) %>
@@ -28,5 +28,6 @@
     <% end %>
   </div>
 <% end %>
+
 <%= link_to "Add row", "#", class: "duplicate_previous_row" %> <span>|</span>
 <%= link_to "Paste", "#", class: "paste_env_variables" %>


### PR DESCRIPTION
- Leading on from #3435 - noted that monospace fonts would be worthwhile in the environment variables section.
- In addition, using `<pre>` with environment variable list page, meaning multi-line env var values actually now render multiline correctly to the user.

## Screenshots
<img width="723" alt="Screen Shot 2019-07-11 at 12 33 25 am" src="https://user-images.githubusercontent.com/1818757/60977890-8d60ab00-a373-11e9-9ffe-bea56cef933e.png">

<img width="968" alt="Screen Shot 2019-07-11 at 12 34 51 am" src="https://user-images.githubusercontent.com/1818757/60977969-b97c2c00-a373-11e9-9c02-0bf4deb0b445.png">

<img width="660" alt="Screen Shot 2019-07-11 at 12 36 15 am" src="https://user-images.githubusercontent.com/1818757/60978070-ec262480-a373-11e9-8bc2-d11c7ecd3bdf.png">

### References
N/A

### Risks
Low: small HTML changes only, nothing functional.
