### PR TITLE
outbound webhook fixes

### DIFF
--- a/app/controllers/outbound_webhooks_controller.rb
+++ b/app/controllers/outbound_webhooks_controller.rb
@@ -22,6 +22,10 @@ class OutboundWebhooksController < ResourceController
     end
   end
 
+  def update
+    super template: 'show'
+  end
+
   private
 
   def search_resources

--- a/app/controllers/outbound_webhooks_controller.rb
+++ b/app/controllers/outbound_webhooks_controller.rb
@@ -49,9 +49,10 @@ class OutboundWebhooksController < ResourceController
   def resource_params
     allowed = [:url, :username, :password]
     allowed << :global if action_name == "create"
-    params = super.permit(*allowed)
-    params[:stages] = [@stage] if @stage && action_name == "create"
-    params
+    permitted = super.permit(*allowed)
+    permitted[:stages] = [@stage] if @stage && action_name == "create"
+    permitted.delete :password if permitted[:password].blank? && permitted[:username].present?
+    permitted
   end
 
   def require_project

--- a/app/views/outbound_webhooks/_fields.html.erb
+++ b/app/views/outbound_webhooks/_fields.html.erb
@@ -2,5 +2,5 @@
 
 <%= form.input :url, required: true %>
 <%= form.input :username %>
-<%= form.input :password, as: :password_field %>
+<%= form.input :password, as: :password_field, input_html: {placeholder: ("--hidden--" if form.object.password?) } %>
 <%= form.input :global, as: :check_box, help: "Can be reused by other stages" if form.object.new_record? %>

--- a/test/controllers/outbound_webhooks_controller_test.rb
+++ b/test/controllers/outbound_webhooks_controller_test.rb
@@ -107,6 +107,20 @@ describe OutboundWebhooksController do
         assert_response :success
       end
 
+      it "does remove stored password from rails not rendering the password fields value" do
+        webhook.update_column(:password, 'b')
+        patch :update, params: {id: webhook.id, outbound_webhook: {username: 'a', password: ''}}
+        assert_response :redirect
+        webhook.reload.password.must_equal 'b'
+      end
+
+      it "allows unsetting username/password by setting both blank" do
+        webhook.update_column(:password, 'b')
+        patch :update, params: {id: webhook.id, outbound_webhook: {username: '', password: ''}}
+        assert_response :redirect
+        webhook.reload.password.must_equal ''
+      end
+
       it "updates via json" do
         patch :update, params: {id: webhook.id, outbound_webhook: params}, format: :json
         assert_response :success

--- a/test/controllers/outbound_webhooks_controller_test.rb
+++ b/test/controllers/outbound_webhooks_controller_test.rb
@@ -96,18 +96,28 @@ describe OutboundWebhooksController do
 
   as_a :deployer do
     describe '#update' do
-      it "fails to update via json" do
-        webhook
-        params[:url] = ""
-        patch :update, params: {id: webhook.id, outbound_webhook: params}, format: :json
-        assert_response 422
+      it "updates" do
+        patch :update, params: {id: webhook.id, outbound_webhook: params}
+        assert_redirected_to "/outbound_webhooks"
       end
 
-      it "renders JSON" do
+      it "fails to update" do
+        params[:url] = ""
+        patch :update, params: {id: webhook.id, outbound_webhook: params}
+        assert_response :success
+      end
+
+      it "updates via json" do
         patch :update, params: {id: webhook.id, outbound_webhook: params}, format: :json
         assert_response :success
         outbound_webhook = JSON.parse(response.body).fetch('outbound_webhook')
         outbound_webhook.fetch('url').must_equal params[:url]
+      end
+
+      it "fails to update via json" do
+        params[:url] = ""
+        patch :update, params: {id: webhook.id, outbound_webhook: params}, format: :json
+        assert_response 422
       end
     end
 


### PR DESCRIPTION
 - render when update failed
 - do not delete passwords when user updates

![Screen Shot 2019-11-08 at 12 28 57 PM](https://user-images.githubusercontent.com/11367/68508873-6aaca900-0224-11ea-8e4c-d56619a7aaf3.png)

@hdt91 
/cc @zendesk/compute 