### PR TITLE
use normal styles for key, it will not include special characters

### DIFF
--- a/app/views/secrets/_row.html.erb
+++ b/app/views/secrets/_row.html.erb
@@ -12,9 +12,7 @@
     <% end %>
   </td>
   <td><%= parts.fetch(:deploy_group_permalink) %></td>
-  <td title="<%= id %>">
-    <code><%= parts.fetch(:key) %></code>
-  </td>
+  <td><%= parts.fetch(:key) %></td>
   <td>
     <span class="ui-buttonset">
       <%= link_to "Edit", secret_path(id) %> |


### PR DESCRIPTION
before:
<img width="714" alt="Screen Shot 2019-07-11 at 11 00 54 PM" src="https://user-images.githubusercontent.com/11367/61105879-19d0a380-a430-11e9-975e-d164f5cd2e5c.png">

after:
<img width="676" alt="Screen Shot 2019-07-11 at 11 02 29 PM" src="https://user-images.githubusercontent.com/11367/61105885-1e955780-a430-11e9-8625-9551b36b2720.png">

@zendesk/compute @magnetikonline 