### PR TITLE
unify dumping logic in rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,18 +38,6 @@ task :asset_compilation_environment do
 end
 Rake::Task['assets:precompile'].prerequisites.unshift :asset_compilation_environment
 
-# normalize schema after dumping so we do not have a diff
-# tested via test/integration/tasks_test.rb
-task "db:schema:dump" do
-  file = "db/schema.rb"
-  schema = File.read(file)
-  schema.gsub!(/, options: .* do/, " do")
-  schema.gsub!('t.text "output", limit: 4294967295', 't.text "output", limit: 268435455')
-  schema.gsub!('t.text "audited_changes", limit: 4294967295', 't.text "audited_changes", limit: 1073741823')
-  schema.gsub!('t.text "object", limit: 4294967295', 't.text "object", limit: 1073741823')
-  File.write(file, schema)
-end
-
 namespace :test do
   task migrate_without_plugins: :environment do
     raise unless ENV.fetch('PLUGINS') == ''

--- a/lib/tasks/dump.rake
+++ b/lib/tasks/dump.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# normalize schema after dumping to avoid diff
+# tested via test/integration/tasks_test.rb
+# TODO: make it not produce a diff without these hacks
+task "db:schema:dump" do
+  next unless ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+  file = "db/schema.rb"
+  schema = File.read(file)
+  schema.gsub!(/, options: .* do/, " do") || raise
+  schema.gsub!('"resource_template", limit: 4294967295', '"resource_template", limit: 1073741823') || raise
+  schema.gsub!('"object", limit: 4294967295', '"object", limit: 1073741823') || raise
+  schema.gsub!('"output", limit: 4294967295', '"output", limit: 268435455') || raise
+  schema.gsub!('"audited_changes", limit: 4294967295', '"audited_changes", limit: 1073741823') || raise
+  File.write(file, schema)
+end


### PR DESCRIPTION
while digging deeper for [last PR](https://github.com/zendesk/samson/pull/3655) I realized that these hacks should live in the `Rakefile`