### PR TITLE
use api hooks to not break gitlab + simplify them

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -101,14 +101,14 @@ class Build < ActiveRecord::Base
     return errors.add(:git_ref, 'must be specified') if git_ref.blank? && git_sha.blank?
     return if errors.include?(:git_ref) || errors.include?(:git_sha)
     return validate_git_sha if git_ref.blank?
-    commit = project.fast_commit_from_ref(git_ref)
+    commit = project.repo_commit_from_ref(git_ref)
     return errors.add(:git_ref, 'is not a valid reference') unless commit
     return validate_git_sha if git_sha.present? && git_sha != commit
     self.git_sha = commit
   end
 
   def validate_git_sha
-    return if project.fast_commit_from_ref(git_sha)
+    return if project.repo_commit_from_ref(git_sha)
     errors.add(:git_sha, 'is not a valid SHA for this project')
   end
 

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -28,7 +28,7 @@ class CommitStatus
   def initialize(project, reference, stage: nil)
     @project = project
     @reference = reference # for display
-    @commit = project.fast_commit_from_ref(reference) # ref->commit but also double-check a commit exists
+    @commit = project.repo_commit_from_ref(reference) # ref->commit but also double-check a commit exists
     @stage = stage
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -174,9 +174,10 @@ class Project < ActiveRecord::Base
     )
   end
 
-  # quick commit from reference without pulling the repository
-  def fast_commit_from_ref(ref)
-    GITHUB.commit(repository_path, ref).sha
+  # quick commit from reference without pulling the repository ... unless we have no remote
+  def repo_commit_from_ref(ref)
+    Samson::Hooks.fire(:repo_commit_from_ref, self, ref).compact.first ||
+      repository.commit_from_ref(ref)
   rescue StandardError
     nil
   end

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -63,7 +63,8 @@ module Samson
       :trace_scope,
       :asynchronous_performance_tracer,
       :repo_provider_status,
-      :changeset_api_request,
+      :repo_commit_from_ref,
+      :repo_compare,
       :validate_deploy
     ].freeze
 

--- a/plugins/airbrake_hook/test/samson_airbrake_hook/samson_plugin_test.rb
+++ b/plugins/airbrake_hook/test/samson_airbrake_hook/samson_plugin_test.rb
@@ -27,7 +27,7 @@ describe SamsonAirbrakeHook::Engine do
               "rails_env" => "staging",
               "scm_revision" => "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1",
               "local_username" => "Super Admin",
-              "scm_repository" => "https://example.com/bar/foo",
+              "scm_repository" => "https://github.com/bar/foo",
             }
           }
         }

--- a/plugins/github/lib/samson_github/samson_plugin.rb
+++ b/plugins/github/lib/samson_github/samson_plugin.rb
@@ -49,19 +49,12 @@ Samson::Hooks.callback :repo_provider_status do
   end
 end
 
-Samson::Hooks.callback :changeset_api_request do |changeset, method|
-  next unless changeset.project.github?
+Samson::Hooks.callback :repo_commit_from_ref do |project, reference|
+  next unless project.github?
+  GITHUB.commit(project.repository_path, reference).sha
+end
 
-  begin
-    case method
-    when :branch
-      GITHUB.commit(changeset.repo, changeset.reference).sha
-    when :compare
-      GITHUB.compare(changeset.repo, changeset.previous_commit, changeset.reference)
-    else
-      raise NoMethodError
-    end
-  rescue Octokit::Error, Faraday::ConnectionFailed => e
-    raise "GitHub: #{e.message.sub("Octokit::", "").underscore.humanize}"
-  end
+Samson::Hooks.callback :repo_compare do |project, previous_commit, reference|
+  next unless project.github?
+  GITHUB.compare(project.repository_path, previous_commit, reference)
 end

--- a/plugins/github/test/samson_github/samson_plugin_test.rb
+++ b/plugins/github/test/samson_github/samson_plugin_test.rb
@@ -102,38 +102,49 @@ describe SamsonDatadog do
     end
   end
 
-  describe :changeset_api_request do
+  describe :repo_commit_from_ref do
     let(:project) { Project.new(repository_url: 'ssh://git@github.com:foo/bar.git') }
-    let(:changeset) { Changeset.new(project, "a", "b") }
 
-    def fire(method)
-      Samson::Hooks.fire(:changeset_api_request, changeset, method)
+    def fire(reference)
+      Samson::Hooks.fire(:repo_commit_from_ref, project, reference)
     end
 
-    only_callbacks_for_plugin :changeset_api_request
+    only_callbacks_for_plugin :repo_commit_from_ref
 
-    it "skips non-gitlab" do
+    it "skips non-github" do
       project.stubs(:github?).returns(false)
-      fire(:branch).must_equal [nil]
+      fire("master").must_equal [nil]
     end
 
-    it "calls branch api endpoint" do
-      stub_github_api("repos/foo/bar/commits/b", sha: "foo")
-      fire(:branch).must_equal ["foo"]
+    it "resolves a refernece" do
+      stub_github_api("repos/foo/bar/commits/master", sha: "foo")
+      fire("master").must_equal ["foo"]
+    end
+  end
+
+  describe :repo_compare do
+    let(:project) { Project.new(repository_url: 'ssh://git@github.com:foo/bar.git') }
+
+    def fire(a, b)
+      Samson::Hooks.fire(:repo_compare, project, a, b)
     end
 
-    it "calls compare api endpoint" do
+    only_callbacks_for_plugin :repo_compare
+
+    it "skips non-github" do
+      project.stubs(:github?).returns(false)
+      fire("a", "b").must_equal [nil]
+    end
+
+    it "resolves a refernece" do
       stub_github_api("repos/foo/bar/compare/a...b", "x" => "y")
-      fire(:compare).first.to_h.must_equal x: "y"
+      fire("a", "b").map(&:to_h).must_equal [{x: "y"}]
     end
 
-    it "requires a valid method" do
-      assert_raises(NoMethodError) { fire(:bad) }
-    end
-
+    # tests config/initializers/octokit.rb patch
     it "catches exception and returns NullComparison" do
       stub_github_api("repos/foo/bar/compare/a...b", {}, 301)
-      assert_raises(RuntimeError) { fire(:compare).first }.message.must_include "GitHub: Get https://"
+      assert_raises(Octokit::RepositoryUnavailable) { fire("a", "b") }.message.must_include "GET https://api.github"
     end
   end
 end

--- a/plugins/gitlab/test/samson_gitlab/samson_plugin_test.rb
+++ b/plugins/gitlab/test/samson_gitlab/samson_plugin_test.rb
@@ -4,44 +4,49 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe SamsonGitlab do
+  let(:project) { Project.new(repository_url: 'ssh://git@gitlab.com:foo/bar.git') }
+  let(:api_path) { "https://gitlab.com/api/v4/projects/foo%2Fbar/repository/" }
+
   it 'configures GitLab API client' do
     Gitlab.endpoint.must_equal "#{Rails.application.config.samson.gitlab.web_url}/api/v4"
     Gitlab.private_token.must_equal ENV['GITLAB_TOKEN']
   end
 
-  describe :changeset_api_request do
-    let(:project) { Project.new(repository_url: 'ssh://git@gitlab.com:foo/bar.git') }
-    let(:changeset) { Changeset.new(project, "a", "b") }
-    let(:api_request) { ->(path) { "https://gitlab.com/api/v4/projects/foo%2Fbar/repository/" + path } }
-
-    def fire(method)
-      Samson::Hooks.fire(:changeset_api_request, changeset, method)
+  describe :repo_commit_from_ref do
+    def fire(commit)
+      Samson::Hooks.fire(:repo_commit_from_ref, project, commit)
     end
 
-    only_callbacks_for_plugin :changeset_api_request
+    only_callbacks_for_plugin :repo_commit_from_ref
 
     it "skips non-gitlab" do
       project.stubs(:gitlab?).returns(false)
-      fire(:branch).must_equal [nil]
+      fire("master").must_equal [nil]
     end
 
-    it "calls branch api endpoint" do
-      stub_request(:get, api_request["branches/b"]).to_return(body: JSON.dump(commit: {id: 'foo'}))
-      fire(:branch).must_equal ["foo"]
+    it "resolves a reference" do
+      stub_request(:get, api_path + "branches/master").to_return(body: JSON.dump(commit: {id: 'foo'}))
+      fire("master").must_equal ["foo"]
+    end
+  end
+
+  describe :repo_compare do
+    def fire(a, b)
+      Samson::Hooks.fire(:repo_compare, project, a, b)
     end
 
-    it "calls compare api endpoint" do
-      stub_request(:get, api_request["compare?from=a&to=b"]).to_return(body: JSON.dump(diffs: [], commits: []))
-      fire(:compare).first.to_h.must_equal(files: [], commits: [])
+    only_callbacks_for_plugin :repo_compare
+
+    it "skips non-gitlab" do
+      project.stubs(:gitlab?).returns(false)
+      fire("a", "b").must_equal [nil]
     end
 
-    it "requires a valid method" do
-      assert_raises(NoMethodError) { fire(:bad) }
-    end
-
-    it "catches exception and returns NullComparison" do
-      stub_request(:get, api_request["compare?from=a&to=b"]).to_return(status: 401)
-      assert_raises(RuntimeError) { fire(:compare).first }.message.must_include "GitLab: Server responded with"
+    it "builds a fake comparisson" do
+      stub_request(:get, api_path + "compare?from=a&to=b").to_return(body: JSON.dump(diffs: [], commits: []))
+      result = fire("a", "b")
+      assert result.first.respond_to?(:commits)
+      result.map(&:to_h).must_equal [{files: [], commits: []}]
     end
   end
 end

--- a/plugins/ledger/test/lib/samson_ledger/client_test.rb
+++ b/plugins/ledger/test/lib/samson_ledger/client_test.rb
@@ -26,8 +26,7 @@ describe SamsonLedger::Client do
     let(:github_user) { nil }
 
     before do
-      Project.any_instance.stubs(:github?).returns(true)
-      stub_github_api("repos/bar/foo/compare/abcabcaaabcabcaaabcabcaaabcabcaaabcabca1...staging", "x" => "y")
+      stub_github_api("repos/bar/foo/commits/staging", sha: "staging")
       GITHUB.stubs(:compare).with("bar/foo", "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1", "staging").returns(comparison)
       Changeset::PullRequest.stubs(:find).with("bar/foo", 42).returns(pull_request)
       GITHUB.stubs(:pull_requests).with("bar/foo", head: "bar:staging").returns([])

--- a/test/controllers/builds_controller_test.rb
+++ b/test/controllers/builds_controller_test.rb
@@ -8,7 +8,7 @@ describe BuildsController do
   let(:build) { builds(:docker_build) }
 
   def stub_git_reference_check(returns)
-    Project.any_instance.stubs(:fast_commit_from_ref).returns(returns)
+    Project.any_instance.stubs(:repo_commit_from_ref).returns(returns)
   end
 
   it "recognizes deprecated api route" do

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -93,7 +93,7 @@ describe Integrations::GithubController do
 
     before do
       request.headers['X-Github-Event'] = 'status'
-      Project.any_instance.stubs(:fast_commit_from_ref).returns(commit)
+      Project.any_instance.stubs(:repo_commit_from_ref).returns(commit)
     end
 
     it 'expires github status' do

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -47,7 +47,7 @@ describe ProjectsController do
         end
 
         it "can combine query and url" do
-          get :index, params: {search: {query: "foo", url: "git@example.com:bar/foo.git"}}
+          get :index, params: {search: {query: "foo", url: "git@github.com:bar/foo.git"}}
           assigns(:projects).map(&:name).must_equal ["Foo"]
         end
 
@@ -66,7 +66,7 @@ describe ProjectsController do
           end
 
           it "renders with ssh in url" do
-            validate_search_url("ssh://git@example.com:bar/foo.git", ["Foo"])
+            validate_search_url("ssh://git@github.com:bar/foo.git", ["Foo"])
           end
 
           it "renders without .git in url" do
@@ -74,7 +74,7 @@ describe ProjectsController do
           end
 
           it "renders without .git and with @git in url" do
-            validate_search_url("git@example.com/bar/foo", ["Foo"])
+            validate_search_url("git@github.com/bar/foo", ["Foo"])
           end
 
           it "does not find when url does not match" do

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,12 +1,12 @@
 test:
   name: Foo
-  repository_url: ssh://git@example.com:bar/foo.git
+  repository_url: ssh://git@github.com:bar/foo.git
   token: kanyewest
   permalink: foo
   include_new_deploy_groups: true
 
 other:
   name: Bar
-  repository_url: ssh://git@example.com:bar/bar.git
+  repository_url: ssh://git@github.com:bar/bar.git
   token: othertoken
   permalink: bar

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -70,10 +70,11 @@ describe ProjectsHelper do
 
   describe "#repository_web_link" do
     let(:current_user) { users(:admin) }
+    let(:project) { projects(:test) }
 
     def config_mock
       Rails.application.config.samson.github.stub(:web_url, "github.com") do
-        Rails.application.config.samson.gitlab.stub(:web_url, "localhost") do
+        Rails.application.config.samson.gitlab.stub(:web_url, "gitlab.com") do
           yield
         end
       end
@@ -81,10 +82,6 @@ describe ProjectsHelper do
 
     it "makes github repository web link" do
       config_mock do
-        project = projects(:test)
-        project.name = "Github Project"
-        project.repository_url = "https://github.com/bar/foo.git"
-
         link = repository_web_link(project)
         assert_includes link, "View repository on GitHub"
       end
@@ -92,18 +89,15 @@ describe ProjectsHelper do
 
     it "makes gitlab repository web link" do
       config_mock do
-        project = projects(:test)
-        project.name = "Gitlab Project"
-        project.repository_url = "http://localhost/bar/foo.git"
-
+        project.repository_url = "http://gitlab.com/bar/foo.git"
         link = repository_web_link(project)
         assert_includes link, "View repository on Gitlab"
       end
     end
 
-    it "makes github repository web link" do
+    it "makes no local web link" do
       config_mock do
-        project = projects(:test)
+        project.repository_url = "http://localhost/bar/foo.git"
         link = repository_web_link(project)
         assert_equal link, ""
       end

--- a/test/models/build_test.rb
+++ b/test/models/build_test.rb
@@ -171,12 +171,12 @@ describe Build do
 
   describe "#commit_url" do
     it "builds a path when the url is unknown" do
+      build.project.repository_url = 'git@example.com:foo/bar.git'
       build.commit_url.must_equal "/tree/da39a3ee5e6b4b0d3255bfef95601890afd80709"
     end
 
     it "builds a full url when host is known" do
-      build.project.repository_url = 'git@github.com:foo/bar.git'
-      build.commit_url.must_equal "https://github.com/foo/bar/tree/da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      build.commit_url.must_equal "https://github.com/bar/foo/tree/da39a3ee5e6b4b0d3255bfef95601890afd80709"
     end
   end
 

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -35,12 +35,12 @@ describe CommitStatus do
   let(:status) { build_status }
 
   before do
-    Project.any_instance.stubs(:fast_commit_from_ref).returns(commit)
+    Project.any_instance.stubs(:repo_commit_from_ref).returns(commit)
     GitRepository.expects(:new).with { raise "Do not use git" }.never
   end
 
   it "is fatal when commit is unknown" do
-    Project.any_instance.stubs(:fast_commit_from_ref).returns(nil)
+    Project.any_instance.stubs(:repo_commit_from_ref).returns(nil)
     status.state.must_equal "fatal"
     status.statuses.map { |s| s[:state] }.must_equal ["missing"]
   end

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -226,7 +226,7 @@ describe Deploy do
 
   describe "#changeset" do
     it "creates a changeset to the previous deploy" do
-      deploy.changeset.reference.must_equal "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1"
+      deploy.changeset.instance_variable_get(:@reference).must_equal "abcabcaaabcabcaaabcabcaaabcabcaaabcabca1"
     end
   end
 

--- a/test/models/stage_test.rb
+++ b/test/models/stage_test.rb
@@ -232,11 +232,11 @@ describe Stage do
     let(:simple_response) { Hashie::Mash.new(commits: [{commit: {author: {email: "pete@example.com"}}}]) }
 
     before do
-      Project.any_instance.stubs(:github?).returns(true)
       user.update_attribute(:integration, true)
       subject.update_column(:static_emails_on_automated_deploy_failure, "static@example.com")
       subject.update_column(:email_committers_on_automated_deploy_failure, true)
       deploys(:failed_staging_test).destroy # this fixture confuses these tests.
+      stub_github_api "repos/bar/foo/commits/commita", sha: "123"
     end
 
     it "includes static emails and committer emails" do

--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -35,8 +35,8 @@ ActiveSupport::TestCase.class_eval do
     after { @assert_requests.each { |assert_args| assert_requested(*assert_args) } }
   end
 
-  def stub_github_api(url, response = {}, status = 200)
-    url = 'https://api.github.com/' + url
+  def stub_github_api(path, response = {}, status = 200)
+    url = "https://api.github.com/" + path
     stub_request(:get, url).to_return(
       status: status,
       body: JSON.dump(response),


### PR DESCRIPTION
 - fix caching logic resetting `@reference` which could remove open PRs when done in the wrong order
 - cache all branch comparisons on their SHA since they can change at any time
 - do not load open pull requests for main branches like "master" since they are never used as PR

followup to https://github.com/zendesk/samson/pull/3527 where I saw all these weirdnesses

@zendesk/compute 