### PR TITLE
Project Specific environment variables in preview

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.4)
+    crass (1.0.5)
     dalli (2.7.6)
     ddtrace (0.14.2)
       msgpack
@@ -344,7 +344,7 @@ GEM
       railties (>= 4)
       request_store (~> 1.0)
     logstash-event (1.2.02)
-    loofah (2.2.3)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -587,6 +587,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-18
 
 DEPENDENCIES
   active_hash

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -55,7 +55,7 @@ class EnvironmentVariableGroupsController < ApplicationController
     end
 
     options = {project_specific: params[:project_specific]}
-    options.merge!(params[:preview] ? {preview: true, resolve_secrets: true} : {resolve_secrets: false})
+    options.merge!(params[:preview].to_s == "false" ? {resolve_secrets: false} : {preview: true, resolve_secrets: true})
 
     @groups = SamsonEnv.env_groups(Deploy.new(project: @project), deploy_groups, **options)
 

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -54,7 +54,10 @@ class EnvironmentVariableGroupsController < ApplicationController
       @project = Project.find(params[:project_id])
     end
 
-    @groups = SamsonEnv.env_groups(Deploy.new(project: @project), deploy_groups, preview: true)
+    options = {project_specific: params[:project_specific]}
+    options.merge!(params[:preview] ? {preview: true, resolve_secrets: true} : {resolve_secrets: false})
+
+    @groups = SamsonEnv.env_groups(Deploy.new(project: @project), deploy_groups, **options)
 
     respond_to do |format|
       format.html

--- a/plugins/env/app/decorators/project_decorator.rb
+++ b/plugins/env/app/decorators/project_decorator.rb
@@ -24,8 +24,18 @@ Project.class_eval do
     EnvironmentVariable.serialize(nested_environment_variables, @env_scopes)
   end
 
-  def nested_environment_variables
-    [self, *environment_variable_groups].flat_map(&:environment_variables)
+  def nested_environment_variables(project_specific: nil)
+    # Project Specific:
+    # nil           => project env + groups env
+    # true/"true"   => project env
+    # false/"false" => groups env
+    if project_specific.to_s == "true"
+      environment_variables
+    elsif project_specific.to_s == "false"
+      environment_variable_groups.flat_map(&:environment_variables)
+    else
+      [self, *environment_variable_groups].flat_map(&:environment_variables)
+    end
   end
 
   private

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -140,7 +140,7 @@ describe EnvironmentVariableGroupsController do
 
       it "calls env with preview" do
         EnvironmentVariable.expects(:env).
-        with(anything, anything, project_specific: nil, resolve_secrets: false).times(3)
+        with(anything, anything, project_specific: nil, preview: true, resolve_secrets: true).times(3)
         get :preview, params: {group_id: env_group.id}
         assert_response :success
       end
@@ -148,7 +148,7 @@ describe EnvironmentVariableGroupsController do
 
     describe "a json GET to #preview" do
       it "succeeds" do
-        get :preview, params: {group_id: env_group.id, project_id: project.id, preview: true}, format: :json
+        get :preview, params: {group_id: env_group.id, project_id: project.id, preview: false}, format: :json
         assert_response :success
         json_response = JSON.parse response.body
         json_response['groups'].sort.must_equal [

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -243,6 +243,16 @@ describe EnvironmentVariable do
         )
       end
 
+      it "includes only project specific environment variables" do
+        EnvironmentVariable.env(deploy, nil, project_specific: true).
+        must_equal("PROJECT" => "PROJECT")
+      end
+
+      it "includes only project groups environment variables" do
+        EnvironmentVariable.env(deploy, nil, project_specific: false).
+        must_equal("X" => "Y", "Y" => "Z")
+      end
+
       describe "secrets" do
         before do
           create_secret 'global/global/global/foobar'


### PR DESCRIPTION
Added project-specific environment variables in preview, so that we will have option to differentiate the project and shared(groups) envs.
eg:
` /environment_variable_groups/preview?project_id=1&project_specific=true`
