### PR TITLE
remove versionupdate logic since that seems to be fixed

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -260,16 +260,6 @@ module Kubernetes
       end
     end
 
-    # normally we don't want to set the resourceVersion since that causes conflicts when our version is out of date
-    # but some resources require it to be set or fail with "metadata.resourceVersion: must be specified for an update"
-    class VersionedUpdate < Base
-      def template_for_update
-        t = super
-        t[:metadata][:resourceVersion] = resource.dig(:metadata, :resourceVersion)
-        t
-      end
-    end
-
     class Service < Base
       private
 
@@ -451,7 +441,7 @@ module Kubernetes
       end
     end
 
-    class CronJob < VersionedUpdate
+    class CronJob < Base
       def desired_pod_count
         0 # we don't know when it will run
       end
@@ -476,11 +466,8 @@ module Kubernetes
       end
     end
 
-    class HorizontalPodAutoscaler < Base
-    end
-
     def self.build(*args)
-      klass = "Kubernetes::Resource::#{args.first.fetch(:kind)}".safe_constantize || VersionedUpdate
+      klass = "Kubernetes::Resource::#{args.first.fetch(:kind)}".safe_constantize || Base
       klass.new(*args)
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -74,7 +74,7 @@ describe Kubernetes::Resource do
 
     it "falls back to using VersionedUpdate" do
       Kubernetes::Resource.build({kind: 'ConfigMap'}, deploy_group, autoscaled: false, delete_resource: false).
-        class.must_equal Kubernetes::Resource::VersionedUpdate
+        class.must_equal Kubernetes::Resource::Base
     end
 
     describe ".build" do
@@ -926,20 +926,6 @@ describe Kubernetes::Resource do
         with = ->(request) { request.body.wont_include "resourceVersion"; true }
         assert_create_and_delete_requests(with: with) do
           resource.revert(template.deep_merge(metadata: {resourceVersion: '123'}))
-        end
-      end
-    end
-  end
-
-  describe Kubernetes::Resource::VersionedUpdate do
-    let(:kind) { 'CustomResourceDefinition' }
-    let(:api_version) { 'apiextensions.k8s.io/v1beta1' }
-
-    it "updates when resourceVersion so it does not fail" do
-      assert_request(:get, url, to_return: {body: {metadata: {resourceVersion: "123"}}.to_json}) do
-        args = ->(x) { x.body.must_include '"resourceVersion":"123"'; true }
-        assert_request(:put, url, to_return: {body: "{}"}, with: args) do
-          resource.deploy
         end
       end
     end


### PR DESCRIPTION
I tried with ApiService and CRDs against a 1.10 cluster and all worked out fine, so let's try removing this or find out where exactly it is still an 

## Risk
 - Med: will break deploys that still need this, simply revert and note which ones these are so we can document better / bring the logic back ... ideally improve it to fetch before retry too

@zendesk/compute 