### PR TITLE
make risks warning simpler / show when there were no PRs

### DIFF
--- a/app/views/changeset/_risks.html.erb
+++ b/app/views/changeset/_risks.html.erb
@@ -1,20 +1,23 @@
 <div class="alert alert-info">
-  If you want Samson to pick up and display any risks associated with your pull request, add a heading called "Risks"
-  in your pull request description. Anything in that section will be listed here as a risk.
+  To display risks from pull request, add a "Risks" heading in the pull request description
 </div>
 
-<% changeset.pull_requests.each do |pr| %>
-  <% if pr.risky? %>
-    <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %></h5>
-    <%= markdown pr.risks %>
-  <% elsif pr.missing_risks? %>
-    <div>
-      <% help_icon = additional_info(
-            "Missing 'Risks' section or failed to parse risks",
-            class: 'glyphicon glyphicon-alert deployment-alert'
-          )
-      %>
-      <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %><%= help_icon %></h5>
-    </div>
+<% if changeset.pull_requests.any? %>
+  <% changeset.pull_requests.each do |pr| %>
+    <% if pr.risky? %>
+      <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %></h5>
+      <%= markdown pr.risks %>
+    <% elsif pr.missing_risks? %>
+      <div>
+        <% help_icon = additional_info(
+              "Missing 'Risks' section or failed to parse risks",
+              class: 'glyphicon glyphicon-alert deployment-alert'
+            )
+        %>
+        <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %><%= help_icon %></h5>
+      </div>
+    <% end %>
   <% end %>
+<% else %>
+  <p>There were no pull requests in this deploy.</p>
 <% end %>


### PR DESCRIPTION
<img width="1167" alt="Screen Shot 2019-10-09 at 10 13 55 AM" src="https://user-images.githubusercontent.com/11367/66504242-9732a100-ea7d-11e9-92d3-ff6e730d4e00.png">

@zendesk/compute 