### PR TITLE
outbound webhook: support token/bearer auth and no ssl verification

### DIFF
--- a/app/controllers/outbound_webhooks_controller.rb
+++ b/app/controllers/outbound_webhooks_controller.rb
@@ -47,7 +47,7 @@ class OutboundWebhooksController < ResourceController
   end
 
   def resource_params
-    allowed = [:url, :username, :password]
+    allowed = [:url, :username, :password, :auth_type, :insecure]
     allowed << :global if action_name == "create"
     permitted = super.permit(*allowed)
     permitted[:stages] = [@stage] if @stage && action_name == "create"

--- a/app/views/outbound_webhooks/_fields.html.erb
+++ b/app/views/outbound_webhooks/_fields.html.erb
@@ -1,6 +1,33 @@
 <%= render 'shared/errors', object: form.object %>
 
 <%= form.input :url, required: true %>
+<%= form.input :insecure, as: :check_box, help: "Do not verify SSL" %>
+<%= form.input :global, as: :check_box, help: "Can be reused by other stages" if form.object.new_record? %>
+
+<%= form.input :auth_type do %>
+  <%= form.select :auth_type, OutboundWebhook::AUTH_TYPES, {}, class: "form-control" %>
+<% end %>
 <%= form.input :username %>
 <%= form.input :password, as: :password_field, input_html: {placeholder: ("--hidden--" if form.object.password?) } %>
-<%= form.input :global, as: :check_box, help: "Can be reused by other stages" if form.object.new_record? %>
+
+<script>
+  // show auth fields as necessary
+  $("#outbound_webhook_auth_type").change(function () {
+    var type = $(this).val();
+    var username = $("#outbound_webhook_username").parent().parent();
+    var password = $("#outbound_webhook_password").parent().parent();
+
+    // reset
+    username.show();
+    password.show();
+    password.find("label").text("Password");
+
+    if(type == "None") {
+      username.hide();
+      password.hide();
+    } else if(type == "Bearer" || type == "Token") {
+      username.hide();
+      password.find("label").text("Token");
+    }
+  }).trigger("change");
+</script>

--- a/app/views/outbound_webhooks/index.html.erb
+++ b/app/views/outbound_webhooks/index.html.erb
@@ -7,7 +7,9 @@
     <thead>
     <tr>
       <th>Url</th>
+      <th>Auth</th>
       <th>Global</th>
+      <th>SSL</th>
       <th>Usages</th>
       <th>Actions</th>
     </tr>
@@ -16,10 +18,10 @@
     <tbody>
     <% @outbound_webhooks.each do |outbound_webhook| %>
       <tr>
-        <td>
-          <%= outbound_webhook.url %>
-        </td>
+        <td><%= outbound_webhook.url %></td>
+        <td><%= outbound_webhook.auth_type %></td>
         <td><%= outbound_webhook.global ? "YES" : "-" %></td>
+        <td><%= outbound_webhook.ssl? ? "YES" : "-" %></td>
         <td><%= usages[outbound_webhook.id] || 0 %></td>
         <td><%= link_to "Edit", outbound_webhook %></td>
       </tr>

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -158,18 +158,23 @@
     <% else %>
       <ul>
         <% outbound_webhook_stages.each do |outbound_webhook_stage| %>
+          <% outbound_webhook = outbound_webhook_stage.outbound_webhook %>
           <li>
             POST to
-            <strong><%= outbound_webhook_stage.outbound_webhook.url %></strong>
+            <strong><%= outbound_webhook.url %></strong>
+            <%= "(no SSL)" unless outbound_webhook.ssl? %>
             on the
             <strong><%= outbound_webhook_stage.stage.name %></strong>
             stage
             <strong>
-            <% if outbound_webhook_stage.outbound_webhook.username.present? %>
-              <%= "with Basic Auth as #{outbound_webhook_stage.outbound_webhook.username}" %>
+            <% case outbound_webhook.auth_type %>
+            <% when "Basic" %>
+              <%= "with Basic Auth as #{outbound_webhook.username}" %>
+            <% when "Bearer", "Token" %>
+              <%= "with #{outbound_webhook.auth_type} Auth" %>
             <% end %>
             </strong>
-            <%= link_to_delete outbound_webhook_path(outbound_webhook_stage.outbound_webhook, stage_id: outbound_webhook_stage.stage_id) %>
+            <%= link_to_delete outbound_webhook_path(outbound_webhook, stage_id: outbound_webhook_stage.stage_id) %>
           </li>
         <% end %>
       </ul>

--- a/db/migrate/20191108204120_add_auth_types_to_outbound_webhooks.rb
+++ b/db/migrate/20191108204120_add_auth_types_to_outbound_webhooks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class AddAuthTypesToOutboundWebhooks < ActiveRecord::Migration[5.2]
+  class OutboundWebhook < ActiveRecord::Base
+  end
+
+  def change
+    add_column :outbound_webhooks, :auth_type, :string, default: "Basic", null: false
+    change_column_default :outbound_webhooks, :auth_type, from: "Basic", to: nil
+    OutboundWebhook.where("username is NULL OR username = ''").update_all(auth_type: "None")
+
+    add_column :outbound_webhooks, :insecure, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_05_170029) do
+ActiveRecord::Schema.define(version: 2019_11_08_204120) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -407,6 +407,8 @@ ActiveRecord::Schema.define(version: 2019_11_05_170029) do
     t.string "username"
     t.string "password"
     t.boolean "global", default: false, null: false
+    t.string "auth_type", null: false
+    t.boolean "insecure", default: false, null: false
     t.index ["deleted_at"], name: "index_outbound_webhooks_on_deleted_at"
     t.index ["project_id"], name: "index_outbound_webhooks_on_project_id"
   end


### PR DESCRIPTION
@zendesk/compute @zendesk/eng-productivity 

![Screen Shot 2019-11-08 at 1 11 49 PM](https://user-images.githubusercontent.com/11367/68511998-04c41f80-022c-11ea-84c5-84b3cda2eb07.png)
![Screen Shot 2019-11-08 at 1 11 53 PM](https://user-images.githubusercontent.com/11367/68511999-04c41f80-022c-11ea-994f-c67e365411a8.png)
![Screen Shot 2019-11-08 at 1 11 56 PM](https://user-images.githubusercontent.com/11367/68512000-04c41f80-022c-11ea-8d79-e384b122aa03.png)
![Screen Shot 2019-11-08 at 1 12 00 PM](https://user-images.githubusercontent.com/11367/68512001-055cb600-022c-11ea-99c0-8f29d0a5d4a7.png)
![Screen Shot 2019-11-08 at 1 42 43 PM](https://user-images.githubusercontent.com/11367/68512584-aac45980-022d-11ea-927d-deb2e1fe7797.png)
