### PR TITLE
Add many-to-many relationship between deploys and builds

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -317,15 +317,36 @@ module ApplicationHelper
 
   # show which stages this reference is deploy(ed+ing) to
   def deployed_or_running_list(stages, reference)
-    html = "".html_safe
-    stages.each do |stage|
+    deploys = stages.map do |stage|
       next unless deploy = stage.deployed_or_running_deploy
       next unless deploy.references?(reference)
+      [stage, deploy]
+    end.compact
+
+    stage_deploy_labels(deploys)
+  end
+
+  # show which stages this build is deploy(ed+ing) to
+  def deployed_or_running_builds(stages, build)
+    deploys = stages.map do |stage|
+      next unless deploy = stage.deployed_or_running_deploy
+      next unless deploy.builds.include?(build)
+      [stage, deploy]
+    end.compact
+
+    stage_deploy_labels(deploys)
+  end
+
+  def stage_deploy_labels(deploy_map)
+    html = "".html_safe
+    deploy_map.each do |stage, deploy|
       label = (deploy.active? ? "label-warning" : "label-success")
 
       text = "".html_safe
       text << stage.name
-      html << content_tag(:span, text, class: "label #{label} release-stage")
+      html << link_to([@project || deploy.project, deploy]) do
+        content_tag(:span, text, class: "label #{label} release-stage")
+      end
       html << " "
     end
     html

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -7,6 +7,8 @@ class Build < ActiveRecord::Base
   belongs_to :project, inverse_of: :builds
   belongs_to :docker_build_job, class_name: 'Job', optional: true
   belongs_to :creator, class_name: 'User', foreign_key: 'created_by', inverse_of: :builds
+  has_many :deploy_builds, dependent: nil
+  has_many :deploys, through: :deploy_builds
 
   before_validation :nil_out_blanks
   before_validation :make_default_dockerfile_and_image_name_not_collide, on: :create

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -7,7 +7,7 @@ class Build < ActiveRecord::Base
   belongs_to :project, inverse_of: :builds
   belongs_to :docker_build_job, class_name: 'Job', optional: true
   belongs_to :creator, class_name: 'User', foreign_key: 'created_by', inverse_of: :builds
-  has_many :deploy_builds, dependent: nil
+  has_many :deploy_builds, dependent: :destroy
   has_many :deploys, through: :deploy_builds
 
   before_validation :nil_out_blanks

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -8,7 +8,7 @@ class Build < ActiveRecord::Base
   belongs_to :docker_build_job, class_name: 'Job', optional: true
   belongs_to :creator, class_name: 'User', foreign_key: 'created_by', inverse_of: :builds
   has_many :deploy_builds, dependent: :destroy
-  has_many :deploys, through: :deploy_builds
+  has_many :deploys, through: :deploy_builds, inverse_of: :builds
 
   before_validation :nil_out_blanks
   before_validation :make_default_dockerfile_and_image_name_not_collide, on: :create

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -12,7 +12,7 @@ class Deploy < ActiveRecord::Base
   belongs_to :job, inverse_of: :deploy
   belongs_to :buddy, -> { unscope(where: "deleted_at") }, class_name: 'User', optional: true, inverse_of: nil
   has_many :deploy_builds, dependent: :destroy
-  has_many :builds, through: :deploy_builds
+  has_many :builds, through: :deploy_builds, inverse_of: :deploys
 
   default_scope { order(id: :desc) }
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -11,6 +11,8 @@ class Deploy < ActiveRecord::Base
   belongs_to :project, inverse_of: :deploys
   belongs_to :job, inverse_of: :deploy
   belongs_to :buddy, -> { unscope(where: "deleted_at") }, class_name: 'User', optional: true, inverse_of: nil
+  has_many :deploy_builds, dependent: :destroy
+  has_many :builds, through: :deploy_builds
 
   default_scope { order(id: :desc) }
 

--- a/app/models/deploy_build.rb
+++ b/app/models/deploy_build.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 class DeployBuild < ActiveRecord::Base
-  belongs_to :deploy
-  belongs_to :build
+  belongs_to :deploy, inverse_of: :deploy_builds
+  belongs_to :build, inverse_of: :deploy_builds
 end

--- a/app/models/deploy_build.rb
+++ b/app/models/deploy_build.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class DeployBuild < ActiveRecord::Base
+  belongs_to :deploy
+  belongs_to :build
+end

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -212,7 +212,7 @@ class JobExecution
 
   def make_builds_available
     # wait for builds to finish
-    builds = build_finder.ensure_succeeded_builds
+    builds = deploy.builds = build_finder.ensure_succeeded_builds
 
     # pre-download the necessary images in case they are not public
     ImageBuilder.local_docker_login do |login_commands|

--- a/app/views/builds/_build.html.erb
+++ b/app/views/builds/_build.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= link_to build.nice_name, project_build_path(build.project, build) %></td>
   <% if @project %>
-    <td><%= deployed_or_running_list @project.stages, build.git_sha %></td>
+    <td><%= deployed_or_running_builds @project.stages, build %></td>
   <% else %>
     <td><%= link_to build.project.name, build.project %></td>
   <% end %>

--- a/db/migrate/20191029181037_add_deploy_builds.rb
+++ b/db/migrate/20191029181037_add_deploy_builds.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class AddDeployBuilds < ActiveRecord::Migration[5.2]
+  def change
+    create_table :deploy_builds do |t|
+      t.references :build, index: true, null: false
+      t.references :deploy, index: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,6 +87,15 @@ ActiveRecord::Schema.define(version: 2019_10_30_151254) do
     t.index ["scope_id", "scope_type"], name: "index_datadog_monitor_queries_on_scope_id_and_scope_type", length: { scope_type: 100 }
   end
 
+  create_table "deploy_builds" do |t|
+    t.bigint "build_id", null: false
+    t.bigint "deploy_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["build_id"], name: "index_deploy_builds_on_build_id"
+    t.index ["deploy_id"], name: "index_deploy_builds_on_deploy_id"
+  end
+
   create_table "deploy_groups", id: :integer do |t|
     t.string "name", null: false
     t.integer "environment_id", null: false

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -38,6 +38,9 @@ module Kubernetes
         unless @release.save
           raise Samson::Hooks::UserError, "Failed to store manifests: #{@release.errors.full_messages.inspect}"
         end
+
+        # save which builds were used in this deploy
+        @job.deploy.builds = @release.builds
       end
 
       prerequisites, deploys = @release.release_docs.partition(&:prerequisite?)

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -168,6 +168,7 @@ describe Kubernetes::DeployExecutor do
       out.must_include "SUCCESS"
       out.must_include waiting_message
       out.wont_include "BigDecimal" # properly serialized configs
+      deploy.builds.must_equal [build]
     end
 
     it "watches resources until they are stable" do
@@ -216,7 +217,7 @@ describe Kubernetes::DeployExecutor do
       end
 
       it "does limited amounts of queries" do
-        assert_sql_queries(16) do
+        assert_sql_queries(17) do
           assert execute, out
         end
       end

--- a/test/models/deploy_build_test.rb
+++ b/test/models/deploy_build_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+SingleCov.covered!
+
+describe DeployBuild do
+  # uncovered
+end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -320,6 +320,11 @@ describe JobExecution do
       job.output.must_include "export BUILD_FROM_Dockerfile=docker-registry.example.com"
     end
 
+    it "saves builds made available to the deploy" do
+      JobExecution.new('master', job).perform
+      job.deploy.builds.must_equal [build]
+    end
+
     it "creates valid env variables when build name is not valid" do
       build.update_columns(dockerfile: nil, image_name: 'foo-bar-∂-baz')
       JobExecution.new('master', job).perform


### PR DESCRIPTION
Add many-to-many relationship between deploys and builds to capture which builds are deployed by a single deploy. This is used for showing the correct "deployed to" stage in the Builds listing, and can be used in the future for ensuring redeploys redeploy the exact same build and not the latest.

Deploys with no builds default back to the old display behaviour, ie may show multiple builds deployed when only one (or none) were.

### References
- Jira link: https://zendesk.atlassian.net/browse/PAAS-4110

### Risks
- Low: Builds are not saved if they don't go through the expected code path, may show builds as being deployed when they weren't and vice-versa.
