### PR TITLE
PAAS-4111 for update of services by re-creating them if they complain…

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -294,3 +294,11 @@ of a Deployment, DaemonSet, or StatefulSet. Assuming you have Istio configured t
 MutatingWebhook in the target namespace, that should trigger Istio to inject the sidecar.
 
 To enable this functionality, set the environment variable `ISTIO_INJECTION_SUPPORTED=true`.
+
+### Forcing updates when kubernetes cannot change a resource
+
+Delete old resource and create new when an update fails because it `cannot change` a resources.
+
+```
+metadata.annotation.samson/force_update: "true"
+```


### PR DESCRIPTION
… that they cannot be updated

Tested with https://github.com/samson-test-org/example-kubernetes
968b2d1 -> 87ba8f5 which modifies `spec.healthCheckNodePort`

Before resulted in
```
[16:47:01] JobExecution failed: Kubernetes error example sdfsfsfs GroupK: Service "example" is invalid: spec.healthCheckNodePort: Invalid value: 30124: cannot change healthCheckNodePort on loadBalancer service with externalTraffic=Local during update
```

this might later be expanded to other resources since we had these issues before

... an alternative would be to require a `samson/force-update` annotation if we think that re-creating a service could have bad consequences like changing it's id

@zendesk/compute 