### PR TITLE
EP-2508 resolve commit early so outbound webhook has the exact sha

### DIFF
--- a/test/models/deploy_service_test.rb
+++ b/test/models/deploy_service_test.rb
@@ -245,7 +245,10 @@ describe DeployService do
     end
 
     describe "with before-deploy outbound webhook" do
-      before { OutboundWebhook.create!(url: "http://foo", auth_type: "None", stages: [stage], before_deploy: true) }
+      before do
+        GITHUB.expects(:commit).returns(stub(sha: "abc"))
+        OutboundWebhook.create!(url: "http://foo", auth_type: "None", stages: [stage], before_deploy: true)
+      end
 
       it "sends" do
         service.deploy(stage, reference: reference)
@@ -310,6 +313,7 @@ describe DeployService do
     end
 
     it "runs after deploy outbound webhooks" do
+      GITHUB.expects(:commit).returns(stub(sha: "abc"))
       OutboundWebhook.create!(url: "http://foo", auth_type: "None", stages: [stage], before_deploy: false)
       service.deploy(stage, reference: reference)
       assert_request(:post, "http://foo/") { job_execution.perform }


### PR DESCRIPTION
only doing it when we have outbound hooks to not spend the extra effort

@zendesk/eng-productivity 

```
\"production\":false,\"commit\":\"6f9da0e88a7811c930700aa5fd73d66f316705e2\",
```