### PR TITLE
Make global webhooks more recognizable by adding names

### DIFF
--- a/app/controllers/outbound_webhooks_controller.rb
+++ b/app/controllers/outbound_webhooks_controller.rb
@@ -56,7 +56,7 @@ class OutboundWebhooksController < ResourceController
   end
 
   def resource_params
-    allowed = [:url, :username, :password, :auth_type, :insecure, :before_deploy, :status_path, :disabled]
+    allowed = [:name, :url, :username, :password, :auth_type, :insecure, :before_deploy, :status_path, :disabled]
     allowed << :global if action_name == "create"
     permitted = super.permit(*allowed)
     permitted[:stages] = [@stage] if @stage && action_name == "create"

--- a/app/views/outbound_webhooks/_fields.html.erb
+++ b/app/views/outbound_webhooks/_fields.html.erb
@@ -1,5 +1,6 @@
 <%= render 'shared/errors', object: form.object %>
 
+<%= form.input :name, help: "For global webhooks" %>
 <%= form.input :url, required: true %>
 <%= form.input :status_path, help: "Json parse the response and poll the returned status url from this path" %>
 <%= form.input :before_deploy, as: :check_box %>

--- a/app/views/outbound_webhooks/index.html.erb
+++ b/app/views/outbound_webhooks/index.html.erb
@@ -6,6 +6,7 @@
   <table class="table table-hover table-condensed">
     <thead>
     <tr>
+      <th>Name</th>
       <th>Url</th>
       <th>Auth</th>
       <th>Global</th>
@@ -18,6 +19,7 @@
     <tbody>
     <% @outbound_webhooks.each do |outbound_webhook| %>
       <tr>
+        <td><%= outbound_webhook.name %></td>
         <td><%= outbound_webhook.url %></td>
         <td><%= outbound_webhook.auth_type %></td>
         <td><%= outbound_webhook.global ? "YES" : "-" %></td>

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -165,6 +165,7 @@
           <% outbound_webhook = outbound_webhook_stage.outbound_webhook %>
           <% disabled = outbound_webhook.disabled? %>
           <li class="<%= 'disabled' if disabled %>">
+            <%= "#{outbound_webhook.name}: " if outbound_webhook.name? %>
             POST to
             <strong><%= outbound_webhook.url %></strong>
             <%= "(no SSL)" unless outbound_webhook.ssl? %>
@@ -203,8 +204,11 @@
 
       <%= form.submit "Add", class: "btn btn-primary" %>
     <% end %>
+  </details>
 
-    <% if global_webhooks = OutboundWebhook.where(global: true).pluck(:url, :id).presence %>
+  <% if global_webhooks = OutboundWebhook.where(global: true).pluck(:name, :id).presence %>
+    <details>
+      <summary>Link global</summary>
       <%= form_for OutboundWebhook.new, url: connect_outbound_webhooks_path, html: {class: "form-horizontal"} do |form| %>
         <div class="form-group">
           <%= form.label "Global Webhook", class: "col-lg-2 control-label" %>

--- a/db/migrate/20191218163745_add_name_to_outbound_webhooks.rb
+++ b/db/migrate/20191218163745_add_name_to_outbound_webhooks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class AddNameToOutboundWebhooks < ActiveRecord::Migration[6.0]
+  class OutboundWebhook < ActiveRecord::Base
+  end
+
+  def change
+    add_column :outbound_webhooks, :name, :string
+    add_index :outbound_webhooks, :name, unique: true, length: 191
+    OutboundWebhook.reset_column_information
+    OutboundWebhook.where(global: true).each do |w|
+      w.update_column :name, w.url
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_03_085811) do
+ActiveRecord::Schema.define(version: 2019_12_18_163745) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -410,6 +410,8 @@ ActiveRecord::Schema.define(version: 2019_12_03_085811) do
     t.boolean "before_deploy", default: false, null: false
     t.string "status_path"
     t.boolean "disabled", default: false, null: false
+    t.string "name"
+    t.index ["name"], name: "index_outbound_webhooks_on_name", unique: true, length: 191
   end
 
   create_table "project_environment_variable_groups", id: :integer do |t|

--- a/test/models/outbound_webhook_test.rb
+++ b/test/models/outbound_webhook_test.rb
@@ -40,6 +40,22 @@ describe OutboundWebhook do
       webhook.auth_type = "Wut"
       refute_valid webhook
     end
+
+    it "needs a name when global" do
+      webhook.global = true
+      refute_valid webhook, :name
+    end
+
+    it "allows multiple blank names" do
+      webhook.name = ""
+      webhook.save!
+      OutboundWebhook.create!(webhook_attributes.merge(name: ""))
+    end
+
+    it "does not allow names for non-global since that leads to duplication" do
+      webhook.name = "foo"
+      refute_valid webhook, :name
+    end
   end
 
   describe "#ssl?" do


### PR DESCRIPTION
@zendesk/eng-productivity @zendesk/compute 

<img width="636" alt="Screen Shot 2019-12-18 at 10 57 41 AM" src="https://user-images.githubusercontent.com/11367/71112476-34ead080-2191-11ea-8b61-aebebd16737d.png">

<img width="602" alt="Screen Shot 2019-12-18 at 12 26 23 PM" src="https://user-images.githubusercontent.com/11367/71112678-a32f9300-2191-11ea-8a44-7914668febc5.png">

Also breaking up the Add UI since it was confusing with 2 buttons
<img width="561" alt="Screen Shot 2019-12-18 at 10 55 49 AM" src="https://user-images.githubusercontent.com/11367/71112487-39af8480-2191-11ea-9314-40707cc3d6b7.png">