### PR TITLE
do not crash with 404 errors when trying to create a namespace-less r…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -137,10 +137,16 @@ module Kubernetes
       @errors << "Needs a metadata.name" unless map_attributes([:metadata, :name]).all?
     end
 
-    # not setting a namespace is safe to ignore, because teplate-filler overrides it with the configured namespace
+    # not setting a namespace is safe to ignore, because template-filler overrides it with the configured namespace
     # and that either sets the namespace or is ignored for namespace-less resources
     def validate_namespace
       return unless namespace = @project&.kubernetes_namespace&.name
+
+      @elements.each do |e|
+        if NAMESPACELESS_KINDS.include?(e[:kind]) && e.dig(:metadata, :namespace)
+          @errors << "Do not set namespace for #{e[:kind]}"
+        end
+      end
 
       namespaces = []
       @elements.each { |e| namespaces << e.dig(:metadata, :namespace) if e[:metadata].key?(:namespace) }

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -332,13 +332,18 @@ describe Kubernetes::RoleValidator do
       end
 
       it "passes without namespaces" do
-        role.each { |e| e[:metadata].delete(:namespace) }
         errors.must_equal nil
       end
 
       it "fails with forced default namespace" do
         role[0][:metadata][:namespace] = nil
         errors.must_equal ["Only use configured namespace \"foo\", not [nil]"]
+      end
+
+      it "fails when namespace is set on namespace-less kind" do
+        role[0][:kind] = "CustomResourceDefinition"
+        role[0][:metadata][:namespace] = "foo"
+        errors.must_equal ["Do not set namespace for CustomResourceDefinition"]
       end
 
       describe "with invalid namespace" do


### PR DESCRIPTION
…esource with a namespace

we saw 404 when trying to create a namespace-less resource with a namespace ... kubectl is smart enough to remove the namespace, but I'd prefer if we stop user early that did not understand they are creating a global resource

```
the server could not find the requested resource
```

@zendesk/compute @swapnil-zendesk 