### PR TITLE
Outbound hook adjustments

### DIFF
--- a/app/models/outbound_webhook.rb
+++ b/app/models/outbound_webhook.rb
@@ -47,6 +47,7 @@ class OutboundWebhook < ActiveRecord::Base
 
   def self.deploy_as_json(deploy)
     deploy.as_json.merge(
+      "deploy_groups" => deploy.stage.deploy_groups.as_json,
       "project" => deploy.project.as_json,
       "stage" => deploy.stage.as_json,
       "user" => deploy.user.as_json

--- a/app/models/outbound_webhook.rb
+++ b/app/models/outbound_webhook.rb
@@ -80,7 +80,11 @@ class OutboundWebhook < ActiveRecord::Base
     loop do
       response = connection.get(url)
       yield response.body
-      break if response.success? && response.status != 202
+      if response.success?
+        break if response.status != 202
+      else
+        raise Samson::Hooks::UserError, "error polling status endpoint"
+      end
       sleep poll_period
     end
   end

--- a/test/models/outbound_webhook_test.rb
+++ b/test/models/outbound_webhook_test.rb
@@ -225,6 +225,7 @@ describe OutboundWebhook do
       json.keys.must_include 'user'
       json.keys.must_include 'project'
       json.keys.must_include 'stage'
+      json.keys.must_include 'deploy_groups'
     end
   end
 end


### PR DESCRIPTION
- Include deploy groups via stage in the outbound payload
- Add sleep period in the hook polling
- Treat `202` as the processing signal instead of `102` as it chokes `Faraday` with an exception.

