### PR TITLE
fix check to ignore hpa events

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/horizontal_pod_autoscaler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/horizontal_pod_autoscaler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Kubernetes
+  module Api
+    class HorizontalPodAutoscaler
+      IGNORED_AUTOSCALE_EVENT_REASONS = [
+        "FailedGetMetrics",
+        "FailedRescale",
+        "FailedGetResourceMetric",
+        "FailedGetExternalMetric",
+        "FailedComputeMetricsReplicas"
+      ].freeze
+
+      def events_indicating_failure(events)
+        events.reject { |e| IGNORED_AUTOSCALE_EVENT_REASONS.include? e[:reason] }
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -43,8 +43,8 @@ module Kubernetes
       elsif kind == "HorizontalPodAutoscaler"
         hpa = Kubernetes::Api::HorizontalPodAutoscaler.new
         failures = hpa.events_indicating_failure(events(type: "Warning"))
-        if failures && !failures.empty?
-          @details = "Error event \n#{failures.join("\n")}"
+        if failures.any?
+          @details = "Error event\n #{failures.join("\n")}"
         else
           @details = "Live"
           @live = true

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -40,6 +40,16 @@ module Kubernetes
         else
           @details = "Waiting (#{@pod.phase}, #{@pod.reason})"
         end
+      elsif kind == "HorizontalPodAutoscaler"
+        hpa = Kubernetes::Api::HorizontalPodAutoscaler.new
+        failures = hpa.events_indicating_failure(events(type: "Warning"))
+        if failures && !failures.empty?
+          @details = "Error event \n#{failures.join("\n")}"
+        else
+          @details = "Live"
+          @live = true
+        end
+        @finished = true
       else
         # NOTE: non-pods are never "Missing" because we create them manually
         @finished = true

--- a/plugins/kubernetes/test/models/kubernetes/api/horizontal_pod_autoscaler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/horizontal_pod_autoscaler_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require_relative '../../../test_helper'
+
+SingleCov.covered!
+
+describe Kubernetes::Api::HorizontalPodAutoscaler do
+  let(:start_time) { "2017-03-31T22:56:20Z" }
+  let(:event) { {metadata: {creationTimestamp: start_time}, type: 'Normal'} }
+  let(:events) { [event] }
+  let(:hpa) { Kubernetes::Api::HorizontalPodAutoscaler.new }
+
+  describe "HorizontalPodAutoscaler events with failures" do
+    before do
+      event.merge!(kind: 'HorizontalPodAutoscaler', type: 'Warning')
+    end
+
+    it "does not ignore bad events" do
+      refute hpa.events_indicating_failure(events).empty?
+    end
+
+    it "ignores failing to get metrics" do
+      event[:reason] = 'FailedGetMetrics'
+
+      assert hpa.events_indicating_failure(events).empty?
+    end
+
+    it "ingores failures to scale" do
+      event[:reason] = 'FailedRescale'
+
+      assert hpa.events_indicating_failure(events).empty?
+    end
+
+    it "ignores failing to get resource metrics" do
+      event[:reason] = 'FailedGetResourceMetric'
+
+      assert hpa.events_indicating_failure(events).empty?
+    end
+
+    it "ignores failing to get external metrics" do
+      event[:reason] = 'FailedGetExternalMetric'
+
+      assert hpa.events_indicating_failure(events).empty?
+    end
+
+    it "ignores failing to compute metrics replicas" do
+      event[:reason] = 'FailedComputeMetricsReplicas'
+
+      assert hpa.events_indicating_failure(events).empty?
+    end
+
+    it "does not ignore an unknown HPA event" do
+      event[:reason] = 'SomeOtherFailure'
+
+      refute hpa.events_indicating_failure(events).empty?
+    end
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/api/horizontal_pod_autoscaler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/horizontal_pod_autoscaler_test.rb
@@ -4,15 +4,12 @@ require_relative '../../../test_helper'
 SingleCov.covered!
 
 describe Kubernetes::Api::HorizontalPodAutoscaler do
-  let(:start_time) { "2017-03-31T22:56:20Z" }
-  let(:event) { {metadata: {creationTimestamp: start_time}, type: 'Normal'} }
-  let(:events) { [event] }
   let(:hpa) { Kubernetes::Api::HorizontalPodAutoscaler.new }
 
-  describe "HorizontalPodAutoscaler events with failures" do
-    before do
-      event.merge!(kind: 'HorizontalPodAutoscaler', type: 'Warning')
-    end
+  describe "#events_indicating_failure" do
+    let(:start_time) { "2017-03-31T22:56:20Z" }
+    let(:event) { {metadata: {creationTimestamp: start_time}, kind: 'HorizontalPodAutoscaler', type: 'Warning'} }
+    let(:events) { [event] }
 
     it "does not ignore bad events" do
       refute hpa.events_indicating_failure(events).empty?

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -288,48 +288,6 @@ describe Kubernetes::Api::Pod do
         assert events_indicate_failure?
       end
     end
-
-    describe "HorizontalPodAutoscaler with failures we don't care about" do
-      before do
-        event.merge!(kind: 'HorizontalPodAutoscaler', type: 'Warning')
-      end
-
-      it "ignores failing to get metrics" do
-        event[:reason] = 'FailedGetMetrics'
-
-        refute events_indicate_failure?, 'FailedGetMetrics must not be recognized as failures'
-      end
-
-      it "ingores failures to scale" do
-        event[:reason] = 'FailedRescale'
-
-        refute events_indicate_failure?, 'FailedRescale must not be recognized as failures'
-      end
-
-      it "ignores failing to get resource metrics" do
-        event[:reason] = 'FailedGetResourceMetric'
-
-        refute events_indicate_failure?, 'FailedGetResourceMetric must not be recognized as failures'
-      end
-
-      it "ignores failing to get external metrics" do
-        event[:reason] = 'FailedGetExternalMetric'
-
-        refute events_indicate_failure?, 'FailedGetExternalMetric must not be recognized as failures'
-      end
-
-      it "ignores failing to compute metrics replicas" do
-        event[:reason] = 'FailedComputeMetricsReplicas'
-
-        refute events_indicate_failure?, 'FailedComputeMetricsReplicas must not be recognized as failures'
-      end
-
-      it "does not ignore an unknown HPA event" do
-        event[:reason] = 'SomeOtherFailure'
-
-        assert events_indicate_failure?, 'Events we dont explicitly ignore must be recognized as failures'
-      end
-    end
   end
 
   describe "#waiting_for_resources?" do

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -67,6 +67,25 @@ describe Kubernetes::ResourceStatus do
       expect_event_request { details.must_equal "Error event" }
     end
 
+    describe "horizontal-pod-autoscaler" do
+      before { resource[:kind] = "HorizontalPodAutoscaler" }
+
+      it "does not fail for normal events" do
+        events.clear
+        expect_event_request { details.must_equal "Live" }
+      end
+
+      it "does not fail for ignored events" do
+        events[0].merge!(type: "Warning", reason: "FailedGetMetrics")
+        expect_event_request { details.must_equal "Live" }
+      end
+
+      it "fails for events indicating failure" do
+        events[0].merge!(type: "Warning", reason: "SomeOtherFailure")
+        expect_event_request { details.must_equal "Error event\n #{events[0]}" }
+      end
+    end
+
     describe "non-pods" do
       before { resource[:kind] = "Service" }
 


### PR DESCRIPTION
Description:
Checks to ignore HPA warnings were done for incorrect resource type and due to that samson was not ignoring warnings from hpa

@zendesk/compute 
@grosser 

