### PR TITLE
PAAS-5262 stop deploys when bad events happen

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -54,6 +54,7 @@ module Kubernetes
           @details = "Waiting for resources (#{@pod.phase}, #{@pod.reason})"
         elsif @pod.events_indicate_failure?
           @details = "Error event"
+          @finished = true
         else
           @details = "Waiting (#{@pod.phase}, #{@pod.reason})"
         end

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -64,7 +64,10 @@ describe Kubernetes::ResourceStatus do
 
     it "errors when bad events happen" do
       events[0].merge!(type: "Warning", reason: "Boom")
-      expect_event_request { details.must_equal "Error event" }
+      expect_event_request do
+        details.must_equal "Error event"
+        assert status.finished
+      end
     end
 
     describe "non-pods" do


### PR DESCRIPTION
instead of running forever and not telling the user which pod failed with which events

broken through https://github.com/zendesk/samson/pull/3497 were the line was removed without breaking any tests or adding new tests

@zendesk/compute 