### PR TITLE
Make outbound webhook errors stop the deploy when used before deploy

### DIFF
--- a/app/controllers/outbound_webhooks_controller.rb
+++ b/app/controllers/outbound_webhooks_controller.rb
@@ -47,7 +47,7 @@ class OutboundWebhooksController < ResourceController
   end
 
   def resource_params
-    allowed = [:url, :username, :password, :auth_type, :insecure]
+    allowed = [:url, :username, :password, :auth_type, :insecure, :before_deploy]
     allowed << :global if action_name == "create"
     permitted = super.permit(*allowed)
     permitted[:stages] = [@stage] if @stage && action_name == "create"

--- a/app/models/outbound_webhook.rb
+++ b/app/models/outbound_webhook.rb
@@ -20,17 +20,25 @@ class OutboundWebhook < ActiveRecord::Base
     prefix = "Webhook notification:"
     output.puts "#{prefix} sending to #{url} ..."
 
-    response = connection.post url do |req|
-      req.headers['Content-Type'] = 'application/json'
-      req.body = self.class.deploy_as_json(deploy).to_json
-    end
+    error_message =
+      begin
+        response = connection.post url do |req|
+          req.headers['Content-Type'] = 'application/json'
+          req.body = self.class.deploy_as_json(deploy).to_json
+        end
 
-    if response.success?
-      output.puts "#{prefix} succeeded"
-    else
-      Rails.logger.error "Outbound Webhook Error #{id} #{url} #{response.body}"
-      output.puts "#{prefix} failed #{response.status}\n#{response.body.to_s.truncate(100)}"
-    end
+        if response.success?
+          output.puts "#{prefix} succeeded"
+          return
+        else
+          Rails.logger.error "Outbound Webhook Error #{id} #{url} #{response.body}"
+          "#{prefix} failed #{response.status}\n#{response.body.to_s.truncate(100)}"
+        end
+      rescue StandardError => e # Timeout or SSL error
+        "#{prefix} failed #{e.class}"
+      end
+
+    raise Samson::Hooks::UserError, error_message
   end
 
   def self.deploy_as_json(deploy)

--- a/app/views/outbound_webhooks/_fields.html.erb
+++ b/app/views/outbound_webhooks/_fields.html.erb
@@ -1,6 +1,7 @@
 <%= render 'shared/errors', object: form.object %>
 
 <%= form.input :url, required: true %>
+<%= form.input :before_deploy, as: :check_box %>
 <%= form.input :insecure, as: :check_box, help: "Do not verify SSL" %>
 <%= form.input :global, as: :check_box, help: "Can be reused by other stages" if form.object.new_record? %>
 

--- a/db/migrate/20191108223054_add_before_deploy_to_outbound_webhooks.rb
+++ b/db/migrate/20191108223054_add_before_deploy_to_outbound_webhooks.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddBeforeDeployToOutboundWebhooks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :outbound_webhooks, :before_deploy, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_08_204120) do
+ActiveRecord::Schema.define(version: 2019_11_08_223054) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -409,6 +409,7 @@ ActiveRecord::Schema.define(version: 2019_11_08_204120) do
     t.boolean "global", default: false, null: false
     t.string "auth_type", null: false
     t.boolean "insecure", default: false, null: false
+    t.boolean "before_deploy", default: false, null: false
     t.index ["deleted_at"], name: "index_outbound_webhooks_on_deleted_at"
     t.index ["project_id"], name: "index_outbound_webhooks_on_project_id"
   end


### PR DESCRIPTION
also show connection errors in the job output just like request errors (500 etc)

@zendesk/compute @hdt91 