### PR TITLE
support persistent fields for all resources

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -160,10 +160,11 @@ Prefer `RollingUpdate` if possible instead.
 To deploy the same repository multiple times, create separate projects and then set `metadata.annotations.samson/override_project_label: "true"`,
 samson will then override the `project` labels and keep deployments/services unique.
 
-### Service updates
+### Updates without overriding
 
-Too keep fields/labels that are manually managed persistent during updates, use `KUBERNETES_SERVICE_PERSISTENT_FIELDS`, see .env.example
-or set `metadata.annotations.samson/persistent_fields`
+Too keep fields/labels that are managed outside of samson during updates
+- for everything set `metadata.annotations.samson/persistent_fields`
+- for `Service` also use `KUBERNETES_SERVICE_PERSISTENT_FIELDS`, see .env.example
 
 ### PodDisruptionBudget
 

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -223,7 +223,7 @@ module Kubernetes
       end
 
       def persistent_fields
-        []
+        [*@template.dig(:metadata, :annotations, :"samson/persistent_fields").to_s.split(/[,\s]+/)]
       end
 
       def fetch_resource
@@ -328,11 +328,10 @@ module Kubernetes
       # we also keep whitelisted fields that are manually changed for load-balancing
       # (meant for labels, but other fields could work too)
       def persistent_fields
-        [
+        super + [
           "spec.clusterIP",
           *(@template.dig(:spec, :ports) || []).each_with_index.map { |_, i| "spec.ports.#{i}.nodePort" },
-          *ENV["KUBERNETES_SERVICE_PERSISTENT_FIELDS"].to_s.split(/\s,/),
-          *@template.dig(:metadata, :annotations, :"samson/persistent_fields").to_s.split(/[,\s]+/)
+          *ENV["KUBERNETES_SERVICE_PERSISTENT_FIELDS"].to_s.split(/\s,/)
         ]
       end
     end

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -151,6 +151,21 @@ describe Kubernetes::Resource do
         end
       end
 
+      it "can keep persistent fields" do
+        with = ->(r) do
+          body = JSON.parse(r.body)
+          body.fetch("foo").must_equal "bar"
+          refute body["baz"]
+          true
+        end
+        template[:metadata][:annotations] = {"samson/persistent_fields": "foo"}
+        assert_request(:get, url, to_return: {body: {foo: "bar", baz: "bar"}.to_json}, times: 1) do
+          assert_request(:put, url, with: with, to_return: {body: "{}"}) do
+            resource.deploy
+          end
+        end
+      end
+
       describe "updating matchLabels" do
         before { template[:spec][:selector] = {matchLabels: {foo: "bar"}} }
 

--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -30,7 +30,7 @@ ActiveSupport::TestCase.class_eval do
   end
 
   def request_with_json(json)
-    ->(r) { p r.body; JSON.parse(r.body, symbolize_names: true) == json }
+    ->(r) { JSON.parse(r.body, symbolize_names: true) == json }
   end
 
   # TODO: prevent this getting called twice in the same test ... leads to weird bugs


### PR DESCRIPTION
now for all resources since we need it for configmaps too

@zendesk/compute 