### PR TITLE
remove outbound webhook columns we no longer use

### DIFF
--- a/app/models/outbound_webhook.rb
+++ b/app/models/outbound_webhook.rb
@@ -5,7 +5,6 @@ require 'faraday'
 class OutboundWebhook < ActiveRecord::Base
   AUTH_TYPES = ["None", "Basic", "Token", "Bearer"].freeze
 
-  self.ignored_columns = ["stage_id", "project_id", "deleted_at"]
   audited
 
   has_many :outbound_webhook_stages, dependent: nil, inverse_of: :outbound_webhook
@@ -46,7 +45,7 @@ class OutboundWebhook < ActiveRecord::Base
   end
 
   def as_json(*)
-    super(except: [:password, :stage_id, :project_id, :delete_at])
+    super(except: [:password])
   end
 
   private

--- a/db/migrate/20191108215712_remove_deleted_webhook_columns.rb
+++ b/db/migrate/20191108215712_remove_deleted_webhook_columns.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class RemoveDeletedWebhookColumns < ActiveRecord::Migration[5.2]
+  class OutboundWebhook < ActiveRecord::Base
+  end
+
+  def change
+    OutboundWebhook.where("deleted_at IS NOT NULL").delete_all
+
+    remove_column :outbound_webhooks, :stage_id
+    remove_column :outbound_webhooks, :project_id
+    remove_column :outbound_webhooks, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -400,9 +400,6 @@ ActiveRecord::Schema.define(version: 2019_11_08_223054) do
   create_table "outbound_webhooks", id: :integer do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
-    t.integer "project_id", default: 0, null: false
-    t.integer "stage_id", default: 0, null: false
     t.string "url", null: false
     t.string "username"
     t.string "password"
@@ -410,8 +407,6 @@ ActiveRecord::Schema.define(version: 2019_11_08_223054) do
     t.string "auth_type", null: false
     t.boolean "insecure", default: false, null: false
     t.boolean "before_deploy", default: false, null: false
-    t.index ["deleted_at"], name: "index_outbound_webhooks_on_deleted_at"
-    t.index ["project_id"], name: "index_outbound_webhooks_on_project_id"
   end
 
   create_table "project_environment_variable_groups", id: :integer do |t|


### PR DESCRIPTION
previous migration was deployed, time for cleanup

@zendesk/compute @hdt91 