### PR TITLE
PAAS-4207 paginate deploy group role index page

### DIFF
--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -5,16 +5,16 @@ require 'csv'
 class ResourceController < ApplicationController
   ADD_MORE = 'Save and add another'
 
-  def index(paginate: true)
+  def index(paginate: true, resources: search_resources)
     assign_resources(
       if paginate
         pagy(
-          search_resources,
+          resources,
           page: params[:page],
           items: [Integer(params[:per_page] || 25), 100].min
         )
       else
-        [nil, search_resources]
+        [nil, resources]
       end
     )
     respond_to do |format|

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/edit_many.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/edit_many.html.erb
@@ -22,7 +22,7 @@
         </tr>
       </thead>
 
-      <% @deploy_group_roles.each do |deploy_group_role| %>
+      <% @kubernetes_deploy_group_roles.each do |deploy_group_role| %>
         <% if deploy_group_role.errors.any? %>
           <tr>
             <td colspan="<%= 2 + rows.size %>"><%= render 'shared/errors', object: deploy_group_role %></td>

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
@@ -31,7 +31,7 @@
         <th>Actions</th>
       </tr>
 
-      <% @deploy_group_roles.each do |deploy_group_role| %>
+      <% @kubernetes_deploy_group_roles.each do |deploy_group_role| %>
         <tr>
           <% unless @project %>
             <td><%= link_to deploy_group_role.project.name, deploy_group_role.project %></td>
@@ -49,17 +49,20 @@
         </tr>
       <% end %>
 
-      <tr>
-        <td colspan="<%= @project ? 2 : 3 %>">Total</td>
-        <td><%= @deploy_group_roles.sum { |d| d.requests_cpu * d.replicas } %> to <%= @deploy_group_roles.sum { |d| d.limits_cpu * d.replicas } %></td>
-        <td><%= @deploy_group_roles.sum { |d| d.requests_memory * d.replicas } %> to <%= @deploy_group_roles.sum { |d| d.limits_memory * d.replicas } %></td>
-        <td><%= @deploy_group_roles.sum(&:replicas) %></td>
-        <td><%= link_to "Edit all", edit_many_project_kubernetes_deploy_group_roles_path(@project) if @project && current_user.admin_for?(@project) %></td>
-      </tr>
+      <% if @project %>
+        <tr>
+          <td colspan="2">Total</td>
+          <td><%= @kubernetes_deploy_group_roles.sum { |d| d.requests_cpu * d.replicas } %> to <%= @kubernetes_deploy_group_roles.sum { |d| d.limits_cpu * d.replicas } %></td>
+          <td><%= @kubernetes_deploy_group_roles.sum { |d| d.requests_memory * d.replicas } %> to <%= @kubernetes_deploy_group_roles.sum { |d| d.limits_memory * d.replicas } %></td>
+          <td><%= @kubernetes_deploy_group_roles.sum(&:replicas) %></td>
+          <td><%= link_to "Edit all", edit_many_project_kubernetes_deploy_group_roles_path(@project) if current_user.admin_for?(@project) %></td>
+        </tr>
+      <% end %>
     </table>
   </div>
 
   <div class="admin-actions">
+    <%= paginate @pagy unless @project %>
     <div class="pull-right">
       <%= link_to "New", new_kubernetes_deploy_group_role_path, class: "btn btn-default" %>
     </div>

--- a/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
@@ -24,7 +24,8 @@ describe Kubernetes::DeployGroupRolesController do
       it "renders" do
         get :index
         assert_template :index
-        assigns[:deploy_group_roles].must_include deploy_group_role
+        assigns[:kubernetes_deploy_group_roles].must_include deploy_group_role
+        assert assigns[:pagy]
       end
 
       it "renders when deploy group got deleted" do
@@ -36,17 +37,23 @@ describe Kubernetes::DeployGroupRolesController do
       it "renders as project tab" do
         get :index, params: {project_id: project}
         assert_template :index
-        assigns[:deploy_group_roles].map(&:project_id).uniq.must_equal [project.id]
+        assigns[:kubernetes_deploy_group_roles].map(&:project_id).uniq.must_equal [project.id]
+        refute assigns[:pagy]
+      end
+
+      it "paginates json project search" do
+        get :index, params: {project_id: project}, format: :json
+        assert assigns[:pagy]
       end
 
       it "can filter by project_id" do
         get :index, params: {search: {project_id: project.id}}
-        assigns[:deploy_group_roles].map(&:project_id).uniq.must_equal [project.id]
+        assigns[:kubernetes_deploy_group_roles].map(&:project_id).uniq.must_equal [project.id]
       end
 
       it "can filter by deploy_group" do
         get :index, params: {search: {deploy_group_id: deploy_groups(:pod100).id}}
-        assigns[:deploy_group_roles].map(&:deploy_group_id).uniq.must_equal [deploy_groups(:pod100).id]
+        assigns[:kubernetes_deploy_group_roles].map(&:deploy_group_id).uniq.must_equal [deploy_groups(:pod100).id]
       end
     end
 


### PR DESCRIPTION
for project tab we keep the sane/sorted/summed view which should be fairly limited, but the search / overview page gets paginated

![Screen Shot 2019-09-24 at 2 16 53 PM](https://user-images.githubusercontent.com/11367/65552712-f323f400-ded9-11e9-91d1-358c133c9598.png)

@zendesk/compute 