### PR TITLE
fail early when cluster is missing to eliminate other sources of the bug

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -441,6 +441,9 @@ module Kubernetes
           deploy: @job.deploy
         )
         grouped_deploy_group_roles.flatten.map do |deploy_group_role|
+          # fail early here, this was randomly not there, also fixes an n+1
+          deploy_group_role.deploy_group.kubernetes_cluster || raise
+
           Kubernetes::ReleaseDoc.new(
             kubernetes_release: release,
             deploy_group: deploy_group_role.deploy_group,

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -182,7 +182,7 @@ describe Kubernetes::DeployExecutor do
           pod_reply[:items] << copy
         end
 
-        assert_nplus1_queries(1) do
+        assert_nplus1_queries 0 do
           assert execute, out
         end
       end


### PR DESCRIPTION
we had this failing in `template_filler.rb" line 499 in static_env` which does not make any sense ... so maybe the template filler did something weird ... if this raise explodes then it's a db bug, if not the the filler does something wrong

@zendesk/compute 