### PR TITLE
npm is not shipped by default with node package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     curl \
     gnupg2 \
   && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-  && apt-get install nodejs -y \
+  && apt-get install nodejs npm -y \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSL https://get.docker.com | bash -
 


### PR DESCRIPTION
Looks like npm is no longer shipped by default in the nodejs
apt package. So adding the explicit dependency so the docker
build can be succesful.

/cc @grosser 

### References
- Jira link:  N/A

### Risks
- Low: Add explicit dependency to npm
