### PR TITLE
tell users to use maxUnavailable setting for DaemonSets so they do no…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -254,6 +254,12 @@ module Kubernetes
         @errors << "set DaemonSet spec.updateStrategy.type to RollingUpdate"
         return
       end
+
+      unless daemon_set.dig(:spec, :updateStrategy, :rollingUpdate, :maxUnavailable)
+        @errors << "set DaemonSet spec.updateStrategy.rollingUpdate.maxUnavailable, the default of 1 is too slow" \
+          " (pick something between '25%' and '100%')"
+        return
+      end
     end
 
     def validate_containers_exist

--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -30,7 +30,7 @@ describe Kubernetes::RoleConfigFile do
 
     it "finds a Daemonset" do
       assert content.sub!('Deployment', 'DaemonSet')
-      assert content.sub!('extensions/v1beta1', 'apps/v1')
+      Kubernetes::RoleValidator.any_instance.expects(:validate)
       assert content.sub!(/\n---.*/m, '')
       config_file.primary[:kind].must_equal 'DaemonSet'
     end

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -603,6 +603,7 @@ describe Kubernetes::RoleValidator do
       before do
         role[0][:kind] = "DaemonSet"
         role[0][:apiVersion] = "apps/v1"
+        role[0][:spec][:updateStrategy] = {type: "RollingUpdate", rollingUpdate: {maxUnavailable: "10%"}}
       end
 
       it "is valid" do
@@ -617,6 +618,11 @@ describe Kubernetes::RoleValidator do
       it "complains about unsupported strategy" do
         role[0][:spec][:updateStrategy] = {type: "OnDelete"}
         errors.must_equal ["set DaemonSet spec.updateStrategy.type to RollingUpdate"]
+      end
+
+      it "complains about unset maxUnavailable which will make the deploy timeout" do
+        role[0][:spec][:updateStrategy].delete(:rollingUpdate)
+        errors.to_s.must_include "default of 1"
       end
     end
   end


### PR DESCRIPTION
…t time out

@zendesk/compute 

finding existing with
```Ruby
bad = []
Kubernetes::Role.find_each do |role|
  next unless project = role.project
  next if role.config_file.blank?
  puts "#{project.permalink} #{role.config_file}"
  begin
    # NOTE: this might be out of date since we cannot trigger pulls from the console
    next unless content = project.repository.file_content(role.config_file, "master", pull: false)
    elements = Array.wrap(Kubernetes::Util.parse_file(content, role.config_file)).compact.map(&:deep_symbolize_keys)
    elements.each do |e|
      next unless e[:kind] == "DaemonSet"
      next if e.dig(:spec, :updateStrategy, :rollingUpdate, :maxUnavailable)
      name = e[:name] || e[:image] || "unknown"
      bad << [role, e]
      puts "BAD #{project.permalink} #{role.config_file} #{e[:kind]} #{name} needs maxUnavailable"
    end
  rescue => e
    puts "Error #{e}"
    bad << [role]
  end
end

```