### PR TITLE
Introduce soak times for a Stage

### DIFF
--- a/app/assets/javascripts/channels/job_outputs_channel.js
+++ b/app/assets/javascripts/channels/job_outputs_channel.js
@@ -59,6 +59,7 @@ function startStream(userId, projectParam, jobId){
   function updateStatusAndTitle(data) {
     $('#header').load("/projects/" + projectParam + "/jobs/" + jobId + "?header=true", function () {
       timeAgoFormat(); // header includes new dates ... show them nicely instantly
+      $(this).trigger('statusAndTitleUpdated');
     });
     window.document.title = data.title;
   }

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -109,7 +109,44 @@ $(function () {
   });
 
   $('[data-toggle="tooltip"]').tooltip();
+
+  function detectIfSoakTimeRequired(){
+    var $soakTimeRemaining = $('#soak_time_remaining');
+    if($soakTimeRemaining.length){
+      $('#header').off('DOMSubtreeModified', '#soak_time_remaining');
+      startCountdownTimer($soakTimeRemaining);
+    }
+  }
+
+  function startCountdownTimer($soakTimeRemaining){
+    var countDownTimer = setInterval(function() {
+        var timeInSeconds = parseInt($soakTimeRemaining.attr('data-soak-time-remaining'));
+        if (timeInSeconds > 0) {
+          var newTimeRemaining = timeInSeconds - 1;
+          $soakTimeRemaining.attr('data-soak-time-remaining', newTimeRemaining)
+          $soakTimeRemaining.html(secondsToHHMMSS(newTimeRemaining));
+        } else {
+          clearInterval(countDownTimer);
+          location.reload(); // HACK: it should just reload the header
+        }
+      }, 1000);
+  }
+
+  // On page load see if soak time countdown is required
+  detectIfSoakTimeRequired();
+
+  // When the header dynamically changes, see if soak time countdown is required
+  $('#header').on('statusAndTitleUpdated', function(){
+    detectIfSoakTimeRequired();
+  });
+
 });
+
+function secondsToHHMMSS(seconds) {
+  var date = new Date(null);
+  date.setSeconds(seconds); // specify value for SECONDS here
+  return date.toISOString().substr(11, 8);
+}
 
 function toggleOutputToolbar() {
   $('.only-active, .only-finished').toggle();

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -122,6 +122,7 @@ class StagesController < ResourceController
       :allow_redeploy_previous_when_failed,
       :static_emails_on_automated_deploy_failure,
       :full_checkout,
+      :soak_time,
       {
         deploy_group_ids: [],
         command_ids: []

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -142,6 +142,18 @@ class Deploy < ActiveRecord::Base
     updated_at - start_time
   end
 
+  def soak_time_remaining # in seconds
+    return unless stage.soak_time && succeeded?
+    soak_completion_time = updated_at + stage.soak_time
+    (soak_completion_time - Time.now()).round()
+  end
+
+  def soak_time_complete?
+    return false unless finished?
+    return true unless stage.soak_time
+    soak_time_remaining <= 0
+  end
+
   def self.start_deploys_waiting_for_restart!
     pending.reorder(nil).reject(&:waiting_for_buddy?).each do |deploy|
       deploy.touch # HACK: refresh is immediate with update

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -35,6 +35,7 @@ class Stage < ActiveRecord::Base
   # n emails separated by ;
   email = '([^\s;]+@[^\s;]+)'
   validates :notify_email_address, format: /\A#{email}((\s*;\s*)?#{email}?)*\z/, allow_blank: true
+  validates :soak_time, numericality: { only_integer: true }, allow_blank: true
   validate :validate_deploy_group_selected
   validate :validate_not_auto_deploying_without_buddy
 

--- a/app/views/deploys/_header.html.erb
+++ b/app/views/deploys/_header.html.erb
@@ -5,7 +5,16 @@
     <% if deployer_for_project? %>
       <%= redeploy_button %>
 
-      <% if @deploy.succeeded? && next_stage = @deploy.stage.next_stage %>
+      <% if @deploy.succeeded? && !@deploy.soak_time_complete? %>
+        <%= link_to "#", class: "btn btn-warning" do %>
+          Soak time remaining:
+          <span id="soak_time_remaining" data-soak-time-remaining="<%= @deploy.soak_time_remaining %>">
+            <%= Time.at(@deploy.soak_time_remaining).utc.strftime("%H:%M:%S") %>
+          </span>
+        <% end %>
+      <% end %>
+
+      <% if @deploy.succeeded? && @deploy.soak_time_complete? && next_stage = @deploy.stage.next_stage  %>
         <% unless Lock.locked_for?(next_stage, current_user) %>
           <%= link_to "Deploy #{@deploy.short_reference} to #{next_stage.name}",
               new_project_stage_deploy_path(@project, next_stage, reference: @deploy.short_reference),

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -6,6 +6,7 @@
         help: "Email addresses to notify of finished deploys, separated by <code>;</code>".html_safe
   %>
   <%= form.input :default_reference, help: "Default reference to deploy e.g. 'master'" %>
+  <%= form.input :soak_time, help: "Time to wait (in seconds) after deploy before moving to next stage" %>
 
   <% if DeployGroup.enabled? %>
     <%= render 'deploy_groups/deploy_group_select', form: form %>

--- a/app/views/stages/_fields.html.erb
+++ b/app/views/stages/_fields.html.erb
@@ -6,7 +6,7 @@
         help: "Email addresses to notify of finished deploys, separated by <code>;</code>".html_safe
   %>
   <%= form.input :default_reference, help: "Default reference to deploy e.g. 'master'" %>
-  <%= form.input :soak_time, help: "Time to wait (in seconds) after deploy before moving to next stage" %>
+  <%= form.input :soak_time, help: "Time a user should wait (in seconds) after deploy to verify the deploy hasn't caused any issues before moving to next stage" %>
 
   <% if DeployGroup.enabled? %>
     <%= render 'deploy_groups/deploy_group_select', form: form %>

--- a/db/migrate/20190808235009_add_soak_time_to_stages.rb
+++ b/db/migrate/20190808235009_add_soak_time_to_stages.rb
@@ -1,0 +1,5 @@
+class AddSoakTimeToStages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stages, :soak_time, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_14_235744) do
+ActiveRecord::Schema.define(version: 2019_08_08_235009) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -575,6 +575,7 @@ ActiveRecord::Schema.define(version: 2019_07_14_235744) do
     t.string "github_pull_request_comment"
     t.boolean "kubernetes_sample_logs_on_success", default: false, null: false
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
+    t.integer "soak_time"
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end
 


### PR DESCRIPTION
I thought it would be interesting to play around with the concept of soak times in Samson so when someone is deploying a Stage they can understand how long the team normally waits for the Stage to soak before moving onto the next stage.

This is what it looks like:
![soak-time-in-samson](https://user-images.githubusercontent.com/562605/62825037-b14b2280-bba5-11e9-8b8d-5934aa42d0ae.gif)
