### PR TITLE
Revert "Revert "Merge pull request #3557 from zendesk/grosser/cache""

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -13,7 +13,7 @@ class Integrations::GithubController < Integrations::BaseController
 
   def create
     expire_commit_status if github_event_type == "status"
-    expire_pull_request if github_event_type == "pull_request"
+    cache_pull_request if github_event_type == "pull_request"
     super
   end
 
@@ -23,8 +23,8 @@ class Integrations::GithubController < Integrations::BaseController
     CommitStatus.new(project, params[:sha].to_s).expire_cache
   end
 
-  def expire_pull_request
-    Changeset::PullRequest.expire(project.repository_path, params[:number])
+  def cache_pull_request
+    Changeset::PullRequest.cache(project.repository_path, payload)
   end
 
   def payload

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -102,7 +102,7 @@ class Changeset
   # github only supports finding open PRs for branches (not commits or tags)
   # https://help.github.com/en/articles/searching-issues-and-pull-requests
   #
-  # List response is not the same as the show response, do not use PullRequest.new
+  # List response is not the same as the show response (missing commits/additions/etc), do not use PullRequest.new
   #
   # @return [Array<Integer>]
   def open_pull_requests

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -87,13 +87,13 @@ describe Integrations::GithubController do
       payload.deep_merge!(pull_request: {body: 'imafixwolves'})
     end
 
-    it "expires PR cache" do
+    it "refreshes PR cache" do
       repo = project.repository_path
       request = stub_github_api("repos/#{repo}/pulls/123", {})
       2.times { assert Changeset::PullRequest.find(repo, 123) }
-      post :create, params: {token: project.token, number: 123}
+      post :create, params: {token: project.token, pull_request: {number: 123}}
       assert Changeset::PullRequest.find(repo, 123)
-      assert_requested request, times: 2
+      assert_requested request, times: 1
     end
   end
 

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -40,12 +40,15 @@ describe Changeset::PullRequest do
     end
   end
 
-  describe ".expire" do
-    it "expires find cache" do
-      GITHUB.expects(:pull_request).with("foo/bar", 42).returns({}).times(2)
-      2.times { assert Changeset::PullRequest.find("foo/bar", 42) }
-      Changeset::PullRequest.expire("foo/bar", 42)
-      assert Changeset::PullRequest.find("foo/bar", 42)
+  describe ".cache" do
+    it "overrides find cache" do
+      GITHUB.expects(:pull_request).with("foo/bar", 42).
+        returns(Sawyer::Resource.new(Octokit.agent, title: "X"))
+
+      2.times { Changeset::PullRequest.find("foo/bar", 42).title.must_equal "X" }
+
+      Changeset::PullRequest.cache("foo/bar", "pull_request" => {"number" => 42, "title" => "C"})
+      Changeset::PullRequest.find("foo/bar", 42).title.must_equal "C"
     end
   end
 


### PR DESCRIPTION
This reverts commit 1f344477007d74e5dc02790e6718c29b3138be7b.
https://github.com/zendesk/samson/pull/3557

try this again and debug why we had trouble

 - fixed 1 bug where the .find would return an empty PR because the rescue was moved
 - fixed 1 bug where the payload was stored in full, and not the pull_request subsection
 - confirmed opening a PR fills the cache correctly

 ```
 Changeset::PullRequest.find('foo', 158)
{:message=>"request.faraday.samson", :duration=>"76.0ms", :method=>:get, :url ...
Changeset::PullRequest.find('zendesk/kube_node_monitor', 158)
 ... no request but risks are there
 ```

@zendesk/compute @alanhogan 

### Risks
- Low: PR caching broken again
