### PR TITLE
link env groups to their edit page

### DIFF
--- a/plugins/env/app/assets/javascripts/env/application.js
+++ b/plugins/env/app/assets/javascripts/env/application.js
@@ -56,26 +56,23 @@
     return $new_row;
   }
 
-  // Update the query string of the associated preview link
-  // with the given group ID, and toggle its visibility
-  function formatEnvGroupPreviewLink($preview, val) {
-    $preview[0].search = $.param({ group_id: val });
-    $preview.toggle(!!val);
+  // Update the query string of the link with the given group ID, and toggle its visibility
+  function formatEnvGroupLinks($links, id) {
+    $.each($links, function(_, a){
+      a.href = a.href.replace(/\d+$/, id || 0);
+    });
+    $links.toggle(!!id);
   }
 
-  // Select the pair of env group input and preview link to:
-  // - Format the query string of the preview link
+  // Select env group input and links to:
+  // - Initially add the query string to the links
   // - Update the query string when the env group input changes
   function setupEnvGroupPreview($input) {
     var $select = $input.find('select');
-    var $preview = $input.find('.checkbox a');
-
     $select.on('change', function(e) {
       e.preventDefault();
-      formatEnvGroupPreviewLink($preview, $select.val());
-    });
-
-    $select.trigger('change');
+      formatEnvGroupLinks($input.find('.checkbox a'), $select.val());
+    }).trigger('change');
   }
 
   function withoutSelectpicker($row, callback){

--- a/plugins/env/app/views/samson_env/_project_form.html.erb
+++ b/plugins/env/app/views/samson_env/_project_form.html.erb
@@ -43,8 +43,9 @@
           %>
         </div>
         <div class="col-lg-2 checkbox">
-          <%# updated dynammically in the client-side JS %>
-          <%= link_to "Preview", preview_environment_variable_groups_path %>
+          <%# linked to selected group in env/app/assets/javascripts/env/application.js %>
+          <%= link_to "Vars", environment_variable_group_path(0) %> |
+          <%= link_to "Preview", preview_environment_variable_groups_path(group_id: 0) %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Often when I work with env groups, I also want to see how they are configured ... now we can do this without going to index and then searching

![Screen Shot 2019-11-26 at 4 57 15 PM](https://user-images.githubusercontent.com/11367/69684855-fa4cb700-106e-11ea-9744-1194626d99e2.png)
![Screen Shot 2019-11-26 at 5 04 55 PM](https://user-images.githubusercontent.com/11367/69684856-fae54d80-106e-11ea-863d-434d823125b4.png)
![Screen Shot 2019-11-26 at 5 04 58 PM](https://user-images.githubusercontent.com/11367/69684857-fae54d80-106e-11ea-90bd-bedfbd85e250.png)

@zendesk/compute 