### PR TITLE
Filters for environment variables groups

### DIFF
--- a/plugins/env/app/controllers/env/environment_controller.rb
+++ b/plugins/env/app/controllers/env/environment_controller.rb
@@ -14,6 +14,19 @@ module Env
       end
     end
 
+    def preview
+      deploy_groups =
+        if deploy_group = params[:deploy_group].presence
+          [DeployGroup.find_by_permalink!(deploy_group)]
+        else
+          DeployGroup.all
+        end
+      deploy = Deploy.new(project: current_project)
+      envs = SamsonEnv.env_groups(deploy, deploy_groups, preview: true, env_group: false)
+
+      render json: {environment_variables: envs || []}
+    end
+
     private
 
     def unexpanded_secrets(env)

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -5,6 +5,18 @@ class EnvironmentVariableGroupsController < ApplicationController
 
   def index
     @groups = EnvironmentVariableGroup.all.includes(:environment_variables)
+
+    if project_id = params[:project_id].presence
+      @groups = @groups.joins(:project_environment_variable_groups).
+      where("project_environment_variable_groups.project_id = ?", project_id)
+    end
+
+    if deploy_group = params[:deploy_group].presence
+      group = DeployGroup.find_by_permalink!(deploy_group)
+      @groups = @groups.references(:environment_variables).
+      where("environment_variables.scope_type = 'DeployGroup' && environment_variables.scope_id", group.id)
+    end
+
     respond_to do |format|
       format.html
       format.json do

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -14,7 +14,7 @@ class EnvironmentVariableGroupsController < ApplicationController
     if deploy_group = params[:deploy_group].presence
       group = DeployGroup.find_by_permalink!(deploy_group)
       @groups = @groups.references(:environment_variables).
-      where("environment_variables.scope_type = 'DeployGroup' && environment_variables.scope_id", group.id)
+      where("environment_variables.scope_type = 'DeployGroup' AND environment_variables.scope_id", group.id)
     end
 
     respond_to do |format|

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -14,7 +14,7 @@ class EnvironmentVariableGroupsController < ApplicationController
     if deploy_group = params[:deploy_group].presence
       group = DeployGroup.find_by_permalink!(deploy_group)
       @groups = @groups.references(:environment_variables).
-      where("environment_variables.scope_type = 'DeployGroup' AND environment_variables.scope_id", group.id)
+      where("environment_variables.scope_type = 'DeployGroup' AND environment_variables.scope_id = ?", group.id)
     end
 
     respond_to do |format|

--- a/plugins/env/config/routes.rb
+++ b/plugins/env/config/routes.rb
@@ -6,7 +6,10 @@ Samson::Application.routes.draw do
     end
   end
   resources :environment_variables, only: [:index, :destroy]
-  resources :projects, only: [] do
-    resource :environment, only: [:show], controller: 'env/environment'
+  resources :projects, param: :project_id do
+    member do
+      get :environment, action: :show, controller: 'env/environment'
+      get :environment_variables_preview, action: :preview, controller: 'env/environment'
+    end
   end
 end

--- a/plugins/env/test/controllers/env/environment_controller_test.rb
+++ b/plugins/env/test/controllers/env/environment_controller_test.rb
@@ -7,24 +7,24 @@ describe Env::EnvironmentController do
   unauthorized :get, :show, project_id: 1, deploy_group: 1
 
   as_a :viewer do
+    let(:project) { projects(:test) }
+    let(:deploy_group) { deploy_groups(:pod1) }
+    let(:secret_id) { 'global/global/global/s' }
+
+    before do
+      EnvironmentVariable.create!(parent: project, name: 'A', value: 'a$C')
+      EnvironmentVariable.create!(parent: projects(:other), name: 'B', value: 'b')
+      EnvironmentVariable.create!(parent: project, scope: deploy_group, name: 'C', value: 'c')
+      EnvironmentVariable.create!(parent: project, scope: deploy_groups(:pod2), name: 'D', value: 'd')
+
+      create_secret secret_id
+      EnvironmentVariable.create!(parent: project, name: 'S', value: 'secret://s')
+
+      group = EnvironmentVariableGroup.create!(name: 'foo', projects: [project])
+      group.environment_variables.create!(name: 'E', value: 'e')
+    end
+
     describe "#show" do
-      let(:project) { projects(:test) }
-      let(:deploy_group) { deploy_groups(:pod1) }
-      let(:secret_id) { 'global/global/global/s' }
-
-      before do
-        EnvironmentVariable.create!(parent: project, name: 'A', value: 'a$C')
-        EnvironmentVariable.create!(parent: projects(:other), name: 'B', value: 'b')
-        EnvironmentVariable.create!(parent: project, scope: deploy_group, name: 'C', value: 'c')
-        EnvironmentVariable.create!(parent: project, scope: deploy_groups(:pod2), name: 'D', value: 'd')
-
-        create_secret secret_id
-        EnvironmentVariable.create!(parent: project, name: 'S', value: 'secret://s')
-
-        group = EnvironmentVariableGroup.create!(name: 'foo', projects: [project])
-        group.environment_variables.create!(name: 'E', value: 'e')
-      end
-
       it 'renders' do
         get :show, params: {project_id: project, deploy_group: deploy_group}
         assert_response :success
@@ -54,6 +54,33 @@ describe Env::EnvironmentController do
         get :show, params: {project_id: project, deploy_group: deploy_group}
         assert_response :unprocessable_entity
         response.body.must_include 'Unexpanded secrets found: secret://s X'
+      end
+    end
+
+    describe "#preview" do
+      it 'render' do
+        get :preview, params: {project_id: project}
+        assert_response :success
+      end
+
+      it "render json GET to #preview" do
+        get :preview, params: {project_id: project.id}
+        assert_response :success
+        json_response = JSON.parse response.body
+        json_response['environment_variables'].sort.must_equal [
+          [".pod-100", {"A" => "a$C", "S" => "secret://global/global/global/s"}],
+          [".pod1", {"C" => "c", "A" => "ac", "S" => "secret://global/global/global/s"}],
+          [".pod2", {"D" => "d", "A" => "a$C", "S" => "secret://global/global/global/s"}]
+        ]
+      end
+
+      it "only shows single deploy_group with filtering on" do
+        get :preview, params: {project_id: project.id, deploy_group: deploy_group}
+        assert_response :success
+        json_response = JSON.parse response.body
+        json_response['environment_variables'].sort.must_equal [
+          [".pod1", {"C" => "c", "A" => "ac", "S" => "secret://global/global/global/s"}]
+        ]
       end
     end
   end

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -189,6 +189,11 @@ describe EnvironmentVariable do
         EnvironmentVariable.env(deploy, nil).must_equal("X" => "Y", "Y" => "Z", "PROJECT" => "PROJECT")
       end
 
+      it "includes only project environment variables" do
+        EnvironmentVariable.env(deploy, nil, env_group: false).
+        must_equal("PROJECT" => "PROJECT")
+      end
+
       it "includes common for scoped groups" do
         EnvironmentVariable.env(deploy, deploy_group).must_equal(
           "PROJECT" => "DEPLOY", "X" => "Y", "Z" => "A", "Y" => "Z"


### PR DESCRIPTION
We need env vars for a project, without the shared environment variables (aka groups), as json.
We want to store both the project vars and the groups so we can reuse the groups.

1. Filter environment variables groups with `project_id` and `deploy_group` parameters.
`eg: /environment_variable_groups.json?deploy_group=pod999&project_id=1`
2. Preview project environment variables without groups.
 `eg: /projects/hello_world/environment_variables_preview.json`

### Risks
- Low