### PR TITLE
alert user when trying to deploy the same resource from different roles

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -426,15 +426,14 @@ module Kubernetes
     def verify_kubernetes_templates!
       # - make sure each file exists
       # - make sure each deploy group has consistent labels
-      grouped_deploy_group_roles.each do |deploy_group_roles|
-        element_groups = deploy_group_roles.map do |deploy_group_role|
-          role = deploy_group_role.kubernetes_role
-          config = role.role_config_file(@job.commit)
-          raise Samson::Hooks::UserError, "Error parsing #{role.config_file}" unless config
-          config.elements
-        end.compact
-        Kubernetes::RoleValidator.validate_groups(element_groups)
-      end
+      # - only do this for one single deploy group since they are all identical
+      element_groups = grouped_deploy_group_roles.first.map do |deploy_group_role|
+        role = deploy_group_role.kubernetes_role
+        config = role.role_config_file(@job.commit)
+        raise Samson::Hooks::UserError, "Error parsing #{role.config_file}" unless config
+        config.elements
+      end.compact
+      Kubernetes::RoleValidator.validate_groups(element_groups)
 
       # make sure each template is valid
       temp_release_docs.each(&:verify_template)

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -690,7 +690,7 @@ describe Kubernetes::RoleValidator do
     it "is invalid with different role labels in a single role" do
       primary = role.first
       primary2 = primary.dup
-      primary2[:metadata] = {labels: {role: "meh", project: primary.dig(:metadata, :labels, :project)}}
+      primary2[:metadata] = {name: "bar", labels: {role: "meh", project: primary.dig(:metadata, :labels, :project)}}
       validate_error([[primary, primary2]]).must_equal(
         "metadata.labels.role must be set and consistent in each config file"
       )
@@ -699,7 +699,7 @@ describe Kubernetes::RoleValidator do
     it "is invalid when a role is not set" do
       primary = role.first
       primary2 = primary.dup
-      primary2[:metadata] = {labels: {project: primary.dig(:metadata, :labels, :project)}}
+      primary2[:metadata] = {name: "bar", labels: {project: primary.dig(:metadata, :labels, :project)}}
       validate_error([[primary, primary2]]).must_equal(
         "metadata.labels.role must be set and consistent in each config file"
       )
@@ -708,9 +708,13 @@ describe Kubernetes::RoleValidator do
     it "is invalid when all role are not set" do
       primary = role.first
       primary[:metadata][:labels].delete :role
-      validate_error([[primary, primary]]).must_equal(
+      validate_error([[primary]]).must_equal(
         "metadata.labels.role must be set and consistent in each config file"
       )
+    end
+
+    it "is invalid when using the same element twice" do
+      validate_error([[role.first, role.first]]).must_equal "Deployment .some-project-rc exists multiple times"
     end
   end
 end


### PR DESCRIPTION
also: do not validate each deploy group, they are all the same for our validations

tested with https://github.com/samson-test-org/example-kubernetes branch grosser/dup
```
[18:45:39] JobExecution failed: ConfigMap .example-server exists multiple times
```

@zendesk/compute 