### PR TITLE
Add deploy_groups includes for stages endpoints

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -20,9 +20,7 @@ class StagesController < ResourceController
         @pagy, @deploys = pagy(@stage.deploys, page: params[:page], items: 15)
       end
       format.json do
-        render_as_json :stage, @stage, nil, allowed_includes: [
-          :last_deploy, :last_succeeded_deploy, :active_deploy, :lock
-        ] do |reply|
+        render_as_json :stage, @stage, nil, allowed_includes: allowed_includes do |reply|
           # deprecated way of inclusion, do not add more
           if params[:include] == "kubernetes_matrix"
             reply[:stage][:kubernetes_matrix] = Kubernetes::DeployGroupRole.matrix(@stage)
@@ -57,6 +55,16 @@ class StagesController < ResourceController
   end
 
   private
+
+  def allowed_includes
+    [
+      :last_deploy,
+      :last_succeeded_deploy,
+      :active_deploy,
+      :lock,
+      :deploy_groups
+    ]
+  end
 
   def search_resources
     @project.stages

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -126,6 +126,17 @@ describe StagesController do
           json["stage"].keys.must_include 'last_succeeded_deploy_id'
           json["stage"].keys.must_include 'active_deploy_id'
         end
+
+        it 'renders deploy_groups if included in the includes param' do
+          get :show, params: {
+            project_id: subject.project.to_param, id: subject.to_param,
+            includes: "deploy_groups"
+          }, format: :json
+
+          assert_equal subject.deploy_group_ids, json['stage']['deploy_group_ids']
+          json.keys.must_include 'deploy_groups'
+          json['deploy_groups'].first.keys.must_include 'id'
+        end
       end
 
       it "fails with invalid project" do


### PR DESCRIPTION
When creating/reading a stage with deploy groups it would be nice to be able to retrieve the deploy group ids in the response to avoid additional requests. The main reason i'd like this is that i'm writing a terraform provider to provision samson resources and I need to handle partial updates without this, which adds a bit of complexity

### Risks
- Low/Med/High: thing that could happen
