### PR TITLE
Allow duplicate builds for a single git sha

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
     pry-byebug (3.3.0)
       byebug (~> 8.0)
       pry (~> 0.10)
-    pry-rails (0.3.4)
+    pry-rails (0.3.5)
       pry (>= 0.9.10)
     pry-rescue (1.4.5)
       interception (>= 0.5)

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -42,11 +42,11 @@ class BuildsController < ApplicationController
   def create
     new = false
     saved = false
-    external_build_has_digest = false
+    external_build_already_has_digest = false
 
     Samson::Retry.retry_when_not_unique do
       if registering_external_build? && @build = find_external_build
-        external_build_has_digest = @build.docker_repo_digest.present?
+        external_build_already_has_digest = @build.docker_repo_digest.present?
         @build.attributes = edit_build_params(validate: false)
       else
         @build = scope.new(new_build_params.merge(creator: current_user))
@@ -55,7 +55,7 @@ class BuildsController < ApplicationController
       new = @build.new_record?
       changed = @build.changed?
 
-      return head :unprocessable_entity if external_build_has_digest && changed
+      return head :unprocessable_entity if external_build_already_has_digest && changed
       saved = !changed || @build.save # nothing has changed or save result
     end
 
@@ -95,6 +95,7 @@ class BuildsController < ApplicationController
   def find_external_build
     build_params = params.require(:build)
     scope = Build.where(git_sha: build_params.require(:git_sha))
+    scope = scope.where(external_url: build_params[:external_url]) if build_params[:external_url].present?
     if image_name = build_params[:image_name].presence
       scope.where(image_name: image_name)
     else

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -17,12 +17,15 @@ class Build < ActiveRecord::Base
   validates :project, presence: true
   validates :git_sha, allow_nil: true, format: SHA1_REGEX
   validates :dockerfile, presence: true, unless: :external?
-  [:dockerfile, :image_name].each do |scope|
-    [:git_sha, :external_url].each do |attribute|
+  [:git_sha, :external_url].each do |attribute|
+    [:dockerfile, :image_name].each do |scope|
       validates(
         attribute,
         allow_nil: true,
-        uniqueness: {scope: [scope, :external_url], message: "already exists with this #{scope} and external_url"},
+        uniqueness: {
+          scope: [:git_sha, scope, :external_url].without(attribute),
+          message: "already exists with this #{attribute} and #{scope}"
+        },
         if: ->(build) { build.send(scope).present? && build.external_url.present? }
       )
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require 'action_mailer/railtie'
 require 'action_cable/engine'
 require 'rails/test_unit/railtie'
 require 'sprockets/railtie'
+require 'pry-rails'
 
 if (google_domain = ENV["GOOGLE_DOMAIN"]) && !ENV['EMAIL_DOMAIN']
   Rails.logger.warn "Stop using deprecated GOOGLE_DOMAIN"

--- a/db/migrate/20190911050155_alter_build_indexes.rb
+++ b/db/migrate/20190911050155_alter_build_indexes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AlterBuildIndexes < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :builds, [:git_sha, :dockerfile]
+    remove_index :builds, [:git_sha, :image_name]
+
+    add_index :builds, [:git_sha, :dockerfile, :external_url],
+      unique: true, length: {git_sha: 80, dockerfile: 80, external_url: 191}
+    add_index :builds, [:git_sha, :image_name, :external_url],
+      unique: true, length: {git_sha: 80, image_name: 80, external_url: 191}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 2019_09_19_212707) do
     t.string "external_status"
     t.string "image_name"
     t.index ["created_by"], name: "index_builds_on_created_by"
-    t.index ["git_sha", "dockerfile"], name: "index_builds_on_git_sha_and_dockerfile", unique: true
-    t.index ["git_sha", "image_name"], name: "index_builds_on_git_sha_and_image_name", unique: true, length: 80
+    t.index ["git_sha", "dockerfile", "external_url"], name: "index_builds_on_git_sha_and_dockerfile_and_external_url", unique: true, length: { git_sha: 80, dockerfile: 80, external_url: 191 }
+    t.index ["git_sha", "image_name", "external_url"], name: "index_builds_on_git_sha_and_image_name_and_external_url", unique: true, length: { git_sha: 80, image_name: 80, external_url: 191 }
     t.index ["project_id"], name: "index_builds_on_project_id"
   end
 

--- a/lib/samson/build_finder.rb
+++ b/lib/samson/build_finder.rb
@@ -90,7 +90,7 @@ module Samson
         commits.unshift previous if previous
       end
 
-      Build.where(git_sha: commits).sort_by { |build| commits.index(build.git_sha) }
+      Build.where(git_sha: commits).sort_by { |build| [commits.index(build.git_sha), -build.updated_at.to_i] }
     end
 
     # we only wait once no matter how many builds are missing since build creation is fast

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -173,16 +173,60 @@ describe BuildsController do
 
       describe "updates external builds" do
         let(:digest) { 'foo.com/test@sha256:5f1d7c7381b2e45ca73216d7b06004fdb0908ed7bb8786b62f2cdfa5035fde2c' }
+        let(:external_url) { 'https://blob.com/1234' }
 
         before do
-          build.update_columns(external_status: 'running', docker_repo_digest: nil)
+          build.update_columns(external_status: 'running', external_url: external_url, docker_repo_digest: nil)
         end
 
-        it 'updates a failed external build' do
+        it 'creates a new build when external url changes for the same git sha' do
+          assert_difference 'Build.count' do
+            create(
+              git_sha: build.git_sha,
+              external_status: 'succeeded',
+              external_url: 'https://blob.com/1235',
+              docker_repo_digest: digest,
+              dockerfile: build.dockerfile,
+              format: :json
+            )
+            assert_response :success
+          end
+
+          build.reload
+          build.external_status.must_equal 'running'
+          build.docker_repo_digest.must_equal nil
+          build.external_url.must_equal external_url
+
+          new_build = Build.last
+          new_build.external_status.must_equal 'succeeded'
+          new_build.docker_repo_digest.must_equal digest
+          new_build.external_url.must_equal 'https://blob.com/1235'
+        end
+
+
+        it 'updates existing running build when succeeded' do
+          create(
+            git_sha: build.git_sha,
+            external_status: 'succeeded',
+            external_url: external_url,
+            docker_repo_digest: digest,
+            dockerfile: build.dockerfile,
+            format: :json
+          )
+          assert_response :success
+
+          build.reload
+          build.external_status.must_equal 'succeeded'
+          build.docker_repo_digest.must_equal digest
+          build.external_url.must_equal external_url
+        end
+
+
+        it 'allows updating a failed external build' do
           create(
             git_sha: build.git_sha,
             external_status: 'failed',
-            external_url: "https://blob.com",
+            external_url: external_url,
             docker_repo_digest: digest,
             dockerfile: build.dockerfile,
             format: :json
@@ -192,21 +236,29 @@ describe BuildsController do
           build.reload
           build.external_status.must_equal 'failed'
           build.docker_repo_digest.must_equal digest
-          build.external_url.must_equal "https://blob.com"
+          build.external_url.must_equal external_url
         end
 
         it 'does not allow updating a succeeded build to prevent tampering' do
-          build.update_columns docker_repo_digest: digest
+          build.update_columns docker_repo_digest: digest, external_status: 'succeeded'
 
-          create external_url: "https://blob.com", git_sha: build.git_sha, dockerfile: build.dockerfile, format: :json
+          create(
+            git_sha: build.git_sha,
+            external_url: external_url,
+            docker_repo_digest: digest.reverse,
+            dockerfile: build.dockerfile,
+            format: :json
+          )
           assert_response 422
 
           build.reload
-          build.external_url.must_be_nil
+          build.external_status.must_equal 'succeeded'
+          build.docker_repo_digest.must_equal digest
+          build.external_url.must_equal external_url
         end
 
         it 'returns no content for succeeded builds that have not changes' do
-          build.update_columns(docker_repo_digest: digest, external_status: 'success', description: 'hello')
+          build.update_columns(docker_repo_digest: digest, external_status: 'succeeded', description: 'hello')
 
           # duplicate success
           create(
@@ -214,7 +266,7 @@ describe BuildsController do
             description: build.description,
             git_sha: build.git_sha,
             dockerfile: build.dockerfile,
-            external_status: 'success',
+            external_status: 'succeeded',
             format: :json
           )
 
@@ -227,7 +279,7 @@ describe BuildsController do
           create(
             git_sha: build.git_sha,
             external_status: 'failed',
-            external_url: "https://blob.com",
+            external_url: external_url,
             docker_repo_digest: digest,
             dockerfile: build.dockerfile,
             format: :json

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -203,7 +203,6 @@ describe BuildsController do
           new_build.external_url.must_equal 'https://blob.com/1235'
         end
 
-
         it 'updates existing running build when succeeded' do
           create(
             git_sha: build.git_sha,
@@ -220,7 +219,6 @@ describe BuildsController do
           build.docker_repo_digest.must_equal digest
           build.external_url.must_equal external_url
         end
-
 
         it 'allows updating a failed external build' do
           create(

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -174,6 +174,16 @@ describe BuildsController do
       describe "updates external builds" do
         let(:digest) { 'foo.com/test@sha256:5f1d7c7381b2e45ca73216d7b06004fdb0908ed7bb8786b62f2cdfa5035fde2c' }
         let(:external_url) { 'https://blob.com/1234' }
+        let(:create_args) do
+          {
+            git_sha: build.git_sha,
+            external_status: 'succeeded',
+            external_url: external_url,
+            docker_repo_digest: digest,
+            dockerfile: build.dockerfile,
+            format: :json
+          }
+        end
 
         before do
           build.update_columns(external_status: 'running', external_url: external_url, docker_repo_digest: nil)
@@ -181,14 +191,7 @@ describe BuildsController do
 
         it 'creates a new build when external url changes for the same git sha' do
           assert_difference 'Build.count' do
-            create(
-              git_sha: build.git_sha,
-              external_status: 'succeeded',
-              external_url: 'https://blob.com/1235',
-              docker_repo_digest: digest,
-              dockerfile: build.dockerfile,
-              format: :json
-            )
+            create create_args.merge(external_url: 'https://blob.com/1235')
             assert_response :success
           end
 
@@ -204,14 +207,7 @@ describe BuildsController do
         end
 
         it 'updates existing running build when succeeded' do
-          create(
-            git_sha: build.git_sha,
-            external_status: 'succeeded',
-            external_url: external_url,
-            docker_repo_digest: digest,
-            dockerfile: build.dockerfile,
-            format: :json
-          )
+          create create_args
           assert_response :success
 
           build.reload
@@ -221,14 +217,7 @@ describe BuildsController do
         end
 
         it 'allows updating a failed external build' do
-          create(
-            git_sha: build.git_sha,
-            external_status: 'failed',
-            external_url: external_url,
-            docker_repo_digest: digest,
-            dockerfile: build.dockerfile,
-            format: :json
-          )
+          create create_args.merge(external_status: 'failed')
           assert_response :success
 
           build.reload
@@ -240,13 +229,7 @@ describe BuildsController do
         it 'does not allow updating a succeeded build to prevent tampering' do
           build.update_columns docker_repo_digest: digest, external_status: 'succeeded'
 
-          create(
-            git_sha: build.git_sha,
-            external_url: external_url,
-            docker_repo_digest: digest.reverse,
-            dockerfile: build.dockerfile,
-            format: :json
-          )
+          create create_args.merge(docker_repo_digest: digest.reverse)
           assert_response 422
 
           build.reload
@@ -259,13 +242,9 @@ describe BuildsController do
           build.update_columns(docker_repo_digest: digest, external_status: 'succeeded', description: 'hello')
 
           # duplicate success
-          create(
+          create create_args.merge(
             name: build.name,
-            description: build.description,
-            git_sha: build.git_sha,
-            dockerfile: build.dockerfile,
-            external_status: 'succeeded',
-            format: :json
+            description: 'hello'
           )
 
           assert_response :ok
@@ -274,14 +253,7 @@ describe BuildsController do
         it 'retries when 2 requests come in at the exact same time and cause uniqueness error' do
           Build.any_instance.expects(:save).returns(true)
           Build.any_instance.expects(:save).raises(ActiveRecord::RecordNotUnique)
-          create(
-            git_sha: build.git_sha,
-            external_status: 'failed',
-            external_url: external_url,
-            docker_repo_digest: digest,
-            dockerfile: build.dockerfile,
-            format: :json
-          )
+          create create_args.merge(external_status: 'failed')
           assert_response :success
         end
       end

--- a/test/lib/samson/build_finder_test.rb
+++ b/test/lib/samson/build_finder_test.rb
@@ -331,16 +331,13 @@ describe Samson::BuildFinder do
     end
 
     it "find builds ordered by most recent first" do
-      attrs = build.attributes
-      attrs.delete("id")
+      attrs = build.attributes.except("id")
+      build1 = Build.new(attrs.merge(git_sha: job.commit, updated_at: Time.now + 30))
+      build2 = Build.new(attrs.merge(git_sha: job.commit, updated_at: Time.now + 0))
+      expected = [build1, build2]
+      expected.map { |b| b.save! validate: false }
 
-      new_builds = (1..3).map do |i|
-        Build.new(attrs.merge(git_sha: job.commit, updated_at: Time.now + i * 30)).tap do |b|
-          b.save! validate: false
-        end
-      end
-
-      finder.send(:possible_builds).must_equal new_builds.reverse
+      finder.send(:possible_builds).must_equal expected
     end
 
     it "find builds from previous deploy when requested" do
@@ -350,14 +347,36 @@ describe Samson::BuildFinder do
     end
 
     it "find builds from previous real deploy when previous on was also reusing" do
+      build.update_column(:git_sha, job.commit)
+      job.deploy.update_column(:kubernetes_reuse_build, true)
+      previous_deploy.update_column(:kubernetes_reuse_build, true)
+
+      pre_previous = deploys(:succeeded_production_test)
+      pre_previous.update_columns(stage_id: job.deploy.stage_id, id: previous_deploy.id - 1)
+      pre_previous_build = Build.new(build.attributes.except("id").merge(git_sha: pre_previous.job.commit))
+      pre_previous_build.save! validate: false
+
+      finder.send(:possible_builds).must_equal [pre_previous_build, build]
+    end
+
+    it "find builds ordered by oldest succeeded deploy, then most recent" do
+      # yes this order is weird, but changing the behaviour is a separate PR
+
       job.deploy.update_column(:kubernetes_reuse_build, true)
       previous_deploy.update_column(:kubernetes_reuse_build, true)
 
       pre_previous = deploys(:succeeded_production_test)
       pre_previous.update_columns(stage_id: job.deploy.stage_id, id: previous_deploy.id - 1)
 
-      build.update_column(:git_sha, pre_previous.job.commit)
-      finder.send(:possible_builds).must_equal [build]
+      attrs = build.attributes.except("id")
+      build1 = Build.new(attrs.merge(git_sha: job.commit, updated_at: Time.now + 30))
+      build2 = Build.new(attrs.merge(git_sha: job.commit, updated_at: Time.now + 0))
+      build3 = Build.new(attrs.merge(git_sha: pre_previous.job.commit, updated_at: Time.now + 40))
+      build4 = Build.new(attrs.merge(git_sha: pre_previous.job.commit, updated_at: Time.now + 20))
+
+      expected = [build3, build4, build1, build2]
+      expected.each { |b| b.save! validate: false }
+      finder.send(:possible_builds).must_equal expected
     end
   end
 

--- a/test/lib/samson/build_finder_test.rb
+++ b/test/lib/samson/build_finder_test.rb
@@ -330,6 +330,19 @@ describe Samson::BuildFinder do
       finder.send(:possible_builds).must_equal [build]
     end
 
+    it "find builds ordered by most recent first" do
+      attrs = build.attributes
+      attrs.delete("id")
+
+      new_builds = (1..3).map do |i|
+        Build.new(attrs.merge(git_sha: job.commit, updated_at: Time.now + i * 30)).tap do |b|
+          b.save! validate: false
+        end
+      end
+
+      finder.send(:possible_builds).must_equal new_builds.reverse
+    end
+
     it "find builds from previous deploy when requested" do
       job.deploy.update_column(:kubernetes_reuse_build, true)
       build.update_column(:git_sha, previous_deploy.job.commit)


### PR DESCRIPTION
Removes the uniqueness constraint for build sha to docker digest, so that newer builds for the same commit can be used and deployed, for example to pick up changes from a base image or internet download in one of the layers.

### References
- Jira link: 

### Risks
- Med: assumptions about docker builds broken where a multiple builds exist for a single git sha.
