### PR TITLE
datadog: link directly to the current scope when stage only has a sin…

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "fe634091bb6f66cef4c61121ee25a00cafcf81d9e3e92458ed2086b9ad824c0a",
+      "fingerprint": "29a4796a9319fe691f5da3c68471b34a26d9940700a6ba0d953a9c9f02cf5c71",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "plugins/datadog/app/views/samson_datadog/_monitor_list.html.erb",
       "line": 3,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to((Unresolved Model).new.name, (Unresolved Model).new.url, :class => (\"label label-#{({ \"OK\" => \"success\", \"Alert\" => \"danger\" }[(Unresolved Model).new.state(Stage.find(params.fetch(:id)).deploy_groups)] or \"warning\")}\"))",
+      "code": "link_to((Unresolved Model).new.name, (Unresolved Model).new.url(Stage.find(params.fetch(:id)).deploy_groups), :class => (\"label label-#{({ \"OK\" => \"success\", \"Alert\" => \"danger\" }[(Unresolved Model).new.state(Stage.find(params.fetch(:id)).deploy_groups)] or \"warning\")}\"))",
       "render_path": [
         {
           "type": "controller",
@@ -27,11 +27,11 @@
         "type": "template",
         "template": "samson_datadog/_monitor_list"
       },
-      "user_input": "(Unresolved Model).new.url",
+      "user_input": "(Unresolved Model).new.url(Stage.find(params.fetch(:id)).deploy_groups)",
       "confidence": "Weak",
-      "note": "DatadogMonitor points links to the external monitor url"
+      "note": ""
     }
   ],
-  "updated": "2019-06-30 15:32:56 -0700",
-  "brakeman_version": "4.5.1"
+  "updated": "2019-11-06 14:04:52 -0800",
+  "brakeman_version": "4.7.1"
 }

--- a/plugins/datadog/app/models/datadog_monitor_query.rb
+++ b/plugins/datadog/app/models/datadog_monitor_query.rb
@@ -36,7 +36,9 @@ class DatadogMonitorQuery < ActiveRecord::Base
 
   def url
     if single_monitor?
-      DatadogMonitor.new(query).url
+      monitor = DatadogMonitor.new(query)
+      monitor.query = self
+      monitor.url([])
     else
       q = URI.encode query.tr(",", " ") # rubocop:disable Lint/UriEscapeUnescape .to_query/CGI.escape do not work here
       "#{DatadogMonitor::BASE_URL}/monitors/manage?q=#{q}"
@@ -73,7 +75,7 @@ class DatadogMonitorQuery < ActiveRecord::Base
         next if groups.to_s.tr('"\'', '').split(",").include?(match_target)
 
         errors.add(
-          :match_target, "#{match_target} must appear in #{m.url} grouping so it can trigger alerts for this tag"
+          :match_target, "#{match_target} must appear in #{m.url([])} grouping so it can trigger alerts for this tag"
         )
       end
     end

--- a/plugins/datadog/app/views/samson_datadog/_monitor_list.html.erb
+++ b/plugins/datadog/app/views/samson_datadog/_monitor_list.html.erb
@@ -1,4 +1,4 @@
 <% @stage.datadog_monitors.each do |monitor| %>
   <% label = {"OK" => "success", "Alert" => "danger"}[monitor.state(@stage.deploy_groups)] || "warning" %>
-  <%= link_to monitor.name, monitor.url, class: "label label-#{label}" %>
+  <%= link_to monitor.name, monitor.url(@stage.deploy_groups), class: "label label-#{label}" %>
 <% end %>

--- a/plugins/datadog/lib/samson_datadog/samson_plugin.rb
+++ b/plugins/datadog/lib/samson_datadog/samson_plugin.rb
@@ -40,7 +40,8 @@ module SamsonDatadog
         end
 
         # some monitors alerting
-        job_execution.output.puts "Alert on datadog monitors:\n#{alerting.map { |m| "#{m.name} #{m.url}" }.join("\n")}"
+        alerts = alerting.map { |m| "#{m.name} #{m.url(deploy.stage.deploy_groups)}" }
+        job_execution.output.puts "Alert on datadog monitors:\n#{alerts.join("\n")}"
 
         alerting.each do |monitor|
           case monitor.query.failure_behavior

--- a/plugins/datadog/test/models/datadog_monitor_test.rb
+++ b/plugins/datadog/test/models/datadog_monitor_test.rb
@@ -164,7 +164,19 @@ describe DatadogMonitor do
 
   describe "#url" do
     it "builds a url" do
-      monitor.url.must_equal "https://app.datadoghq.com/monitors/123"
+      monitor.url([]).must_equal "https://app.datadoghq.com/monitors/123"
+    end
+
+    describe "with match source" do
+      before { monitor.query = DatadogMonitorQuery.new(match_source: "deploy_group.permalink", match_target: "pod") }
+
+      it "builds a url for exact matches" do
+        monitor.url([deploy_groups(:pod100)]).must_equal "https://app.datadoghq.com/monitors/123?q=pod%3Apod100"
+      end
+
+      it "does not build urls when multiple tags need to match" do
+        monitor.url([deploy_groups(:pod100), deploy_groups(:pod1)]).must_equal "https://app.datadoghq.com/monitors/123"
+      end
     end
   end
 


### PR DESCRIPTION
…gle deploy-group

this will help with projects that deploy 1 deploy group at a time and to debug scope mismatches

```
https://foo.datadoghq.com/monitors/abc?q=pod%3Asandbox
```

@zendesk/compute 

### Risks
 - None