### PR TITLE
Fix Travis (bump brakeman)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       sassc (>= 2.0.0)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
-    brakeman (4.5.1)
+    brakeman (4.6.1)
     builder (3.2.3)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)


### PR DESCRIPTION
Travis is failing on the brakeman task

```
$ bundle exec rake $TASK
Brakeman 4.5.1 is not the latest version 4.6.1
```