### PR TITLE
Prevent mystery @_touch_attr_names nil error caused by threaded execu…

### DIFF
--- a/app/jobs/csv_export_job.rb
+++ b/app/jobs/csv_export_job.rb
@@ -11,6 +11,9 @@ class CsvExportJob
     "csv-export-#{@csv_export.id}"
   end
 
+  def reload!
+  end
+
   def perform
     ActiveRecord::Base.connection_pool.with_connection do
       create_export_folder(@csv_export)

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -36,6 +36,12 @@ class JobExecution
     @repository.full_checkout = true if @stage&.full_checkout
   end
 
+  # reload instance var to avoid multithreading bug that results in @_touch_attr_names begin unset
+  # NoMethodError: undefined method `include?' for nil:NilClass
+  def reload!
+    @job = Job.find(@job.id)
+  end
+
   def perform
     @output.write('', :started)
     @start_callbacks.each(&:call)

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -399,6 +399,14 @@ describe JobExecution do
     end
   end
 
+  describe "#reload!" do
+    it "unsets instance vars" do
+      execution.job.instance_variable_set(:@_touch_attr_names, 1)
+      execution.reload!
+      refute execution.job.instance_variable_get(:@_touch_attr_names)
+    end
+  end
+
   describe "#perform" do
     delegate :perform, to: :execution
 


### PR DESCRIPTION
AR keeps track of @_touch_attr_names and it looks like we are doing 2 parallel saves which results in the instance variable being unset when doing `job.running!`

/Zendesk/Samson/items/2364
`File "app/models/job.rb" line 148 in status!`

so adding a hacky fix to hopefully get rid of that

@zendesk/compute 