### PR TITLE
PAAS-3503 keep secrets from serviceaccounts so they do not get re-cre…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -493,6 +493,14 @@ module Kubernetes
     class HorizontalPodAutoscaler < Base
     end
 
+    class ServiceAccount < VersionedUpdate
+      def template_for_update
+        t = super
+        t[:secrets] ||= resource[:secrets]
+        t
+      end
+    end
+
     def self.build(*args)
       klass = "Kubernetes::Resource::#{args.first.fetch(:kind)}".safe_constantize || VersionedUpdate
       klass.new(*args)

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -942,6 +942,22 @@ describe Kubernetes::Resource do
     end
   end
 
+  describe Kubernetes::Resource::ServiceAccount do
+    let(:kind) { 'ServiceAccount' }
+    let(:api_version) { 'v1' }
+
+    describe "#deploy" do
+      it "updates" do
+        with = ->(r) { r.body.must_include '"a":1' }
+        assert_request(:get, url, to_return: [{body: {secrets: [{a: 1}]}.to_json}]) do
+          assert_request(:put, url, to_return: {body: '{}'}, with: with) do
+            resource.deploy
+          end
+        end
+      end
+    end
+  end
+
   describe Kubernetes::Resource::VersionedUpdate do
     let(:kind) { 'CustomResourceDefinition' }
     let(:api_version) { 'apiextensions.k8s.io/v1beta1' }


### PR DESCRIPTION
…ated on every deploy

@zendesk/compute 

tested with example-kubernetes grosser/serviceaccount branch ... kept the same secret around instead of duplicating

Migration:

```ruby
Kubernetes::Cluster.all.each do |cluster|
  puts "NOW #{cluster.name}"
  begin
    client = cluster.client("v1")
    secrets = client.get_secrets.fetch(:items).select { |s| s[:type] == "kubernetes.io/service-account-token" }
    groups = secrets.
      sort_by { |s| s.dig(:metadata, :creationTimestamp) }.
      group_by { |s| s.dig(:metadata, :annotations, :"kubernetes.io/service-account.name") }
    used = client.get_pods.fetch(:items).flat_map do |pod|
      (pod[:spec][:volumes] || []).map { |v| "#{pod[:metadata][:namespace]}/#{v[:name]}" if v[:secret] }.compact
    end

    groups.each do |account, secrets|
      next unless account
      (secrets[0..-2] || []).each do |s|
        name = s.dig(:metadata, :name)
        namespace = s.dig(:metadata, :namespace)
        if used.include?("#{namespace}/#{name}")
          puts "USED #{namespace}/#{name} from #{s.dig(:metadata, :creationTimestamp)}"
        else
          puts "DELETE #{namespace}/#{name} from #{s.dig(:metadata, :creationTimestamp)}"
          client.delete_secret name, namespace
        end
      end
    end
  rescue => e
    puts "ERROR #{cluster.name} #{e}"
  end
end;nil
```

... and `kubectl get events --watch --all-namespaces | grep FailedMount` so check that nothing breaks

### Risks
 - Low: service account trouble