### PR TITLE
Filter env-variables group by project

### DIFF
--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -5,6 +5,12 @@ class EnvironmentVariableGroupsController < ApplicationController
 
   def index
     @groups = EnvironmentVariableGroup.all.includes(:environment_variables)
+
+    if project_id = params[:project_id].presence
+      @groups = @groups.joins(:project_environment_variable_groups).
+        where("project_environment_variable_groups.project_id = ?", project_id)
+    end
+
     respond_to do |format|
       format.html
       format.json do

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -106,6 +106,20 @@ describe EnvironmentVariableGroupsController do
         project = JSON.parse(response.body)
         project.keys.must_include "environment_variables"
       end
+
+      it "filters by project" do
+        ProjectEnvironmentVariableGroup.create!(environment_variable_group: other_env_group, project: other_project)
+        get :index, params: {project_id: other_project.id, format: :json}
+        assert_response :success
+        json_response = JSON.parse response.body
+        first_group = json_response['environment_variable_groups'].first
+
+        json_response['environment_variable_groups'].count.must_equal 1
+        first_group.keys.must_include "name"
+        first_group.keys.must_include "variable_names"
+        first_group['name'].must_equal other_env_group.name
+        first_group['variable_names'].must_equal ["X", "Y"]
+      end
     end
 
     describe "#show" do


### PR DESCRIPTION
We need env-variable group names used by the project.
This PR gives the ability to filter the env-variable groups for the project by passing `project_id` in parameters.
`eg: /environment_variable_groups.json?project_id=1` 

### Risks
- Low