### PR TITLE
do not link to nil urls ... they end up linking to the same page

### DIFF
--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -20,7 +20,7 @@
   <p>
     <% CommitStatus.new(@release.project, @release.commit).statuses.each do |status| %>
       <%= commit_status_icon(status.fetch(:state)) %>
-      <b><%= status[:context] %>:</b> <%= link_to status[:description], status[:target_url] %><br/>
+      <b><%= status[:context] %>:</b> <%= link_to_if status[:target_url], status[:description], status[:target_url] %><br/>
     <% end %>
   </p>
 


### PR DESCRIPTION
one commit status was missing their url ... so the page linked to itself ... which was kinda weird

@zendesk/compute 