### PR TITLE
when copying a row, checkboxes need to signal true/false and not blank

### DIFF
--- a/plugins/env/app/assets/javascripts/env/application.js
+++ b/plugins/env/app/assets/javascripts/env/application.js
@@ -33,7 +33,10 @@
 
   function copyRow($row, callback) {
     var $new_row = $row.clone();
-    $new_row.find(':input').val('');
+
+    // clear out values except for checkboxes and their hidden counterparts (1/0 value mostly)
+    // (this might get weird if we end up copying a regular hidden field)
+    $new_row.find(':input[type!=hidden][type!=checkbox]').val('');
 
     // each row needs a new unique name and id to make rails do the update logic correctly for environment_variables
     $new_row.find(':input').each(function(i, input){


### PR DESCRIPTION
caused a bug when saving copied stage-roles since the boolean was being set to `nil`

before:
![image](https://user-images.githubusercontent.com/11367/63065053-4d806c80-beb9-11e9-887a-5a6c87213097.png)


after:
<img width="406" alt="Screen Shot 2019-08-14 at 5 12 33 PM" src="https://user-images.githubusercontent.com/11367/63065029-2c1f8080-beb9-11e9-8276-4e16ebecb251.png">

@zendesk/compute @madhatter215 