### PR TITLE
limit env var index table with so it stays inside the page

### DIFF
--- a/plugins/env/app/views/environment_variables/index.html.erb
+++ b/plugins/env/app/views/environment_variables/index.html.erb
@@ -31,7 +31,7 @@
     <% @environment_variables.each do |variable| %>
       <tr>
         <td><code><%= variable.name %></code></td>
-        <td><pre><%= variable.value %></pre></td>
+        <td><pre style="max-width: 450px"><%= variable.value %></pre></td>
         <td><%= variable.scope_type ? (variable.scope&.name || "Deleted #{variable.scope_type} ##{variable.scope_id}") : 'All' %></td>
         <td>
           <% if parent = variable.parent %>


### PR DESCRIPTION
before:
![Screen Shot 2019-08-09 at 9 43 47 AM](https://user-images.githubusercontent.com/11367/62794910-350fec80-ba8a-11e9-8271-778ef9c1198c.png)


after:
![Screen Shot 2019-08-09 at 9 39 56 AM](https://user-images.githubusercontent.com/11367/62794913-36d9b000-ba8a-11e9-9985-9003c6298ac2.png)

@zendesk/compute 