### PR TITLE
Fix regression causing prerequisite stages to stop working 

### DIFF
--- a/plugins/prerequisite_stages/lib/samson_prerequisite_stages/samson_plugin.rb
+++ b/plugins/prerequisite_stages/lib/samson_prerequisite_stages/samson_plugin.rb
@@ -14,8 +14,12 @@ module SamsonPrerequisiteStages
   Samson::Hooks.view :stage_show, 'samson_prerequisite_stages'
 
   Samson::Hooks.callback :before_deploy do |deploy, _|
+    # This check is technically redundant (undeployed_prerequisite_stages above will be empty anyway if this
+    # is not true) but a whole bunch of unrelated tests will complain about a missing HTTP stub from resolving
+    # the ref to a commit if we don't do this.
+    next unless deploy.stage.prerequisite_stage_ids?
     error = SamsonPrerequisiteStages.validate_deployed_to_all_prerequisite_stages(
-      deploy.stage, deploy.reference, deploy.commit
+      deploy.stage, deploy.reference, deploy.project.repo_commit_from_ref(deploy.reference)
     )
     raise error if error
   end


### PR DESCRIPTION
SamsonPrerequisisteStages::validate_deployed_to_all_prerequisiste_stages
was changed to accept a commit instead of a reference, but it was still
being called with a reference from the before_deploy hook. This made
prerequisiste stages never be satisfied (unless the deploy was done with
the acutal commit SHA).

Fix it by resolving the ref to a commit in the before_deploy hook.

### Risks
- Low: This only changes the `before_deploy` codepath for prerequisite stages, and this is already broken for those projects that have them. Any further breakage is easily worked around by disabling the prerequisite.
