### PR TITLE
PAAS-5072 enable ad-hoc pipelining through all production stages

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_30_151254) do
+ActiveRecord::Schema.define(version: 2019_10_31_151553) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2019_10_30_151254) do
     t.integer "triggering_deploy_id"
     t.boolean "redeploy_previous_when_failed", default: false, null: false
     t.boolean "kubernetes_ignore_kritis_vulnerabilities", default: false, null: false
+    t.boolean "pipeline_to_next_stages", default: false, null: false
     t.index ["deleted_at"], name: "index_deploys_on_deleted_at"
     t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
     t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at"
@@ -589,6 +590,7 @@ ActiveRecord::Schema.define(version: 2019_10_30_151254) do
     t.boolean "kubernetes_sample_logs_on_success", default: false, null: false
     t.string "jira_transition_id"
     t.boolean "kubernetes_hide_error_logs", default: false, null: false
+    t.boolean "pipeline_to_next_stages_allowed", default: false, null: false
     t.index ["project_id", "permalink"], name: "index_stages_on_project_id_and_permalink", unique: true, length: { permalink: 191 }
     t.index ["template_stage_id"], name: "index_stages_on_template_stage_id"
   end

--- a/plugins/pipelines/app/views/samson_pipelines/_deploy_form.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_deploy_form.html.erb
@@ -1,0 +1,8 @@
+<% if @stage.pipeline_to_next_stages_allowed? %>
+  <% # TODO: add to next_stages logic or reuse somehow %>
+  <% stages = @project.stages.to_a %>
+  <% next_stages = stages[(stages.index(@stage) + 1)..-1] %>
+  <% if next_stages.any? && next_stages.map(&:production?).uniq == [@stage.production?] %>
+    <%= form.input :pipeline_to_next_stages, as: :check_box, label: "Pipeline to #{next_stages.size} next stages" %>
+  <% end %>
+<% end %>

--- a/plugins/pipelines/app/views/samson_pipelines/_stage_form.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_stage_form.html.erb
@@ -1,2 +1,4 @@
 <% help_text = 'Set the stages that will get automatically deployed after this one.' %>
 <%= check_box_section('Pipelining', help_text, :stage, :next_stage_ids, @project.stages - [@stage]) %>
+
+<%= form.input :pipeline_to_next_stages_allowed, as: :check_box, label: "Ad-hoc pipeline to next stages allowed" %>

--- a/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
+++ b/plugins/pipelines/app/views/samson_pipelines/_stage_show.html.erb
@@ -1,4 +1,5 @@
 <%
+  # TODO: add next ad-hoc pipelining stages
   next_stages = @stage.next_stages.sort_by(&:name)
   previous_stages = @stage.previous_stages.sort_by(&:name)
 %>
@@ -19,8 +20,8 @@
     <div>
       After this stage finishes deploying it will deploy to:
       <%= unordered_list next_stages do |stage| %>
-        <%= link_to stage.name, [@project, stage] %>  
-        <% if last_deploy = stage.last_deploy %> 
+        <%= link_to stage.name, [@project, stage] %>
+        <% if last_deploy = stage.last_deploy %>
           Last Deploy: <%= render_time last_deploy.start_time %> <%= status_badge last_deploy.status %>
         <% end %>
       <% end %>

--- a/plugins/pipelines/db/migrate/20191031151553_add_pipeline_to_next_stages_to_deploys.rb
+++ b/plugins/pipelines/db/migrate/20191031151553_add_pipeline_to_next_stages_to_deploys.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddPipelineToNextStagesToDeploys < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stages, :pipeline_to_next_stages_allowed, :boolean, default: false, null: false
+    add_column :deploys, :pipeline_to_next_stages, :boolean, default: false, null: false
+  end
+end


### PR DESCRIPTION
### Problem

We don't always want to pipeline our deploys, so an opt-in to pipeline through all prod would be nice,
combine this with after-deploy monitoring from datadog plugin + notify deployer on failure and we got a nice pipelining tool.

Alternatives: 
 - setup pipelining between all prod stages and then use a flag to opt-in / opt-out of it ... I'll explore that next since it would be duplicating less logic.
 - have multiple copies of stages, one pipelined on not ... but that's ugh

@zendesk/compute 

 - stages can allow "ad-hoc" pipelining
 - deploys can then opt-in to "ad-hoc" pipelining (if all next stages (as defined by stage ordering) are in the same environment)
 - deploy-to-next is copied after deploy so the train keeps going

<img width="265" alt="Screen Shot 2019-10-31 at 8 46 54 AM" src="https://user-images.githubusercontent.com/11367/67962967-17e74780-fbbb-11e9-92a9-9ddfaf36872c.png">
<img width="513" alt="Screen Shot 2019-10-31 at 8 46 32 AM" src="https://user-images.githubusercontent.com/11367/67962971-187fde00-fbbb-11e9-9831-ee6650d96074.png">
