### PR TITLE
Remove build_id from deploys table

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -7,7 +7,6 @@ class Build < ActiveRecord::Base
   belongs_to :project, inverse_of: :builds
   belongs_to :docker_build_job, class_name: 'Job', optional: true
   belongs_to :creator, class_name: 'User', foreign_key: 'created_by', inverse_of: :builds
-  has_many :deploys, dependent: nil
 
   before_validation :nil_out_blanks
   before_validation :make_default_dockerfile_and_image_name_not_collide, on: :create

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -8,7 +8,6 @@ class Deploy < ActiveRecord::Base
   extend Inlinable
 
   belongs_to :stage, touch: true, inverse_of: :deploys
-  belongs_to :build, optional: true, inverse_of: :deploys
   belongs_to :project, inverse_of: :deploys
   belongs_to :job, inverse_of: :deploy
   belongs_to :buddy, -> { unscope(where: "deleted_at") }, class_name: 'User', optional: true, inverse_of: nil

--- a/db/migrate/20191029174730_remove_deploy_build_id.rb
+++ b/db/migrate/20191029174730_remove_deploy_build_id.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class RemoveDeployBuildId < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :deploys, :build_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_023140) do
+ActiveRecord::Schema.define(version: 2019_10_29_174730) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -125,7 +125,6 @@ ActiveRecord::Schema.define(version: 2019_10_22_023140) do
     t.integer "buddy_id"
     t.datetime "started_at"
     t.datetime "deleted_at"
-    t.integer "build_id"
     t.boolean "release", default: false, null: false
     t.boolean "kubernetes", default: false, null: false
     t.integer "project_id", null: false
@@ -135,7 +134,6 @@ ActiveRecord::Schema.define(version: 2019_10_22_023140) do
     t.integer "triggering_deploy_id"
     t.boolean "redeploy_previous_when_failed", default: false, null: false
     t.boolean "kubernetes_ignore_kritis_vulnerabilities", default: false, null: false
-    t.index ["build_id"], name: "index_deploys_on_build_id"
     t.index ["deleted_at"], name: "index_deploys_on_deleted_at"
     t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
     t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at"


### PR DESCRIPTION
Remove build_id from deploys table. Seems unused and doesn't make sense as Deploys to Builds is a many-to-many association.

### Risks
- Medium: Deploy build_id is used somewhere that we don't know of