### PR TITLE
Do not link to duration when it is not correlated + make it only use …

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -298,7 +298,7 @@ module ApplicationHelper
   end
 
   # See https://developers.google.com/chart/image/docs/chart_params
-  def link_to_chart(name, values)
+  def link_to_chart(name, values, title:)
     return if values.size < 3
 
     max = values.max.round
@@ -306,14 +306,14 @@ module ApplicationHelper
     y_values = values.reverse.map { |v| max == 0 ? max : (v * 100.0 / max).round }.join(",") # values as % of max
     params = {
       cht: "lc", # chart type
-      chtt: name,
+      chtt: title,
       chd: "t:#{y_values}", # data
       chxt: "y", # axis to draw
       chxl: "0:|#{y_axis}", # axis labels
       chs: "1000x200", # size
     }
     url = "https://chart.googleapis.com/chart?#{params.to_query}"
-    link_to icon_tag('signal'), url, target: :blank
+    link_to name, url, target: :blank
   end
 
   # show which stages this reference is deploy(ed+ing) to

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -41,8 +41,11 @@
       <% end %>
       <th>Created</th>
       <th>
-        Duration
-        <%= link_to_chart "Build duration", @builds.map(&:duration).compact %>
+        <% if @project %>
+          <%= link_to_chart "Duration", @builds.map(&:duration).compact, title: "Build duration" %>
+        <% else %>
+          Duration
+        <% end %>
       </th>
       <th>Git Ref</th>
       <th></th>

--- a/app/views/deploys/_table.html.erb
+++ b/app/views/deploys/_table.html.erb
@@ -7,8 +7,11 @@
       <% end %>
       <th>Started</th>
       <th>
-        Duration
-        <%= link_to_chart "#{@project&.name || @stage&.name} Deploy duration", @deploys.map(&:duration) %>
+        <% if @project || @stage %>
+          <%= link_to_chart "Duration", @deploys.map(&:duration), title: "#{@project&.name || @stage&.name} Deploy duration" %>
+        <% else %>
+          Duration
+        <% end %>
       </th>
       <th>Deploy</th>
       <% unless @stage %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -685,19 +685,19 @@ describe ApplicationHelper do
 
   describe "#link_to_chart" do
     it "renders" do
-      chart = link_to_chart("Hello world", [200, 3, 4, 100, 500])
+      chart = link_to_chart("Hello world", [200, 3, 4, 100, 500], title: "Hello")
       chart.must_include "https://chart.googleapis.com/chart"
     end
 
     it "renders all 0" do
-      chart = link_to_chart("Hello world", [0, 0, 0, 0, 0])
+      chart = link_to_chart("Hello world", [0, 0, 0, 0, 0], title: "Hello")
       chart.must_include "https://chart.googleapis.com/chart"
     end
 
     it "does not render for useless data" do
-      link_to_chart("Hello world", []).must_equal nil
-      link_to_chart("Hello world", [1]).must_equal nil
-      link_to_chart("Hello world", [1, 2]).must_equal nil
+      link_to_chart("Hello world", [], title: "Hello").must_equal nil
+      link_to_chart("Hello world", [1], title: "Hello").must_equal nil
+      link_to_chart("Hello world", [1, 2], title: "Hello").must_equal nil
     end
   end
 


### PR DESCRIPTION
…a single line height

before:
<img width="396" alt="Screen Shot 2019-11-13 at 4 37 05 PM" src="https://user-images.githubusercontent.com/11367/68816617-d97a6f80-0633-11ea-86c8-b2149362c90e.png">

after:
<img width="324" alt="Screen Shot 2019-11-13 at 4 35 26 PM" src="https://user-images.githubusercontent.com/11367/68816626-df705080-0633-11ea-9978-637d1fb9f3e3.png">
<img width="326" alt="Screen Shot 2019-11-13 at 4 34 58 PM" src="https://user-images.githubusercontent.com/11367/68816627-df705080-0633-11ea-881b-05ff0c82b70b.png">

@zendesk/compute 