### PR TITLE
tell users that controller helper methods should be private

### DIFF
--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -213,7 +213,8 @@ describe "cleanliness" do
       # check if all actions were tested
       missing = controller_actions - unauthorized_actions - viewer_actions - public_actions
       if missing.any?
-        "#{f} is missing unauthorized, viewer accessible, or public accessible test for #{missing.join(', ')}"
+        "#{f} is missing unauthorized, viewer accessible, or public accessible test for #{missing.join(', ')}\n" \
+        "actions (if these are helpers and not actions, make them private)"
       end
     end.compact
 


### PR DESCRIPTION
just saw that in https://github.com/zendesk/samson/pull/3646 and the error message was confusing

@zendesk/compute 