### PR TITLE
PAAS-4603 expire pull requests cache so updated risks are visible

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -13,6 +13,7 @@ class Integrations::GithubController < Integrations::BaseController
 
   def create
     expire_commit_status if github_event_type == "status"
+    expire_pull_request if github_event_type == "pull_request"
     super
   end
 
@@ -20,6 +21,10 @@ class Integrations::GithubController < Integrations::BaseController
 
   def expire_commit_status
     CommitStatus.new(project, params[:sha].to_s).expire_cache
+  end
+
+  def expire_pull_request
+    Changeset::PullRequest.expire(project.repository_path, params[:number])
   end
 
   def payload

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -95,6 +95,7 @@ class Changeset
 
   # github only supports finding open PRs for branches (not commits or tags)
   # https://help.github.com/en/articles/searching-issues-and-pull-requests
+  # TODO: can we just use .new here to avoid extra fetch ?
   def open_pull_requests
     return [] if static? || MAIN_BRANCHES.include?(@reference)
     org = @repo.split("/", 2).first

--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -36,6 +36,7 @@ class Changeset::Commit
     @data.sha.slice(0, 7)
   end
 
+  # @return [Integer, NilClass]
   def pull_request_number
     if number = summary[PULL_REQUEST_MERGE_MESSAGE, 1] || summary[PULL_REQUEST_SQUASH_MESSAGE, 1]
       Integer(number)


### PR DESCRIPTION
found this while poking at risks vs commit status ticket

@zendesk/compute 