### PR TITLE
Refactor DatadogNotification and rename to DatadogDeployEvent

### DIFF
--- a/plugins/datadog/test/models/datadog_deploy_event_test.rb
+++ b/plugins/datadog/test/models/datadog_deploy_event_test.rb
@@ -3,52 +3,41 @@ require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe DatadogNotification do
+describe DatadogDeployEvent do
   let(:deploy) { deploys(:succeeded_test) }
-  let(:notification) { DatadogNotification.new(deploy) }
 
-  describe '#initialize' do
-    it 'initializes' do
-      notification.instance_variable_get(:@deploy).must_equal deploy
-      notification.instance_variable_get(:@stage).must_equal deploy.stage
+  describe '.deliver' do
+    def deliver(*args)
+      DatadogDeployEvent.deliver(deploy, *args)
     end
-  end
 
-  describe '#deliver' do
     def expected_body(overrides = {})
       {
         title: 'Super Admin deployed staging to Staging',
         text: 'super-admin@example.com deployed staging to Staging',
         alert_type: 'success',
         source_type_name: 'samson',
-        date_happened: 1388607000,
+        date_happened: happened.to_i,
         tags: ['deploy']
       }.merge(overrides).to_json
     end
 
     let(:url) { 'https://api.datadoghq.com/api/v1/events?api_key=dapikey' }
+    let(:happened) { Time.at(1388607000) }
 
-    it 'delivers correct notification with deploy updated_at' do
+    it 'delivers correct event with deploy updated_at' do
       assert_request(:post, url, with: {body: expected_body}) do
-        notification.deliver
+        deliver(tags: [], time: happened)
       end
     end
 
-    it 'delivers correct notification with current time' do
-      freeze_time
-      assert_request(:post, url, with: {body: expected_body(date_happened: Time.now.to_i)}) do
-        notification.deliver(now: true)
+    it 'delivers correct event with additional tags' do
+      assert_request(:post, url, with: {body: expected_body(tags: ['one', 'two', 'deploy'])}) do
+        deliver(tags: ['one', 'two'], time: happened)
       end
     end
 
-    it 'delivers correct notification with additional tags' do
-      freeze_time
-      assert_request(:post, url, with: {body: expected_body(tags: ['deploy', 'one', 'two'])}) do
-        notification.deliver(additional_tags: ['one', 'two'])
-      end
-    end
-
-    it 'delivers info notification if deploy is in progress' do
+    it 'delivers info event if deploy is in progress' do
       deploy.job.update_column(:status, 'running')
 
       expected_values = {
@@ -57,11 +46,11 @@ describe DatadogNotification do
       }
 
       assert_request(:post, url, with: {body: expected_body(expected_values)}) do
-        notification.deliver
+        deliver(tags: [], time: happened)
       end
     end
 
-    it 'delivers error notification if deploy did not succeed' do
+    it 'delivers error event if deploy did not succeed' do
       deploy.job.update_column(:status, 'failed')
 
       expected_values = {
@@ -69,27 +58,27 @@ describe DatadogNotification do
         title: 'Super Admin failed to deploy staging to Staging'
       }
       assert_request(:post, url, with: {body: expected_body(expected_values)}) do
-        notification.deliver
+        deliver(tags: [], time: happened)
       end
     end
 
     it 'logs success message if status is 202' do
       assert_request(:post, url, with: {body: expected_body}, to_return: {status: 202}) do
-        notification.deliver
+        deliver(tags: [], time: happened)
       end
     end
 
     it 'logs failure message if status is not 202' do
       Samson::ErrorNotifier.expects(:notify)
       assert_request(:post, url, with: {body: expected_body}, to_return: {status: 400}) do
-        notification.deliver
+        deliver(tags: [], time: happened)
       end
     end
 
     it "notifies of errors but does not block deploys when datadog is unreachable" do
       Samson::ErrorNotifier.expects(:notify)
       assert_request(:post, url, with: {body: expected_body}, to_timeout: []) do
-        notification.deliver
+        deliver(tags: [], time: happened)
       end
     end
   end

--- a/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
+++ b/plugins/datadog/test/samson_datadog/samson_plugin_test.rb
@@ -6,19 +6,18 @@ SingleCov.covered!
 describe SamsonDatadog do
   let(:deploy) { deploys(:succeeded_test) }
   let(:stage) { deploy.stage }
+  let(:happened) { Time.now }
 
-  describe '.send_notification' do
-    it 'sends notification' do
+  describe '.send_event' do
+    it 'sends event' do
       stage.datadog_tags = "foo"
-      dd_notification_mock = mock
-      dd_notification_mock.expects(:deliver).with(additional_tags: ['started'])
-      DatadogNotification.expects(:new).with(deploy).returns(dd_notification_mock)
+      DatadogDeployEvent.expects(:deliver).with(deploy, tags: ['foo', 'started'], time: happened)
 
-      SamsonDatadog.send_notification(deploy, additional_tags: ['started'])
+      SamsonDatadog.send_event(deploy, tags: ['started'], time: happened)
     end
 
-    it 'does not send notifications when disabled' do
-      DatadogNotification.expects(:new).never
+    it 'does not send events when disabled' do
+      DatadogDeployEvent.expects(:deliver).never
       Samson::Hooks.fire(:after_deploy, deploy, stub(output: nil))
     end
   end
@@ -157,8 +156,9 @@ describe SamsonDatadog do
   describe :before_deploy do
     only_callbacks_for_plugin :before_deploy
 
-    it 'sends notification on before hook' do
-      SamsonDatadog.expects(:send_notification).with(deploy, additional_tags: ['started'], now: true)
+    it 'sends event on before hook' do
+      freeze_time
+      SamsonDatadog.expects(:send_event).with(deploy, tags: ['started'], time: Time.now)
       Samson::Hooks.fire(:before_deploy, deploy, nil)
     end
   end
@@ -166,9 +166,8 @@ describe SamsonDatadog do
   describe :after_deploy do
     only_callbacks_for_plugin :after_deploy
 
-    it 'sends notification on after hook' do
-      stage.stubs(:send_datadog_notifications?).returns(true)
-      SamsonDatadog.expects(:send_notification).with(deploy, additional_tags: ['finished'])
+    it 'sends event on after hook' do
+      SamsonDatadog.expects(:send_event).with(deploy, tags: ['finished'], time: deploy.updated_at)
       Samson::Hooks.fire(:after_deploy, deploy, stub(output: nil))
     end
   end
@@ -176,7 +175,7 @@ describe SamsonDatadog do
   describe :validate_deploy do
     only_callbacks_for_plugin :validate_deploy
 
-    it 'sends notification on after hook' do
+    it 'sends event on after hook' do
       Samson::Hooks.fire(:validate_deploy, deploy, stub(output: nil)).must_equal [true]
     end
   end


### PR DESCRIPTION
cc: @grosser

Rename DatadogNotification in favor of DatagoDeployEvent.
Use interactor method to simply calling logic.
Remove time logic from within class and instead pass in as argument.

### Risks
- Med: Could cause failures in datadog callouts, altering metrics. Maybe failing deploys? 
