### PR TITLE
Added json preview to secrets search controller

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -35,6 +35,13 @@ class SecretsController < ApplicationController
       @secrets.select! { |id, _, _| matching.include?(id) }
     end
     @pagy, @secrets = pagy_array(@secrets, page: params[:page], items: 50)
+
+    respond_to do |format|
+      format.html
+      format.json do
+        render_as_json :secrets, @secrets, @pagy
+      end
+    end
   rescue Samson::Secrets::BackendError => e
     flash[:alert] = e.message
     render html: "", layout: true

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -113,6 +113,11 @@ describe SecretsController do
         get :index
         assert flash[:alert]
       end
+
+      it "renders json" do
+        get :index, format: "json"
+        assert_response :ok
+      end
     end
 
     describe "#duplicates" do


### PR DESCRIPTION
This allows a proper integration from external tooling to lookup where
vault secrets are present with proper secret resolving done by samson.

### References
- Jira link: https://zendesk.atlassian.net/browse/GUIDEOPS-1284

### Risks
- Low: this only adds a seperate format for an existing controller