### PR TITLE
short circuit commit status logic when commit was not found

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -19,8 +19,7 @@ class Integrations::GithubController < Integrations::BaseController
   protected
 
   def expire_commit_status
-    commit = params[:sha].to_s
-    CommitStatus.new(project, commit).expire_cache(commit)
+    CommitStatus.new(project, params[:sha].to_s).expire_cache
   end
 
   def payload

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -101,22 +101,15 @@ class Build < ActiveRecord::Base
     return errors.add(:git_ref, 'must be specified') if git_ref.blank? && git_sha.blank?
     return if errors.include?(:git_ref) || errors.include?(:git_sha)
     return validate_git_sha if git_ref.blank?
-    commit = commit_from_ref(git_ref)
+    commit = project.fast_commit_from_ref(git_ref)
     return errors.add(:git_ref, 'is not a valid reference') unless commit
     return validate_git_sha if git_sha.present? && git_sha != commit
     self.git_sha = commit
   end
 
   def validate_git_sha
-    return if commit_from_ref(git_sha)
+    return if project.fast_commit_from_ref(git_sha)
     errors.add(:git_sha, 'is not a valid SHA for this project')
-  end
-
-  # TODO: support local / github / gitlab ?
-  def commit_from_ref(ref)
-    GITHUB.commit(project.repository_path, ref).sha
-  rescue StandardError
-    nil
   end
 
   def assign_number

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -27,52 +27,65 @@ class CommitStatus
 
   def initialize(project, reference, stage: nil)
     @project = project
-    @reference = reference
+    @reference = reference # for display
+    @commit = project.fast_commit_from_ref(reference) # ref->commit but also double-check a commit exists
     @stage = stage
   end
 
+  # @return [String]
   def state
     combined_status.fetch(:state)
   end
 
+  # @return [Array<Hash>]
   def statuses
     combined_status.fetch(:statuses).map(&:to_h)
   end
 
-  def expire_cache(commit)
-    Rails.cache.delete(cache_key(commit))
+  # @return [NilClass]
+  def expire_cache
+    Rails.cache.delete(cache_key(@commit))
   end
 
   private
 
+  # @return [Hash]
   def combined_status
     @combined_status ||= begin
-      statuses = [github_state]
-      statuses += [release_status, *ref_statuses].compact if @stage
-      merge_statuses(statuses)
+      if @commit
+        statuses = [github_combined_status]
+        statuses += [release_status, *only_production_status, *plugin_statuses].compact if @stage
+        merge_statuses(statuses)
+      else
+        {
+          state: 'fatal',
+          statuses: [{state: 'missing', description: "Reference #{@reference} not found"}]
+        }
+      end
     end
   end
 
   # Gets a reference's state, combining results from both the Status and Checks API
   # NOTE: reply is an api object that does not support .fetch
-  def github_state
-    static = @reference.match?(Build::SHA1_REGEX) || @reference.match?(Release::VERSION_REGEX)
+  # @return [Hash]
+  def github_combined_status
     expires_in = ->(reply) { cache_duration(reply) }
-    Samson::DynamicTtlCache.cache_fetch_if static, cache_key(@reference), expires_in: expires_in do
-      checks_result = octokit_error_as_status('checks') { github_check }
-      status_result = octokit_error_as_status('status') { github_status }
+    Samson::DynamicTtlCache.cache_fetch_if true, cache_key(@commit), expires_in: expires_in do
+      checks_result = octokit_error_as_status('checks') { github_check_status }
+      status_result = octokit_error_as_status('status') { github_commit_status }
 
       results_with_statuses = [checks_result, status_result].select { |result| result[:statuses].any? }
 
-      results_with_statuses.empty? ? NO_STATUSES_REPORTED_RESULT.dup : merge_statuses(results_with_statuses)
+      results_with_statuses.empty? ? NO_STATUSES_REPORTED_RESULT : merge_statuses(results_with_statuses)
     end
   end
 
   # Gets commit statuses using GitHub's check API. Currently parsing it to match status structure to better facilitate
   # transition to new API. See https://developer.github.com/v3/checks/runs/ and
   # https://developer.github.com/v3/checks/suites/ for details
-  def github_check
-    base_url = "repos/#{@project.repository_path}/commits/#{@reference}"
+  # @return [Hash]
+  def github_check_status
+    base_url = "repos/#{@project.repository_path}/commits/#{@commit}"
     preview_header = {Accept: 'application/vnd.github.antiope-preview+json'}
 
     check_suites = GITHUB.get("#{base_url}/check-suites", headers: preview_header).to_attrs.fetch(:check_suites)
@@ -96,12 +109,13 @@ class CommitStatus
         updated_at: check_run[:started_at]
       }
     end
-    statuses += missing_check_runs_as_status(check_suites, check_runs)
+    statuses += missing_check_runs_statuses(check_suites, check_runs)
 
     {state: overall_state || 'pending', statuses: statuses}
   end
 
-  def missing_check_runs_as_status(check_suites, check_runs)
+  # @return [Array<Hash>]
+  def missing_check_runs_statuses(check_suites, check_runs)
     reported = check_runs.map { |c| c.dig_fetch(:check_suite, :id) }
     pending_suites = check_suites.reject { |s| reported.include?(s.fetch(:id)) }
     pending_suites.map do |suite|
@@ -117,22 +131,27 @@ class CommitStatus
   end
 
   # convert github api url to html url without doing another request for the PR
+  # @return [String]
   def github_pr_checks_url(suite)
     return unless pr = suite.fetch(:pull_requests).first
     pr.dig(:url).sub('://api.', '://').sub('/repos/', '/').sub('/pulls/', '/pull/') + "/checks"
   end
 
-  def github_status
-    GITHUB.combined_status(@project.repository_path, @reference).to_h
+  # @return [Hash]
+  def github_commit_status
+    GITHUB.combined_status(@project.repository_path, @commit).to_h
   end
 
+  # merges multiple statuses into a single status
+  # @return [Hash]
   def merge_statuses(statuses)
-    statuses[1..-1].each_with_object(statuses[0]) do |status, merged|
+    statuses[1..-1].each_with_object(statuses[0].dup) do |status, merged|
       merged[:state] = [merged.fetch(:state), status.fetch(:state)].max_by { |s| STATE_PRIORITY.index(s.to_sym) }
       merged.fetch(:statuses).concat(status.fetch(:statuses))
     end
   end
 
+  # @return [String]
   def check_state(check_conclusion)
     case check_conclusion
     when *CHECK_STATE[:success] then 'success'
@@ -143,6 +162,7 @@ class CommitStatus
     end
   end
 
+  # @return [Integer] seconds
   def cache_duration(github_result)
     statuses = github_result[:statuses]
     if github_result == NO_STATUSES_REPORTED_RESULT # does not have any statuses, chances are commit is new
@@ -161,7 +181,7 @@ class CommitStatus
   end
 
   # checks if other stages that deploy to the same hosts as this stage have deployed a newer release
-  # @return [nil, error-state]
+  # @return [nil, Hash]
   def release_status
     return unless DeployGroup.enabled?
     return unless current_version = version(@reference)
@@ -182,27 +202,32 @@ class CommitStatus
     }
   end
 
-  def ref_statuses
-    statuses = []
-    # Check if ref has been deployed to any non-production stages first if deploying to production
-    if @stage.production? && !@stage.project.deployed_reference_to_non_production_stage?(@reference)
-      statuses << {
-        state: "pending",
-        statuses: [{
-          state: "Production Only Reference",
-          description: "#{@reference} has not been deployed to a non-production stage."
-        }]
-      }
-    end
-    statuses + Samson::Hooks.fire(:ref_status, @stage, @reference).compact
+  # Check if ref has been deployed to any non-production stages first if deploying to production
+  def only_production_status
+    return if !@stage.production? || @stage.project.deployed_to_non_production_stage?(@commit)
+
+    {
+      state: "pending",
+      statuses: [{
+        state: "Production Only Reference",
+        description: "#{@reference} has not been deployed to a non-production stage."
+      }]
+    }
   end
 
+  # @return [Array<Hash>]
+  def plugin_statuses
+    Samson::Hooks.fire(:ref_status, @stage, @reference, @commit).compact
+  end
+
+  # @return [Gem::Version, NilClass]
   def version(reference)
     return unless plain = reference[Release::VERSION_REGEX, 1]
     Gem::Version.new(plain)
   end
 
   # optimized to sql instead of AR fanciness to make it go from 1s -> 0.01s on our worst case stage
+  # @return [Array<String>]
   def last_deployed_references
     last_deployed = deploy_scope.pluck(Arel.sql('max(deploys.id)'))
     Deploy.reorder(id: :asc).where(id: last_deployed).pluck(Arel.sql('distinct reference, id')).map(&:first)
@@ -212,6 +237,7 @@ class CommitStatus
     @deploy_scope ||= Deploy.reorder(nil).succeeded.where(stage_id: @stage.influencing_stage_ids).group(:stage_id)
   end
 
+  # don't blow up when github is down, but show a nice error
   def octokit_error_as_status(type)
     yield
   rescue Octokit::ClientError => e

--- a/plugins/github/lib/samson_github/samson_plugin.rb
+++ b/plugins/github/lib/samson_github/samson_plugin.rb
@@ -50,13 +50,14 @@ Samson::Hooks.callback :repo_provider_status do
 end
 
 Samson::Hooks.callback :changeset_api_request do |changeset, method|
+  next unless changeset.project.github?
+
   begin
-    next unless changeset.project.github?
     case method
     when :branch
-      GITHUB.branch(changeset.repo, CGI.escape(changeset.commit)).commit[:sha]
+      GITHUB.commit(changeset.repo, changeset.reference).sha
     when :compare
-      GITHUB.compare(changeset.repo, changeset.previous_commit, changeset.commit)
+      GITHUB.compare(changeset.repo, changeset.previous_commit, changeset.reference)
     else
       raise NoMethodError
     end

--- a/plugins/github/test/samson_github/samson_plugin_test.rb
+++ b/plugins/github/test/samson_github/samson_plugin_test.rb
@@ -118,7 +118,7 @@ describe SamsonDatadog do
     end
 
     it "calls branch api endpoint" do
-      stub_github_api("repos/foo/bar/branches/b", commit: {sha: "foo"})
+      stub_github_api("repos/foo/bar/commits/b", sha: "foo")
       fire(:branch).must_equal ["foo"]
     end
 

--- a/plugins/gitlab/lib/samson_gitlab/samson_plugin.rb
+++ b/plugins/gitlab/lib/samson_gitlab/samson_plugin.rb
@@ -13,13 +13,14 @@ end
 
 Samson::Hooks.callback :changeset_api_request do |changeset, method|
   next unless changeset.project.gitlab?
+
   begin
     case method
     when :branch
-      Gitlab.branch(changeset.repo, changeset.commit).commit.id
+      Gitlab.branch(changeset.repo, changeset.reference).commit.id
     when :compare
       Gitlab::ChangesetPresenter.new(
-        Gitlab.compare(changeset.repo, changeset.previous_commit, changeset.commit)
+        Gitlab.compare(changeset.repo, changeset.previous_commit, changeset.reference)
       ).build
     else
       raise NoMethodError

--- a/plugins/prerequisite_stages/app/decorators/stage_decorator.rb
+++ b/plugins/prerequisite_stages/app/decorators/stage_decorator.rb
@@ -5,9 +5,8 @@ Stage.class_eval do
       prerequisite_stage_ids.any? ? Stage.where(id: prerequisite_stage_ids) : []
     end
 
-    def undeployed_prerequisite_stages(reference)
-      commit = project.repository.commit_from_ref(reference)
-      return [] unless commit && stages = prerequisite_stages.presence
+    def undeployed_prerequisite_stages(commit)
+      return [] unless stages = prerequisite_stages.presence
 
       deployed_stages = stages.joins(deploys: :job).where(
         jobs: {status: 'succeeded', commit: commit}

--- a/plugins/prerequisite_stages/lib/samson_prerequisite_stages/samson_plugin.rb
+++ b/plugins/prerequisite_stages/lib/samson_prerequisite_stages/samson_plugin.rb
@@ -4,8 +4,8 @@ module SamsonPrerequisiteStages
   class Engine < Rails::Engine
   end
 
-  def self.validate_deployed_to_all_prerequisite_stages(stage, reference)
-    return unless missing = stage.undeployed_prerequisite_stages(reference).presence
+  def self.validate_deployed_to_all_prerequisite_stages(stage, reference, commit)
+    return unless missing = stage.undeployed_prerequisite_stages(commit).presence
     stage_names = missing.map(&:name).join(', ')
     "Reference '#{reference}' has not been deployed to these prerequisite stages: #{stage_names}."
   end
@@ -14,13 +14,14 @@ module SamsonPrerequisiteStages
   Samson::Hooks.view :stage_show, 'samson_prerequisite_stages'
 
   Samson::Hooks.callback :before_deploy do |deploy, _|
-    if error = SamsonPrerequisiteStages.validate_deployed_to_all_prerequisite_stages(deploy.stage, deploy.reference)
-      raise error
-    end
+    error = SamsonPrerequisiteStages.validate_deployed_to_all_prerequisite_stages(
+      deploy.stage, deploy.reference, deploy.commit
+    )
+    raise error if error
   end
 
-  Samson::Hooks.callback :ref_status do |stage, reference|
-    if error = SamsonPrerequisiteStages.validate_deployed_to_all_prerequisite_stages(stage, reference)
+  Samson::Hooks.callback :ref_status do |stage, reference, commit|
+    if error = SamsonPrerequisiteStages.validate_deployed_to_all_prerequisite_stages(stage, reference, commit)
       {
         state: 'fatal',
         statuses: [{

--- a/plugins/prerequisite_stages/test/decorators/stage_decorator_test.rb
+++ b/plugins/prerequisite_stages/test/decorators/stage_decorator_test.rb
@@ -36,21 +36,19 @@ describe Stage do
     end
 
     it 'returns empty array if ref has been deployed to all prereq stages' do
-      stage1.project.repository.expects(:commit_from_ref).with('123').returns(job.commit)
       stage3.deploys << deploys(:failed_staging_test)
       stage1.prerequisite_stages.each { |s| s.deploys.first.update_column(:job_id, job.id) }
 
       assert_sql_queries(2) do
-        stage1.undeployed_prerequisite_stages('123').must_equal []
+        stage1.undeployed_prerequisite_stages(job.commit).must_equal []
       end
     end
 
     it 'returns prereq stages where ref has not been deployed yet' do
-      stage1.project.repository.expects(:commit_from_ref).with('123').returns(job.commit)
       stage2.deploys.first.update_column(:job_id, job.id)
 
       assert_sql_queries(2) do
-        stage1.undeployed_prerequisite_stages('123').must_equal [stage3]
+        stage1.undeployed_prerequisite_stages(job.commit).must_equal [stage3]
       end
     end
   end

--- a/plugins/prerequisite_stages/test/samson_prerequisite_stages/samson_plugin_test.rb
+++ b/plugins/prerequisite_stages/test/samson_prerequisite_stages/samson_plugin_test.rb
@@ -16,14 +16,16 @@ describe SamsonPrerequisiteStages do
   describe SamsonPrerequisiteStages::Engine do
     describe '.validate_deployed_to_all_prerequisite_stages' do
       it 'shows unmet prerequisite stages' do
-        stage1.expects(:undeployed_prerequisite_stages).with(deploy.reference).returns([stage2])
-        error = SamsonPrerequisiteStages.validate_deployed_to_all_prerequisite_stages(stage1, deploy.reference)
+        stage1.expects(:undeployed_prerequisite_stages).with(deploy.commit).returns([stage2])
+        error = SamsonPrerequisiteStages.
+          validate_deployed_to_all_prerequisite_stages(stage1, deploy.reference, deploy.commit)
         error.must_equal "Reference 'staging' has not been deployed to these prerequisite stages: Production."
       end
 
       it 'is silent when there are no unmet prerequisites' do
-        stage1.expects(:undeployed_prerequisite_stages).with(deploy.reference).returns([])
-        SamsonPrerequisiteStages.validate_deployed_to_all_prerequisite_stages(stage1, deploy.reference).must_be_nil
+        stage1.expects(:undeployed_prerequisite_stages).with(deploy.commit).returns([])
+        SamsonPrerequisiteStages.
+          validate_deployed_to_all_prerequisite_stages(stage1, deploy.reference, deploy.commit).must_be_nil
       end
     end
   end
@@ -53,7 +55,7 @@ describe SamsonPrerequisiteStages do
       only_callbacks_for_plugin :ref_status
 
       it 'returns status if stage does not meet prerequisites' do
-        stage1.expects(:undeployed_prerequisite_stages).with(deploy.reference).returns([stage2])
+        stage1.expects(:undeployed_prerequisite_stages).with(deploy.commit).returns([stage2])
 
         error_message = "Reference 'staging' has not been deployed to these prerequisite stages: Production."
         expected = {
@@ -64,12 +66,12 @@ describe SamsonPrerequisiteStages do
           }]
         }
 
-        Samson::Hooks.fire(:ref_status, stage1, deploy.reference).must_include expected
+        Samson::Hooks.fire(:ref_status, stage1, deploy.reference, deploy.commit).must_include expected
       end
 
       it 'returns nil if stage meets prerequisites' do
-        stage1.expects(:undeployed_prerequisite_stages).with(deploy.reference).returns([])
-        Samson::Hooks.fire(:ref_status, stage1, deploy.reference).must_equal [nil]
+        stage1.expects(:undeployed_prerequisite_stages).with(deploy.commit).returns([])
+        Samson::Hooks.fire(:ref_status, stage1, deploy.reference, deploy.commit).must_equal [nil]
       end
     end
 

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -8,7 +8,7 @@ describe BuildsController do
   let(:build) { builds(:docker_build) }
 
   def stub_git_reference_check(returns)
-    Build.any_instance.stubs(:commit_from_ref).returns(returns)
+    Project.any_instance.stubs(:fast_commit_from_ref).returns(returns)
   end
 
   it "recognizes deprecated api route" do

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -89,11 +89,16 @@ describe Integrations::GithubController do
   end
 
   describe 'with a commit status event' do
-    before { request.headers['X-Github-Event'] = 'status' }
+    let(:commit) { 'dc395381e650f3bac18457909880829fc20e34ba' }
+
+    before do
+      request.headers['X-Github-Event'] = 'status'
+      Project.any_instance.stubs(:fast_commit_from_ref).returns(commit)
+    end
 
     it 'expires github status' do
-      Rails.cache.expects(:delete).with(['commit-status', project.id, 'dc395381e650f3bac18457909880829fc20e34ba'])
-      post :create, params: {token: project.token, sha: "dc395381e650f3bac18457909880829fc20e34ba"}
+      Rails.cache.expects(:delete).with(['commit-status', project.id, commit])
+      post :create, params: {token: project.token, sha: commit}
       assert_response :success
     end
   end

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -35,25 +35,11 @@ describe ReleasesController do
       ]
     }
 
-    headers = {
-      "Content-Type" => "application/json",
-    }
-    preview_headers = {
-      'Accept' => 'application/vnd.github.antiope-preview+json'
-    }
-
-    stub_request(:get, "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/status").
-      to_return(status: 200, body: status_response.to_json, headers: headers)
-
-    stub_request(
-      :get,
-      "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-suites"
-    ).to_return(status: 200, body: check_suite_response.to_json, headers: headers.merge(preview_headers))
-
-    stub_request(
-      :get,
-      "https://api.github.com/repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-runs"
-    ).to_return(status: 200, body: check_run_response.to_json, headers: headers.merge(preview_headers))
+    stub_github_api "repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+      sha: "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
+    stub_github_api "repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/status", status_response
+    stub_github_api "repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-suites", check_suite_response
+    stub_github_api "repos/bar/foo/commits/abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd/check-runs", check_run_response
   end
 
   as_a :viewer do

--- a/test/helpers/deploys_helper_test.rb
+++ b/test/helpers/deploys_helper_test.rb
@@ -54,9 +54,10 @@ describe DeploysHelper do
       end
 
       it "renders buddy check when waiting for buddy" do
-        stub_github_api "repos/bar/foo/commits/staging/status", state: "success", statuses: []
-        stub_github_api "repos/bar/foo/commits/staging/check-suites", check_suites: []
-        stub_github_api "repos/bar/foo/commits/staging/check-runs", check_runs: []
+        stub_github_api "repos/bar/foo/commits/staging", sha: "abc"
+        stub_github_api "repos/bar/foo/commits/abc/status", state: "success", statuses: []
+        stub_github_api "repos/bar/foo/commits/abc/check-suites", check_suites: []
+        stub_github_api "repos/bar/foo/commits/abc/check-runs", check_runs: []
 
         deploy.expects(:waiting_for_buddy?).returns(true)
         result.wont_include output

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -29,11 +29,11 @@ describe Changeset do
     describe "with master" do
       describe "when GitHub project" do
         it "doesn't cache" do
-          stub_github_api("repos/foo/bar/branches/master", commit: {sha: "foo"})
+          stub_github_api("repos/foo/bar/commits/master", sha: "foo")
           stub_github_api("repos/foo/bar/compare/a...foo", "x" => "y")
           Changeset.new(project, "a", "master").comparison.to_h.must_equal x: "y"
 
-          stub_github_api("repos/foo/bar/branches/master", commit: {sha: "bar"})
+          stub_github_api("repos/foo/bar/commits/master", sha: "bar")
           stub_github_api("repos/foo/bar/compare/a...bar", "x" => "z")
           Changeset.new(project, "a", "master").comparison.to_h.must_equal x: "z"
         end
@@ -69,14 +69,14 @@ describe Changeset do
 
     # tests config/initializers/octokit.rb Octokit::RedirectAsError
     it "converts a redirect into a NullComparison" do
-      stub_github_api("repos/foo/bar/branches/master", {}, 301)
+      stub_github_api("repos/foo/bar/commits/master", {}, 301)
       stub_github_api("repos/foo/bar/compare/a...master", {}, 301)
       Changeset.new(project, "a", "master").comparison.class.must_equal Changeset::NullComparison
     end
 
     # tests config/initializers/octokit.rb Octokit::RedirectAsError
     it "uses the cached body of a 304" do
-      stub_github_api("repos/foo/bar/branches/master", {commit: {sha: "bar"}}, 304)
+      stub_github_api("repos/foo/bar/commits/master", {sha: "bar"}, 304)
       stub_github_api("repos/foo/bar/compare/a...bar", "x" => "z")
       Changeset.new(project, "a", "master").comparison.to_h.must_equal x: "z"
     end
@@ -155,7 +155,7 @@ describe Changeset do
 
     it "skips fetching pull request for non PR branches" do
       comparison = Sawyer::Resource.new(sawyer_agent, commits: [commit2])
-      stub_github_api("repos/foo/bar/branches/master", commit: {sha: "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"})
+      stub_github_api("repos/foo/bar/commits/master", sha: "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd")
       GITHUB.stubs(:compare).returns(comparison)
       find_pr_stub = stub_github_api("repos/foo/bar/pulls", []).with(query: hash_including({}))
 

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -31,16 +31,28 @@ describe CommitStatus do
 
   let(:stage) { stages(:test_staging) }
   let(:reference) { 'master' }
+  let(:commit) { "a" * 40 }
   let(:status) { build_status }
+
+  before do
+    Project.any_instance.stubs(:fast_commit_from_ref).returns(commit)
+    GitRepository.expects(:new).with { raise "Do not use git" }.never
+  end
+
+  it "is fatal when commit is unknown" do
+    Project.any_instance.stubs(:fast_commit_from_ref).returns(nil)
+    status.state.must_equal "fatal"
+    status.statuses.map { |s| s[:state] }.must_equal ["missing"]
+  end
 
   describe "using state api" do
     def stub_checks_api(commit_status: status)
-      commit_status.stubs(:github_check).returns(state: 'pending', statuses: [])
+      commit_status.stubs(:github_check_status).returns(state: 'pending', statuses: [])
     end
 
     before { stub_checks_api } # user only using Status API
 
-    let(:url) { "repos/#{stage.project.repository_path}/commits/#{reference}/status" }
+    let(:url) { "repos/#{stage.project.repository_path}/commits/#{commit}/status" }
 
     describe "#state" do
       it "returns state" do
@@ -60,36 +72,23 @@ describe CommitStatus do
         s.state.must_equal "success"
       end
 
-      it "does not cache changing references" do
+      it "caches github state accross instances" do
         request = stub_github_api_success
         status.state.must_equal 'success'
         new_status = build_status
         stub_checks_api(commit_status: new_status)
         new_status.state.must_equal 'success'
-        assert_requested request, times: 2
+        assert_requested request, times: 1
       end
 
-      describe "caching static references" do
-        let(:reference) { 'v4.2' }
-
-        it "caches github state accross instances" do
-          request = stub_github_api_success
-          status.state.must_equal 'success'
-          new_status = build_status
-          stub_checks_api(commit_status: new_status)
-          new_status.state.must_equal 'success'
-          assert_requested request, times: 1
-        end
-
-        it "can expire cache" do
-          request = stub_github_api_success
-          status.state.must_equal 'success'
-          status.expire_cache reference
-          new_status = build_status
-          stub_checks_api(commit_status: new_status)
-          new_status.state.must_equal 'success'
-          assert_requested request, times: 2
-        end
+      it "can expire cache" do
+        request = stub_github_api_success
+        status.state.must_equal 'success'
+        status.expire_cache
+        new_status = build_status
+        stub_checks_api(commit_status: new_status)
+        new_status.state.must_equal 'success'
+        assert_requested request, times: 2
       end
 
       describe "when deploying a previous release" do
@@ -224,8 +223,8 @@ describe CommitStatus do
   end
 
   describe "using checks api" do
-    let(:check_suite_url) { "repos/#{stage.project.repository_path}/commits/#{reference}/check-suites" }
-    let(:check_run_url) { "repos/#{stage.project.repository_path}/commits/#{reference}/check-runs" }
+    let(:check_suite_url) { "repos/#{stage.project.repository_path}/commits/#{commit}/check-suites" }
+    let(:check_run_url) { "repos/#{stage.project.repository_path}/commits/#{commit}/check-runs" }
     let(:check_suites) do
       [
         {
@@ -248,7 +247,9 @@ describe CommitStatus do
       ]
     end
 
-    before { status.expects(:github_status).returns(state: 'pending', statuses: []) } # user only using Checks API
+    before do
+      status.expects(:github_commit_status).returns(state: 'pending', statuses: []) # user only using Checks API
+    end
 
     describe '#state' do
       before do
@@ -308,7 +309,7 @@ describe CommitStatus do
       end
 
       it 'raises with unknown conclusion' do
-        status.unstub(:github_status)
+        status.unstub(:github_commit_status)
 
         stub_github_api(
           check_suite_url,
@@ -444,15 +445,15 @@ describe CommitStatus do
   describe 'using both status and checks api' do
     describe '#state' do
       it 'prioritizes success of one api result over missing statuses of another' do
-        status.expects(:github_check).returns(state: 'pending', statuses: [])
-        status.expects(:github_status).returns(state: 'success', statuses: [{foo: "bar", updated_at: 1.day.ago}])
+        status.expects(:github_check_status).returns(state: 'pending', statuses: [])
+        status.expects(:github_commit_status).returns(state: 'success', statuses: [{foo: "bar", updated_at: 1.day.ago}])
         status.state.must_equal('success')
       end
 
       describe 'both APIs missing statuses' do
         before do
-          status.expects(:github_check).returns(state: 'pending', statuses: [])
-          status.expects(:github_status).returns(state: 'pending', statuses: [])
+          status.expects(:github_check_status).returns(state: 'pending', statuses: [])
+          status.expects(:github_commit_status).returns(state: 'pending', statuses: [])
         end
 
         it 'correctly handles missing statuses from both APIs' do
@@ -462,41 +463,48 @@ describe CommitStatus do
     end
   end
 
-  describe '#ref_statuses' do
+  describe '#expire_cache' do
+    it "does not blow up when commit is not found" do
+      GitRepository.any_instance.stubs(:commit_from_ref).returns(nil)
+      status.expire_cache
+    end
+  end
+
+  describe '#only_production_status' do
     let(:production_stage) { stages(:test_production) }
 
     it 'returns nothing if stage is not production' do
-      status.send(:ref_statuses).must_equal []
+      status.send(:only_production_status).must_be_nil
     end
 
     it 'returns nothing if ref has been deployed to non-production stage' do
-      production_stage.project.expects(:deployed_reference_to_non_production_stage?).returns(true)
+      production_stage.project.expects(:deployed_to_non_production_stage?).returns(true)
 
-      build_status(stage_param: production_stage).send(:ref_statuses).must_equal []
+      build_status(stage_param: production_stage).send(:only_production_status).must_be_nil
     end
 
     it 'returns status if ref has not been deployed to non-production stage' do
-      production_stage.project.expects(:deployed_reference_to_non_production_stage?).returns(false)
+      production_stage.project.expects(:deployed_to_non_production_stage?).returns(false)
 
-      expected_hash = [
-        {
-          state: "pending",
-          statuses: [
-            {
-              state: "Production Only Reference",
-              description: "master has not been deployed to a non-production stage."
-            }
-          ]
-        }
-      ]
+      expected_hash = {
+        state: "pending",
+        statuses: [
+          {
+            state: "Production Only Reference",
+            description: "master has not been deployed to a non-production stage."
+          }
+        ]
+      }
 
-      build_status(stage_param: production_stage).send(:ref_statuses).must_equal expected_hash
+      build_status(stage_param: production_stage).send(:only_production_status).must_equal expected_hash
     end
+  end
 
-    it 'includes plugin statuses' do
-      Samson::Hooks.expects(:fire).with(:ref_status, stage, reference).returns([{foo: :bar}])
+  describe "#plugin_statuses" do
+    it 'shows plugin statuses' do
+      Samson::Hooks.expects(:fire).with(:ref_status, stage, reference, commit).returns([{foo: :bar}])
 
-      status.send(:ref_statuses).must_equal [{foo: :bar}]
+      status.send(:plugin_statuses).must_equal [{foo: :bar}]
     end
   end
 

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -226,7 +226,7 @@ describe Deploy do
 
   describe "#changeset" do
     it "creates a changeset to the previous deploy" do
-      deploy.changeset.commit.must_equal "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1"
+      deploy.changeset.reference.must_equal "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1"
     end
   end
 


### PR DESCRIPTION
 - avoid multiple ref -> commit resolutions
 - avoids 1-off logic for empty changesets / github api errors

### Risks
- Low: errors / bugs during commit status resolution

@zendesk/compute 
