### PR TITLE
PAAS-4154 show oomkill in deploy output since it does not have logs

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -41,8 +41,7 @@ module Kubernetes
 
         if !@resource
           @details = "Missing"
-        elsif @pod.restarted?
-          @details = "Restarted"
+        elsif @details = @pod.restart_details
           @finished = true
         elsif @pod.failed?
           @details = "Failed"

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -417,7 +417,7 @@ describe Kubernetes::DeployExecutor do
 
       refute execute
 
-      out.must_include "resque-worker Pod pod-resque-worker: Restarted\n"
+      out.must_include "resque-worker Pod pod-resque-worker: Restarted"
       out.must_include "UNSTABLE"
     end
 
@@ -428,7 +428,7 @@ describe Kubernetes::DeployExecutor do
 
       refute execute
 
-      out.must_include "Pod 100 resque-worker Pod: Restarted\n"
+      out.must_include "Pod 100 resque-worker Pod: Restarted"
       out.must_include "UNSTABLE"
     end
 
@@ -612,7 +612,7 @@ describe Kubernetes::DeployExecutor do
 
         refute execute
 
-        out.must_include "resque-worker Pod: Restarted\n"
+        out.must_include "resque-worker Pod: Restarted"
         out.must_include "UNSTABLE"
         out.must_include rollback_indicator
         out.must_include rollback_instructions
@@ -624,7 +624,7 @@ describe Kubernetes::DeployExecutor do
       it "deletes when there was no previous deployed resource" do
         refute execute
 
-        out.must_include "resque-worker Pod: Restarted\n"
+        out.must_include "resque-worker Pod: Restarted"
         out.must_include "UNSTABLE"
         out.must_include "Deleting"
         out.wont_include rollback_indicator
@@ -638,7 +638,7 @@ describe Kubernetes::DeployExecutor do
 
         refute execute
 
-        out.must_include "resque-worker Pod: Restarted\n"
+        out.must_include "resque-worker Pod: Restarted"
         out.must_include "UNSTABLE"
         out.must_include "DONE" # DONE is shown ... we got past the rollback
         out.must_include "FAILED: Weird error" # rollback error cause is shown
@@ -650,7 +650,7 @@ describe Kubernetes::DeployExecutor do
 
         refute execute
 
-        out.must_include "resque-worker Pod: Restarted\n"
+        out.must_include "resque-worker Pod: Restarted"
         out.must_include "UNSTABLE"
         out.must_include "DONE" # DONE is shown ... we got past the rollback
         out.wont_include rollback_instructions
@@ -692,7 +692,7 @@ describe Kubernetes::DeployExecutor do
         refute execute
 
         # failed
-        out.must_include "resque-worker Pod: Restarted\n"
+        out.must_include "resque-worker Pod: Restarted"
         out.must_include "UNSTABLE"
 
         # correct debugging output

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -32,8 +32,8 @@ describe Kubernetes::ResourceStatus do
     end
 
     it "is restarted when pod is restarted" do
-      resource[:status][:containerStatuses] = [{restartCount: 1}]
-      details.must_equal "Restarted"
+      resource[:status][:containerStatuses] = [{restartCount: 1, name: "foo", state: {terminated: {reason: "Backoff"}}}]
+      details.must_equal "Restarted (foo Backoff)"
     end
 
     it "is failed when pod is failed" do


### PR DESCRIPTION
![Screen Shot 2019-09-30 at 4 45 56 PM](https://user-images.githubusercontent.com/11367/65924490-d38d3f80-e3a1-11e9-939a-733bf45acb50.png)

reproduce by setting memory to 10m and deploying

@zendesk/compute 