### PR TITLE
Add Kubernetes manifest preview feature

### DIFF
--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -4,6 +4,7 @@ require 'csv'
 # Abstract controller that handles all resources, subclasses handle custom logic by overwriting
 class ResourceController < ApplicationController
   ADD_MORE = 'Save and add another'
+  DEFAULT_BRANCH = "master"
 
   def index(paginate: true, resources: search_resources)
     assign_resources(

--- a/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
@@ -4,8 +4,6 @@ class Kubernetes::DeployGroupRolesController < ResourceController
   before_action :find_stage, only: [:seed]
   before_action :authorize_project_admin!, except: [:index, :show, :new]
 
-  DEFAULT_BRANCH = "master"
-
   def index
     if params[:project_id] && request.format.html? # nice but slow display on project tab
       super resources: sorted_resources, paginate: false

--- a/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/roles_controller.rb
@@ -2,8 +2,6 @@
 class Kubernetes::RolesController < ResourceController
   include CurrentProject
 
-  DEFAULT_BRANCH = 'master'
-
   PUBLIC = [:index, :show, :example].freeze
   before_action :authorize_project_deployer!, except: PUBLIC
   before_action :authorize_project_admin!, except: PUBLIC

--- a/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Kubernetes::StagesController < ResourceController
+  include CurrentProject
+  include CurrentStage
+
+  DEFAULT_BRANCH = "master"
+
+  before_action :authorize_resource!
+
+  def manifest_preview
+    # find ref and sha ... sha takes priority since it's most accurate
+    git_sha = params[:git_sha]
+    git_ref = params[:git_ref] || git_sha || current_project.release_branch || DEFAULT_BRANCH
+    git_sha ||= current_project.repository.commit_from_ref(git_ref)
+    if git_sha.empty?
+      return render body: '# Git reference not found', content_type: 'application/yaml'
+    end
+
+    # build a new deploy/job in memory to process the builds/templates
+    resolve_build = params[:resolve_build] == 'true'
+    job = Job.new(
+      deploy: current_stage.deploys.new(project: current_project, reference: git_ref || git_sha),
+      project: current_project,
+      user: current_user,
+      commit: git_sha
+    )
+    output = OutputBuffer.new
+    deploy_executor = Kubernetes::DeployExecutor.new(job, output)
+    release_docs = deploy_executor.preview(resolve_build: resolve_build)
+
+    template_fillers = release_docs.map(&:verification_template)
+    log = "# Manifest preview for #{current_project.name} - #{current_stage.name}. Git ref: #{git_ref} (#{git_sha})\n" +
+      yaml_comment(output.messages)
+    yaml = log + YAML.dump_stream(*template_fillers.map { |tf| tf.to_hash(verification: !resolve_build).deep_stringify_keys })
+    render body: yaml
+  rescue Samson::Hooks::UserError
+    render status: 400, body: yaml_comment($!.message)
+  end
+
+  private
+
+  def yaml_comment(message)
+    "# #{message.split("\n").join("\n# ")}\n"
+  end
+end

--- a/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
@@ -6,6 +6,7 @@ class Kubernetes::StagesController < ResourceController
 
   before_action :authorize_resource!
 
+  # used internally for deploy tab preview as well as an external API to render manifests for external tools
   def manifest_preview
     git_ref = params[:git_ref] || current_project.release_branch || DEFAULT_BRANCH
     git_sha = current_project.repository.commit_from_ref(git_ref)

--- a/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
@@ -4,35 +4,34 @@ class Kubernetes::StagesController < ResourceController
   include CurrentProject
   include CurrentStage
 
-  DEFAULT_BRANCH = "master"
-
   before_action :authorize_resource!
 
   def manifest_preview
-    # find ref and sha ... sha takes priority since it's most accurate
-    git_sha = params[:git_sha]
-    git_ref = params[:git_ref] || git_sha || current_project.release_branch || DEFAULT_BRANCH
-    git_sha ||= current_project.repository.commit_from_ref(git_ref)
-    if git_sha.empty?
-      return render body: '# Git reference not found', content_type: 'application/yaml'
-    end
+    git_ref = params[:git_ref] || current_project.release_branch || DEFAULT_BRANCH
+    git_sha = current_project.repository.commit_from_ref(git_ref)
+    raise Samson::Hooks::UserError, 'Git reference not found' unless git_sha.present?
+
+    # resolving builds can take some time, best to leave it off by default
+    resolve_build = params[:resolve_build] == 'true'
 
     # build a new deploy/job in memory to process the builds/templates
-    resolve_build = params[:resolve_build] == 'true'
     job = Job.new(
-      deploy: current_stage.deploys.new(project: current_project, reference: git_ref || git_sha),
+      deploy: current_stage.deploys.new(project: current_project, reference: git_ref),
       project: current_project,
       user: current_user,
       commit: git_sha
     )
     output = OutputBuffer.new
     deploy_executor = Kubernetes::DeployExecutor.new(job, output)
-    release_docs = deploy_executor.preview(resolve_build: resolve_build)
-
+    release_docs = deploy_executor.preview_release_docs(resolve_build: resolve_build)
     template_fillers = release_docs.map(&:verification_template)
+
+    # build yaml file with comment header for debugging
     log = "# Manifest preview for #{current_project.name} - #{current_stage.name}. Git ref: #{git_ref} (#{git_sha})\n" +
       yaml_comment(output.messages)
-    yaml = log + YAML.dump_stream(*template_fillers.map { |tf| tf.to_hash(verification: !resolve_build).deep_stringify_keys })
+    template_yaml = template_fillers.map { |tf| tf.to_hash(verification: !resolve_build).deep_stringify_keys }
+    yaml = log + YAML.dump_stream(*template_yaml)
+
     render body: yaml
   rescue Samson::Hooks::UserError
     render status: 400, body: yaml_comment($!.message)

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -20,11 +20,11 @@ module Kubernetes
       @reference = job.deploy.reference
     end
 
-    def preview(resolve_build: true)
+    def preview_release_docs(resolve_build: true)
       verify_kubernetes_templates!
       @release = build_release(resolve_build: resolve_build)
       unless @release.valid?
-        raise Samson::Hooks::UserError, "Failed to store manifests: #{release.errors.full_messages.inspect}"
+        raise Samson::Hooks::UserError, "Failed to store manifests: #{@release.errors.full_messages.inspect}"
       end
 
       @release.release_docs
@@ -36,7 +36,7 @@ module Kubernetes
 
       Kubernetes::Release.transaction do
         unless @release.save
-          raise Samson::Hooks::UserError, "Failed to store manifests: #{release.errors.full_messages.inspect}"
+          raise Samson::Hooks::UserError, "Failed to store manifests: #{@release.errors.full_messages.inspect}"
         end
       end
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -136,9 +136,10 @@ module Kubernetes
     end
 
     def set_deploy_url
+      return unless @doc.kubernetes_release.deploy&.persisted?
       [template, pod_template].compact.each do |t|
         annotations = (t[:metadata][:annotations] ||= {})
-        annotations[:"samson/deploy_url"] = @doc.kubernetes_release.deploy&.url if @doc.kubernetes_release.deploy&.persisted?
+        annotations[:"samson/deploy_url"] = @doc.kubernetes_release.deploy&.url
       end
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -138,7 +138,7 @@ module Kubernetes
     def set_deploy_url
       [template, pod_template].compact.each do |t|
         annotations = (t[:metadata][:annotations] ||= {})
-        annotations[:"samson/deploy_url"] = @doc.kubernetes_release.deploy&.url
+        annotations[:"samson/deploy_url"] = @doc.kubernetes_release.deploy&.url if @doc.kubernetes_release.deploy&.persisted?
       end
     end
 

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
@@ -1,5 +1,5 @@
-<% if @deploy.persisted? %>
-  <% if @deploy.kubernetes %>
+<% if @deploy&.persisted? %>
+  <% if @deploy.kubernetes? %>
     <div class="tab-pane" id="manifests">
       <% if release = @deploy.kubernetes_release %>
         <% release.release_docs.sort_by { |rd| DeployGroup.with_deleted{ rd.deploy_group&.name_sortable }}.each do |release_doc| %>
@@ -14,7 +14,7 @@
   <% end %>
 <% elsif @stage&.kubernetes? %>
   <div class="tab-pane" id="manifests">
-    <!-- using an iframe to lazy-load the manifest preview as it is potentially expensive / slow -->
+    <!-- using an iframe to lazy-load the manifest preview as it can be slow -->
     <pre><iframe frameborder="0" seamless src="<%= manifest_preview_project_kubernetes_stage_url(@stage.project, @stage, :yaml) %>" width="100%" height="400"></iframe></pre>
   </div>
 <% end %>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
@@ -1,14 +1,20 @@
-<% if @deploy.kubernetes %>
-  <div class="tab-pane" id="manifests">
-    <% if release = @deploy.kubernetes_release %>
-      <% release.release_docs.sort_by { |rd| DeployGroup.with_deleted{ rd.deploy_group&.name_sortable }}.each do |release_doc| %>
-        <div>
-          <h3><%= release_doc.deploy_group.name %> - <%= link_to release_doc.kubernetes_role.name, [@deploy.project, release_doc.kubernetes_role] %></h3>
-          <pre><%= release_doc.resource_template.map(&:deep_stringify_keys).map(&:to_yaml).join("\n") %></pre>
-        </div>
+<% if @deploy.persisted? %>
+  <% if @deploy.kubernetes %>
+    <div class="tab-pane" id="manifests">
+      <% if release = @deploy.kubernetes_release %>
+        <% release.release_docs.sort_by { |rd| DeployGroup.with_deleted{ rd.deploy_group&.name_sortable }}.each do |release_doc| %>
+          <div>
+            <h3><%= release_doc.deploy_group.name %> - <%= link_to release_doc.kubernetes_role.name, [@deploy.project, release_doc.kubernetes_role] %></h3>
+            <pre><%= release_doc.resource_template.map(&:deep_stringify_keys).map(&:to_yaml).join("\n") %></pre>
+          </div>
+        <% end %>
+      <% else %>
+        Manifests not yet create, reload page.
       <% end %>
-    <% else %>
-      Manifests not yet create, reload page.
-    <% end %>
+  <% end %>
+<% elsif @stage.kubernetes? %>
+  <div class="tab-pane" id="manifests">
+    <!-- using an iframe to lazy-load the manifest preview as it is potentially expensive / slow -->
+    <pre><iframe frameborder="0" seamless src="<%= manifest_preview_project_kubernetes_stage_url(@stage.project, @stage, :yaml) %>" width="100%" height="400"></iframe></pre>
   </div>
 <% end %>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
@@ -12,7 +12,7 @@
         Manifests not yet create, reload page.
       <% end %>
   <% end %>
-<% elsif @stage.kubernetes? %>
+<% elsif @stage&.kubernetes? %>
   <div class="tab-pane" id="manifests">
     <!-- using an iframe to lazy-load the manifest preview as it is potentially expensive / slow -->
     <pre><iframe frameborder="0" seamless src="<%= manifest_preview_project_kubernetes_stage_url(@stage.project, @stage, :yaml) %>" width="100%" height="400"></iframe></pre>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_nav.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_nav.html.erb
@@ -1,3 +1,3 @@
-<% if @deploy ? @deploy.kubernetes : @stage&.kubernetes? %>
+<% if @deploy&.persisted? ? @deploy.kubernetes? : @stage&.kubernetes? %>
   <li><a href="#manifests" data-toggle="tab">Manifests</a></li>
 <% end %>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_nav.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_nav.html.erb
@@ -1,3 +1,3 @@
-<% if @deploy&.kubernetes || @stage&.kubernetes? %>
+<% if @deploy ? @deploy.kubernetes : @stage&.kubernetes? %>
   <li><a href="#manifests" data-toggle="tab">Manifests</a></li>
 <% end %>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_nav.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_nav.html.erb
@@ -1,3 +1,3 @@
-<% if @deploy.kubernetes %>
+<% if @deploy&.kubernetes || @stage&.kubernetes? %>
   <li><a href="#manifests" data-toggle="tab">Manifests</a></li>
 <% end %>

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -8,6 +8,11 @@ Samson::Application.routes.draw do
           put :update_many
         end
       end
+      resources :stages do
+        member do
+          get :manifest_preview
+        end
+      end
       resources :roles, except: :edit do
         collection do
           post :seed
@@ -15,13 +20,6 @@ Samson::Application.routes.draw do
         end
       end
       resources :usage_limits, only: [:index]
-    end
-    resources :stages do
-      member do
-        namespace :kubernetes do
-          get :manifest_preview
-        end
-      end
     end
   end
 

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -16,6 +16,13 @@ Samson::Application.routes.draw do
       end
       resources :usage_limits, only: [:index]
     end
+    resources :stages do
+      member do
+        namespace :kubernetes do
+          get :manifest_preview
+        end
+      end
+    end
   end
 
   namespace :kubernetes do

--- a/plugins/kubernetes/test/controllers/kubernetes/stages_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/stages_controller_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Kubernetes::StagesController do
+  let(:deploy_group_role) { kubernetes_deploy_group_roles(:test_pod1_app_server) }
+  let(:deploy_group) { deploy_group_role.deploy_group }
+  let(:worker_role) { Kubernetes::Role.find_by(name: "resque-worker") }
+  let(:app_role) { deploy_group_role.kubernetes_role }
+  let(:project) { stage.project }
+  let(:stage) { stages(:test_staging) }
+  let(:git_sha) { SecureRandom.hex(40) }
+
+  unauthorized :get, :manifest_preview, project_id: 1, id: 1
+
+  as_a :admin do
+    before do
+      stage.update(deploy_groups: [deploy_group])
+
+      stage.kubernetes_stage_roles.create(kubernetes_role: worker_role, ignored: true)
+
+      GitRepository.any_instance.stubs(:file_content).with('kubernetes/app_server.yml', git_sha, anything).
+        returns(read_kubernetes_sample_file('kubernetes_deployment.yml'))
+      Kubernetes::TemplateFiller.any_instance.stubs(:set_image_pull_secrets)
+      Kubernetes::RoleValidator.any_instance.stubs(:validate)
+      Kubernetes::RoleValidator.stubs(:validate_groups)
+      Kubernetes::Role.stubs(:configured_for_project).returns([app_role])
+    end
+
+    describe '#manifest_preview' do
+      it 'fails if reference invalid' do
+        GitRepository.any_instance.expects(:commit_from_ref)
+        get :manifest_preview, params: {project_id: project.id, id: stage.id}
+        assert_response 400, '# Git reference not found'
+      end
+
+      it 'captures template validation errors' do
+        Kubernetes::DeployExecutor.any_instance.stubs(:preview_release_docs).raises(Samson::Hooks::UserError, "foobar")
+        get :manifest_preview, params: {project_id: project.id, id: stage.id}
+        assert_response 400, '# foobar'
+      end
+
+      it 'builds kubernetes manifest' do
+        GitRepository.any_instance.expects(:commit_from_ref).returns(git_sha)
+
+        get :manifest_preview, params: {project_id: project.id, id: stage.id}
+        assert_response 200
+        yaml = YAML.safe_load(response.body, symbolize_names: true)
+        yaml.dig(:metadata, :name).must_equal "test-app-server"
+        yaml.dig(:metadata, :namespace).must_equal "pod1"
+      end
+    end
+  end
+end

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -38,35 +38,29 @@ describe Kubernetes::Release do
     end
   end
 
-  describe '#create_release' do
-    def assert_create_fails(&block)
-      refute_difference 'Kubernetes::Release.count', &block
-    end
-
-    def assert_create_succeeds(params)
-      release = nil
-      assert_difference 'Kubernetes::Release.count', +1 do
-        release = Kubernetes::Release.create_release(params)
-      end
-      release
-    end
-
+  describe '#build_release_docs' do
     before do
       Kubernetes::TemplateFiller.any_instance.stubs(:set_image_pull_secrets)
     end
 
     it 'creates with 1 role' do
       expect_file_contents_from_repo
-      release = assert_create_succeeds(release_params)
-      release.release_docs.count.must_equal 1
+      release = Kubernetes::Release.build_release_with_docs(release_params)
+      release.must_be :valid?
+      release.release_docs.size.must_equal 1
       release.release_docs.first.kubernetes_role.id.must_equal app_server.id
       release.release_docs.first.kubernetes_role.name.must_equal app_server.name
+
+      assert_difference -> { Kubernetes::Release.count } => +1, -> { Kubernetes::ReleaseDoc.count } => +1 do
+        release.save
+      end
     end
 
     it 'creates with multiple roles' do
       2.times { expect_file_contents_from_repo }
-      release = assert_create_succeeds(multiple_roles_release_params)
-      release.release_docs.count.must_equal 2
+      release = Kubernetes::Release.build_release_with_docs(multiple_roles_release_params)
+      release.must_be :valid?
+      release.release_docs.size.must_equal 2
       release.release_docs.first.kubernetes_role.name.must_equal app_server.name
       release.release_docs.first.replica_target.must_equal 1
       release.release_docs.first.limits_cpu.must_equal 1
@@ -75,31 +69,29 @@ describe Kubernetes::Release do
       release.release_docs.second.replica_target.must_equal 2
       release.release_docs.second.limits_cpu.must_equal 2
       release.release_docs.second.limits_memory.must_equal 100
-    end
 
-    it "fails to save when invalid" do
-      assert_create_fails do
-        release_params[:git_sha] = ""
-        refute Kubernetes::Release.create_release(release_params).persisted?
+      assert_difference -> { Kubernetes::Release.count } => +1, -> { Kubernetes::ReleaseDoc.count } => +2 do
+        release.save
       end
     end
 
     it "fails to save with missing deploy groups" do
-      assert_create_fails do
-        release_params.delete :grouped_deploy_group_roles
-        assert_raises Samson::Hooks::UserError do
-          Kubernetes::Release.create_release(release_params)
-        end
+      release_params.delete :grouped_deploy_group_roles
+      assert_raises Samson::Hooks::UserError do
+        Kubernetes::Release.build_release_with_docs(release_params)
       end
     end
 
     it "fails to save with empty deploy groups" do
-      assert_create_fails do
-        release_params[:grouped_deploy_group_roles].first.clear
-        assert_raises Samson::Hooks::UserError do
-          Kubernetes::Release.create_release(release_params)
-        end
+      release_params[:grouped_deploy_group_roles].first.clear
+      assert_raises Samson::Hooks::UserError do
+        Kubernetes::Release.build_release_with_docs(release_params)
       end
+    end
+
+    it "fails to populate release docs when invalid" do
+      Kubernetes::Release.any_instance.expects(:valid?).returns(false)
+      Kubernetes::Release.build_release_with_docs(release_params).release_docs.must_be :empty?
     end
 
     describe "blue green" do
@@ -107,20 +99,20 @@ describe Kubernetes::Release do
 
       it 'does not set when not using blue_green' do
         app_server.blue_green = false
-        expect_file_contents_from_repo
-        assert_create_succeeds(release_params).blue_green_color.must_be_nil
+        subject = Kubernetes::Release.build_release_with_docs(release_params)
+        subject.blue_green_color.must_be_nil
       end
 
       it 'creates first as blue' do
-        expect_file_contents_from_repo
-        assert_create_succeeds(release_params).blue_green_color.must_equal "blue"
+        subject = Kubernetes::Release.build_release_with_docs(release_params)
+        subject.blue_green_color.must_equal "blue"
       end
 
       it 'creates followup as green' do
-        expect_file_contents_from_repo
         release.blue_green_color = "blue"
         Kubernetes::Release.any_instance.expects(:previous_succeeded_release).returns(release)
-        assert_create_succeeds(release_params).blue_green_color.must_equal "green"
+        subject = Kubernetes::Release.build_release_with_docs(release_params)
+        subject.blue_green_color.must_equal "green"
       end
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -132,6 +132,13 @@ describe Kubernetes::TemplateFiller do
         must_equal doc.kubernetes_release.deploy.url
     end
 
+    it "skips deploy url when deploy is not persisted" do
+      doc.kubernetes_release.deploy.delete
+      result = template.to_hash
+      result.dig(:metadata, :annotations, :"samson/deploy_url").must_be :blank?
+      result.dig(:spec, :template, :metadata, :annotations, :"samson/deploy_url").must_be :blank?
+    end
+
     it "sets replicas for templates" do
       raw_template[:kind] = "foobar"
       raw_template[:spec].delete :replicas


### PR DESCRIPTION
Kubernetes manifest preview - get rendered manifest before deploying

```
# Manifest preview for Example-kubernetes - Master. Git ref: master (536826b62edc0c6990b4a05497f73b9df0f76ec0)
# 
---
apiVersion: v1
kind: Pod
metadata:
  name: example-migrate
  labels:
    project: example
    role: migrate
    team: foo
    release_id: ''
    deploy_group_id: '2'
    deploy_id: ''
    project_id: '2'
    role_id: '1'
    deploy_group: groupk
    revision: 536826b62edc0c6990b4a05497f73b9df0f76ec0
    tag: master
```

https://zendesk.atlassian.net/browse/PAAS-1699

### Risks
- Low: Kubernetes deploys break / are not persisted correctly
