### PR TITLE
make new button somewhat usable on smaller screens

### DIFF
--- a/app/views/secret_sharing_grants/index.html.erb
+++ b/app/views/secret_sharing_grants/index.html.erb
@@ -5,11 +5,6 @@
 
   <% projects = Project.order(:permalink).pluck(:permalink, :id) %>
   <%= search_select :project_id, projects, live: true, label: "Project" %>
-
-  <div class="pull-right">
-    <label>&nbsp;</label>
-    <%= link_to "New", new_secret_sharing_grant_path, class: "btn btn-default", style: "display: block" %>
-  </div>
 <% end %>
 
 <section class="clearfix">
@@ -19,7 +14,7 @@
         <th>Key</th>
         <th>Project</th>
         <th>Created</th>
-        <th></th>
+        <th><%= link_to "New", new_secret_sharing_grant_path, class: "btn btn-default" %></th>
       </tr>
     </thead>
 

--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -26,11 +26,6 @@
       <%= password_field_tag 'search[value_hashed]', params.dig(:search, :value_hashed), class: "form-control" %>
     <% end %>
   </div>
-
-  <div class="pull-right">
-    <label>&nbsp;</label>
-    <%= link_to "New", new_secret_path, class: "btn btn-default", style: "display: block" %>
-  </div>
 <% end %>
 
 <section class="clearfix">
@@ -41,7 +36,7 @@
         <th>Project</th>
         <th>Deploy Group</th>
         <th>Key <%= additional_info "To use a key in commands, prefix with #{TerminalExecutor::SECRET_PREFIX}" %></th>
-        <th></th>
+        <th><%= link_to "New", new_secret_path, class: "btn btn-default" %></th>
       </tr>
     </thead>
 


### PR DESCRIPTION
replaces https://github.com/zendesk/samson/pull/3610 which tried to do that by adding more styles ... but I don't want to add new styles for a screen-size nobody uses, prefer to make the structure simpler instead (less floaty/overlay things)

before:
![Screen Shot 2019-11-08 at 8 50 53 AM](https://user-images.githubusercontent.com/11367/68495371-e565cc00-0204-11ea-9c07-d89229c395f5.png)


after:
![Screen Shot 2019-11-08 at 8 48 31 AM](https://user-images.githubusercontent.com/11367/68495332-d252fc00-0204-11ea-9d4a-b9e599869572.png)


@rubynho @zendesk/compute 