### PR TITLE
try again to fix missing kube-cluster error

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -325,6 +325,9 @@ module Kubernetes
 
         # check that all roles have a matching deploy_group_role and all roles are configured
         @job.deploy.stage.deploy_groups.map do |deploy_group|
+          # fail early here, this was randomly not there, also fixes an n+1
+          deploy_group.kubernetes_cluster || raise
+
           group_roles = deploy_group_roles.select { |dgr| dgr.deploy_group_id == deploy_group.id }
 
           # safe some sql queries during release creation
@@ -444,9 +447,6 @@ module Kubernetes
           deploy: @job.deploy
         )
         grouped_deploy_group_roles.flatten.map do |deploy_group_role|
-          # fail early here, this was randomly not there, also fixes an n+1
-          deploy_group_role.deploy_group.kubernetes_cluster || raise
-
           Kubernetes::ReleaseDoc.new(
             kubernetes_release: release,
             deploy_group: deploy_group_role.deploy_group,

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -334,7 +334,10 @@ describe JobExecution do
   end
 
   describe "kubernetes" do
-    before { stage.update_column :kubernetes, true }
+    before do
+      stage.update_column :kubernetes, true
+      DeployGroup.any_instance.stubs(kubernetes_cluster: true)
+    end
 
     it "does the execution with the kubernetes executor" do
       Kubernetes::DeployExecutor.any_instance.expects(:execute).returns true


### PR DESCRIPTION
last change narrowed down that it came from the temp-release-docs area, moving it further up the chain to see if that fixes it somehow 🤷‍♂ 
(looked for any funny business, but all looks good ...)

@zendesk/compute 