### PR TITLE
support only RollingUpdate of DaemonSet

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -30,6 +30,7 @@ describe Kubernetes::RoleConfigFile do
 
     it "finds a Daemonset" do
       assert content.sub!('Deployment', 'DaemonSet')
+      assert content.sub!('extensions/v1beta1', 'apps/v1')
       assert content.sub!(/\n---.*/m, '')
       config_file.primary[:kind].must_equal 'DaemonSet'
     end

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -598,6 +598,27 @@ describe Kubernetes::RoleValidator do
         end
       end
     end
+
+    describe "#validate_daemon_set_supported" do
+      before do
+        role[0][:kind] = "DaemonSet"
+        role[0][:apiVersion] = "apps/v1"
+      end
+
+      it "is valid" do
+        errors.must_equal nil
+      end
+
+      it "complains about unsupported apiVersion" do
+        role[0][:apiVersion] = "extensions/v1beta1"
+        errors.must_equal ["set DaemonSet apiVersion to apps/v1"]
+      end
+
+      it "complains about unsupported strategy" do
+        role[0][:spec][:updateStrategy] = {type: "OnDelete"}
+        errors.must_equal ["set DaemonSet spec.updateStrategy.type to RollingUpdate"]
+      end
+    end
   end
 
   describe '.map_attributes' do


### PR DESCRIPTION
testing with https://github.com/samson-test-org/example-kubernetes grosser/daemonset branch and it seems to work alright

there seem to be no restrictions on which fields can be updated either (like statefulset)
afaik we'll never need OnDelete so I'm locking things down to RollingUpdate and apps/v1 only to get rid of all the old code

also we need apps/v1 to make the DaemonSet delete request delete all the pods (for rollback / un-deploy)

@zendesk/compute 