### PR TITLE
PAAS-5286 allow ignoring datadog monitors by id so we can add all mon…

### DIFF
--- a/plugins/datadog/app/models/datadog_monitor.rb
+++ b/plugins/datadog/app/models/datadog_monitor.rb
@@ -18,8 +18,13 @@ class DatadogMonitor
     end
 
     # returns pre-filled [DatadogMonitor]
-    def list(tags)
-      data = request("/api/v1/monitor", params: {monitor_tags: tags, group_states: GROUP_STATES}, fallback: [{id: 0}])
+    def list(tag_query)
+      ignored, queried = tag_query.split(",").partition { |t| t.match?(/^-\d+$/) }
+      data = request(
+        "/api/v1/monitor",
+        params: {monitor_tags: queried.join(","), group_states: GROUP_STATES}, fallback: [{id: 0}]
+      )
+      data.reject! { |d| ignored.include?("-#{d[:id]}") }
       data.map { |d| new(d[:id], d) }
     end
 

--- a/plugins/datadog/app/models/datadog_monitor_query.rb
+++ b/plugins/datadog/app/models/datadog_monitor_query.rb
@@ -75,7 +75,9 @@ class DatadogMonitorQuery < ActiveRecord::Base
         next if groups.to_s.tr('"\'', '').split(",").include?(match_target)
 
         errors.add(
-          :match_target, "#{match_target} must appear in #{m.url([])} grouping so it can trigger alerts for this tag"
+          :match_target,
+          "#{match_target} must appear in #{m.url([])} grouping so it can trigger alerts for this tag, " \
+          "or ignored by adding ',-#{m.id}' to the tag query"
         )
       end
     end


### PR DESCRIPTION
…itors for a service except the quirky ones

atm when a service has 10 monitors and 1 of them is not scoped by the desired tag, the query cannot be added since the scoping logic would always display the monitor as passing

Validation error looks like this:
`Ooops! There was an error: Datadog monitor queries match target kube_cluster must appear in https://fff.datadoghq.com/monitors/123 grouping so it can trigger alerts for this tag`

Now we allow adding `,-123` to the tag query so offending monitors can be ignored.

@zendesk/compute 

### Alternatives
add a "ignore" column to pass validations and then at display time do not scope the mismatched monitors ... could still be an independent feature later on

### Risks
 - Low: monitors not displayed