### PR TITLE
PAAS-3866 do not allow nginx ingress config for everyone

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -263,3 +263,12 @@ If you still want to change a matchLabel, for example project/role:
  - deploy with renamed project/role
  - manually delete pods from old Deployment (`kubectl delete pods -l project=old-name,role=old-role`)
  - unset annotations from step 1
+
+### Blocking Ingress Nginx annotations
+
+Annotations like `nginx.ingress.kubernetes.io/whitelist-source-range` can make apps publicly accessible.
+To block them except for allowed projects, use:
+
+```
+KUBERNETES_INGRESS_NGINX_ANNOTATION_ALLOWED=project-permalink,[project-permalink,...]
+```


### PR DESCRIPTION
@zendesk/compute 

found existing usages with
```ruby
bad = []
Kubernetes::Role.all.uniq { |r| [r.project_id, r.config_file] }.each do |role|
  next unless project = role.project
  next if role.config_file.blank?
  puts "#{project.permalink} #{role.config_file}"
  begin
    # NOTE: this might be out of date since we cannot trigger pulls from the console
    next unless content = project.repository.file_content(role.config_file, "master", pull: false)
    elements = Array.wrap(Kubernetes::Util.parse_file(content, role.config_file)).compact.map(&:deep_symbolize_keys)
    elements.each do |e|
      next unless e[:kind] == "Ingress"
      (e.dig(:metadata, :annotations) || {}).each_key do |key|
        next unless key.to_s.start_with?("nginx.ingress.kubernetes.io/")
        puts "BAD #{project.permalink} #{role.config_file} #{e[:kind]} #{e.dig(:metadata, :name)} #{key}"
      end
      next if !e.dig(:spec, :template, :spec, :securityContext, :readOnlyRootFilesystem) &&
        !e.dig(:spec, :securityContext, :readOnlyRootFilesystem)
    end
  rescue => e
    puts "Error #{e}"
    bad << [role]
  end
end

```