### PR TITLE
PAAS-5201 only real crashes should be marked as errors in rollbar

### DIFF
--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -80,7 +80,7 @@ module Samson
             begin
               vault_path(secret_path, :decode)
             rescue ActiveRecord::RecordNotFound => e
-              Samson::ErrorNotifier.notify(e, notice: true)
+              Samson::ErrorNotifier.notify(e)
               nil
             end
           end

--- a/plugins/ledger/lib/samson_ledger/client.rb
+++ b/plugins/ledger/lib/samson_ledger/client.rb
@@ -13,7 +13,7 @@ module SamsonLedger
       def post_deployment(deploy)
         post_event(deploy) if ledger_token && ledger_base_url && !deploy.stage.no_code_deployed?
       rescue StandardError
-        Samson::ErrorNotifier.notify($!, notice: true)
+        Samson::ErrorNotifier.notify($!)
       end
 
       private

--- a/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
+++ b/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
@@ -9,7 +9,7 @@ module SamsonRollbar
 end
 
 Samson::Hooks.callback :error do |exception, sync: false, **options|
-  data = Rollbar.error(exception, options)
+  data = Rollbar.warn(exception, options)
 
   if sync
     Rollbar::Util.uuid_rollbar_url(data, Rollbar.configuration) if data.is_a?(Hash)

--- a/plugins/rollbar/test/samson_rollbar/samson_plugin_test.rb
+++ b/plugins/rollbar/test/samson_rollbar/samson_plugin_test.rb
@@ -11,13 +11,13 @@ describe SamsonRollbar do
     only_callbacks_for_plugin :error
 
     it 'reports error' do
-      Rollbar.expects(:error).with(exception, foo: 'bar').returns(123)
+      Rollbar.expects(:warn).with(exception, foo: 'bar').returns(123)
       Samson::Hooks.fire(:error, exception, foo: 'bar').must_equal [123]
     end
 
     describe "with sync" do
       it 'returns url' do
-        Rollbar.expects(:error).with(exception, foo: 'bar').returns(uuid: '123')
+        Rollbar.expects(:warn).with(exception, foo: 'bar').returns(uuid: '123')
         Samson::Hooks.fire(:error, exception, foo: 'bar', sync: true).must_equal(
           ["https://rollbar.com/instance/uuid?uuid=123"]
         )


### PR DESCRIPTION
/cc @zendesk/compute @zendesk/eng-productivity 

### Risks
 - None