### PR TITLE
when deleting an autoscaled deployment, set the replicas to 0

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -159,11 +159,12 @@ module Kubernetes
       def template_for_update
         copy = @template.deep_dup
 
-        # when autoscaling on a resource with replicas we should keep replicas constant
+        # when updating a autoscaling resource we should keep replicas constant unless we are trying to delete
         # (not setting replicas will make it use the default of 1)
         path = [:spec, :replicas]
-        replica_source = (@autoscaled && resource) || @template
-        copy.dig_set(path, replica_source.dig(*path)) if @template.dig(*path)
+        if @autoscaled && resource && copy.dig(*path).to_i != 0
+          copy.dig_set(path, resource.dig(*path))
+        end
 
         # copy fields
         persistent_fields.each do |keep|

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -532,6 +532,18 @@ describe Kubernetes::Resource do
         resource.delete
       end
 
+      it "can delete when using autoscaling" do
+        resource.instance_variable_set(:@autoscaling, true)
+        client = resource.send(:client)
+        client.expects(:update_deployment).with do |template|
+          template[:spec][:replicas].must_equal 0
+        end
+        client.expects(:get_deployment).raises(Kubeclient::ResourceNotFoundError.new(404, 'Not Found', {}))
+        client.expects(:get_deployment).times(3).returns(deployment_stub(0))
+        client.expects(:delete_deployment)
+        resource.delete
+      end
+
       it "does not fail on unset replicas" do
         client = resource.send(:client)
         client.expects(:update_deployment)


### PR DESCRIPTION
noticed this old bug when testing locally

@zendesk/compute 