### PR TITLE
show users when their formatting is wrong instead of exploding

### DIFF
--- a/plugins/github/app/decorators/stage_decorator.rb
+++ b/plugins/github/app/decorators/stage_decorator.rb
@@ -8,7 +8,7 @@ Stage.class_eval do
     if comment = github_pull_request_comment.presence
       comment % Hash[GithubNotification::SUPPORTED_KEYS.map { |k| [k, ''] }] # Validate no extra keys are supplied
     end
-  rescue KeyError => e
+  rescue KeyError, ArgumentError => e
     errors.add(:github_pull_request_comment, e.message)
   end
 end

--- a/plugins/github/test/decorators/stage_decorator_test.rb
+++ b/plugins/github/test/decorators/stage_decorator_test.rb
@@ -4,29 +4,28 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe Stage do
-  let(:stage) { Stage.new }
+  let(:stage) { stages(:test_staging) }
 
-  it('allows supported keys') do
-    stage.github_pull_request_comment = 'This %{stage_name} has this ref: %{reference}'
+  describe "#validate_github_pull_request_comment_variables" do
+    it "allows empty comment" do
+      assert_valid stage
+    end
 
-    stage.save
+    it "allows supported keys" do
+      stage.github_pull_request_comment = "This %{stage_name} has this ref: %{reference}"
+      assert_valid stage
+    end
 
-    stage.errors.messages[:github_pull_request_comment].must_be_empty
-  end
+    it "does not allow unsupported keys" do
+      stage.github_pull_request_comment = "This is %{unsupported}"
+      refute_valid stage
+      stage.errors.full_messages.must_equal ["Github pull request comment key{unsupported} not found"]
+    end
 
-  it('throws validation error if unsupported keys are used') do
-    stage.github_pull_request_comment = 'This is %{unsupported}'
-
-    stage.save
-
-    stage.errors.messages[:github_pull_request_comment].must_equal ['key{unsupported} not found']
-  end
-
-  it('handles no github_pull_request_comment') do
-    stage.github_pull_request_comment = nil
-
-    stage.save
-
-    stage.errors.messages[:github_pull_request_comment].must_be_empty
+    it "does not allow invalid format" do
+      stage.github_pull_request_comment = "This is %{"
+      refute_valid stage
+      stage.errors.full_messages.must_equal ["Github pull request comment malformed name - unmatched parenthesis"]
+    end
   end
 end


### PR DESCRIPTION
```
ArgumentError: malformed format string - %(
```
@zendesk/compute 

### Risks
 - None