### PR TITLE
allow more time for pod deletion and stop early if it failed

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -380,11 +380,16 @@ module Kubernetes
       end
 
       def wait_for_termination_of_all_pods
-        30.times do
+        60.times do
           sleep TICK
           expire_resource_cache
           return if pods_count == 0
         end
+
+        raise(
+          Samson::Hooks::UserError,
+          "#{error_location}: DaemonSet was unable to delete existing pods, delete them manually or try again"
+        )
       end
     end
 


### PR DESCRIPTION
before we waited 2*30s ... let's bump this a bit more to make sure it's not randomness ...
also fail when waiting did not work so the error is less confusing and we don't trigger an update if the old version could not be removed

@zendesk/compute 