### PR TITLE
Increase preStop delay for 35 seconds to allow DNS TTL to expire and die gracefully without spilling over requests

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -207,9 +207,11 @@ To make Samson leave your resource name alone, set `metadata.annotations.samson/
 
 To enable the following functionality you need to set `KUBERNETES_ADD_PRESTOP=true`.
 
-Samson automatically adds `container[].lifecycle.preStop` `sleep 3` if a preStop hook is not set and
+Samson automatically adds `container[].lifecycle.preStop` `sleep 3` if a `preStop` hook is not set and
 `container[].samson/preStop` is not set to `disabled`, to prevent in-flight requests from getting lost when taking a pod
 out of rotation (alternatively set `metadata.annoations.container-nameofcontainer-samson/preStop: disabled`).
+
+Set `KUBERNETES_PRESTOP_SLEEP_DURATION` in seconds if you want to override default sleep duration.
 
 ### Showing logs on succeeded deploys
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -850,6 +850,12 @@ describe Kubernetes::TemplateFiller do
           )
         end
 
+        it "bumps termination grace period if we would sleep longer that termination allows" do
+          with_env(KUBERNETES_PRESTOP_SLEEP_DURATION: "50") do
+            template.to_hash.dig_fetch(:spec, :template, :spec, :terminationGracePeriodSeconds).must_equal(53)
+          end
+        end
+
         it "does not add preStop when it was already defined" do
           raw_template.dig_fetch(:spec, :template, :spec, :containers, 0)[:lifecycle] = {preStop: "OLD"}
           template.to_hash.dig_fetch(:spec, :template, :spec, :containers, 0, :lifecycle).must_equal(


### PR DESCRIPTION
### References
- Jira link: PAAS-3874

### Risks
- Low