### PR TITLE
Revamp build search

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -16,6 +16,16 @@ class BuildsController < ApplicationController
         left_outer_joins(:docker_build_job).
         where("jobs.status = ? OR external_status = ?", status, status)
     end
+
+    if commit = search.delete(:commit)
+      builds =
+        if commit.match?(Build::SHA1_REGEX)
+          builds.where(git_sha: commit)
+        else
+          builds.where(git_ref: commit)
+        end
+    end
+
     @builds = builds.where(search).order(id: :desc)
     @pagy, @builds = pagy(@builds, page: params[:page], items: 15)
 

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -6,21 +6,21 @@
   <div class="row">
     <%= search_form do %>
       <%= search_select :status, Job::VALID_STATUSES, size: 2 %>
-      <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
-      <% projects = Project.order(:name).pluck(:name, :id) %>
-      <%= search_select :project_id, projects, live: true, label: "Project" %>
+      <% unless @project %>
+        <% projects = Project.order(:name).pluck(:name, :id) %>
+        <%= search_select :project_id, projects, live: true, label: "Project" %>
+      <% end %>
       <div class="col-sm-2">
-        <%= label_tag :git_sha, "Git SHA (commit)" %><br/>
-        <%= text_field_tag 'search[git_sha]', params.dig(:search, :git_sha), class: "form-control" %>
-      </div>
-      <div class="col-sm-2">
-        <%= label_tag :git_ref, "Git Reference" %><br/>
-        <%= text_field_tag 'search[git_ref]', params.dig(:search, :git_ref), class: "form-control" %>
+        <%= label_tag :git_sha, "Git Commit" %>
+        <%= additional_info "Full SHA or exact reference, does not resolve" %>
+        <br/>
+        <%= text_field_tag 'search[git_commit]', params.dig(:search, :git_sha), class: "form-control" %>
       </div>
       <div class="col-sm-2">
         <%= label_tag :docker_repo_digest, "Docker Digest" %><br/>
         <%= text_field_tag 'search[docker_repo_digest]', params.dig(:search, :docker_repo_digest), class: "form-control" %>
       </div>
+      <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
     <% end %>
   </div>
 

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -5,6 +5,7 @@
 <section class="tabs">
   <div class="row">
     <%= search_form do %>
+      <%= search_select :external_status, Job::VALID_STATUSES, size: 1, label: "Status" %>
       <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
       <% projects = Project.order(:permalink).pluck(:permalink, :id) %>
       <%= search_select :project_id, projects, live: true, label: "Project" %>

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -5,7 +5,7 @@
 <section class="tabs">
   <div class="row">
     <%= search_form do %>
-      <%= search_select :external_status, Job::VALID_STATUSES, size: 2 %>
+      <%= search_select :status, Job::VALID_STATUSES, size: 2 %>
       <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
       <% projects = Project.order(:name).pluck(:name, :id) %>
       <%= search_select :project_id, projects, live: true, label: "Project" %>

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -5,8 +5,21 @@
 <section class="tabs">
   <div class="row">
     <%= search_form do %>
-      <%= search_select :external, [["Yes", "true"], ["No", "false"]], size: 1 %>
       <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
+      <% projects = Project.order(:permalink).pluck(:permalink, :id) %>
+      <%= search_select :project_id, projects, live: true, label: "Project" %>
+      <div class="col-sm-2">
+        <%= label_tag :git_sha, "Git SHA (commit)" %><br/>
+        <%= text_field_tag 'search[git_sha]', params.dig(:search, :git_sha), class: "form-control" %>
+      </div>
+      <div class="col-sm-2">
+        <%= label_tag :git_ref, "Git Reference" %><br/>
+        <%= text_field_tag 'search[git_ref]', params.dig(:search, :git_ref), class: "form-control" %>
+      </div>
+      <div class="col-sm-2">
+        <%= label_tag :docker_repo_digest, "Docker Digest" %><br/>
+        <%= text_field_tag 'search[docker_repo_digest]', params.dig(:search, :docker_repo_digest), class: "form-control" %>
+      </div>
     <% end %>
   </div>
 

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -5,7 +5,7 @@
 <section class="tabs">
   <div class="row">
     <%= search_form do %>
-      <%= search_select :external_status, Job::VALID_STATUSES, size: 1, label: "Status" %>
+      <%= search_select :external_status, Job::VALID_STATUSES, size: 2 %>
       <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
       <% projects = Project.order(:name).pluck(:name, :id) %>
       <%= search_select :project_id, projects, live: true, label: "Project" %>

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -7,7 +7,7 @@
     <%= search_form do %>
       <%= search_select :external_status, Job::VALID_STATUSES, size: 1, label: "Status" %>
       <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
-      <% projects = Project.order(:permalink).pluck(:permalink, :id) %>
+      <% projects = Project.order(:name).pluck(:name, :id) %>
       <%= search_select :project_id, projects, live: true, label: "Project" %>
       <div class="col-sm-2">
         <%= label_tag :git_sha, "Git SHA (commit)" %><br/>

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -51,28 +51,16 @@ describe BuildsController do
         assert_response :success
       end
 
-      describe "external" do
-        it "ignores search for external blank" do
-          get :index, params: {search: {external: ''}}
+      describe "external status" do
+        it "ignores search for external status blank" do
+          get :index, params: {search: {external_status: ''}}
           assigns(:builds).count.must_equal Build.count
         end
 
-        it "can search for external YES" do
+        it "can search for external succeeded" do
           build.update_column(:external_status, "succeeded")
-          get :index, params: {search: {external: true}}
+          get :index, params: {search: {external_status: "succeeded"}}
           assigns(:builds).must_equal [build]
-        end
-
-        it "can search for external NO" do
-          Build.where.not(id: build.id).update(external_status: "succeeded")
-          get :index, params: {search: {external: false}}
-          assigns(:builds).must_equal [build]
-        end
-
-        it "cannot search for unknown external" do
-          assert_raises do
-            get :index, params: {search: {external: 'FOOBAR'}}
-          end
         end
       end
 

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -51,15 +51,21 @@ describe BuildsController do
         assert_response :success
       end
 
-      describe "external status" do
-        it "ignores search for external status blank" do
-          get :index, params: {search: {external_status: ''}}
+      describe "status" do
+        it "ignores search for status blank" do
+          get :index, params: {search: {status: ''}}
           assigns(:builds).count.must_equal Build.count
         end
 
-        it "can search for external succeeded" do
+        it "can search for external status" do
           build.update_column(:external_status, "succeeded")
-          get :index, params: {search: {external_status: "succeeded"}}
+          get :index, params: {search: {status: "succeeded"}}
+          assigns(:builds).must_equal [build]
+        end
+
+        it "can search for internal status" do
+          build.update_column(:docker_build_job_id, jobs(:succeeded_test).id)
+          get :index, params: {search: {status: "succeeded"}}
           assigns(:builds).must_equal [build]
         end
       end

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -42,7 +42,12 @@ describe BuildsController do
       end
 
       it 'can search for sha' do
-        get :index, params: {project_id: project.to_param, search: {git_sha: build.git_sha}}
+        get :index, params: {search: {commit: build.git_sha}}
+        assigns(:builds).must_equal [build]
+      end
+
+      it 'can search for ref' do
+        get :index, params: {search: {commit: build.git_ref}}
         assigns(:builds).must_equal [build]
       end
 


### PR DESCRIPTION
External status makes no sense, we have multiple states.

Added search possibilities for Git SHA, Git Reference and Docker digest.

### Risks
- Low: Search for builds could break