### PR TITLE
wait longer for desired to be filled for larger daemonsets to work

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -329,7 +329,7 @@ module Kubernetes
 
           desired = 0
 
-          3.times do |i|
+          6.times do |i|
             if i != 0
               # last iteration had bad state or does not yet know how many it needs, expire cache
               sleep TICK

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -472,8 +472,8 @@ describe Kubernetes::Resource do
       end
 
       it "blows up when desired count cannot be found (bad state or no nodes are available)" do
-        assert_request(:get, url, to_return: {body: {status: {desiredNumberScheduled: 0}}.to_json}, times: 3) do
-          resource.expects(:sleep).times(2)
+        assert_request(:get, url, to_return: {body: {status: {desiredNumberScheduled: 0}}.to_json}, times: 6) do
+          resource.expects(:sleep).times(5)
           assert_raises Samson::Hooks::UserError do
             resource.desired_pod_count
           end


### PR DESCRIPTION
ds with 190 pods failed on this step, but looked fine in the api ...

@zendesk/compute 