### PR TITLE
remove bad validation that did not work

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -64,7 +64,6 @@ module Kubernetes
       validate_team_labels
       validate_not_matching_team
       validate_stateful_set_service_consistent
-      validate_stateful_set_restart_policy
       validate_load_balancer
       unless validate_annotations
         validate_prerequisites_kinds
@@ -240,13 +239,6 @@ module Kubernetes
       return unless set = find_stateful_set
       return if set.dig(:spec, :serviceName) == service.dig(:metadata, :name)
       @errors << "Service metadata.name and StatefulSet spec.serviceName must be consistent"
-    end
-
-    def validate_stateful_set_restart_policy
-      return unless set = find_stateful_set
-      return if set.dig(:spec, :updateStrategy)
-      @errors << "StatefulSet spec.updateStrategy must be set. " \
-        "OnDelete will be supported soon but is brittle/rough, prefer RollingUpdate on kubernetes 1.7+."
     end
 
     def validate_containers_exist

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -94,7 +94,6 @@ describe Kubernetes::RoleValidator do
     describe 'StatefulSet' do
       before do
         stateful_set_role[0][:metadata][:name] = 'foobar'
-        stateful_set_role[1][:spec][:updateStrategy] = 'OnDelete'
         role.replace(stateful_set_role)
       end
 
@@ -105,11 +104,6 @@ describe Kubernetes::RoleValidator do
       it "enforces service and serviceName consistency" do
         stateful_set_role[0][:metadata][:name] = 'nope'
         errors.must_equal ["Service metadata.name and StatefulSet spec.serviceName must be consistent"]
-      end
-
-      it "enforces updateStrategy" do
-        stateful_set_role[1][:spec][:updateStrategy] = nil
-        errors.first.must_include "updateStrategy"
       end
     end
 


### PR DESCRIPTION
we support OnDelete and RollingUpdate strategies for StatefulSets and users could bypass it
by setting spec.updateStrategy.type anyway

@zendesk/compute 