### PR TITLE
Render JSON instead of HTML for 404's on json requests

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,6 +5,14 @@ class ProjectsController < ResourceController
   before_action :set_resource, only: [:show, :edit, :update, :destroy, :deploy_group_versions, :new, :create]
   before_action :authorize_resource!, except: [:deploy_group_versions, :edit]
 
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    if request.format.json?
+      render json: {error: 'Resource not found'}, status: :not_found
+    else
+      raise exception
+    end
+  end
+
   # TODO: make this behave more like resource_controller
   def index
     projects = projects_for_user

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -161,6 +161,13 @@ describe ProjectsController do
           refute project.key?('token')
         end
 
+        it "renders 404 when project is not found" do
+          get :show, params: {id: 'doesnotexist', format: :json}
+          assert_response 404
+          body = JSON.parse(response.body)
+          assert_equal(body, 'error' => 'Resource not found')
+        end
+
         it "renders with envionment_variable_groups if present" do
           get :show, params: {id: project.to_param, includes: "environment_variable_groups", format: :json}
           assert_response :success


### PR DESCRIPTION
Im provisioning some resources through the json api and noticed the api returns html instead of json if there's a 404. This adds a rescue for project endpoints that renders a json error for json requests and raises otherwise to keep behaviour the same.

### References
- Jira link: 

### Risks
- Low/Med/High: thing that could happen
