### PR TITLE
seeding database fails if kubernetes roles not present

### DIFF
--- a/plugins/kubernetes/db/seeds.rb
+++ b/plugins/kubernetes/db/seeds.rb
@@ -44,10 +44,14 @@ Stage.new(
 ).save!(validate: false)
 
 ["migrate", "server"].each do |name|
-  role = Kubernetes::Role.find_by_name!(name)
+  role = Kubernetes::Role.new(
+    name: name,
+    project: project
+  )
   if name == "server"
-    role.update_column(:service_name, "example-server")
+    role.service_name = "example-server"
   end
+  role.save!
   Kubernetes::DeployGroupRole.create!(
     project: project,
     deploy_group: groupk,


### PR DESCRIPTION
Setting up and seeding an empty database fails because the Kubernetes roles have not been created.

### To Reproduce
* Drop samson databases
```
(none)> drop database samson_development;
Query OK, 50 rows affected (0.18 sec)

(none)> drop database samson_test;
Query OK, 50 rows affected (0.14 sec)
```
* Run `bin/setup`, which fails:
```
rake aborted!
ActiveRecord::RecordNotFound: Couldn't find Kubernetes::Role
/Users/soberther/projects/zendesk/samson/plugins/kubernetes/db/seeds.rb:47:in `block in <main>'
/Users/soberther/projects/zendesk/samson/plugins/kubernetes/db/seeds.rb:46:in `each'
/Users/soberther/projects/zendesk/samson/plugins/kubernetes/db/seeds.rb:46:in `<main>'
/Users/soberther/projects/zendesk/samson/db/seeds.rb:32:in `block in <main>'
/Users/soberther/projects/zendesk/samson/db/seeds.rb:32:in `each'
/Users/soberther/projects/zendesk/samson/db/seeds.rb:32:in `<main>'
/Users/soberther/.rbenv/versions/2.5.3/bin/bundle:23:in `load'
/Users/soberther/.rbenv/versions/2.5.3/bin/bundle:23:in `<main>'
Tasks: TOP => db:setup => db:seed
(See full trace by running task with --trace)
FAIL
```

### References
- Jira link: 

### Risks
- Low: database seed code should only be run when setting up a brand new testing/dev environment.
