### PR TITLE
Allow show action for inbound webhooks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Samson::Application.routes.draw do
 
     resource :changelog, only: [:show]
     resource :stars, only: [:create]
-    resources :webhooks, only: [:index, :create, :update, :destroy]
+    resources :webhooks, only: [:index, :show, :create, :update, :destroy]
     resources :outbound_webhooks, only: [:index, :create, :update, :destroy]
     resources :references, only: [:index]
     resources :user_project_roles, only: [:index]

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -40,6 +40,20 @@ describe WebhooksController do
         assert_template :index
       end
     end
+
+    describe '#show' do
+      it 'renders json' do
+        get :show, params: {project_id: project.to_param, id: webhook.id, format: :json}
+        assert_response :success
+        assert_equal webhook.id, JSON.parse(response.body)["webhook"]["id"]
+      end
+
+      it 'returns 404 when webhook not found' do
+        assert_raises ActiveRecord::RecordNotFound do
+          get :show, params: {project_id: project.to_param, id: 123456, format: :json}
+        end
+      end
+    end
   end
 
   as_a :project_deployer do


### PR DESCRIPTION
I'd like to be able to fetch the state of a single webhook for a given project with the json api. This PR allows requests to `GET /projects/:id/webhooks/:webhook_id`

Not sure what to do about html requests though.. previously it would 404 in the web app because the route wasn't defined but now that it is, it'll respond with 406 because there's no view. I think it's not a problem though as this view has never existed so nobody should try to reach it.

One option to handle it a bit more gracefully would be to add something like the following to webhooks controller
```ruby
def show
  respond_to do |format|
    format.html { head :not_found } # or something similar  
    format.json { render_resource_as_json } 
  end
end
```

### References
- Jira link: 

### Risks
- Low: thing that could happen
