### PR TITLE
show latest deploy as outbound webhook example

### DIFF
--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -147,10 +147,10 @@
     Outbound Webhooks
     <%= additional_info "POST to an external url after a deploy has finished. The request body will contain deploy, stage, and project information." %>
   </h2>
-  <% if @project.deploys.first %>
+  <% if latest_deploy = @project.deploys.first %>
     <details>
       <summary>Example payload</summary>
-      <pre><%= JSON.pretty_generate(OutboundWebhook.deploy_as_json(@project.deploys.first)) %></pre>
+      <pre><%= JSON.pretty_generate(OutboundWebhook.deploy_as_json(latest_deploy)) %></pre>
     </details>
   <% else %>
     <p>Deploy this project at least once to see a sample payload.</p>

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -147,10 +147,10 @@
     Outbound Webhooks
     <%= additional_info "POST to an external url after a deploy has finished. The request body will contain deploy, stage, and project information." %>
   </h2>
-  <% if @project.deploys.last %>
+  <% if @project.deploys.first %>
     <details>
       <summary>Example payload</summary>
-      <pre><%= JSON.pretty_generate(OutboundWebhook.deploy_as_json(@project.deploys.last)) %></pre>
+      <pre><%= JSON.pretty_generate(OutboundWebhook.deploy_as_json(@project.deploys.first)) %></pre>
     </details>
   <% else %>
     <p>Deploy this project at least once to see a sample payload.</p>


### PR DESCRIPTION
Fix the outbound webhook example payload to show the latest deploy instead of the first deploy. This is because deploys has a default order scope of descending id.

This change also addresses this rollbar: https://rollbar-us.zendesk.com/Zendesk/Samson/items/2383/ where the project webhook page won't load if the example deploy's stage does not exists


### Risks
- Low: only affects the webhook page which wasn't working for some teams
