### PR TITLE
Restrict namespaces to only those managed by samson

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -344,9 +344,9 @@ describe Kubernetes::RoleValidator do
       describe "with invalid namespace" do
         before { role[0][:metadata][:namespace] = "bar" }
 
-        it "passes when namespace is not configured" do
+        it "fails when namespace is not configured" do
           validator.instance_variable_set(:@project, nil)
-          errors.must_equal nil
+          errors.must_equal ["Project is not configured to use namespace [\"bar\"]"]
         end
 
         it "fails with invalid namespace" do
@@ -654,7 +654,10 @@ describe Kubernetes::RoleValidator do
     end
 
     describe "#validate_load_balancer" do
-      before { role[1][:metadata][:namespace] = "foo" }
+      before do
+        project.create_kubernetes_namespace! name: "foo"
+        role[1][:metadata][:namespace] = "foo"
+      end
 
       it "allows when not configured" do
         errors.must_be_nil


### PR DESCRIPTION
Restrict namespaces to only those managed by samson.
Need a way to migrate existing applications which are deploying to other namespaces....

### References
- Jira link: https://zendesk.atlassian.net/browse/PAAS-4185

### Risks
- Low: breaks deployment of apps outside their namespace, potentially breaking some complex use cases
