### PR TITLE
Work around job save errors by using update_columns take 2

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -145,9 +145,9 @@ class Job < ActiveRecord::Base
   end
 
   def status!(status)
-    # TODO: use update_attribute instead if this hack once we figure out why it causes nil errors see #3662
+    # TODO: use update_attribute instead if this hack once we figure out why it causes nil errors see #3662 + #3664
     update_columns(status: status, updated_at: Time.now)
-    deploy&.touch # same as after_update
+    deploy&.update_column(:updated_at, Time.now) # same as after_update
 
     report_state if finished?
     true


### PR DESCRIPTION
https://github.com/zendesk/samson/pull/3664 showed that touching the deploy caused the issue

so either touching anything blows up in which case we have to revert or the deploy had the issue ...
if it is indeed the deploy then we might see strange errors further down the line, but it will either fix the issue or mean we need to load a fresh job/deploy

@zendesk/compute 