### PR TITLE
Fetch commit status parts in parallel to speed it up

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -34,7 +34,7 @@ class Changeset
   def pull_requests
     @pull_requests ||= begin
       numbers = (merged_pull_requests + open_pull_requests)
-      PullRequest.name # avoid require race conditions in development
+      PullRequest.name # call no-op method to load class before running in parallel
       Samson::Parallelizer.map(numbers) { |number| PullRequest.find(@repo, number) }.compact
     end
   end

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -308,8 +308,6 @@ describe CommitStatus do
       end
 
       it 'raises with unknown conclusion' do
-        status.unstub(:github_commit_status)
-
         stub_github_api(
           check_suite_url,
           check_suites: [{conclusion: 'bingbong', id: 1}]

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -247,7 +247,7 @@ describe CommitStatus do
     end
 
     before do
-      status.expects(:github_commit_status).returns(state: 'pending', statuses: []) # user only using Checks API
+      status.stubs(:github_commit_status).returns(state: 'pending', statuses: []) # user only using Checks API
     end
 
     describe '#state' do


### PR DESCRIPTION
this takes it in dev from `2810ms` to `1445ms`

@zendesk/compute 

### Risks
- Low: parallel bugs making status not work
