### PR TITLE
allow showing a sample of logs from deploy UI to get a quick look if …

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_27_211709) do
+ActiveRecord::Schema.define(version: 2019_07_14_235744) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -573,6 +573,7 @@ ActiveRecord::Schema.define(version: 2019_06_27_211709) do
     t.integer "aws_sts_iam_role_session_duration"
     t.boolean "allow_redeploy_previous_when_failed", default: false, null: false
     t.string "github_pull_request_comment"
+    t.boolean "kubernetes_sample_logs_on_success", default: false, null: false
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_form.html.erb
@@ -1,6 +1,7 @@
 <fieldset>
   <legend>Kubernetes</legend>
   <%= form.input :kubernetes, as: :check_box, label: "Deploy via kubernetes / ignore commands" %>
+  <%= form.input :kubernetes_sample_logs_on_success, as: :check_box, label: "Sample logs on success" %>
 
   <h3>Role config (optional)</h3>
   <% @stage.kubernetes_stage_roles.build %>

--- a/plugins/kubernetes/db/migrate/20190714235744_add_sample_logs_to_stages.rb
+++ b/plugins/kubernetes/db/migrate/20190714235744_add_sample_logs_to_stages.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddSampleLogsToStages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stages, :kubernetes_sample_logs_on_success, :boolean, default: false, null: false
+  end
+end

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -42,6 +42,7 @@ end
 Samson::Hooks.callback(:stage_permitted_params) do
   [
     :kubernetes,
+    :kubernetes_sample_logs_on_success,
     {kubernetes_stage_roles_attributes: [:kubernetes_role_id, :ignored, :_destroy, :id]}
   ]
 end


### PR DESCRIPTION
…things are alright

after a deployment I often take a look at the logs to see if anything looks suspicious, that takes a bit of time and is easy to forget ... so add an option to do that during the deploy
(reuses same limited lines/limited timeframe logic we already use to show error logs)

@zendesk/compute 

<img width="635" alt="Screen Shot 2019-07-15 at 7 14 35 AM" src="https://user-images.githubusercontent.com/11367/61191122-aa2d1380-a6d0-11e9-8c4f-69cefc29dd3d.png">
<img width="620" alt="Screen Shot 2019-07-15 at 7 16 06 AM" src="https://user-images.githubusercontent.com/11367/61191124-aac5aa00-a6d0-11e9-9e64-750ecb227dd9.png">
