### PR TITLE
PAAS-5919 allow removing kuberntes cluster from a deploy group

### DIFF
--- a/plugins/kubernetes/app/decorators/deploy_group_decorator.rb
+++ b/plugins/kubernetes/app/decorators/deploy_group_decorator.rb
@@ -16,8 +16,15 @@ DeployGroup.class_eval do
   accepts_nested_attributes_for(
     :cluster_deploy_group,
     allow_destroy: true,
-    update_only: true,
-    reject_if: ->(h) { h[:kubernetes_cluster_id].blank? }
+    reject_if: ->(h) do
+      empty = h[:kubernetes_cluster_id].blank?
+      if h[:id]
+        h[:_destroy] = true if empty # user removed cluster -> delete connection
+        false
+      else
+        empty
+      end
+    end
   )
 
   def kubernetes_namespace

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_group_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_group_form.html.erb
@@ -1,5 +1,5 @@
 <% form.object.cluster_deploy_group || form.object.build_cluster_deploy_group %>
-<%= form.fields_for :cluster_deploy_group, include_id: false do |cluster_form| %>
+<%= form.fields_for :cluster_deploy_group do |cluster_form| %>
   <%= cluster_form.input :kubernetes_cluster_id, label: "Kubernetes Cluster" do %>
     <%= cluster_form.collection_select(:kubernetes_cluster_id, Kubernetes::Cluster.all, :id, :name, { include_blank: true }, { class: 'form-control' }) %>
   <% end %>

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -37,7 +37,7 @@ Samson::Hooks.view :deploy_group_table_header, "samson_kubernetes"
 Samson::Hooks.view :deploy_group_table_cell, "samson_kubernetes"
 
 Samson::Hooks.callback :deploy_group_permitted_params do
-  {cluster_deploy_group_attributes: [:kubernetes_cluster_id, :namespace]}
+  {cluster_deploy_group_attributes: [:id, :kubernetes_cluster_id, :namespace]}
 end
 Samson::Hooks.callback(:stage_permitted_params) do
   [

--- a/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
+++ b/plugins/kubernetes/test/samson_kubernetes/samson_plugin_test.rb
@@ -28,7 +28,7 @@ describe SamsonKubernetes do
   describe :deploy_group_permitted_params do
     it "adds ours" do
       params = Samson::Hooks.fire(:deploy_group_permitted_params).flatten(1)
-      params.must_include cluster_deploy_group_attributes: [:kubernetes_cluster_id, :namespace]
+      params.must_include cluster_deploy_group_attributes: [:id, :kubernetes_cluster_id, :namespace]
     end
   end
 


### PR DESCRIPTION
Currently submitting an empty cluster is ignored by the backend

@zendesk/compute 