### PR TITLE
Use a single read-multi to render project show

### DIFF
--- a/app/views/deploys/_table.html.erb
+++ b/app/views/deploys/_table.html.erb
@@ -18,7 +18,7 @@
     </tr>
     </thead>
     <tbody>
-    <%= render partial: "deploys/deploy", collection: @deploys %>
+    <%= render partial: "deploys/deploy", collection: @deploys, cached: true %>
     </tbody>
   </table>
   <%= paginate @pagy if @pagy %>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -13,7 +13,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'job', collection: @jobs %>
+      <%= render partial: 'job', collection: @jobs, cached: true %>
     </tbody>
   </table>
 

--- a/app/views/projects/_stage.html.erb
+++ b/app/views/projects/_stage.html.erb
@@ -1,5 +1,5 @@
-<tr>
-  <% cache [@project.permalink, stage, Lock.cache_key] do %>
+<% cache [@project.permalink, stage, Lock.cache_key, deployer_for_project?] do %>
+  <tr>
     <td>
       <%= link_to stage.name, [@project, stage] %>
       <%= resource_lock_icon stage %>
@@ -21,11 +21,9 @@
     <% else %>
       <td>-</td>
     <% end %>
-  <% end %>
 
-  <td align="right">
-    <% if deployer_for_project? %>
+    <td align="right">
       <%= deploy_link @project, stage %>
-    <% end %>
-  </td>
-</tr>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -21,9 +21,7 @@
     </thead>
     <tbody>
       <% if @project.stages.to_a.any? %>
-        <% cache [@project, 'stages', Lock.cache_key, @project.stages.map(&:updated_at).max] do %>
-          <%= render partial: "stage", collection: @project.stages %>
-        <% end %>
+        <%= render partial: "stage", collection: @project.stages, cached: true %>
       <% else %>
         <tr>
           <td colspan="3">


### PR DESCRIPTION
 - single request to memcached instead of 1 (project)+N(stages)
 - fix caching logic to not cache deploy buttons when user is a viewer

```
Cache read_multi: views/projects/_stage: ...
```

see https://blog.bigbinary.com/2016/03/09/rails-5-makes-partial-redering-from-cache-substantially-faster.html for details

@zendesk/compute 