### PR TITLE
remove airbrake user informer since it no longer works on rails 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ PATH
   specs:
     samson_airbrake (0.0.0)
       airbrake
-      airbrake-user_informer
 
 PATH
   remote: plugins/assertible
@@ -205,14 +204,10 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (7.3.0)
-      airbrake-ruby (~> 2.5)
-    airbrake-ruby (2.9.0)
-    airbrake-user_informer (0.6.0)
-      airbrake (~> 7.0)
-      airbrake-ruby (~> 2.0)
-      rack
-      railties (>= 5.0.0, < 5.3.0)
+    airbrake (9.5.0)
+      airbrake-ruby (~> 4.8)
+    airbrake-ruby (4.8.0)
+      rbtree3 (~> 0.5)
     ansible (0.2.2)
     ar_multi_threaded_transactional_tests (0.3.0)
       activerecord (>= 4.2.0, < 5.3.0)
@@ -500,6 +495,7 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
+    rbtree3 (0.5.0)
     recursive-open-struct (1.1.0)
     request_store (1.4.0)
       rack (>= 1.4)

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,11 @@ task :asset_compilation_environment do
   ar = ActiveRecord::Base
   def ar.establish_connection
   end
+
+  # for https://github.com/airbrake/airbrake/issues/1022
+  def ar.connection_config
+    {}
+  end
 end
 Rake::Task['assets:precompile'].prerequisites.unshift :asset_compilation_environment
 

--- a/plugins/airbrake/config/initializers/airbrake.rb
+++ b/plugins/airbrake/config/initializers/airbrake.rb
@@ -2,11 +2,6 @@
 
 if key = ENV['AIRBRAKE_API_KEY']
   ActiveSupport.on_load(:samson_version) do |version|
-    Airbrake.user_information_placeholder = Samson::ErrorNotifier::USER_INFORMATION_PLACEHOLDER
-    Airbrake.user_information = # replaces replaces user_information_placeholder on 500 pages
-      "<br/><br/>Error number: <a href='https://airbrake.io/locate/{{error_id}}'>{{error_id}}</a>" +
-        ((link = ENV['HELP_LINK']) ? "<br/><br/>#{link}" : "")
-
     Airbrake.configure do |config|
       config.project_id = ENV.fetch('AIRBRAKE_PROJECT_ID')
       config.project_key = key

--- a/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
+++ b/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 require 'airbrake'
-require 'airbrake/user_informer'
 
 module SamsonAirbrake
   class Engine < Rails::Engine
     def self.exception_debug_info(notice)
       return unless notice
       return 'Airbrake did not return an error id' unless id = notice['id']
-      return 'Unable to find Airbrake url' unless url = Airbrake.user_information[/['"](http.*?)['"]/, 1]
-      return 'Unable to find error_id placeholder' unless url.sub!('{{error_id}}', id)
-      "Error #{url}"
+      "Error https://airbrake.io/locate/#{id}"
     end
   end
 end

--- a/plugins/airbrake/samson_airbrake.gemspec
+++ b/plugins/airbrake/samson_airbrake.gemspec
@@ -7,5 +7,4 @@ Gem::Specification.new 'samson_airbrake', '0.0.0' do |s|
   s.files = Dir['{app,config,db,lib}/**/*']
 
   s.add_runtime_dependency 'airbrake'
-  s.add_runtime_dependency 'airbrake-user_informer'
 end

--- a/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
+++ b/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
@@ -8,9 +8,6 @@ describe SamsonAirbrake do
   describe '.exception_debug_info' do
     it 'returns error debug info' do
       notice = {'id' => '1'}
-      Airbrake.
-        expects(:user_information).
-        returns("<br/><br/>Error number: <a href='https://airbrake.io/locate/{{error_id}}'>{{error_id}}</a>")
       SamsonAirbrake::Engine.exception_debug_info(notice).must_equal 'Error https://airbrake.io/locate/1'
     end
 
@@ -20,18 +17,6 @@ describe SamsonAirbrake do
 
     it 'returns airbrake id error if there is no id' do
       SamsonAirbrake::Engine.exception_debug_info({}).must_equal 'Airbrake did not return an error id'
-    end
-
-    it 'returns url error if error finding url' do
-      notice = {'id' => '1'}
-      Airbrake.expects(:user_information).returns('')
-      SamsonAirbrake::Engine.exception_debug_info(notice).must_equal 'Unable to find Airbrake url'
-    end
-
-    it 'returns error_id error if there is no error_id placeholder' do
-      notice = {'id' => '1'}
-      Airbrake.expects(:user_information).returns('"httpfoobar"')
-      SamsonAirbrake::Engine.exception_debug_info(notice).must_equal 'Unable to find error_id placeholder'
     end
   end
 

--- a/test/controllers/concerns/json_exceptions_test.rb
+++ b/test/controllers/concerns/json_exceptions_test.rb
@@ -30,7 +30,10 @@ describe "JsonExceptions Integration" do
       end
     end
 
-    before { stub_session_auth }
+    before do
+      stub_session_auth
+      Airbrake.stubs(:build_notice) # prevent threadpool creation
+    end
 
     it "presents validation errors" do
       # HACK: to deal with new controller implementation.

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -16,6 +16,8 @@ describe "ResourceController Integration" do
 
   let(:project) { projects(:test) }
 
+  before { Airbrake.stubs(:build_notice) } # prevent threadpool creation
+
   as_a :admin do
     describe "#index" do
       describe "html" do

--- a/test/lib/samson/error_notifier_test.rb
+++ b/test/lib/samson/error_notifier_test.rb
@@ -18,6 +18,7 @@ describe Samson::ErrorNotifier do
     end
 
     it 'raises if in the test environment' do
+      Airbrake.expects(:notify) # prevert threadpool creation
       exception = ArgumentError.new('motherofgod')
       exception.set_backtrace(["neatbacktraceyougotthere"])
       e = assert_raises RuntimeError do
@@ -31,6 +32,7 @@ describe Samson::ErrorNotifier do
     end
 
     it 'logs error if not in test environment' do
+      Airbrake.expects(:notify) # prevert threadpool creation
       Rails.env.expects(:test?).returns(false)
       error = ArgumentError.new('oh no!')
       error.set_backtrace('foobar')
@@ -41,8 +43,8 @@ describe Samson::ErrorNotifier do
     end
 
     it 'can log error if exception is a string' do
+      Airbrake.expects(:notify) # prevert threadpool creation
       Rails.env.expects(:test?).returns(false)
-
       Rails.logger.expects(:error).with('ErrorNotifier: Oh no!')
 
       Samson::ErrorNotifier.notify('Oh no!')


### PR DESCRIPTION
https://github.com/grosser/airbrake-user_informer/issues/6

we don't use it and it would be some hours to get this back working again ... so remove unless someone is willing to put in the work 🤷‍♂ 

tests needed new stubs since Airbrake creates a threadpool when reporting now, ideally we'd just noop that so we can test deeper or start it before tests start ... but stubbing is good enough for now ...

@zendesk/compute 