### PR TITLE
Added resolve endpoint to secrets controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,8 @@ Samson::Application.routes.draw do
   resources :secrets, except: [:edit] do
     collection do
       get :duplicates
+      get :resolve
+      post :resolve
     end
     member do
       get :history

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -28,6 +28,19 @@ Secrets can be resolved to their full path in the context of a projects deploy g
 
 In the below example we have a secret configured for `a` in the deploy group `group1`, but no secret configured for `b`.
 
+The endpoint supports both GET:
+
+```
+$ curl -s -H "Content-Type: application/json" -H "Authorization: Bearer $SAMSON_ACCESS_TOKEN" $SAMSON_BASE_URL/secrets/resolve.json?project_id=2&deploy_group=group1&keys[]=a&keys[]=b
+{
+  "a": "global/example-kubernetes/global/a",
+  "b": null
+}
+```
+
+For ease of use to clients parameters can be sent in JSON format in a POST request. This way clients doesn't need to deal with url encoding semantics.
+
+
 ```
 # params.json
 {
@@ -45,3 +58,5 @@ $ curl -s -d @params.json -H "Content-Type: application/json" -H "Authorization:
   "b": null
 }
 ```
+
+This endpoint was added and is useful for resolving secrets as defined in kubernetes manifests, in the format that the `samson_secret_puller` or similar solutions use. The secrets are usually a list of names, with actual paths in the backend being different because of scoping/sharing concerns.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -22,13 +22,13 @@ For these the `visible` flag can be used to keep them visible for everyone.
 
 Secrets can be `deprecated` first and deleted when all use outside of samson (vault backend or accessing secrets via api client) has stopped.
 
-### Resolving secrets from external tools
+### Resolving secrets via API
 
 Secrets can be resolved to their full path in the context of a projects deploy group with the `/secrets/resolve.json` endpoint.
 
-In the below example we have a secret configured for `a` in the deploy group `group1`, but no secret configured for `b`.
+In the below example we have a secret configured for key `a` in the deploy group `group1`, but no secret configured for key `b`.
 
-The endpoint supports both GET:
+The endpoint supports both GET and POST:
 
 ```
 $ curl -s -H "Content-Type: application/json" -H "Authorization: Bearer $SAMSON_ACCESS_TOKEN" $SAMSON_BASE_URL/secrets/resolve.json?project_id=2&deploy_group=group1&keys[]=a&keys[]=b
@@ -36,27 +36,4 @@ $ curl -s -H "Content-Type: application/json" -H "Authorization: Bearer $SAMSON_
   "a": "global/example-kubernetes/global/a",
   "b": null
 }
-```
 
-For ease of use to clients parameters can be sent in JSON format in a POST request. This way clients doesn't need to deal with url encoding semantics.
-
-
-```
-# params.json
-{
-  "project_id": 2,
-  "deploy_group": "group1",
-  "keys": [
-    "a",
-    "b"
-  ]
-}
-
-$ curl -s -d @params.json -H "Content-Type: application/json" -H "Authorization: Bearer $SAMSON_ACCESS_TOKEN" $SAMSON_BASE_URL/secrets/resolve.json | jq '.'
-{
-  "a": "global/example-kubernetes/global/a",
-  "b": null
-}
-```
-
-This endpoint was added and is useful for resolving secrets as defined in kubernetes manifests, in the format that the `samson_secret_puller` or similar solutions use. The secrets are usually a list of names, with actual paths in the backend being different because of scoping/sharing concerns.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -21,3 +21,27 @@ For these the `visible` flag can be used to keep them visible for everyone.
 ### Deprecated
 
 Secrets can be `deprecated` first and deleted when all use outside of samson (vault backend or accessing secrets via api client) has stopped.
+
+### Resolving secrets from external tools
+
+Secrets can be resolved in the context of a projects deploy group with the `/secrets/resolve.json` endpoint.
+
+In the below example we have a secret configured for `a` in the deploy group `group1`, but no secret configured for `b`.
+
+```
+# params.json
+{
+  "project_id": 2,
+  "deploy_group": "group1",
+  "keys": [
+    "a",
+    "b"
+  ]
+}
+
+$ curl -s -d @params.json -H "Content-Type: application/json" -H "Authorization: Bearer $SAMSON_ACCESS_TOKEN" $SAMSON_BASE_URL/secrets/resolve.json | jq '.'
+{
+  "a": "global/example-kubernetes/global/a",
+  "b": null
+}
+```

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -24,7 +24,7 @@ Secrets can be `deprecated` first and deleted when all use outside of samson (va
 
 ### Resolving secrets from external tools
 
-Secrets can be resolved in the context of a projects deploy group with the `/secrets/resolve.json` endpoint.
+Secrets can be resolved to their full path in the context of a projects deploy group with the `/secrets/resolve.json` endpoint.
 
 In the below example we have a secret configured for `a` in the deploy group `group1`, but no secret configured for `b`.
 

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -524,9 +524,34 @@ describe SecretsController do
         assert_response :success
 
         result = JSON.parse(response.body)
-        secrets = result['secrets']
-        secrets['bar'].must_equal 'production/z/pod2/bar'
-        secrets['foo'].must_be_nil
+        resolved = result['resolved']
+        resolved['bar'].must_equal 'production/z/pod2/bar'
+        resolved['foo'].must_be_nil
+      end
+      it "supports permalink given as project_id" do
+        get :resolve, params: {
+          project_id: other_project.permalink, deploy_group: 'pod2', keys: ['bar', 'foo'], format: 'json'
+        }
+        assert_response :success
+      end
+      it "supports resolving by projet permalink param" do
+        get :resolve, params: {
+          project_permalink: other_project.permalink, deploy_group: 'pod2', keys: ['bar', 'foo'], format: 'json'
+        }
+        assert_response :success
+      end
+      it "raises when no project can be resolved" do
+        assert_raise(RuntimeError) do
+          get :resolve, params: {format: 'json'}
+        end
+      end
+      it "handles keys passed as comma delimited list" do
+        get :resolve, params: {
+          project_permalink: other_project.permalink, deploy_group: 'pod2', keys: 'bar,foo,baz', format: 'json'
+        }
+        result = JSON.parse(response.body)
+        resolved = result['resolved']
+        resolved.keys.size.must_equal 3
       end
     end
   end

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -528,23 +528,19 @@ describe SecretsController do
         resolved['bar'].must_equal 'production/z/pod2/bar'
         resolved['foo'].must_be_nil
       end
-      it "supports permalink given as project_id" do
-        get :resolve, params: {
-          project_id: other_project.permalink, deploy_group: 'pod2', keys: ['bar', 'foo'], format: 'json'
-        }
-        assert_response :success
-      end
-      it "supports resolving by projet permalink param" do
+
+      it "supports resolving by project permalink param" do
         get :resolve, params: {
           project_permalink: other_project.permalink, deploy_group: 'pod2', keys: ['bar', 'foo'], format: 'json'
         }
         assert_response :success
       end
-      it "raises when no project can be resolved" do
-        assert_raise(RuntimeError) do
-          get :resolve, params: {format: 'json'}
-        end
+
+      it "errors when no project can be resolved" do
+        get :resolve, params: {format: 'json'}
+        assert_response :bad_request
       end
+
       it "handles keys passed as comma delimited list" do
         get :resolve, params: {
           project_permalink: other_project.permalink, deploy_group: 'pod2', keys: 'bar,foo,baz', format: 'json'


### PR DESCRIPTION
This allows resolving secrets to get their paths in the context of a
project and deploy group.

This could be used for external integrations, while keeping the logic of
resolving secrets, and the currently underlying path structure in place,
without needing to explicitly know where a key resides in vault.

### References
- Jira link: https://zendesk.atlassian.net/browse/GUIDEOPS-1284

### Risks
- Low: This adds a new endpoint