### PR TITLE
PAAS-5121 fail deploys when init containers crashed

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -34,7 +34,8 @@ module Kubernetes
       end
 
       def restart_details
-        @pod.dig(:status, :containerStatuses)&.detect do |s|
+        statuses = (@pod.dig(:status, :containerStatuses) || []) + (@pod.dig(:status, :initContainerStatuses) || [])
+        statuses.detect do |s|
           next unless s.fetch(:restartCount) > 0
           reason = s.dig(:lastState, :terminated, :reason) || s.dig(:state, :terminated, :reason) || "Unknown"
           return "Restarted (#{s[:name]} #{reason})"

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -116,6 +116,11 @@ describe Kubernetes::Api::Pod do
       refute pod.restart_details
     end
 
+    it "shows restarted for init containers" do
+      pod_attributes[:status][:initContainerStatuses] = [{name: "foo", restartCount: 1}]
+      pod.restart_details.must_equal "Restarted (foo Unknown)"
+    end
+
     describe "when restarted" do
       before { pod_attributes[:status][:containerStatuses][0][:restartCount] = 1 }
 


### PR DESCRIPTION
@zendesk/compute 

tested with 
```
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
  labels:
    app: myapp
spec:
  containers:
  - name: myapp-container
    image: busybox
    command: ['sleep', '1000']
  initContainers:
    - name: foo
      image: busybox
      command: ['sleepnoooo']
```

### Risks
 - None