### PR TITLE
stop using columns that we will remove shortly

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Kubernetes
   class ReleaseDoc < ActiveRecord::Base
+    # TODO: remove once they are removed + samson is restarted
+    self.ignored_columns = ["requests_cpu", "requests_memory", "no_cpu_limit"]
     self.table_name = 'kubernetes_release_docs'
 
     belongs_to :kubernetes_role, class_name: 'Kubernetes::Role', inverse_of: nil


### PR DESCRIPTION
Steps:
 - manually alter to remove not-null (will block all deploys)
```
ActiveRecord::Base.connection.execute "ALTER TABLE `kubernetes_release_docs` CHANGE `requests_cpu` `requests_cpu` decimal(6,2) DEFAULT NULL, CHANGE `requests_memory` `requests_memory` integer DEFAULT NULL"
```

 - deploy this
 - manually remove columns  (will block all deploys)
```
ActiveRecord::Base.connection.execute "ALTER TABLE `kubernetes_release_docs` DROP COLUMN `requests_cpu`, DROP COLUMN `requests_memory`, DROP COLUMN `no_cpu_limit`"
```
 - deploy revert of this

/cc @zendesk/compute @zendesk/eng-productivity 