### PR TITLE
update puma to fix vulns

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,7 +441,7 @@ GEM
     pry-stack_explorer (0.4.9.3)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    puma (4.2.1)
+    puma (4.3.1)
       nio4r (~> 2.0)
     pyu-ruby-sasl (0.0.3.3)
     rack (2.0.7)


### PR DESCRIPTION
@zendesk/compute 

```
Name: puma
Version: 4.2.1
Advisory: CVE-2019-16770
Criticality: High
URL: https://github.com/puma/puma/security/advisories/GHSA-7xx3-m584-x994
Title: Keepalive thread overload/DoS in puma
Solution: upgrade to ~> 3.12.2, >= 4.3.1
```