### PR TITLE
Swanjr/use dr region when using dr bucket

### DIFF
--- a/plugins/env/README.md
+++ b/plugins/env/README.md
@@ -22,8 +22,8 @@ for a project and deploy_group.
 Run a service that writes config to an s3 bucket, 1 folder per project and 1 file per deploy group.
 To enable reading environment variables from an S3 bucket,
 set samson environment variables `CONFIG_SERVICE_BUCKET` and `CONFIG_SERVICE_REGION`.
-To support reading from a replicated S3 bucket on failure, also set the `CONFIG_SERVICE_DR_BUCKET` environment variable.
-
+To support reading from a replicated S3 bucket on failure, also set `CONFIG_SERVICE_DR_BUCKET`
+and `CONFIG_SERVICE_DR_REGION` environment variables.
 Database environment variable config will override returned env variables.
 
 For details, see `app/models/environment_variable.rb`

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -119,6 +119,7 @@ describe EnvironmentVariable do
 
       with_env CONFIG_SERVICE_REGION: "us-east-1",
         CONFIG_SERVICE_BUCKET: "a-bucket",
+        CONFIG_SERVICE_DR_REGION: "ap-southeast-2",
         CONFIG_SERVICE_DR_BUCKET: "dr-bucket"
       let(:s3) { stub("S3") }
 


### PR DESCRIPTION
* Needed to add DR region to the existing Config Service related code. It was using the wrong region with the DR bucket.

### References
- Jira link: https://zendesk.atlassian.net/browse/CONFIG-551

### Risks
- Low
