### PR TITLE
PAAS-5207 supported secrets with unknown project/group/env

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -15,8 +15,13 @@ class SecretsController < ApplicationController
       [id, Samson::Secrets::Manager.parse_id(id), secret_stub]
     end
 
+    @project_permalinks =
+      @secrets.map { |_, parts, _| parts.fetch(:project_permalink) }.uniq.sort - ['global'] + ['global']
+    @deploy_group_permalinks =
+      @secrets.map { |_, parts, _| parts.fetch(:deploy_group_permalink) }.uniq.sort - ['global'] + ['global']
+    @environment_permalinks =
+      @secrets.map { |_, parts, _| parts.fetch(:environment_permalink) }.uniq.sort - ['global'] + ['global']
     @keys = @secrets.map { |_, parts, _| parts.fetch(:key) }.uniq.sort
-    @project_permalinks = @secrets.map { |_, parts, _| parts.fetch(:project_permalink) }.uniq.sort
 
     Samson::Secrets::Manager::ID_PARTS.each do |part|
       if value = params.dig(:search, part).presence

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -18,8 +18,7 @@
         <%= form.select :project_ids, @projects.pluck(:name, :id), {include_hidden: false}, multiple: true, **Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
       <% end %>
       <%= form.input :role_id, required: true do %>
-        <%= select_tag 'access_request[role_id]', options_from_collection_for_select(@roles, :id, :display_name),
-            class: 'form-control' %>
+        <%= select_tag 'access_request[role_id]', options_from_collection_for_select(@roles, :id, :display_name), class: 'form-control' %>
       <% end %>
       <%= form.actions %>
     <% end %>

--- a/app/views/secrets/index.html.erb
+++ b/app/views/secrets/index.html.erb
@@ -5,15 +5,9 @@
 </h1>
 
 <%= search_form('data-secret-base': Samson::Secrets::Manager::VALUE_HASHED_BASE) do %>
-  <% environments = [['global']] + Environment.pluck(:permalink) %>
-  <%= search_select :environment_permalink, environments, live: true, label: "Environment" %>
-
-  <% projects = ['global'] + (@project_permalinks - ['global']) %>
-  <%= search_select :project_permalink, projects, live: true, label: "Project" %>
-
-  <% deploy_groups = [['global']] + Samson::Secrets::Manager.backend.deploy_groups.map(&:permalink) %>
-  <%= search_select :deploy_group_permalink, deploy_groups, live: true, label: "Deploy Group" %>
-
+  <%= search_select :environment_permalink, @environment_permalinks, live: true, label: "Environment" %>
+  <%= search_select :project_permalink, @project_permalinks, live: true, label: "Project" %>
+  <%= search_select :deploy_group_permalink, @deploy_group_permalinks, live: true, label: "Deploy Group" %>
   <%= search_select :key, @keys, live: true %>
 
   <div class="col-sm-2">

--- a/app/views/secrets/show.html.erb
+++ b/app/views/secrets/show.html.erb
@@ -19,21 +19,35 @@
 
   <%= form_for OpenStruct.new(secret), as: :secret, url: url, method: method, html: {class: "form-horizontal"} do |form| %>
     <fieldset>
-      <%= form.input :environment_permalink, label: "Environment" do %>
-        <%= form.select :environment_permalink,
-          options_for_select(environment_permalinks, secret[:environment_permalink]),
-          {include_blank: true}, class: "form-control", required: true, disabled: !!id %>
+      <%= form.input :environment_permalink, label: "Environment", required: true do %>
+        <% if id %>
+          <%= form.text_field :environment_permalink, disabled: true, class: "form-control" %>
+        <% else %>
+          <%= form.select :environment_permalink,
+            options_for_select(environment_permalinks, secret[:environment_permalink]),
+            {include_blank: true}, required: true, **Samson::FormBuilder::LIVE_SELECT_OPTIONS %>
+        <% end %>
       <% end %>
 
-      <%= form.input :project_permalink, label: "Project" do %>
-        <%= live_select_tag 'secret[project_permalink]',
-          options_for_select(@writable_project_permalinks, secret[:project_permalink]), include_blank: true, required: true, disabled: !!id %>
+      <%= form.input :project_permalink, label: "Project", required: true do %>
+        <% if id %>
+          <%= form.text_field :project_permalink, disabled: true, class: "form-control" %>
+        <% else %>
+          <%= form.select :project_permalink,
+            options_for_select(@writable_project_permalinks, secret[:project_permalink]),
+            {include_blank: true}, required: true, **Samson::FormBuilder::LIVE_SELECT_OPTIONS
+          %>
+        <% end %>
       <% end %>
 
-      <%= form.input :deploy_group_permalink, label: "Deploy Group" do %>
-        <%= form.select :deploy_group_permalink,
-          options_for_select([['Loading ...', secret[:deploy_group_permalink]]], secret[:deploy_group_permalink]),
-          {include_blank: true}, class: "form-control", required: true, disabled: !!id %>
+      <%= form.input :deploy_group_permalink, label: "Deploy Group", required: true do %>
+        <% if id %>
+          <%= form.text_field :deploy_group_permalink, disabled: true, class: "form-control" %>
+        <% else %>
+          <%= form.select :deploy_group_permalink,
+            options_for_select([['Loading ...', secret[:deploy_group_permalink]]], secret[:deploy_group_permalink]),
+            {include_blank: true}, class: "form-control", required: true %>
+        <% end %>
       <% end %>
 
       <%= form.input :key, input_html: {class: "form-control monospace", disabled: !!id}, required: true %>

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -261,8 +261,13 @@ describe Samson::Secrets::HashicorpVaultBackend do
     end
 
     it ".write" do
-      manager.expects(:read).returns(nil)
-      manager.expects(:write).raises(Vault::HTTPConnectionError.new("address", RuntimeError.new('no write for you')))
+      manager.expects(:read).returns(nil) # does not exist -> create
+      # tries to revert after failure ... but also fails
+      manager.expects(:delete).
+        raises(Vault::HTTPConnectionError.new("address", RuntimeError.new('no delete for you')))
+      manager.expects(:write).
+        raises(Vault::HTTPConnectionError.new("address", RuntimeError.new('no write for you')))
+
       e = assert_raises Samson::Secrets::BackendError do
         backend.write(
           'production/foo/group/isbar/foo', value: 'whatever', visible: false, user_id: 1, comment: 'secret!'


### PR DESCRIPTION
 - no longer shows "first if not found"
 - correctly mark label as required `*`

before:
<img width="615" alt="Screen Shot 2019-11-13 at 5 08 43 PM" src="https://user-images.githubusercontent.com/11367/68817981-4d1e7b80-0638-11ea-93e5-9a9218df5764.png">

after:
<img width="590" alt="Screen Shot 2019-11-13 at 5 07 20 PM" src="https://user-images.githubusercontent.com/11367/68817987-50196c00-0638-11ea-9ab7-e1f9590039d4.png">


 - show all available envs/deploy-groups in search:
<img width="239" alt="Screen Shot 2019-11-13 at 5 19 29 PM" src="https://user-images.githubusercontent.com/11367/68818891-58bf7180-063b-11ea-81dd-3aa7e095291f.png">

 - allow deletion when no server is deemed responsible for a secret by deleting from all + make "no vault server found" more specific


reproduce with:
```
Samson::Secrets::DbBackend::Secret.find('master/example-kubernetes/groupk/dfdffd').update_column(:id, 'nope/nope/nope/nope')
```

@zendesk/compute 