### PR TITLE
Update project show page when stages change

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -21,7 +21,7 @@
     </thead>
     <tbody>
       <% if @project.stages.to_a.any? %>
-        <% cache [@project, 'stages', Lock.cache_key] do %>
+        <% cache [@project, 'stages', Lock.cache_key, @project.stages.map(&:updated_at).max] do %>
           <%= render partial: "stage", collection: @project.stages %>
         <% end %>
       <% else %>


### PR DESCRIPTION
nameand deploy group changes were stale before

this adds an extra query for the stages, but I'd prefer that over explicit expire

@zendesk/compute