### PR TITLE
Support JSON CRUD operations for environment variable groups

### DIFF
--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -26,7 +26,17 @@ class EnvironmentVariableGroupsController < ApplicationController
   def create
     group.attributes = attributes
     group.save!
-    redirect_to action: :index
+
+    respond_to do |format|
+      format.html { redirect_to action: :index }
+      format.json do
+        render_as_json :environment_variable_group,
+          group,
+          nil,
+          allowed_includes: allowed_includes,
+          status: :created
+      end
+    end
   end
 
   def show

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -14,9 +14,7 @@ class EnvironmentVariableGroupsController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render_as_json :environment_variable_groups, @groups, nil, allowed_includes: [
-          :environment_variables,
-        ]
+        render_as_json :environment_variable_groups, @groups, nil, allowed_includes: allowed_includes
       end
     end
   end
@@ -32,7 +30,12 @@ class EnvironmentVariableGroupsController < ApplicationController
   end
 
   def show
-    render 'form'
+    respond_to do |format|
+      format.html { render 'form' }
+      format.json do
+        render_as_json :environment_variable_group, @group, nil, allowed_includes: allowed_includes
+      end
+    end
   end
 
   def update
@@ -76,6 +79,10 @@ class EnvironmentVariableGroupsController < ApplicationController
   end
 
   private
+
+  def allowed_includes
+    [:environment_variables]
+  end
 
   def group
     @group ||= if ['new', 'create'].include?(action_name)

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -60,7 +60,10 @@ class EnvironmentVariableGroupsController < ApplicationController
 
   def destroy
     group.destroy!
-    redirect_to action: :index
+    respond_to do |format|
+      format.html { redirect_to action: :index }
+      format.json { head(:ok) }
+    end
   end
 
   def preview

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -50,7 +50,12 @@ class EnvironmentVariableGroupsController < ApplicationController
 
   def update
     group.update!(attributes)
-    redirect_to action: :index
+    respond_to do |format|
+      format.html { redirect_to action: :index }
+      format.json do
+        render_as_json :environment_variable_group, group, nil, allowed_includes: allowed_includes
+      end
+    end
   end
 
   def destroy

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -132,6 +132,26 @@ describe EnvironmentVariableGroupsController do
         assert_response :success
       end
 
+      it "renders json" do
+        get :show, params: {id: env_group.id}, format: :json
+        json = JSON.parse(response.body)
+        group = json['environment_variable_group']
+        group.keys.must_include 'name'
+        group.keys.must_include 'variable_names'
+        assert_response :success
+      end
+
+      it "renders with envionment_variables if present" do
+        get :show, params: {id: env_group.id, includes: 'environment_variables', format: :json}
+        assert_response :success
+        json = JSON.parse(response.body)
+        json.keys.must_include 'environment_variables'
+
+        group = json['environment_variable_group']
+        group.keys.must_include 'environment_variable_ids'
+        env_group.environment_variable_ids.must_equal group['environment_variable_ids']
+      end
+
       it 'disables fields if user cannot edit env group' do
         unauthorized_env_group
         get :show, params: {id: env_group.id}

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -406,6 +406,12 @@ describe EnvironmentVariableGroupsController do
         delete :destroy, params: {id: env_group.id}
         assert_response :unauthorized
       end
+
+      it 'renders json' do
+        delete :destroy, params: {id: env_group.id}, format: :json
+        assert_response :success
+        response.body.must_equal ''
+      end
     end
   end
 

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -264,18 +264,36 @@ describe EnvironmentVariableGroupsController do
     end
 
     describe "#create" do
+      let(:params) do
+        {
+          environment_variable_group: {
+            environment_variables_attributes: {'0' => {name: 'N1', value: 'V1'}},
+            name: 'G2'
+          }
+        }
+      end
+
       it "creates" do
         assert_difference "EnvironmentVariable.count", +1 do
           assert_difference "EnvironmentVariableGroup.count", +1 do
-            post :create, params: {
-              environment_variable_group: {
-                environment_variables_attributes: {"0" => {name: "N1", value: "V1"}},
-                name: "G2"
-              }
-            }
+            post :create, params: params
           end
         end
         assert_redirected_to "/environment_variable_groups"
+      end
+
+      it 'renders json' do
+        assert_difference "EnvironmentVariable.count", +1 do
+          assert_difference "EnvironmentVariableGroup.count", +1 do
+            post :create, params: params, format: :json
+          end
+        end
+        assert_response :created
+
+        json = JSON.parse(response.body)
+        group = json['environment_variable_group']
+        group.keys.must_include 'name'
+        group.keys.must_include 'variable_names'
       end
     end
 


### PR DESCRIPTION
Similar to previous contributions, i'd like to be able to perform CRUD operations on environment variable groups via a json api and this PR adds support for this

Probably this could also be cleaned up and simplified to inherit from `ResourceController` but not sure about your stance on sharing code between plugins & the main codebase and also wanted to get buy-in on the change itself first

### References
- Jira link: 

### Risks
- Low/Med/High: thing that could happen
