### PR TITLE
fix reversed code_deployed logic in deploy search

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -167,7 +167,7 @@ class DeploysController < ApplicationController
         stages = stages.where(project: projects)
       end
       unless code_deployed.nil?
-        stages = stages.where(no_code_deployed: param_to_bool(code_deployed))
+        stages = stages.where.not(no_code_deployed: param_to_bool(code_deployed))
       end
       unless production.nil?
         production = param_to_bool(production)

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -338,7 +338,7 @@ describe DeploysController do
 
       it "filters for code_deployed" do
         Deploy.last.stage.update_column(:no_code_deployed, true)
-        get :index, params: {search: {code_deployed: "true"}}, format: "json"
+        get :index, params: {search: {code_deployed: "false"}}, format: "json"
         assert_response :ok
         deploys["deploys"].count.must_equal 3
       end


### PR DESCRIPTION
On the deploys page, users can search by `code_deployed`. However, the associated key on the Stage is the inverse (`no_code_deployed`). 

This fixes the query to return the correct deploys


### References
- Jira link: 

### Risks
- Low. Fixes deploy search query
