### PR TITLE
Revert "Allow expanding k8s template from deploy group role"

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/deploy_group_roles_controller.rb
@@ -13,23 +13,6 @@ class Kubernetes::DeployGroupRolesController < ResourceController
     end
   end
 
-  # TODO: use super
-  def show
-    respond_to do |format|
-      format.html
-      format.json do
-        deploy_group_role = @kubernetes_deploy_group_role.as_json
-        if params[:include].to_s.split(',').include?("verification_template")
-          deploy_group_role[:verification_template] = verification_template.to_hash(verification: true)
-        end
-
-        render json: {
-          kubernetes_deploy_group_role: deploy_group_role
-        }
-      end
-    end
-  end
-
   def edit_many
     @kubernetes_deploy_group_roles = sorted_resources
   end
@@ -94,37 +77,6 @@ class Kubernetes::DeployGroupRolesController < ResourceController
     end
 
     deploy_group_roles
-  end
-
-  def verification_template
-    role = @kubernetes_deploy_group_role
-    project = role.project
-
-    # find ref and sha ... sha takes priority since it's most accurate
-    git_sha = params[:git_sha]
-    git_ref = params[:git_ref] || git_sha || DEFAULT_BRANCH
-    git_sha ||= project.repository.commit_from_ref(git_ref)
-
-    release = Kubernetes::Release.new(
-      git_ref: git_ref,
-      git_sha: git_sha,
-      project: project,
-      user: current_user,
-      builds: [],
-      deploy_groups: [role.deploy_group]
-    )
-    release_doc = Kubernetes::ReleaseDoc.new(
-      kubernetes_release: release,
-      kubernetes_role: role.kubernetes_role,
-      deploy_group: role.deploy_group,
-      requests_cpu: role.requests_cpu,
-      limits_cpu: role.limits_cpu,
-      requests_memory: role.requests_memory,
-      limits_memory: role.limits_memory,
-      replica_target: role.replicas
-    )
-
-    release_doc.verification_template
   end
 
   def find_stage

--- a/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
@@ -8,8 +8,6 @@ describe Kubernetes::DeployGroupRolesController do
   let(:deploy_group) { deploy_group_role.deploy_group }
   let(:project) { deploy_group_role.project }
   let(:stage) { stages(:test_staging) }
-  let(:json) { JSON.parse(response.body) }
-  let(:commit) { '1a6f551a2ffa6d88e15eef5461384da0bfb1c194' }
 
   id = ActiveRecord::FixtureSet.identify(:test_pod1_app_server)
   project_id = ActiveRecord::FixtureSet.identify(:test)
@@ -61,35 +59,6 @@ describe Kubernetes::DeployGroupRolesController do
       it "renders" do
         get :show, params: {id: deploy_group_role.id}
         assert_template :show
-      end
-
-      it "renders JSON" do
-        get :show, params: {id: deploy_group_role.id}, format: :json
-        assert_response :success
-        json.keys.must_equal ['kubernetes_deploy_group_role']
-      end
-
-      describe "rendering verification_template" do
-        before do
-          GitRepository.any_instance.expects(:clone!).never
-          GitRepository.any_instance.stubs(:file_content).with('kubernetes/app_server.yml', commit, anything).
-            returns(read_kubernetes_sample_file('kubernetes_deployment.yml'))
-          Kubernetes::TemplateFiller.any_instance.stubs(:set_image_pull_secrets)
-        end
-
-        it "renders JSON with template" do
-          GitRepository.any_instance.stubs(:commit_from_ref).with("master").returns(commit)
-          get :show, params: {id: deploy_group_role.id, include: "verification_template"}, format: :json
-          assert_response :success
-          json.keys.must_equal ['kubernetes_deploy_group_role']
-          json["kubernetes_deploy_group_role"].keys.must_include 'verification_template'
-        end
-
-        it "can request exact ref" do
-          GitRepository.any_instance.stubs(:commit_from_ref).with("foo").returns(commit)
-          get :show, params: {id: deploy_group_role.id, include: "verification_template", git_ref: "foo"}, format: :json
-          assert_response :success
-        end
       end
     end
 


### PR DESCRIPTION
This reverts commit 2c385670e3831bcfe0563f247c3110990432a86d.

We now have [template preview](https://github.com/zendesk/samson/pull/3528) which can take care of this

reverts https://github.com/zendesk/samson/pull/2416

@zendesk/compute @davidreuss 