### PR TITLE
[PAAS-5604] Use persistent fields for nodePorts when updating Services 

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -214,7 +214,7 @@ module Kubernetes
 
         # copy fields
         persistent_fields.each do |keep|
-          path = keep.split(".").map!(&:to_sym)
+          path = TemplateFiller.dig_path(keep)
           old_value = resource.dig(*path)
           copy.dig_set path, old_value unless old_value.nil? # boolean fields are kept, but nothing is nil in kubernetes
         end
@@ -330,6 +330,7 @@ module Kubernetes
       def persistent_fields
         [
           "spec.clusterIP",
+          *(@template.dig(:spec, :ports) || []).each_with_index.map { |_, i| "spec.ports.#{i}.nodePort" },
           *ENV["KUBERNETES_SERVICE_PERSISTENT_FIELDS"].to_s.split(/\s,/),
           *@template.dig(:metadata, :annotations, :"samson/persistent_fields").to_s.split(/[,\s]+/)
         ]

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -77,6 +77,12 @@ module Kubernetes
       all_containers.each_with_index.map { |c, i| build_selector_for_container(c, first: i == 0) }.compact
     end
 
+    def self.dig_path(path)
+      path = path.split(/\.(labels|annotations)\./) # make sure we do not split inside of labels or annotations
+      path[0..0] = path[0].split(".")
+      path.map! { |k| k.match?(/^\d+$/) ? Integer(k) : k.to_sym }
+    end
+
     private
 
     def set_via_env_json
@@ -95,9 +101,7 @@ module Kubernetes
 
       # set values
       data.each do |path, v|
-        path = path.split(/\.(labels|annotations)\./) # make sure we do not split inside of labels or annotations
-        path[0..0] = path[0].split(".")
-        path.map! { |k| k.match?(/^\d+$/) ? Integer(k) : k.to_sym }
+        path = self.class.dig_path(path)
 
         begin
           template.dig_set(path, JSON.parse(static_env.fetch(v), symbolize_names: true))

--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -29,6 +29,10 @@ ActiveSupport::TestCase.class_eval do
     end
   end
 
+  def request_with_json(json)
+    ->(r) { p r.body; JSON.parse(r.body, symbolize_names: true) == json }
+  end
+
   # TODO: prevent this getting called twice in the same test ... leads to weird bugs
   def self.assert_requests
     before { @assert_requests = [] } # set here so we can check that users did not forget to set the block


### PR DESCRIPTION
To fix issue with random nodePort issue during rollback.
(for service with spec.type NodePort and LoadBalancer)

### References
- Jira link: PAAS-5604

### Risks
- Low: Service update may break.