### PR TITLE
Ignore load errors in pry-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,18 +88,19 @@ group :assets do
   end
 end
 
+group :debugging do
+  gem 'pry-byebug'
+  gem 'pry-rails'
+  gem 'pry-rescue'
+  gem 'pry-stack_explorer'
+end
+
 group :development, :staging do
   gem 'rack-mini-profiler'
 end
 
 group :development, :test do
-  gem 'byebug'
   gem 'bootsnap'
-  gem 'pry'
-  gem 'pry-byebug'
-  gem 'pry-rails'
-  gem 'pry-rescue'
-  gem 'pry-stack_explorer'
   gem 'awesome_print'
   gem 'brakeman'
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,7 +601,6 @@ DEPENDENCIES
   brakeman
   bundler
   bundler-audit
-  byebug
   coderay
   concurrent-ruby
   connection_pool
@@ -640,7 +639,6 @@ DEPENDENCIES
   parallel
   parallel_tests
   pg
-  pry
   pry-byebug
   pry-rails
   pry-rescue

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,12 @@ require 'action_mailer/railtie'
 require 'action_cable/engine'
 require 'rails/test_unit/railtie'
 require 'sprockets/railtie'
-require 'pry-rails'
+
+begin
+  require 'pry-rails'
+rescue LoadError # rubocop:disable Lint/HandleExceptions
+  # ignore if pry-rails is not included in bundle
+end
 
 if (google_domain = ENV["GOOGLE_DOMAIN"]) && !ENV['EMAIL_DOMAIN']
   Rails.logger.warn "Stop using deprecated GOOGLE_DOMAIN"


### PR DESCRIPTION
Ignore load errors in pry-rails. Can happen if bundled without test.

### References
- Jira link: 

### Risks
- Low: pry-rails unavailable in production console.
