### PR TITLE
be more efficient by reusing the response of create and update

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -117,23 +117,19 @@ module Kubernetes
         remove_instance_variable(:@resource) if defined?(@resource)
       end
 
-      # TODO: remove the expire_cache and assign @resource but that breaks a bunch of deploy_executor tests
       def create
         return if @delete_resource
         restore_template do
           @template[:metadata].delete(:resourceVersion)
-          request(:create, @template)
+          @resource = request(:create, @template)
         end
-        expire_resource_cache
       rescue Kubeclient::ResourceNotFoundError => e
         raise_kubernetes_error(e.message)
       end
 
-      # TODO: remove the expire_cache and assign @resource but that breaks a bunch of deploy_executor tests
       def update
         ensure_not_updating_match_labels
-        request(:update, template_for_update)
-        expire_resource_cache
+        @resource = request(:update, template_for_update)
       end
 
       def ensure_not_updating_match_labels

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -107,7 +107,7 @@ describe Kubernetes::Resource do
       let(:url) { "#{origin}/apis/extensions/v1beta1/namespaces/pod1/deployments/some-project" }
 
       it "creates when missing" do
-        assert_request(:get, url, to_return: [{status: 404}, {body: "{}"}]) do
+        assert_request(:get, url, to_return: {status: 404}) do
           assert_request(:post, base_url, to_return: {body: "{}"}) do
             resource.deploy
           end
@@ -119,7 +119,7 @@ describe Kubernetes::Resource do
       end
 
       it "updates existing" do
-        assert_request(:get, url, to_return: {body: "{}"}, times: 2) do
+        assert_request(:get, url, to_return: {body: "{}"}) do
           args = ->(x) { x.body.must_include '"replicas":2'; true }
           assert_request(:put, url, to_return: {body: "{}"}, with: args) do
             resource.deploy


### PR DESCRIPTION
this fails because deployment deletion logic is very complicated and tests break when we do not fake a 404 to avoid rollback