### PR TITLE
bump rack to fix cve

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,7 @@ GEM
     puma (4.3.1)
       nio4r (~> 2.0)
     pyu-ruby-sasl (0.0.3.3)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-mini-profiler (0.10.2)
       rack (>= 1.2.0)
     rack-test (1.1.0)


### PR DESCRIPTION
```
Name: rack
Version: 2.0.7
Advisory: CVE-2019-16782
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-hrqr-hxpp-chr3
Title: Possible information leak / session hijack vulnerability
Solution: upgrade to ~> 1.6.12, >= 2.0.8
```
