### PR TITLE
bring schema dumping back

### DIFF
--- a/db/migrate/20130807182821_create_projects.rb
+++ b/db/migrate/20130807182821_create_projects.rb
@@ -5,7 +5,7 @@ class CreateProjects < ActiveRecord::Migration[4.2]
       t.string :name, null: false
       t.string :repository_url, null: false
 
-      t.timestamp :deleted_at
+      t.datetime :deleted_at
       t.timestamps
     end
   end

--- a/db/migrate/20140114004419_add_deletion_time_to_stages.rb
+++ b/db/migrate/20140114004419_add_deletion_time_to_stages.rb
@@ -2,7 +2,7 @@
 class AddDeletionTimeToStages < ActiveRecord::Migration[4.2]
   def change
     change_table :stages do |t|
-      t.timestamp :deleted_at
+      t.datetime :deleted_at
     end
   end
 end

--- a/db/migrate/20140116001521_add_soft_deletion_to_users.rb
+++ b/db/migrate/20140116001521_add_soft_deletion_to_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AddSoftDeletionToUsers < ActiveRecord::Migration[4.2]
   def change
-    add_column :users, :deleted_at, :timestamp
+    add_column :users, :deleted_at, :datetime
   end
 end

--- a/db/migrate/20140116050403_create_locks.rb
+++ b/db/migrate/20140116050403_create_locks.rb
@@ -6,7 +6,7 @@ class CreateLocks < ActiveRecord::Migration[4.2]
       t.belongs_to :user
 
       t.timestamps
-      t.timestamp :deleted_at
+      t.datetime :deleted_at
     end
   end
 end

--- a/db/migrate/20140707225625_add_started_at_to_deploys.rb
+++ b/db/migrate/20140707225625_add_started_at_to_deploys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AddStartedAtToDeploys < ActiveRecord::Migration[4.2]
   def change
-    add_column :deploys, :started_at, :timestamp
+    add_column :deploys, :started_at, :datetime
   end
 end

--- a/db/migrate/20140804204455_add_soft_deletion_to_deploys.rb
+++ b/db/migrate/20140804204455_add_soft_deletion_to_deploys.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AddSoftDeletionToDeploys < ActiveRecord::Migration[4.2]
   def change
-    add_column :deploys, :deleted_at, :timestamp
+    add_column :deploys, :deleted_at, :datetime
   end
 end

--- a/db/migrate/20141014165353_add_deleted_at_column_to_webhooks.rb
+++ b/db/migrate/20141014165353_add_deleted_at_column_to_webhooks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AddDeletedAtColumnToWebhooks < ActiveRecord::Migration[4.2]
   def change
-    add_column :webhooks, :deleted_at, :timestamp
+    add_column :webhooks, :deleted_at, :datetime
   end
 end

--- a/db/migrate/20150223135916_create_deploy_groups.rb
+++ b/db/migrate/20150223135916_create_deploy_groups.rb
@@ -4,7 +4,7 @@ class CreateDeployGroups < ActiveRecord::Migration[4.2]
     create_table :environments do |t|
       t.string :name, null: false
       t.boolean :is_production, default: false, null: false
-      t.timestamp :deleted_at
+      t.datetime :deleted_at
 
       t.timestamps null: false
     end
@@ -12,7 +12,7 @@ class CreateDeployGroups < ActiveRecord::Migration[4.2]
     create_table :deploy_groups do |t|
       t.string :name, null: false
       t.references :environment, index: true, null: false
-      t.timestamp :deleted_at
+      t.datetime :deleted_at
 
       t.timestamps null: false
     end

--- a/db/migrate/20150924082915_create_user_project_roles.rb
+++ b/db/migrate/20150924082915_create_user_project_roles.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class CreateUserProjectRoles < ActiveRecord::Migration[4.2]
-  create_table :user_project_roles do |t|
-    t.belongs_to :project, null: false, index: true
-    t.belongs_to :user,    null: false, index: true
+  create_table :user_project_roles, id: :integer do |t|
+    t.belongs_to :project, null: false, index: true, type: :integer
+    t.belongs_to :user,    null: false, index: true, type: :integer
     t.integer :role_id,    null: false
     t.timestamps           null: false
   end

--- a/db/migrate/20160316233616_soft_delete_stage_command.rb
+++ b/db/migrate/20160316233616_soft_delete_stage_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class SoftDeleteStageCommand < ActiveRecord::Migration[4.2]
   def change
-    add_column :stage_commands, :deleted_at, :timestamp
+    add_column :stage_commands, :deleted_at, :datetime
 
     # Mark all old StageCommand as deleted
     deleted_stages = Stage.with_deleted { Stage.where('deleted_at IS NOT NULL').pluck(:id) }

--- a/db/migrate/20160815185747_create_outbound_webhooks.rb
+++ b/db/migrate/20160815185747_create_outbound_webhooks.rb
@@ -3,7 +3,7 @@ class CreateOutboundWebhooks < ActiveRecord::Migration[4.2]
   def change
     create_table :outbound_webhooks do |t|
       t.timestamps null: false
-      t.timestamp :deleted_at
+      t.datetime :deleted_at
 
       t.integer :project_id, null: false
       t.integer :stage_id, null: false

--- a/db/migrate/20161028173926_add_last_login_at_to_users.rb
+++ b/db/migrate/20161028173926_add_last_login_at_to_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AddLastLoginAtToUsers < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :last_login_at, :timestamp
+    add_column :users, :last_login_at, :datetime
   end
 end

--- a/db/migrate/20161028211415_track_last_seen_at.rb
+++ b/db/migrate/20161028211415_track_last_seen_at.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class TrackLastSeenAt < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :last_seen_at, :timestamp
+    add_column :users, :last_seen_at, :datetime
   end
 end

--- a/db/migrate/20161102201243_add_metadata_to_access_tokens.rb
+++ b/db/migrate/20161102201243_add_metadata_to_access_tokens.rb
@@ -2,6 +2,6 @@
 class AddMetadataToAccessTokens < ActiveRecord::Migration[5.0]
   def change
     add_column :oauth_access_tokens, :description, :string
-    add_column :oauth_access_tokens, :last_used_at, :timestamp
+    add_column :oauth_access_tokens, :last_used_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
   create_table "builds", id: :integer do |t|
     t.integer "project_id", null: false
     t.integer "number"
-    t.string "git_sha", null: false
+    t.string "git_sha", limit: 128, null: false
     t.string "git_ref", null: false
     t.string "docker_tag"
     t.string "docker_repo_digest"
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.string "name", null: false
     t.text "comment"
     t.string "owners"
-    t.index ["name"], name: "index_environment_variable_groups_on_name", unique: true
+    t.index ["name"], name: "index_environment_variable_groups_on_name", unique: true, length: 191
   end
 
   create_table "environment_variables", id: :integer do |t|
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "permalink", null: false
-    t.index ["permalink"], name: "index_environments_on_permalink", unique: true
+    t.index ["permalink"], name: "index_environments_on_permalink", unique: true, length: 191
   end
 
   create_table "flowdock_flows", id: :integer do |t|
@@ -210,7 +210,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.string "tag"
     t.integer "canceller_id"
     t.index ["project_id"], name: "index_jobs_on_project_id"
-    t.index ["status"], name: "index_jobs_on_status"
+    t.index ["status"], name: "index_jobs_on_status", length: 191
     t.index ["user_id"], name: "index_jobs_on_user_id"
   end
 
@@ -343,7 +343,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
   create_table "new_relic_applications", id: :integer do |t|
     t.string "name"
     t.integer "stage_id"
-    t.index ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true
+    t.index ["stage_id", "name"], name: "index_new_relic_applications_on_stage_id_and_name", unique: true, length: { name: 191 }
   end
 
   create_table "oauth_access_grants", id: :integer do |t|
@@ -438,7 +438,6 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.string "dockerfiles"
     t.boolean "build_with_gcb", default: false, null: false
     t.boolean "show_gcr_vulnerabilities", default: false, null: false
-    t.boolean "kubernetes_allow_writing_to_root_filesystem", default: false, null: false
     t.boolean "jenkins_status_checker", default: false, null: false
     t.boolean "use_env_repo", default: false, null: false
     t.integer "kubernetes_rollout_timeout"
@@ -491,8 +490,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.index ["project_id", "key"], name: "index_secret_sharing_grants_on_project_id_and_key", unique: true, length: { key: 160 }
   end
 
-  create_table "secrets", id: false do |t|
-    t.string "id"
+  create_table "secrets", id: :string do |t|
     t.string "encrypted_value", null: false
     t.string "encrypted_value_iv", null: false
     t.string "encryption_key_sha", null: false
@@ -504,15 +502,6 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.string "comment"
     t.timestamp "deprecated_at"
     t.index ["id"], name: "index_secrets_on_id", unique: true, length: 191
-  end
-
-  create_table "slack_channels", id: :integer do |t|
-    t.string "name", null: false
-    t.string "channel_id", null: false
-    t.integer "stage_id", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["stage_id"], name: "index_slack_channels_on_stage_id"
   end
 
   create_table "slack_identifiers", id: :integer do |t|
@@ -554,6 +543,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.integer "project_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "notify_email_address"
     t.integer "order", null: false
     t.datetime "deleted_at"
     t.boolean "confirm", default: true, null: false
@@ -562,19 +552,19 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.boolean "deploy_on_release", default: false, null: false
     t.boolean "comment_on_zendesk_tickets", default: false, null: false
     t.boolean "production", default: false, null: false
-    t.string "permalink", null: false
     t.boolean "use_github_deployment_api", default: false, null: false
+    t.string "permalink", null: false
     t.text "dashboard"
     t.boolean "email_committers_on_automated_deploy_failure", default: false, null: false
     t.string "static_emails_on_automated_deploy_failure"
     t.string "jenkins_job_names"
     t.string "next_stage_ids"
     t.boolean "no_code_deployed", default: false, null: false
+    t.boolean "kubernetes", default: false, null: false
     t.boolean "is_template", default: false, null: false
     t.boolean "notify_airbrake", default: false, null: false
     t.integer "template_stage_id"
     t.boolean "jenkins_email_committers", default: false, null: false
-    t.boolean "kubernetes", default: false, null: false
     t.boolean "run_in_parallel", default: false, null: false
     t.boolean "jenkins_build_params", default: false, null: false
     t.boolean "cancel_queued_deploys", default: false, null: false
@@ -583,13 +573,12 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.boolean "builds_in_environment", default: false, null: false
     t.boolean "block_on_gcr_vulnerabilities", default: false, null: false
     t.boolean "notify_assertible", default: false, null: false
-    t.string "notify_email_address"
     t.float "average_deploy_time"
     t.string "prerequisite_stage_ids"
     t.string "default_reference"
-    t.boolean "full_checkout", default: false, null: false
     t.string "aws_sts_iam_role_arn"
     t.integer "aws_sts_iam_role_session_duration"
+    t.boolean "full_checkout", default: false, null: false
     t.boolean "allow_redeploy_previous_when_failed", default: false, null: false
     t.string "github_pull_request_comment"
     t.boolean "kubernetes_sample_logs_on_success", default: false, null: false
@@ -668,11 +657,10 @@ ActiveRecord::Schema.define(version: 2019_11_13_043345) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "source", null: false
-    t.index ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch"
-    t.index ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch"
+    t.index ["project_id", "branch"], name: "index_webhooks_on_project_id_and_branch", length: { branch: 191 }
+    t.index ["stage_id", "branch"], name: "index_webhooks_on_stage_id_and_branch", length: { branch: 191 }
   end
 
-  add_foreign_key "deploy_groups", "environments"
   add_foreign_key "deploys", "deploys", column: "triggering_deploy_id"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/plugins/kubernetes/db/migrate/20151116174240_add_soft_delete_to_kubernetes_role.rb
+++ b/plugins/kubernetes/db/migrate/20151116174240_add_soft_delete_to_kubernetes_role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AddSoftDeleteToKubernetesRole < ActiveRecord::Migration[4.2]
   def change
-    add_column :kubernetes_roles, :deleted_at, :timestamp
+    add_column :kubernetes_roles, :deleted_at, :datetime
   end
 end


### PR DESCRIPTION
... broke that in https://github.com/zendesk/samson/pull/2487 🤦‍♂ 
changing a few old migrations so they produce the schema we have in production ... there seem to be some rails bugs that make the old migrations not produce what they used to do (bigint / datetime etc)

### Risks
 - Low: column types mismatch for old apps that never migrated