### PR TITLE
PAAS-5273 allow projects to ignore global check-suites that do not ap…

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -93,6 +93,7 @@ class ProjectsController < ResourceController
         :docker_build_method,
         :include_new_deploy_groups,
         :dashboard,
+        :ignore_pending_checks,
       ] + Samson::Hooks.fire(:project_permitted_params)
     ).merge(current_user: current_user)
   end

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -105,7 +105,11 @@ class CommitStatus
 
     # ignore pending unimportant
     check_suites.reject! do |s|
-      check_state(s[:conclusion]) == "pending" && IGNORE_PENDING_CHECKS.include?(s.dig(:app, :name))
+      check_state(s[:conclusion]) == "pending" &&
+        (
+          IGNORE_PENDING_CHECKS.include?(s.dig(:app, :name)) ||
+          @project.ignore_pending_checks.to_s.split(",").include?(s.dig(:app, :name))
+        )
     end
 
     overall_state = check_suites.

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -15,6 +15,7 @@
     <%= form.input :release_source, help: 'Selects which type of webhook will create a release' do %>
       <%= form.collection_select :release_source, webhook_sources_for_select(Samson::Integration::SOURCES, none: true), :second, :first, {}, class: "form-control" %>
     <% end %>
+    <%= form.input :ignore_pending_checks, help: 'Github checks to ignore if they are pending, comma separated, "Codecov,Travis CI" etc' %>
     <% if DeployGroup.enabled? %>
       <%= form.input :include_new_deploy_groups, as: :check_box, label: 'Include in New Deploy Groups', help: 'The "Create all stages" button for a deploy group will create a stage for this project.' %>
     <% end %>

--- a/db/migrate/20191101221308_add_pending_checks_ignore_to_project.rb
+++ b/db/migrate/20191101221308_add_pending_checks_ignore_to_project.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddPendingChecksIgnoreToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :ignore_pending_checks, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_30_151254) do
+ActiveRecord::Schema.define(version: 2019_11_01_221308) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -440,6 +440,7 @@ ActiveRecord::Schema.define(version: 2019_10_30_151254) do
     t.integer "kubernetes_namespace_id"
     t.boolean "config_service", default: false, null: false
     t.string "jira_issue_prefix"
+    t.string "ignore_pending_checks"
     t.index ["build_command_id"], name: "index_projects_on_build_command_id"
     t.index ["kubernetes_namespace_id"], name: "index_projects_on_kubernetes_namespace_id"
     t.index ["permalink"], name: "index_projects_on_permalink", unique: true, length: 191

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -398,6 +398,12 @@ describe CommitStatus do
         end
       end
 
+      it "does not show pending suites that are ignored per project" do
+        stub_github_api(check_run_url, check_runs: [])
+        stage.project.ignore_pending_checks = "Foo,My App,Bar"
+        status.statuses.map { |s| s[:description].first(22) }.must_equal ["No status was reported"]
+      end
+
       it "passes when other statuses passed except the ignored unreliable" do
         check_suites << {
           id: 2,


### PR DESCRIPTION
…ply to their project

allows projects to get a green commit status check / makes things not look broken

![Screen Shot 2019-11-01 at 3 23 52 PM](https://user-images.githubusercontent.com/11367/68059946-a4792f00-fcbb-11e9-8cb9-5969cab92883.png)

![Screen Shot 2019-11-01 at 3 25 13 PM](https://user-images.githubusercontent.com/11367/68059991-d4c0cd80-fcbb-11e9-920d-c92d7aed367a.png)


@zendesk/compute @hkjorgensen 

### Risks
 - None