### PR TITLE
properly indent changeset subclasses so they do not cause load errors…

### DIFF
--- a/app/models/changeset/code_push.rb
+++ b/app/models/changeset/code_push.rb
@@ -1,33 +1,35 @@
 # frozen_string_literal: true
-class Changeset::CodePush
-  attr_reader :repo, :data
+class Changeset
+  class CodePush
+    attr_reader :repo, :data
 
-  def initialize(repo, data)
-    @repo = repo
-    @data = data
-  end
+    def initialize(repo, data)
+      @repo = repo
+      @data = data
+    end
 
-  def self.changeset_from_webhook(project, payload)
-    new(project.repository_path, payload)
-  end
+    def self.changeset_from_webhook(project, payload)
+      new(project.repository_path, payload)
+    end
 
-  def self.valid_webhook?(_)
-    true
-  end
+    def self.valid_webhook?(_)
+      true
+    end
 
-  def sha
-    data['after']
-  end
+    def sha
+      data['after']
+    end
 
-  def branch
-    data['ref'][/\Arefs\/heads\/(\S+)\z/, 1]
-  end
+    def branch
+      data['ref'][/\Arefs\/heads\/(\S+)\z/, 1]
+    end
 
-  def message
-    data['head_commit']&.[]('message')
-  end
+    def message
+      data['head_commit']&.[]('message')
+    end
 
-  def service_type
-    'code' # Samson webhook category
+    def service_type
+      'code' # Samson webhook category
+    end
   end
 end

--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -1,49 +1,51 @@
 # frozen_string_literal: true
-class Changeset::Commit
-  PULL_REQUEST_MERGE_MESSAGE = /\AMerge pull request #(\d+)/.freeze
-  PULL_REQUEST_SQUASH_MESSAGE = /\A.*\(#(\d+)\)$/.freeze
+class Changeset
+  class Commit
+    PULL_REQUEST_MERGE_MESSAGE = /\AMerge pull request #(\d+)/.freeze
+    PULL_REQUEST_SQUASH_MESSAGE = /\A.*\(#(\d+)\)$/.freeze
 
-  attr_reader :project
+    attr_reader :project
 
-  def initialize(project, data)
-    @project = project
-    @repo = project.repository_path
-    @data = data
-  end
-
-  def author_name
-    @data.commit.author.name
-  end
-
-  def author_email
-    @data.commit.author.email
-  end
-
-  def author
-    @author ||= Changeset::GithubUser.new(@data.author) if @data.author
-  end
-
-  def summary
-    summary = @data.commit.message.split("\n").first
-    summary.truncate(80)
-  end
-
-  def sha
-    @data.sha
-  end
-
-  def short_sha
-    @data.sha.slice(0, 7)
-  end
-
-  # @return [Integer, NilClass]
-  def pull_request_number
-    if number = summary[PULL_REQUEST_MERGE_MESSAGE, 1] || summary[PULL_REQUEST_SQUASH_MESSAGE, 1]
-      Integer(number)
+    def initialize(project, data)
+      @project = project
+      @repo = project.repository_path
+      @data = data
     end
-  end
 
-  def url
-    "#{project.repository_homepage}/commit/#{sha}"
+    def author_name
+      @data.commit.author.name
+    end
+
+    def author_email
+      @data.commit.author.email
+    end
+
+    def author
+      @author ||= Changeset::GithubUser.new(@data.author) if @data.author
+    end
+
+    def summary
+      summary = @data.commit.message.split("\n").first
+      summary.truncate(80)
+    end
+
+    def sha
+      @data.sha
+    end
+
+    def short_sha
+      @data.sha.slice(0, 7)
+    end
+
+    # @return [Integer, NilClass]
+    def pull_request_number
+      if number = summary[PULL_REQUEST_MERGE_MESSAGE, 1] || summary[PULL_REQUEST_SQUASH_MESSAGE, 1]
+        Integer(number)
+      end
+    end
+
+    def url
+      "#{project.repository_homepage}/commit/#{sha}"
+    end
   end
 end

--- a/app/models/changeset/github_user.rb
+++ b/app/models/changeset/github_user.rb
@@ -3,44 +3,46 @@ require 'uri'
 
 # unknown users are considered the same since we do not have any identifying information in the user data
 # and we don't want to show 10 'unknown' users on the release show page
-class Changeset::GithubUser
-  def initialize(data)
-    @data = data
-  end
-
-  def avatar_url(size = 20)
-    url = @data.avatar_url
-    if url
-      uri = URI(@data.avatar_url)
-      params = URI.decode_www_form(uri.query || [])
-
-      # The `s` parameter controls the size of the avatar.
-      params << ["s", size.to_s]
-
-      uri.query = URI.encode_www_form(params)
-      uri.to_s
-    else
-      'https://assets-cdn.github.com/images/gravatars/gravatar-user-420.png'
+class Changeset
+  class GithubUser
+    def initialize(data)
+      @data = data
     end
-  end
 
-  def url
-    "#{Rails.application.config.samson.github.web_url}/#{login}" if login
-  end
+    def avatar_url(size = 20)
+      url = @data.avatar_url
+      if url
+        uri = URI(@data.avatar_url)
+        params = URI.decode_www_form(uri.query || [])
 
-  def login
-    @data.login
-  end
+        # The `s` parameter controls the size of the avatar.
+        params << ["s", size.to_s]
 
-  def identifier
-    "@#{login}" if login
-  end
+        uri.query = URI.encode_www_form(params)
+        uri.to_s
+      else
+        'https://assets-cdn.github.com/images/gravatars/gravatar-user-420.png'
+      end
+    end
 
-  def eql?(other)
-    login == other.login
-  end
+    def url
+      "#{Rails.application.config.samson.github.web_url}/#{login}" if login
+    end
 
-  def hash
-    login&.hash || 123456789
+    def login
+      @data.login
+    end
+
+    def identifier
+      "@#{login}" if login
+    end
+
+    def eql?(other)
+      login == other.login
+    end
+
+    def hash
+      login&.hash || 123456789
+    end
   end
 end

--- a/app/models/changeset/issue_comment.rb
+++ b/app/models/changeset/issue_comment.rb
@@ -1,46 +1,48 @@
 # frozen_string_literal: true
-class Changeset::IssueComment
-  attr_reader :repo, :data, :comment
-  VALID_ACTIONS = ['created'].freeze
+class Changeset
+  class IssueComment
+    attr_reader :repo, :data, :comment
+    VALID_ACTIONS = ['created'].freeze
 
-  def initialize(repo, data)
-    @repo = repo
-    @body = data['body']
-    @comment = data['comment']
-    @data = data['issue']
-  end
-
-  def self.changeset_from_webhook(project, payload)
-    new(project.repository_path, payload)
-  end
-
-  def self.valid_webhook?(payload)
-    return false unless VALID_ACTIONS.include? payload['action']
-    payload.dig('comment', 'body') =~ Changeset::PullRequest::WEBHOOK_FILTER
-  end
-
-  def sha
-    pull_request.sha
-  end
-
-  def branch
-    pull_request.branch
-  end
-
-  def service_type
-    'pull_request' # Samson webhook category
-  end
-
-  def message
-    nil
-  end
-
-  private
-
-  def pull_request
-    pr_data = Rails.cache.fetch(['IssueComment', repo, comment['id']].join("-")) do
-      GITHUB.pull_request(repo, data['number'])
+    def initialize(repo, data)
+      @repo = repo
+      @body = data['body']
+      @comment = data['comment']
+      @data = data['issue']
     end
-    @pull_request ||= Changeset::PullRequest.new(repo, pr_data)
+
+    def self.changeset_from_webhook(project, payload)
+      new(project.repository_path, payload)
+    end
+
+    def self.valid_webhook?(payload)
+      return false unless VALID_ACTIONS.include? payload['action']
+      payload.dig('comment', 'body') =~ Changeset::PullRequest::WEBHOOK_FILTER
+    end
+
+    def sha
+      pull_request.sha
+    end
+
+    def branch
+      pull_request.branch
+    end
+
+    def service_type
+      'pull_request' # Samson webhook category
+    end
+
+    def message
+      nil
+    end
+
+    private
+
+    def pull_request
+      pr_data = Rails.cache.fetch(['IssueComment', repo, comment['id']].join("-")) do
+        GITHUB.pull_request(repo, data['number'])
+      end
+      @pull_request ||= Changeset::PullRequest.new(repo, pr_data)
+    end
   end
 end

--- a/app/models/changeset/jira_issue.rb
+++ b/app/models/changeset/jira_issue.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
-class Changeset::JiraIssue
-  attr_reader :url
+class Changeset
+  class JiraIssue
+    attr_reader :url
 
-  def initialize(url)
-    @url = url
-  end
+    def initialize(url)
+      @url = url
+    end
 
-  def reference
-    @url.split("/").last
-  end
+    def reference
+      @url.split("/").last
+    end
 
-  def ==(other)
-    url == other.url
+    def ==(other)
+      url == other.url
+    end
   end
 end

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -1,181 +1,183 @@
 # frozen_string_literal: true
-class Changeset::PullRequest
-  # Common patterns
-  CODE_ONLY = "[A-Z][A-Z\\d]+-\\d+" # e.g., S4MS0N-123, SAM-456
-  PUNCT = "\\s|\\p{Punct}|~|="
+class Changeset
+  class PullRequest
+    # Common patterns
+    CODE_ONLY = "[A-Z][A-Z\\d]+-\\d+" # e.g., S4MS0N-123, SAM-456
+    PUNCT = "\\s|\\p{Punct}|~|="
 
-  WEBHOOK_FILTER = /(^|\s)\[samson review\]($|\s)/i.freeze
+    WEBHOOK_FILTER = /(^|\s)\[samson review\]($|\s)/i.freeze
 
-  # Matches URLs to JIRA issues.
-  JIRA_ISSUE_URL = %r[https?:\/\/[\da-z\.\-]+\.[a-z\.]{2,6}\/browse\/#{CODE_ONLY}(?=#{PUNCT}|$)].freeze
+    # Matches URLs to JIRA issues.
+    JIRA_ISSUE_URL = %r[https?:\/\/[\da-z\.\-]+\.[a-z\.]{2,6}\/browse\/#{CODE_ONLY}(?=#{PUNCT}|$)].freeze
 
-  # Matches "VOICE-1234" or "[VOICE-1234]"
-  JIRA_CODE_TITLE = /(\[)*(#{CODE_ONLY})(\])*/.freeze
+    # Matches "VOICE-1234" or "[VOICE-1234]"
+    JIRA_CODE_TITLE = /(\[)*(#{CODE_ONLY})(\])*/.freeze
 
-  # Matches "VOICE-1234" only
-  JIRA_CODE = /(?<=#{PUNCT}|^)(#{CODE_ONLY})(?=#{PUNCT}|$)/.freeze
+    # Matches "VOICE-1234" only
+    JIRA_CODE = /(?<=#{PUNCT}|^)(#{CODE_ONLY})(?=#{PUNCT}|$)/.freeze
 
-  # Github pull request events can be triggered by a number of actions such as 'labeled', 'assigned'
-  # Actions which aren't related to a code push should not trigger a samson deploy.
-  # Docs on the pull request event: https://developer.github.com/v3/activity/events/types/#pullrequestevent
-  VALID_ACTIONS = ['opened', 'edited', 'synchronize'].freeze
+    # Github pull request events can be triggered by a number of actions such as 'labeled', 'assigned'
+    # Actions which aren't related to a code push should not trigger a samson deploy.
+    # Docs on the pull request event: https://developer.github.com/v3/activity/events/types/#pullrequestevent
+    VALID_ACTIONS = ['opened', 'edited', 'synchronize'].freeze
 
-  class << self
-    # Finds the pull request with the given number.
-    #
-    # @param [String] repository name, e.g. "zendesk/samson".
-    # @param [Integer] pull request number
-    #
-    # @return [ChangeSet::PullRequest, nil]
-    def find(repo, number)
-      data = Rails.cache.fetch(cache_key(repo, number)) do
-        GITHUB.pull_request(repo, number)
+    class << self
+      # Finds the pull request with the given number.
+      #
+      # @param [String] repository name, e.g. "zendesk/samson".
+      # @param [Integer] pull request number
+      #
+      # @return [ChangeSet::PullRequest, nil]
+      def find(repo, number)
+        data = Rails.cache.fetch(cache_key(repo, number)) do
+          GITHUB.pull_request(repo, number)
+        end
+
+        new(repo, data)
+      rescue Octokit::NotFound
+        nil
       end
 
-      new(repo, data)
-    rescue Octokit::NotFound
+      def expire(repo, number)
+        Rails.cache.delete cache_key(repo, number)
+      end
+
+      def changeset_from_webhook(project, payload)
+        data = Sawyer::Resource.new(Octokit.agent, payload.fetch('pull_request'))
+        new(project.repository_path, data)
+      end
+
+      # Webhook events that are valid should be related to a pr code push or someone adding [samson review]
+      # to the description. The actions related to a code push are 'opened' and 'synchronized'
+      # The 'edited' action gets sent when the PR description is edited. To trigger a deploy from an edit - it
+      # should only be when the edit is related to adding the text [samson review]
+      def valid_webhook?(payload)
+        data = payload['pull_request'] || {}
+        action = payload['action']
+        return false if data['state'] != 'open' || !VALID_ACTIONS.include?(action)
+
+        if action == 'edited'
+          previous_desc = payload.dig('changes', 'body', 'from')
+          return false if !previous_desc || (previous_desc =~ WEBHOOK_FILTER && data['body'] =~ WEBHOOK_FILTER)
+        end
+
+        data['body'].match? WEBHOOK_FILTER
+      end
+
+      private
+
+      def cache_key(repo, number)
+        [self, repo, number].join("-")
+      end
+    end
+
+    attr_reader :repo
+
+    def initialize(repo, data)
+      @repo = repo
+      @data = data # Sawyer::Resource
+    end
+
+    delegate :number, :title, :additions, :deletions, to: :@data
+
+    def title_without_jira
+      title.gsub(JIRA_CODE_TITLE, "").strip
+    end
+
+    def url
+      "#{Rails.application.config.samson.github.web_url}/#{repo}/pull/#{number}"
+    end
+
+    def reference
+      "##{number}"
+    end
+
+    def sha
+      @data['head']['sha']
+    end
+
+    # does not include refs/head
+    def branch
+      @data['head']['ref']
+    end
+
+    def state
+      @data['state']
+    end
+
+    def users
+      users = [@data['user'], @data['merged_by']]
+      users.compact.map { |user| Changeset::GithubUser.new(user) }.uniq
+    end
+
+    def created_at
+      @data['created_at']
+    end
+
+    def risky?
+      risks.present?
+    end
+
+    def risks
+      return @risks if defined?(@risks)
+      @risks = parse_risks(@data.body.to_s)
+      @missing_risks = @risks.nil?
+      @risks = nil if @risks&.match?(/\A\s*\-?\s*None\Z/i)
+      @risks
+    end
+
+    def missing_risks?
+      risks
+      @missing_risks
+    end
+
+    def jira_issues
+      @jira_issues ||= parse_jira_issues
+    end
+
+    def service_type
+      'pull_request' # Samson webhook category
+    end
+
+    def message
       nil
-    end
-
-    def expire(repo, number)
-      Rails.cache.delete cache_key(repo, number)
-    end
-
-    def changeset_from_webhook(project, payload)
-      data = Sawyer::Resource.new(Octokit.agent, payload.fetch('pull_request'))
-      new(project.repository_path, data)
-    end
-
-    # Webhook events that are valid should be related to a pr code push or someone adding [samson review]
-    # to the description. The actions related to a code push are 'opened' and 'synchronized'
-    # The 'edited' action gets sent when the PR description is edited. To trigger a deploy from an edit - it
-    # should only be when the edit is related to adding the text [samson review]
-    def valid_webhook?(payload)
-      data = payload['pull_request'] || {}
-      action = payload['action']
-      return false if data['state'] != 'open' || !VALID_ACTIONS.include?(action)
-
-      if action == 'edited'
-        previous_desc = payload.dig('changes', 'body', 'from')
-        return false if !previous_desc || (previous_desc =~ WEBHOOK_FILTER && data['body'] =~ WEBHOOK_FILTER)
-      end
-
-      data['body'].match? WEBHOOK_FILTER
     end
 
     private
 
-    def cache_key(repo, number)
-      [self, repo, number].join("-")
+    def section_content(section_title, text)
+      # ### Risks or Risks followed by === / ---
+      desired_header_regexp = "^(?:\\s*#+\\s*#{section_title}.*|\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
+      content_regexp = '([\W\w]*?)' # capture all section content, including new lines, but not next header
+      next_header_regexp = '(?=^(?:\s*#+|.*\n\s*(?:-{2,}|={2,}\s*\n))|\z)'
+
+      text[/#{desired_header_regexp}#{content_regexp}#{next_header_regexp}/i, 1]
     end
-  end
 
-  attr_reader :repo
+    def parse_risks(body)
+      body_stripped = ActionController::Base.helpers.strip_tags(body)
+      section_content('Risks', body_stripped).to_s.rstrip.sub(/\A\s*\n/, "").presence
+    end
 
-  def initialize(repo, data)
-    @repo = repo
-    @data = data # Sawyer::Resource
-  end
-
-  delegate :number, :title, :additions, :deletions, to: :@data
-
-  def title_without_jira
-    title.gsub(JIRA_CODE_TITLE, "").strip
-  end
-
-  def url
-    "#{Rails.application.config.samson.github.web_url}/#{repo}/pull/#{number}"
-  end
-
-  def reference
-    "##{number}"
-  end
-
-  def sha
-    @data['head']['sha']
-  end
-
-  # does not include refs/head
-  def branch
-    @data['head']['ref']
-  end
-
-  def state
-    @data['state']
-  end
-
-  def users
-    users = [@data['user'], @data['merged_by']]
-    users.compact.map { |user| Changeset::GithubUser.new(user) }.uniq
-  end
-
-  def created_at
-    @data['created_at']
-  end
-
-  def risky?
-    risks.present?
-  end
-
-  def risks
-    return @risks if defined?(@risks)
-    @risks = parse_risks(@data.body.to_s)
-    @missing_risks = @risks.nil?
-    @risks = nil if @risks&.match?(/\A\s*\-?\s*None\Z/i)
-    @risks
-  end
-
-  def missing_risks?
-    risks
-    @missing_risks
-  end
-
-  def jira_issues
-    @jira_issues ||= parse_jira_issues
-  end
-
-  def service_type
-    'pull_request' # Samson webhook category
-  end
-
-  def message
-    nil
-  end
-
-  private
-
-  def section_content(section_title, text)
-    # ### Risks or Risks followed by === / ---
-    desired_header_regexp = "^(?:\\s*#+\\s*#{section_title}.*|\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
-    content_regexp = '([\W\w]*?)' # capture all section content, including new lines, but not next header
-    next_header_regexp = '(?=^(?:\s*#+|.*\n\s*(?:-{2,}|={2,}\s*\n))|\z)'
-
-    text[/#{desired_header_regexp}#{content_regexp}#{next_header_regexp}/i, 1]
-  end
-
-  def parse_risks(body)
-    body_stripped = ActionController::Base.helpers.strip_tags(body)
-    section_content('Risks', body_stripped).to_s.rstrip.sub(/\A\s*\n/, "").presence
-  end
-
-  # @return [Array<Changeset::JiraIssue>]
-  def parse_jira_issues
-    custom_jira_url = ENV['JIRA_BASE_URL']
-    title_and_body = "#{title} #{body}"
-    jira_issue_map = {}
-    if custom_jira_url
-      title_and_body.scan(JIRA_CODE).each do |match|
-        jira_issue_map[match[0]] = custom_jira_url + match[0]
+    # @return [Array<Changeset::JiraIssue>]
+    def parse_jira_issues
+      custom_jira_url = ENV['JIRA_BASE_URL']
+      title_and_body = "#{title} #{body}"
+      jira_issue_map = {}
+      if custom_jira_url
+        title_and_body.scan(JIRA_CODE).each do |match|
+          jira_issue_map[match[0]] = custom_jira_url + match[0]
+        end
       end
+      # explicit URLs should take precedence for issue links
+      title_and_body.scan(JIRA_ISSUE_URL).each do |match|
+        jira_issue_map[match.match(JIRA_CODE)[0]] = match
+      end
+      jira_issue_map.values.map { |x| Changeset::JiraIssue.new(x) }
     end
-    # explicit URLs should take precedence for issue links
-    title_and_body.scan(JIRA_ISSUE_URL).each do |match|
-      jira_issue_map[match.match(JIRA_CODE)[0]] = match
-    end
-    jira_issue_map.values.map { |x| Changeset::JiraIssue.new(x) }
-  end
 
-  def body
-    @data.body.to_s
+    def body
+      @data.body.to_s
+    end
   end
 end


### PR DESCRIPTION
… when doing things in parallel

@zendesk/compute 