### PR TITLE
inject a uniq label to ensure PDB targets deployment, not pod

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -114,9 +114,16 @@ module Kubernetes
         },
         spec: {
           minAvailable: target,
-          selector: {matchLabels: deployment.dig_fetch(:spec, :selector, :matchLabels).dup}
+          selector: {
+            matchLabels: deployment.
+              dig_fetch(:spec, :selector, :matchLabels).
+              merge(samsonAutoPDB: 'true')
+          }
         }
       }
+
+      deployment.dig_fetch(:metadata, :labels)[:samsonAutoPDB] = 'true'
+
       if deployment[:metadata].key? :namespace
         budget[:metadata][:namespace] = deployment.dig(:metadata, :namespace)
       end

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -205,6 +205,12 @@ describe Kubernetes::ReleaseDoc do
         create!
         create!.resource_template[2][:spec][:minAvailable].must_equal 1
       end
+
+      it "adds a unique label to metadata.labels do it only targets deployments, not pods" do
+        result = create!
+        result.resource_template[0][:metadata][:labels][:samsonAutoPDB].must_equal 'true'
+        result.resource_template[2][:spec][:selector][:matchLabels][:samsonAutoPDB].must_equal 'true'
+      end
     end
   end
 


### PR DESCRIPTION
Been seeing lots of deployments where the `PodDisruptionBudget` can't find a controller, so it generates a warning event cause Samson to abort the deploy. 

```
Warning NoControllers: found no controllers for pod "classic-sync-attachments-85869c4d4b-9x6d9" x2
Warning CalculateExpectedPodCountFailed: Failed to calculate the number of expected pods: found no controllers for pod "classic-sync-attachments-85869c4d4b-9x6d9" x2
```

This adds a new samson-specific label to `metadata.labels` and then to `spec.selector.matchLabels` of the PDB in the hopes that this will ensure the PDB targets the Deployment object, or really the ReplicationController it creates, rather than targeting individual Pod resources. 

This is mostly a theory, but if I define my own PDB and do this same thing, the deploys are reliably successful. 

### Risks
- Low. Just injecting a new label, but that could have unintended side-effects if someone is expecting an exact set of labels.