### PR TITLE
Changed session store from cookie store to cache store

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -179,9 +179,8 @@ end
 # Must be here instead of in an initializer because plugin initializers run before app initializers
 # Used in plugins/airbrake + rollbar which do not support the 'foo.bar' syntax as rails does
 # https://github.com/airbrake/airbrake-ruby/issues/137
-Samson::Application.config.session_key = :"_samson_session_#{Rails.env}"
 Rails.application.config.filter_parameters.concat [
-  :password, :value, :value_hashed, :token, :access_token, Samson::Application.config.session_key, 'HTTP_AUTHORIZATION'
+  :password, :value, :value_hashed, :token, :access_token, 'HTTP_AUTHORIZATION'
 ]
 
 # Avoid starting up another background thread if we don't need it, see lib/samson/boot_check.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -179,8 +179,9 @@ end
 # Must be here instead of in an initializer because plugin initializers run before app initializers
 # Used in plugins/airbrake + rollbar which do not support the 'foo.bar' syntax as rails does
 # https://github.com/airbrake/airbrake-ruby/issues/137
+Samson::Application.config.session_key = :"_samson_session_#{Rails.env}"
 Rails.application.config.filter_parameters.concat [
-  :password, :value, :value_hashed, :token, :access_token, 'HTTP_AUTHORIZATION'
+  :password, :value, :value_hashed, :token, :access_token, Samson::Application.config.session_key, 'HTTP_AUTHORIZATION'
 ]
 
 # Avoid starting up another background thread if we don't need it, see lib/samson/boot_check.rb

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 # Restart your server when you modify this file.
 
-Samson::Application.config.session_store :cookie_store, key: Samson::Application.config.session_key
+Samson::Application.config.session_store :cache_store


### PR DESCRIPTION
Fix For: Cookie overflow error for big flash notice.

Changed session store to cache store.
Cache store can be either memory or memcached.