### PR TITLE
Use full path for sleep

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -580,7 +580,7 @@ module Kubernetes
         next if samson_container_config(container, :"samson/preStop") == "disabled"
         # set sleep to 35 seconds to allow for DNS TTL to expire.
         # Default termination grace period for pods
-        (container[:lifecycle] ||= {})[:preStop] ||= {exec: {command: ["sleep", pre_stop_sleep.to_s]}}
+        (container[:lifecycle] ||= {})[:preStop] ||= {exec: {command: ["/bin/sleep", pre_stop_sleep.to_s]}}
       end
       if pre_stop_sleep.to_i > DEFAULT_TERMINATION_GRACE_PERIOD
         # add few seconds to make sure servers shut down after they are done waiting

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -846,7 +846,7 @@ describe Kubernetes::TemplateFiller do
 
         it "adds preStop to avoid 502 errors when server addresses are cached for a few seconds" do
           template.to_hash.dig_fetch(:spec, :template, :spec, :containers, 0, :lifecycle).must_equal(
-            preStop: {exec: {command: ["sleep", "3"]}}
+            preStop: {exec: {command: ["/bin/sleep", "3"]}}
           )
         end
 


### PR DESCRIPTION
Found during classic deploy/undeploy: 

```
13m         Warning   FailedPreStopHook        Pod    Exec lifecycle hook ([sleep 3]) for Container "raingutter" in Pod "... " failed - error: command 'sleep 3' exited with 126: , message: "OCI runtime exec failed: exec failed: container_linux.go:345: starting container process caused \"exec: \\\"sleep\\\": executable file not found in $PATH\": unknown\r\n"
```

PATH is unset, so sleep is not found.

### Risks
- Low: /bin/sleep is a canonical path for it.