### PR TITLE
display project resources in project view for consistent navigation

### DIFF
--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @kubernetes_deploy_group_role, html: { class: "form-horizontal" } do |form| %>
+<%= form_for [@project, @kubernetes_deploy_group_role], html: { class: "form-horizontal" } do |form| %>
   <%= redirect_to_field %>
   <%= render 'shared/errors', object: form.object %>
   <%
@@ -11,13 +11,9 @@
       <%= form.select :deploy_group_id, DeployGroup.pluck(:name, :id), {}, class: "form-control", disabled: updating %>
     <% end %>
 
-    <%= form.input :project_id do %>
-      <% projects = current_user.administrated_projects.with_kubernetes_roles.pluck(:name, :id) %>
-      <%= form.select :project_id, projects, {}, class: "form-control", disabled: updating %>
-    <% end %>
-
     <%= form.input :kubernetes_role_id, label: 'Role' do %>
-      <%= form.select :kubernetes_role_id, [['Loading ...', form.object.kubernetes_role_id]], {}, class: "form-control", disabled: updating %>
+      <% roles = @project.kubernetes_roles.not_deleted.pluck(:name, :id) %>
+      <%= form.select :kubernetes_role_id, roles, {}, class: "form-control", disabled: updating %>
     <% end %>
 
     <%= form.input :delete_resource, as: :check_box, help: "Delete all resources on next deploy. Always set replicas to 0 too." %>
@@ -26,6 +22,7 @@
       <%= form.input :no_cpu_limit, as: :check_box, help: "Cpu limit will not be set when deploying, but still be used for cluster math, so pick a good estimate." %>
     <% end %>
 
+    <%# display fields and their suggested defaults %>
     <% [
          [:replicas, @kubernetes_deploy_group_role.kubernetes_role&.autoscaled? ? "Min Replicas" : "Replicas"],
          [:requests_cpu, 'Requests CPU Cores'],
@@ -41,39 +38,15 @@
       <% end %>
     <% end %>
 
-    <%# use form.actions with delete: true, history: true and block %>
+    <%# TODO: use form.actions with delete: true, history: true and block %>
     <div class="form-group">
       <div class="col-lg-offset-2 col-lg-10">
         <%= form.submit 'Save', class: "btn btn-primary" %>
         <%= submit_tag ResourceController::ADD_MORE, class: 'btn btn-default' %>
-        <%= link_to_delete form.object, class: 'btn btn-default', redirect_back: true if form.object.persisted? %>
+        <%= link_to_delete [@project, form.object], class: 'btn btn-default', redirect_back: true if form.object.persisted? %>
         <%= link_to "Cancel", :back, class: 'btn btn-default' %>
         <%= link_to_history form.object %>
       </div>
     </div>
   </fieldset>
 <% end %>
-
-<script>
-  // change selectable roles when project changes, since every project has different roles
-  $(function(){
-    var project_data = <%= Kubernetes::Role.not_deleted.pluck(:project_id, :id, :name).group_by(&:first).to_json.html_safe %>
-    $('#kubernetes_deploy_group_role_project_id').change(function () {
-      var $role_select = $('#kubernetes_deploy_group_role_kubernetes_role_id');
-      var project_id = parseInt($(this).val(), 10);
-      var val = parseInt($role_select.val(), 10);
-      var roles = project_data[project_id];
-
-      // clear out previous options and refresh the select
-      $role_select.html('').val('');
-
-      // fill in currently selectable roles, keeping the current selection for edit or failed create
-      $.each(roles, function(i, e){
-        $role_select.append($("<option>", { value: e[1], html: e[2], selected: (e[1] === val) }));
-      });
-
-      // highlight the changed select so user sees the effect
-      $role_select.effect("highlight", {color: "#ffffe0"}, 500);
-    }).trigger('change');
-  });
-</script>

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/edit.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/edit.html.erb
@@ -1,5 +1,1 @@
-<%= page_title "Edit Kubernetes Deploy Group Role" %>
-
-<section>
-  <%= render 'form' %>
-</section>
+<%= render template: "kubernetes/deploy_group_roles/show" %>

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/index.html.erb
@@ -34,7 +34,7 @@
       <% @kubernetes_deploy_group_roles.each do |deploy_group_role| %>
         <tr>
           <% unless @project %>
-            <td><%= link_to deploy_group_role.project.name, deploy_group_role.project %></td>
+            <td><%= link_to_resource deploy_group_role.project %></td>
           <% end %>
           <td><%= link_to deploy_group_role.deploy_group.name, deploy_group_role.deploy_group %></td>
           <td><%= link_to deploy_group_role.kubernetes_role.name, [deploy_group_role.project, deploy_group_role.kubernetes_role] %></td>
@@ -43,7 +43,7 @@
           <td><%= kubernetes_deploy_group_role_replica deploy_group_role.kubernetes_role, deploy_group_role %></td>
           <td>
             <% if current_user.admin_for?(deploy_group_role.project) %>
-              <%= link_to 'Edit', edit_kubernetes_deploy_group_role_path(deploy_group_role, redirect_to: request.fullpath) %>
+              <%= link_to 'Edit', edit_project_kubernetes_deploy_group_role_path(deploy_group_role.project, deploy_group_role, redirect_to: request.fullpath) %>
             <% end %>
           </td>
         </tr>
@@ -62,9 +62,12 @@
   </div>
 
   <div class="admin-actions">
-    <%= paginate @pagy unless @project %>
-    <div class="pull-right">
-      <%= link_to "New", new_kubernetes_deploy_group_role_path, class: "btn btn-default" %>
-    </div>
+    <% if @project %>
+      <div class="pull-right">
+        <%= link_to "New", new_project_kubernetes_deploy_group_role_path(@project), class: "btn btn-default" %>
+      </div>
+    <% else %>
+      <%= paginate @pagy %>
+    <% end %>
   </div>
 </section>

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/new.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/new.html.erb
@@ -1,5 +1,1 @@
-<%= page_title "New Kubernetes Deploy Group Role" %>
-
-<section>
-  <%= render 'form' %>
-</section>
+<%= render template: "kubernetes/deploy_group_roles/show" %>

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/show.html.erb
@@ -1,57 +1,8 @@
-<%= page_title "Kubernetes Deploy Group Role" %>
+<%= render 'projects/header', project: @project, tab: 'kubernetes' %>
 
-<section class="form-horizontal">
-  <div class="form-group">
-    <label class="col-lg-2 control-label">Role</label>
-    <div class="col-lg-4">
-      <p class="form-control-static"><%= link_to @kubernetes_deploy_group_role.kubernetes_role.name, [@kubernetes_deploy_group_role.project, @kubernetes_deploy_group_role.kubernetes_role] %></p>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label class="col-lg-2 control-label">Project</label>
-    <div class="col-lg-4">
-      <p class="form-control-static"><%= link_to @kubernetes_deploy_group_role.project.name, project_path(@kubernetes_deploy_group_role.project) %></p>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label class="col-lg-2 control-label">Deploy Group</label>
-    <div class="col-lg-4">
-      <p class="form-control-static"><%= link_to @kubernetes_deploy_group_role.deploy_group.name, deploy_group_path(@kubernetes_deploy_group_role.deploy_group) %></p>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label class="col-lg-2 control-label">Replicas</label>
-    <div class="col-lg-4">
-      <p class="form-control-static"><%= @kubernetes_deploy_group_role.replicas %></p>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label class="col-lg-2 control-label">CPU</label>
-    <div class="col-lg-4">
-      <p class="form-control-static">
-        <%= @kubernetes_deploy_group_role.requests_cpu %> to <%= @kubernetes_deploy_group_role.limits_cpu %>
-        <%= "(Not enforced)" if @kubernetes_deploy_group_role.no_cpu_limit?  %>
-      </p>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label class="col-lg-2 control-label">Memory Request</label>
-    <div class="col-lg-4">
-      <p class="form-control-static"><%= @kubernetes_deploy_group_role.requests_memory %> to <%= @kubernetes_deploy_group_role.limits_memory %> MiB</p>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <div class="col-lg-offset-2 col-lg-10">
-      <% if current_user.admin_for?(@kubernetes_deploy_group_role.project) %>
-        <%= link_to "Edit", edit_kubernetes_deploy_group_role_path(@kubernetes_deploy_group_role), class: "btn btn-primary" %>
-      <% end %>
-      <%= link_to "Back", kubernetes_deploy_group_roles_path, class: "btn btn-default" %>
-    </div>
-  </div>
+<section class="tabs kubernetes-section clearfix">
+  <%= render 'samson_kubernetes/role_navigation' %>
+  <% title = (@kubernetes_deploy_group_role.new_record? ? "New Kubernetes Deploy Group Role" : "Kubernetes Deploy Group Role") %>
+  <%= page_title title, in_tab: true %>
+  <%= render 'form' %>
 </section>

--- a/plugins/kubernetes/app/views/kubernetes/roles/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/show.html.erb
@@ -3,9 +3,7 @@
 <section class="tabs kubernetes-section clearfix">
   <%= render 'samson_kubernetes/role_navigation' %>
 
-  <section>
-    <% title = (@kubernetes_role.new_record? ? "New Kubernetes Role" : "Kubernetes Role #{@kubernetes_role.name}") %>
-    <%= page_title title, in_tab: true %>
-    <%= render 'form' %>
-  </section>
+  <% title = (@kubernetes_role.new_record? ? "New Kubernetes Role" : "Kubernetes Role #{@kubernetes_role.name}") %>
+  <%= page_title title, in_tab: true %>
+  <%= render 'form' %>
 </section>

--- a/plugins/kubernetes/app/views/kubernetes/usage_limits/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/usage_limits/_form.html.erb
@@ -1,25 +1,23 @@
-<section>
-  <%= form_for @kubernetes_usage_limit, html: { class: "form-horizontal" } do |form| %>
-    <%= render 'shared/errors', object: form.object %>
+<%= form_for @kubernetes_usage_limit, html: { class: "form-horizontal" } do |form| %>
+  <%= render 'shared/errors', object: form.object %>
 
-    <fieldset>
-      <% if DeployGroup.enabled? %>
-        <%= form.input :scope_type_and_id, label: "Scope" do %>
-          <%= form.select :scope_type_and_id, Environment.env_deploy_group_array(include_all: true), {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
-        <% end %>
+  <fieldset>
+    <% if DeployGroup.enabled? %>
+      <%= form.input :scope_type_and_id, label: "Scope" do %>
+        <%= form.select :scope_type_and_id, Environment.env_deploy_group_array(include_all: true), {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
       <% end %>
+    <% end %>
 
-      <%= form.input :project_id do %>
-        <% projects = Project.with_kubernetes_roles.pluck(:name, :id).unshift ["All", nil] %>
-        <%= form.select :project_id, projects, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
-      <% end %>
+    <%= form.input :project_id do %>
+      <% projects = Project.with_kubernetes_roles.pluck(:name, :id).unshift ["All", nil] %>
+      <%= form.select :project_id, projects, {}, Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
+    <% end %>
 
-      <%= form.input :cpu, required: true %>
-      <%= form.input :memory, required: true %>
+    <%= form.input :cpu, required: true %>
+    <%= form.input :memory, required: true %>
 
-      <%= form.input :comment, as: :text_area %>
-    </fieldset>
+    <%= form.input :comment, as: :text_area %>
+  </fieldset>
 
-    <%= form.actions delete: true, history: true %>
-  <% end %>
-</section>
+  <%= form.actions delete: true, history: true %>
+<% end %>

--- a/plugins/kubernetes/app/views/kubernetes/usage_limits/edit.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/usage_limits/edit.html.erb
@@ -1,2 +1,1 @@
-<%= page_title "Edit Kubernetes Limit" %>
-<%= render 'form' %>
+<%= render template: "kubernetes/usage_limits/show" %>

--- a/plugins/kubernetes/app/views/kubernetes/usage_limits/new.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/usage_limits/new.html.erb
@@ -1,2 +1,1 @@
-<%= page_title "New Kubernetes Limit" %>
-<%= render 'form' %>
+<%= render template: "kubernetes/usage_limits/show" %>

--- a/plugins/kubernetes/app/views/kubernetes/usage_limits/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/usage_limits/show.html.erb
@@ -1,2 +1,15 @@
-<%= page_title "Edit Kubernetes Limit" %>
-<%= render 'form' %>
+<% @project = @kubernetes_usage_limit.project %>
+<% title = (@kubernetes_usage_limit.new_record? ? "New Kubernetes Limit" : "Kubernetes Limit") %>
+<% if @project %>
+  <%= render 'projects/header', project: @project, tab: 'kubernetes' %>
+<% else %>
+  <%= page_title title %>
+<% end %>
+
+<section class="tabs kubernetes-section clearfix">
+  <% if @project %>
+    <%= render 'samson_kubernetes/role_navigation' %>
+    <%= page_title title, in_tab: true %>
+  <% end %>
+  <%= render 'form' %>
+</section>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_role_navigation.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_role_navigation.html.erb
@@ -1,5 +1,5 @@
 <% links = [
-  ["Roles", project_kubernetes_roles_path],
+  ["Roles", project_kubernetes_roles_path(@project)],
   ["Resources", project_kubernetes_deploy_group_roles_path(@project)],
   ["Limits", project_kubernetes_usage_limits_path(@project)],
 ] %>

--- a/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_stage_show.html.erb
@@ -36,8 +36,8 @@
               </td>
               <td><%= dg_role.requests_memory %> to <%= dg_role.limits_memory %></td>
               <td>
-                <% if current_user.admin_for?(@stage.project) %>
-                  <%= link_to 'Edit', edit_kubernetes_deploy_group_role_path(dg_role) %>
+                <% if current_user.admin_for?(@project) %>
+                  <%= link_to 'Edit', edit_project_kubernetes_deploy_group_role_path(@project, dg_role) %>
                 <% end %>
               </td>
             <% else %>

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -2,8 +2,9 @@
 Samson::Application.routes.draw do
   resources :projects do
     namespace :kubernetes do
-      resources :deploy_group_roles, only: [:index] do
+      resources :deploy_group_roles do
         collection do
+          post :seed
           get :edit_many
           put :update_many
         end
@@ -30,11 +31,7 @@ Samson::Application.routes.draw do
         post :seed_ecr
       end
     end
-    resources :deploy_group_roles do
-      collection do
-        post :seed
-      end
-    end
+    resources :deploy_group_roles, only: [:index]
     resources :usage_limits, except: [:edit]
     resources :namespaces, except: [:edit] do
       member do

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -65,7 +65,10 @@ end
 Samson::Hooks.callback(:link_parts_for_resource) do
   [
     "Kubernetes::DeployGroupRole",
-    ->(dgr) { ["#{dgr.project&.name} role #{dgr.kubernetes_role&.name} for #{dgr.deploy_group&.name}", dgr] }
+    ->(dgr) do
+      name = "#{dgr.project&.name} role #{dgr.kubernetes_role&.name} for #{dgr.deploy_group&.name}"
+      [name, [dgr.project, dgr]]
+    end
   ]
 end
 Samson::Hooks.callback(:link_parts_for_resource) do

--- a/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
+++ b/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
@@ -39,7 +39,7 @@ describe SamsonKubernetes do
 
     it "links to deploy group role" do
       dg_role = kubernetes_deploy_group_roles(:test_pod1_app_server)
-      link_parts(dg_role).must_equal ["Foo role app-server for Pod1", dg_role]
+      link_parts(dg_role).must_equal ["Foo role app-server for Pod1", [dg_role.project, dg_role]]
     end
 
     it "links to role" do


### PR DESCRIPTION
 - before they were on a empty page that interrupted the flow when editing / controller had logic to accommodate that
 - remove now obsolete js
 - remove show view which was not used

<img width="857" alt="Screen Shot 2019-10-21 at 11 10 11 PM" src="https://user-images.githubusercontent.com/11367/67262003-fe762b00-f457-11e9-8e8f-82b426e91972.png">

@zendesk/compute 