### PR TITLE
Support kubernetes 1.16 not setting lastTimestamp for all events

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -86,10 +86,10 @@ module Kubernetes
         ).fetch(:items)
 
         # ignore events from before the deploy, comparing strings for speed
-        events.select! { |e| e.dig(:lastTimestamp) >= @start }
+        events.select! { |e| last_timestamp(e) >= @start }
 
         # https://github.com/kubernetes/kubernetes/issues/29838
-        events.sort_by! { |e| e.dig(:lastTimestamp) }
+        events.sort_by! { |e| last_timestamp(e) }
 
         events
       end
@@ -100,6 +100,11 @@ module Kubernetes
     end
 
     private
+
+    # prefer lastTimestamp but sometime it is empty, see https://github.com/eclipse/che/issues/15395
+    def last_timestamp(event)
+      event[:lastTimestamp] || event.dig(:metadata, :creationTimestamp)
+    end
 
     # ignore known events that randomly happen
     def failures(kind)

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -103,6 +103,12 @@ describe Kubernetes::ResourceStatus do
       result.size.must_equal 0
     end
 
+    it "does not fail when missing lastTimestamp" do
+      events[0][:lastTimestamp] = nil
+      events[0][:metadata] = {creationTimestamp: 30.seconds.from_now.utc.iso8601}
+      result.size.must_equal 1
+    end
+
     it "sorts" do
       new = 60.seconds.from_now.utc.iso8601
       events.unshift lastTimestamp: new


### PR DESCRIPTION
```
NoMethodError: undefined method `>=' for nil:NilClass
```

see https://github.com/eclipse/che/issues/15395

@zendesk/compute 