### PR TITLE
redo/fix rollbar dashboard plugin

### DIFF
--- a/app/views/projects/_header.html.erb
+++ b/app/views/projects/_header.html.erb
@@ -4,8 +4,6 @@
   <%= repository_web_link(project) %>
 </h1>
 
-<%= Samson::Hooks.render_views(:project_view, self, project: @project) %>
-
 <div class="project-lock-buttons">
   <%= render "locks/button", lock: project.lock, resource: @project %>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -7,6 +7,8 @@
 <section class="clearfix tabs">
   <%= render 'shared/dashboard', resource: @project %>
 
+  <%= Samson::Hooks.render_views(:project_dashboard, self) %>
+
   <table class="project-stages table table-condensed">
     <thead>
       <tr>

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -25,8 +25,8 @@ module Samson
       :deploy_form, # for external plugin, so they can add extra form fields
       :admin_menu,
       :manage_menu,
-      :project_tabs_view,
-      :project_view
+      :project_dashboard,
+      :project_tabs_view
     ].freeze
 
     EVENT_HOOKS = [

--- a/plugins/rollbar_dashboards/app/assets/stylesheets/rollbar_dashboards/application.css
+++ b/plugins/rollbar_dashboards/app/assets/stylesheets/rollbar_dashboards/application.css
@@ -15,10 +15,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  width:75%;
-  max-width:75%;
-}
-
-.rollbar-table__env {
-  width: 15%;
+  width: 90%;
+  max-width: 90%;
 }

--- a/plugins/rollbar_dashboards/app/helpers/rollbar_dashboards/dashboards_helper.rb
+++ b/plugins/rollbar_dashboards/app/helpers/rollbar_dashboards/dashboards_helper.rb
@@ -2,13 +2,14 @@
 
 module RollbarDashboards
   module DashboardsHelper
-    DASHBOARD_HEIGHT = 22 # em
+    ROLLBAR_DASHBOARD_HEIGHT = 18 # em
 
     def rollbar_dashboard_placeholder_size(settings)
-      settings.size * DASHBOARD_HEIGHT
+      settings.size * ROLLBAR_DASHBOARD_HEIGHT
     end
 
-    def rollbar_dashboard_container(item_path, settings)
+    # replaced by responsive_load.js.erb
+    def rollbar_lazy_load_dashboard_container(item_path, settings)
       content_tag(
         :div,
         '',
@@ -21,16 +22,9 @@ module RollbarDashboards
       )
     end
 
-    def item_link(item_title, item_id, dashboard_setting)
-      if account_and_project_name = dashboard_setting.account_and_project_name.presence
-        # Removes path and handles https://api.rollbar.com cases
-        domain = URI.join(dashboard_setting.base_url, '/').to_s.sub('://api.', '://')
-
-        item_url = "#{domain}#{account_and_project_name}/items/#{item_id}"
-        link_to item_title, item_url
-      else
-        item_title
-      end
+    def rollbar_item_link(item_title, item_id, dashboard_setting)
+      url = dashboard_setting.items_url
+      url ? link_to(item_title, "#{url}/#{item_id}") : item_title
     end
   end
 end

--- a/plugins/rollbar_dashboards/app/models/rollbar_dashboards/setting.rb
+++ b/plugins/rollbar_dashboards/app/models/rollbar_dashboards/setting.rb
@@ -7,5 +7,12 @@ module RollbarDashboards
     belongs_to :project, inverse_of: :rollbar_dashboards_settings
 
     validates :base_url, :read_token, presence: true
+    validates :account_and_project_name, presence: true, if: :new_record? # TODO: backfill all and then always validate
+
+    def items_url
+      return unless account_and_project_name?
+      domain = URI.join(base_url, '/').to_s.sub('://api.', '://') # Removes path and handle https://api.rollbar.com
+      "#{domain}#{account_and_project_name}/items"
+    end
   end
 end

--- a/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_dashboard.html.erb
+++ b/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_dashboard.html.erb
@@ -1,21 +1,16 @@
-<div class="panel panel-default" style="min-height: <%= RollbarDashboards::DashboardsHelper::DASHBOARD_HEIGHT %>em">
+<% setting, items = dashboard_data %>
+
+<div class="panel panel-default" style="min-height: <%= RollbarDashboards::DashboardsHelper::ROLLBAR_DASHBOARD_HEIGHT %>em">
   <div class="panel-heading">
-    <%= image_tag 'rollbar_dashboards/icon.png', height: '30px' %>
-    <%= "#{title} (#{dashboard_data.first.base_url})" %>
+    <%= link_to_if setting.items_url, image_tag('rollbar_dashboards/icon.png', height: '30px'), setting.items_url %>
+    <%= title %>
+    <%= "Warning: missing Account/Project setting" unless setting.account_and_project_name? %> <%# TODO: remove after migration to make it required %>
   </div>
-  <% items = dashboard_data.second %>
   <% if items.present? %>
     <table class="table rollbar-table">
-      <tr>
-        <th class="rollbar-table__count">Count</th>
-        <th class="rollbar-table__title">Title</th>
-        <th class="rollbar-table__env">Environment</th>
-      </tr>
-      <%= render partial: 'rollbar_dashboards/item', collection: items, locals: {dashboard_setting: dashboard_data.first} %>
+      <%= render partial: 'rollbar_dashboards/item', collection: items, locals: {dashboard_setting: setting} %>
     </table>
   <% else %>
-    <div class="panel-body">
-      <p>There are no items to display at this time...</p>
-    </div>
+    <div class="panel-body"><p>No items found</p></div>
   <% end %>
 </div>

--- a/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_item.html.erb
+++ b/plugins/rollbar_dashboards/app/views/rollbar_dashboards/_item.html.erb
@@ -1,5 +1,4 @@
 <tr>
-  <td class="rollbar-table__count"><span class="badge"><%= item[:occurrences] %></span></td>
-  <td class="rollbar-table__title"><%= item_link(item[:title], item[:counter], dashboard_setting) %></td>
-  <td class="rollbar-table__env"><%= item[:environment] %></td>
+  <td class="rollbar-table__count"><%= item[:occurrences] %> x</td>
+  <td class="rollbar-table__title"><%= rollbar_item_link(item[:title], item[:counter], dashboard_setting) %></td>
 </tr>

--- a/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_deploy_show_view.html.erb
+++ b/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_deploy_show_view.html.erb
@@ -1,8 +1,4 @@
 <% if deploy.succeeded? && (settings = deploy.project.rollbar_dashboards_settings.presence) %>
   <%# replaced by responsive_load.js.erb %>
-  <%= rollbar_dashboard_container(
-        deploy_dashboard_deploy_rollbar_dashboards_dashboards_path(deploy),
-        settings
-      )
-  %>
+  <%= rollbar_lazy_load_dashboard_container deploy_dashboard_deploy_rollbar_dashboards_dashboards_path(deploy), settings %>
 <% end %>

--- a/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_project_dashboard.html.erb
+++ b/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_project_dashboard.html.erb
@@ -1,0 +1,3 @@
+<% if settings = @project.rollbar_dashboards_settings.presence %>
+  <%= rollbar_lazy_load_dashboard_container project_dashboard_project_rollbar_dashboards_dashboards_path(@project), settings %>
+<% end %>

--- a/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_project_form.html.erb
+++ b/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_project_form.html.erb
@@ -7,19 +7,19 @@
   <p>
     Show a dashboard of most frequent errors on the project page and successful deploys.<br/>
     <b>Base URL:</b> https://api.rollbar.com/api/1 unless you are using a self-hosted instance of Rollbar, then url + /api/1<br/>
-    <b>Access token:</b> From 'Project > Settings > Project Access Tokens'. Supports secret lookup (e.g. secret://rollbar_read_token)<br/>
+    <b>Project Read Token:</b> From 'Project > Settings > Project Access Tokens'. Supports secret lookup (e.g. secret://rollbar_read_token)<br/>
     <b>Account/Project:</b> Account and project '/' separated, copy from url. (to link Rollbar items in dashboards)<br/>
   </p>
 
   <%= form.fields_for_many(:rollbar_dashboards_settings, add_rows_allowed: true) do |setting| %>
     <div class="col-lg-4">
-      <%= setting.url_field :base_url, class: "form-control", placeholder: "Base URL"  %>
+      <%= setting.url_field :base_url, class: "form-control", placeholder: "Base URL" %>
     </div>
     <div class="col-lg-3">
       <%= setting.text_field :read_token, class: "form-control", placeholder: "Project Read Token" %>
     </div>
     <div class="col-lg-3">
-      <%= setting.text_field :account_and_project_name, class: "form-control", placeholder: "{Account}/{Project}" %>
+      <%= setting.text_field :account_and_project_name, class: "form-control", placeholder: "Account/Project" %>
     </div>
   <% end %>
 </fieldset>

--- a/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_project_view.html.erb
+++ b/plugins/rollbar_dashboards/app/views/samson_rollbar_dashboards/_project_view.html.erb
@@ -1,8 +1,0 @@
-<% if settings = project.rollbar_dashboards_settings.presence %>
-  <%# replaced by responsive_load.js.erb %>
-  <%= rollbar_dashboard_container(
-        project_dashboard_project_rollbar_dashboards_dashboards_path(project),
-        settings
-      )
-  %>
-<% end %>

--- a/plugins/rollbar_dashboards/lib/rollbar_dashboards/client.rb
+++ b/plugins/rollbar_dashboards/lib/rollbar_dashboards/client.rb
@@ -3,7 +3,7 @@
 module RollbarDashboards
   class Client
     MAX_RQL_JOB_WAIT_TIME = 5
-    REQUEST_TIMEOUT = 1
+    REQUEST_TIMEOUT = 5
 
     def initialize(dashboard)
       @base = dashboard.base_url
@@ -11,75 +11,57 @@ module RollbarDashboards
     end
 
     # returns array hashes of top items
-    def top_errors(hours: 24, environments: ['production'])
+    def top_errors(hours:, environments:)
       args = {
         access_token: @token,
         hours: hours,
         environments: environments.join(',')
       }.to_query
 
-      response = Faraday.get("#{@base}/reports/top_active_items?#{args}") do |req|
-        req.options.timeout = req.options.open_timeout = REQUEST_TIMEOUT
-      end
-
-      if response.success?
-        data = ::JSON.parse(response.body, symbolize_names: true)
+      request :get, "#{@base}/reports/top_active_items?#{args}" do |data|
         data.fetch(:result).map { |item_hash| item_hash.fetch(:item) }
       end
-    rescue StandardError
-      Samson::ErrorNotifier.notify($!)
-      nil
     end
 
     # creates a new rql job
     def create_rql_job(query_string)
-      args = {
+      params = {
         access_token: @token,
         query_string: query_string,
         force_refresh: 1
       }
-
-      response = Faraday.post("#{@base}/rql/jobs", args) do |req|
-        req.options.timeout = req.options.open_timeout = REQUEST_TIMEOUT
+      request :post, "#{@base}/rql/jobs", params do |data|
+        data.dig_fetch(:result, :id)
       end
-
-      if response.success?
-        Rails.logger.info "Created RQL job: #{response.body}"
-        ::JSON.parse(response.body, symbolize_names: true).dig_fetch(:result, :id)
-      end
-    rescue StandardError
-      Rails.logger.error "Failed to create RQL job"
-      Samson::ErrorNotifier.notify($!)
-      nil
     end
 
     # gets the rql job result, returns array of hashes e.g. [{ col1: row_val_1 ...}, { col1: row_val_2 ...}]
     def rql_job_result(id)
       MAX_RQL_JOB_WAIT_TIME.times do |i|
-        response = Faraday.get("#{@base}/rql/job/#{id}/result?access_token=#{@token}") do |req|
-          req.options.timeout = req.options.open_timeout = REQUEST_TIMEOUT
-        end
-
-        break unless response.success?
-
-        data = ::JSON.parse(response.body, symbolize_names: true)
-
-        if data.dig_fetch(:result, :result).nil?
-          Rails.logger.info "Waiting for RQL job #{id}"
-          sleep(1) if i < (MAX_RQL_JOB_WAIT_TIME - 1)
-        else
-          columns = data.dig_fetch(:result, :result, :columns).map(&:to_sym)
-          rows = data.dig_fetch(:result, :result, :rows)
-
-          return rows.map { |row| columns.zip(row).to_h }.presence
+        request :get, "#{@base}/rql/job/#{id}/result?access_token=#{@token}" do |data|
+          if data.dig_fetch(:result, :result).nil?
+            Rails.logger.info "Waiting for RQL job #{id}"
+            sleep 1 if i < (MAX_RQL_JOB_WAIT_TIME - 1)
+          else
+            columns = data.dig_fetch(:result, :result, :columns).map(&:to_sym)
+            rows = data.dig_fetch(:result, :result, :rows)
+            return rows.map { |row| columns.zip(row).to_h }.presence
+          end
         end
       end
 
-      nil
+      raise Samson::Hooks::UserError, "Timeout retrieving RQL job #{id} result"
+    end
+
+    def request(method, url, *args)
+      response = Faraday.send(method, url, *args) do |req|
+        req.options.timeout = req.options.open_timeout = REQUEST_TIMEOUT
+      end
+      raise "Response #{response.status}" unless response.success?
+      yield JSON.parse(response.body, symbolize_names: true)
     rescue StandardError
-      Rails.logger.error "Error retrieving RQL job #{id} result"
       Samson::ErrorNotifier.notify($!)
-      nil
+      raise Samson::Hooks::UserError, "Failed to contact rollbar"
     end
   end
 end

--- a/plugins/rollbar_dashboards/lib/samson_rollbar_dashboards/samson_plugin.rb
+++ b/plugins/rollbar_dashboards/lib/samson_rollbar_dashboards/samson_plugin.rb
@@ -5,7 +5,7 @@ module SamsonRollbarDashboards
     config.assets.precompile.append ['rollbar_dashboards/icon.png', 'rollbar_dashboards/deploy_dashboard.js']
   end
 
-  Samson::Hooks.view :project_view, 'samson_rollbar_dashboards'
+  Samson::Hooks.view :project_dashboard, 'samson_rollbar_dashboards'
   Samson::Hooks.view :project_form, 'samson_rollbar_dashboards'
   Samson::Hooks.view :deploy_show_view, 'samson_rollbar_dashboards'
 

--- a/plugins/rollbar_dashboards/test/helpers/rollbar_dashboards/dashboards_helper_test.rb
+++ b/plugins/rollbar_dashboards/test/helpers/rollbar_dashboards/dashboards_helper_test.rb
@@ -8,46 +8,41 @@ describe RollbarDashboards::DashboardsHelper do
   describe '#rollbar_dashboard_placeholder_size' do
     it 'reports correct size' do
       settings = mock(size: 2)
-      rollbar_dashboard_placeholder_size(settings).must_equal 44
+      rollbar_dashboard_placeholder_size(settings).must_equal 36
     end
   end
 
-  describe '#rollbar_dashboard_container' do
+  describe '#rollbar_lazy_load_dashboard_container' do
     let(:path) { 'dummy/path' }
     let(:settings) { mock('RollbarDashboards::Setting', size: 1) }
 
     it 'renders containter div' do
-      rollbar_dashboard_container(path, settings).must_equal <<~HTML.delete("\n")
-        <div class="lazy-load dashboard-container" style="min-height: 22em;" data-url="dummy/path" data-delay="1000">
+      rollbar_lazy_load_dashboard_container(path, settings).must_equal <<~HTML.delete("\n")
+        <div class="lazy-load dashboard-container" style="min-height: 18em;" data-url="dummy/path" data-delay="1000">
         </div>
       HTML
     end
   end
 
-  describe '#item_link' do
-    def setting(stubs = {account_and_project_name: 'Account/Cool-Project', base_url: 'https://rollbar-us.com/api/1'})
-      @setting ||= mock(stubs)
+  describe '#rollbar_item_link' do
+    let(:setting) do
+      RollbarDashboards::Setting.new(
+        project: projects(:test),
+        base_url: 'http://thegurn.org',
+        account_and_project_name: "Foo/Bar",
+        read_token: '1234'
+      )
     end
 
     it 'generates item link' do
-      item_link('title', '123', setting).must_equal <<~HTML.delete("\n")
-        <a href="https://rollbar-us.com/Account/Cool-Project/items/123">title</a>
+      rollbar_item_link('title', '123', setting).must_equal <<~HTML.delete("\n")
+        <a href="http://thegurn.org/Foo/Bar/items/123">title</a>
       HTML
     end
 
-    it 'returns item title if account_and_project_name is nil' do
-      item_link('title', '123', setting(account_and_project_name: nil)).must_equal 'title'
-    end
-
-    it 'returns item title if account_and_project_name is empty string' do
-      item_link('title', '123', setting(account_and_project_name: '')).must_equal 'title'
-    end
-
-    it 'handles api subdomain' do
-      setting(account_and_project_name: 'Account/Cool-Project', base_url: 'https://api.rollbar.com')
-      item_link('title', '123', setting).must_equal <<~HTML.delete("\n")
-        <a href="https://rollbar.com/Account/Cool-Project/items/123">title</a>
-      HTML
+    it 'returns item title if account_and_project_name is blank' do
+      setting.account_and_project_name = nil
+      rollbar_item_link('title', '123', setting).must_equal 'title'
     end
   end
 end

--- a/plugins/rollbar_dashboards/test/samson_rollbar_dashboards/samson_plugin_test.rb
+++ b/plugins/rollbar_dashboards/test/samson_rollbar_dashboards/samson_plugin_test.rb
@@ -28,9 +28,10 @@ describe SamsonRollbarDashboards do
       view_context
     end
 
-    describe 'project_view callback' do
+    describe 'project_dashboard callback' do
       def render_view(project)
-        Samson::Hooks.render_views(:project_view, view_context, project: project)
+        view_context.instance_variable_set(:@project, project)
+        Samson::Hooks.render_views(:project_dashboard, view_context)
       end
 
       it 'renders nothing if project has no dashboard settings' do

--- a/test/lib/samson/form_builder_test.rb
+++ b/test/lib/samson/form_builder_test.rb
@@ -188,6 +188,7 @@ describe Samson::FormBuilder do
       RollbarDashboards::Setting.create!(
         project: projects(:test),
         base_url: 'https://bingbong.gov/api/1',
+        account_and_project_name: "Foo/Bar",
         read_token: '12345'
       )
     end


### PR DESCRIPTION
 - longer timeout since rollbar is slow
 - do not show "no items" when the request failed (giving users a false sense of safety)
 - do not cache results for 10 minutes, that is way too long -> false sense of safety
 - display only on projects show and not on release/edit etc pages where we don't need it
 - call out what is being shown "production" errors / "staging" errors
 - simplify UI to get 1 extra line (22em -> 18em)
 - say that the errors are from last 24 hours
 - dry up client.rb
 - dry up controller
 - link to rollbar page from widget
 - force users to add account/project for new dashboards so we can eventually backfill
 - do not show environment column since we only display from a single environment

@zendesk/compute @zendesk/eng-productivity 

![Screen Shot 2019-11-26 at 1 36 43 PM](https://user-images.githubusercontent.com/11367/69680336-7ccd7a80-105f-11ea-815b-e8ab9f583dd8.png)
![Screen Shot 2019-11-26 at 3 06 49 PM](https://user-images.githubusercontent.com/11367/69680337-7ccd7a80-105f-11ea-9f9a-a154644b9260.png)


### Risks
 - Low: rollbar dashboards not working