### PR TITLE
Simplify flashes and add warning flash

### DIFF
--- a/app/controllers/unauthorized_controller.rb
+++ b/app/controllers/unauthorized_controller.rb
@@ -19,16 +19,31 @@ class UnauthorizedController < ActionController::Metal
 
   def respond
     action = (["patch", "post", "put"].include?(params[:_method]) ? "make this change" : "view this page")
-    message = "You are not #{request.env['warden']&.user ? "authorized to #{action}" : "logged in"}"
+    message = "You are not #{current_user ? "authorized to #{action}" : "logged in"}"
     respond_to do |format|
       format.json do
         render json: {error: message + ", see docs/api.md on how to authenticate"}, status: :unauthorized
       end
       format.html do
-        flash[:authorization_error] = message
         attempted_path = "/#{url_for(params).split("/", 4).last}" # request.fullpath is /unauthenticated
+        flash[:alert] = "".html_safe << message << ". " << access_request_link
         redirect_to login_path(redirect_to: attempted_path)
       end
+    end
+  end
+
+  private
+
+  def current_user
+    request.env['warden']&.user
+  end
+
+  def access_request_link
+    return '' if !AccessRequestsController.feature_enabled? || !current_user || current_user.super_admin?
+    if current_user.access_request_pending?
+      'Access request pending.'
+    else
+      ActionController::Base.helpers.link_to('Request additional access rights', new_access_request_path)
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@ require 'ansible'
 require 'github/markdown'
 
 module ApplicationHelper
-  BOOTSTRAP_FLASH_MAPPINGS = {notice: :info, alert: :danger, authorization_error: :danger, success: :success}.freeze
+  BOOTSTRAP_FLASH_MAPPINGS = {notice: :info, alert: :danger, warn: :warning, success: :success}.freeze
   BOOTSTRAP_TOOLTIP_PROPS = {toggle: 'popover', placement: 'right', trigger: 'hover'}.freeze
 
   include Ansible
@@ -176,17 +176,6 @@ module ApplicationHelper
   # @param [String] add
   def add_to_url(url, add)
     url.include?("?") ? "#{url}&#{add}" : "#{url}?#{add}"
-  end
-
-  # Flash type -> Bootstrap alert class
-  def flash_messages
-    flash.flat_map do |type, messages|
-      type = type.to_sym
-      bootstrap_class = BOOTSTRAP_FLASH_MAPPINGS.fetch(type)
-      Array.wrap(messages).map do |message|
-        [type, bootstrap_class, message]
-      end
-    end
   end
 
   def link_to_url(url)

--- a/app/views/layouts/_alerts.html.erb
+++ b/app/views/layouts/_alerts.html.erb
@@ -1,7 +1,6 @@
-<% flash_messages.each do |type, klass, message| %>
-  <div class="alert alert-<%= klass %>">
+<% flash.each do |type, message| %>
+  <div class="alert alert-<%= ApplicationHelper::BOOTSTRAP_FLASH_MAPPINGS.fetch(type.to_sym) %>">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     <%= message %>
-    <%= link_to_request_access if type == :authorization_error && display_access_request_link? %>
   </div>
 <% end %>

--- a/plugins/kubernetes/app/controllers/kubernetes/namespaces_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/namespaces_controller.rb
@@ -10,10 +10,10 @@ class Kubernetes::NamespacesController < ResourceController
 
   def sync_all
     clusters = Kubernetes::Cluster.all.to_a
-    errors = Samson::Parallelizer.map(Kubernetes::Namespace.all.to_a) do |namespace|
+    warnings = Samson::Parallelizer.map(Kubernetes::Namespace.all.to_a) do |namespace|
       upsert_namespace clusters, namespace
     end.flatten(1)
-    show_namespace_errors errors
+    show_namespace_warnings warnings
     redirect_to action: :index
   end
 
@@ -29,8 +29,8 @@ class Kubernetes::NamespacesController < ResourceController
   end
 
   def sync_namespace
-    errors = upsert_namespace Kubernetes::Cluster.all, @kubernetes_namespace
-    show_namespace_errors errors
+    warnings = upsert_namespace Kubernetes::Cluster.all, @kubernetes_namespace
+    show_namespace_warnings warnings
   end
 
   # @return [Array<String>] errors
@@ -54,9 +54,9 @@ class Kubernetes::NamespacesController < ResourceController
     end.compact
   end
 
-  def show_namespace_errors(errors)
-    return if errors.empty?
-    flash[:alert] = helpers.simple_format("Error upserting namespace in some clusters:\n" + errors.join("\n"))
+  def show_namespace_warnings(warnings)
+    return if warnings.empty?
+    flash[:warn] = helpers.simple_format("Error upserting namespace in some clusters:\n" + warnings.join("\n"))
   end
 
   def resource_params

--- a/plugins/kubernetes/test/controllers/kubernetes/namespaces_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/namespaces_controller_test.rb
@@ -107,7 +107,7 @@ describe Kubernetes::NamespacesController do
           end
         end
         assert_redirected_to "http://test.host/kubernetes/namespaces/#{namespace.id}"
-        refute flash[:alert]
+        refute flash[:warn]
       end
     end
 
@@ -119,7 +119,7 @@ describe Kubernetes::NamespacesController do
           end
         end
         assert_redirected_to "http://test.host/kubernetes/namespaces"
-        refute flash[:alert]
+        refute flash[:warn]
       end
 
       it "shows errors" do
@@ -129,7 +129,7 @@ describe Kubernetes::NamespacesController do
           end
         end
         assert_redirected_to "http://test.host/kubernetes/namespaces"
-        flash[:alert].must_include "Failed to upsert namespace test in cluster test: 404"
+        flash[:warn].must_include "Failed to upsert namespace test in cluster test: 404"
       end
     end
 
@@ -142,7 +142,7 @@ describe Kubernetes::NamespacesController do
             @controller.send(:create_callback)
           end
         end
-        refute flash[:alert]
+        refute flash[:warn]
       end
 
       it "shows creation errors" do
@@ -152,7 +152,7 @@ describe Kubernetes::NamespacesController do
             @controller.send(:create_callback)
           end
         end
-        flash[:alert].must_equal <<~TEXT.rstrip
+        flash[:warn].must_equal <<~TEXT.rstrip
           <p>Error upserting namespace in some clusters:
           <br />Failed to upsert namespace test in cluster test: Timed out connecting to server</p>
         TEXT
@@ -164,7 +164,7 @@ describe Kubernetes::NamespacesController do
             @controller.send(:create_callback)
           end
         end
-        refute flash[:alert]
+        refute flash[:warn]
       end
     end
   end

--- a/test/controllers/unauthorized_controller_test.rb
+++ b/test/controllers/unauthorized_controller_test.rb
@@ -31,20 +31,39 @@ describe 'Unauthorized' do
 
       it 'sets the flash' do
         request
-        flash[:authorization_error].must_equal('You are not logged in')
+        flash[:alert].must_equal 'You are not logged in. '
       end
 
       describe 'when user is not authorized' do
-        let(:headers) { {'warden' => stub(user: 111)} }
+        let(:headers) { {'warden' => stub(user: User.new)} }
 
         it 'uses a custom flash message for viewing' do
           request
-          flash[:authorization_error].must_equal('You are not authorized to view this page')
+          flash[:alert].must_equal 'You are not authorized to view this page. '
         end
 
         it 'uses a custom flash message for changes' do
           request(params: {_method: "patch"})
-          flash[:authorization_error].must_equal('You are not authorized to make this change')
+          flash[:alert].must_equal "You are not authorized to make this change. "
+        end
+
+        describe "with request access" do
+          with_env REQUEST_ACCESS_FEATURE: 'true'
+
+          it "adds link" do
+            request(params: {_method: "patch"})
+            flash[:alert].must_equal(
+              "You are not authorized to make this change." \
+              " <a href=\"/access_requests/new\">Request additional access rights</a>"
+            )
+            assert flash[:alert].html_safe?
+          end
+
+          it "does not add link when user already requested" do
+            headers['warden'].user.access_request_pending = true
+            request(params: {_method: "patch"})
+            flash[:alert].must_equal "You are not authorized to make this change. Access request pending."
+          end
         end
       end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -232,29 +232,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#flash_messages" do
-    let(:flash) { {} }
-
-    it "returns empty" do
-      flash_messages.must_equal []
-    end
-
-    it "fails on unknown" do
-      flash[:foo] = "bar"
-      assert_raises(KeyError) { flash_messages }
-    end
-
-    it "translates bootstrap classes" do
-      flash[:notice] = "N"
-      flash_messages.must_equal [[:notice, :info, "N"]]
-    end
-
-    it "returns arrays of messages" do
-      flash[:notice] = ["bar", "baz"]
-      flash_messages.must_equal [[:notice, :info, "bar"], [:notice, :info, "baz"]]
-    end
-  end
-
   describe "#link_to_delete" do
     it "builds a link" do
       link_to_delete("/foo").must_include ">Delete</a>"


### PR DESCRIPTION
 - layout should not have special logic to support certain controllers
 - flashes should be standardized
 - we need warning flashes for ignorable errors

@zendesk/compute 

<img width="432" alt="Screen Shot 2019-11-15 at 1 44 41 PM" src="https://user-images.githubusercontent.com/11367/68979919-d0181100-07b3-11ea-992f-7009eee948c7.png">
<img width="550" alt="Screen Shot 2019-11-15 at 2 37 15 PM" src="https://user-images.githubusercontent.com/11367/68980510-89c3b180-07b5-11ea-9b40-bf621c1918fa.png">
