### PR TITLE
PAAS-4013 make sure we do not use ineffective/misleading readOnlyRoot…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -60,6 +60,7 @@ module Kubernetes
       validate_job_restart_policy
       validate_pod_disruption_budget
       validate_numeric_cpu_limits
+      validate_security_context
       validate_project_and_role_consistent
       validate_team_labels
       validate_not_matching_team
@@ -184,6 +185,13 @@ module Kubernetes
           next if [NilClass, String].include?(container.dig(*path).class)
           @errors << "Numeric cpu resources are not supported"
         end
+      end
+    end
+
+    def validate_security_context
+      templates.each do |template|
+        next unless template.dig(:spec, :securityContext, :readOnlyRootFilesystem)
+        @errors << "securityContext.readOnlyRootFilesystem can only be set at the container level"
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -9,7 +9,7 @@ describe Kubernetes::RoleValidator do
   end
   let(:role) { deployment_role }
 
-  describe '.verify' do
+  describe "#validate" do
     let(:spec) { role[0][:spec][:template][:spec] }
     let(:job_role) do
       [YAML.safe_load(read_kubernetes_sample_file('kubernetes_job.yml')).deep_symbolize_keys]
@@ -88,6 +88,13 @@ describe Kubernetes::RoleValidator do
       role[1][:spec] = {containers: []}
       errors.must_include(
         "Only use a maximum of 1 template with containers, found: 2"
+      )
+    end
+
+    it "does not allow ineffective securityContext" do
+      role[0][:spec][:template][:spec][:securityContext] = {readOnlyRootFilesystem: true}
+      errors.must_include(
+        "securityContext.readOnlyRootFilesystem can only be set at the container level"
       )
     end
 


### PR DESCRIPTION
…Filesystem directive

@uthark found that gotcha thanks to Intellij plugin 🎉 

Already made PRs for all our projects, so will give a week of grace period and then merge this 🤷‍♂ 
```ruby
bad = []
Kubernetes::Role.all.uniq { |r| [r.project_id, r.config_file] }.each do |role|
  next unless project = role.project
  next if role.config_file.blank?
  puts "#{project.permalink} #{role.config_file}"
  begin
    # NOTE: this might be out of date since we cannot trigger pulls from the console
    next unless content = project.repository.file_content(role.config_file, "master", pull: false)
    elements = Array.wrap(Kubernetes::Util.parse_file(content, role.config_file)).compact.map(&:deep_symbolize_keys)
    elements.each do |e|
      next if !e.dig(:spec, :template, :spec, :securityContext, :readOnlyRootFilesystem) &&
        !e.dig(:spec, :securityContext, :readOnlyRootFilesystem)
      puts "BAD #{project.permalink} #{role.config_file} #{e[:kind]} #{e.dig(:metadata, :name)}"
    end
  rescue => e
    puts "Error #{e}"
    bad << [role]
  end
end

```

@zendesk/compute 