### PR TITLE
cleanup unused global commands to reduce stage edit size

### DIFF
--- a/.env.bootstrap
+++ b/.env.bootstrap
@@ -5,7 +5,7 @@ AUTH_GITHUB=true
 RAILS_MIN_THREADS=2
 RAILS_MAX_THREADS=10
 CACHE_STORE=memory
-PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60
+PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60,global_command_cleanup:86400
 
 # random string, do not use in live server
 bin/decode_dot_env-U0VDUkVUX1RPS0VOPWUzNzExYzc3N2I0OWE5YmE2ZjRjZDQ0NTM5ZjRjNjc3ZTc2ZjdjMDhjMzQ2ODc1ZTUwYjExMTE5YzYxODM5ZDM4NWIyNzA5ZjFmZDhhYzJkODk5YjMyZGM4MThkMTQ1OWIyNjVjZmY5MWY2ZGNjNjM1NDA2YTQ3M2NkOTAzZjRh

--- a/.env.example
+++ b/.env.example
@@ -97,8 +97,9 @@ GITLAB_TOKEN=
 # periodical_deploy:86400
 # cancel_stalled_builds:3600
 # repo_provider_status:60 (for plugins that use repo_provider_status hook, like samson_github)
+# global_command_cleanup:86400
 # Recommended setup:
-PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60
+PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60,global_command_cleanup:86400
 
 ## Buddy Check feature: deploys to production require a buddy
 # BUDDY_CHECK_FEATURE=1 # enable

--- a/app.json
+++ b/app.json
@@ -64,7 +64,7 @@
     },
     "PERIODICAL": {
       "description": "Tasks to run periodically inside the server process",
-      "value": "stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60"
+      "value": "stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:60,report_process_stats:60,periodical_deploy:86400,cancel_stalled_builds:3600,repo_provider_status:60,global_command_cleanup:86400"
     }
   },
   "scripts": {

--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -51,6 +51,16 @@ class Command < ActiveRecord::Base
     Project.pluck(:build_command_id).compact
   end
 
+  def self.cleanup_global
+    global.find_each do |command|
+      project_ids = command.usages.map { |u| u.is_a?(Project) ? u.id : u.project_id }
+      case project_ids.size
+      when 0 then command.destroy
+      when 1 then command.update_attribute(:project_id, project_ids.first)
+      end
+    end
+  end
+
   private
 
   def ensure_unused

--- a/config/initializers/audited.rb
+++ b/config/initializers/audited.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class << Audited
+  def with_username(username)
+    old = store[:audited_user]
+    store[:audited_user] = username
+    yield
+  ensure
+    store[:audited_user] = old
+  end
+end

--- a/config/initializers/periodical.rb
+++ b/config/initializers/periodical.rb
@@ -45,6 +45,10 @@ Samson::Periodical.register :repo_provider_status, "Refresh repo provider status
   Samson::RepoProviderStatus.refresh
 end
 
+Samson::Periodical.register :global_command_cleanup, "Scope global commands to projects and delete unused" do
+  Command.cleanup_global
+end
+
 if ENV['SERVER_MODE']
   Rails.application.config.after_initialize do
     Samson::Periodical.enabled = true

--- a/lib/samson/periodical.rb
+++ b/lib/samson/periodical.rb
@@ -118,7 +118,9 @@ module Samson
       end
 
       def execute_block(config)
-        config.fetch(:block).call # needs a Proc
+        Audited.with_username "Samson::Periodical" do
+          config.fetch(:block).call # needs a Proc
+        end
       end
 
       def env_settings(name)

--- a/test/lib/samson/periodical_test.rb
+++ b/test/lib/samson/periodical_test.rb
@@ -89,6 +89,14 @@ describe Samson::Periodical do
         with(instance_of(custom_error), error_message: "Samson::Periodical remove_expired_locks failed")
       Samson::Periodical.run_once(:remove_expired_locks)
     end
+
+    it "uses distinct user in audits" do
+      assert_difference "Audited::Audit.count", +1 do
+        Samson::Periodical.run_once(:global_command_cleanup)
+      end
+      Audited::Audit.last.username.must_equal "Samson::Periodical"
+      Audited.store[:audited_user].must_be_nil # unsets after
+    end
   end
 
   # starts background threads and should always shut them down


### PR DESCRIPTION
stage pages are so full with global commands ... let's cut that down a bit

only used in 1 project -> no longer global
not used -> delete (we have audits to find/restore old commands if someone still needs them)

@zendesk/compute @zendesk/eng-productivity 