### PR TITLE
PAAS-5913 use server-side apply to avoid weird statefulset bugs

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -151,9 +151,13 @@ These can be configured (in seconds) using `KUBERNETES_STABILITY_CHECK_DURATION`
 
 ### StatefulSet
 
-On kubernetes <1.7 they can only be updated with `OnDelete` updateStrategy,
-which is supported by updating only the pod containers and replica count (not set metadata/annotations).
-Prefer `RollingUpdate` if possible instead.
+Prefer `spec.updateStrategy.type=RollingUpdate`
+
+### Server-side apply
+
+Set `metadata.annotation.samson/server_side_apply='true'` and use a valid template.
+This only works for kubernetes 1.16+ clusters, but will soon be the default way samson works,
+see [kubernetes docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#server-side-apply) for details.
 
 ### Duplicate deployments
 

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -60,7 +60,8 @@ module Kubernetes
           }
         ]
       end
-      # avoiding doing a .uniq on clients which might do weird stuff
+
+      # avoiding doing a .uniq on clients which might trigger api calls
       scopes.uniq.map { |group, query| [group.kubernetes_cluster.client('v1'), query] }
     end
 


### PR DESCRIPTION
@zendesk/compute 

`metadata.annotation.samson/server_side_apply='true'`

should work with all resources, we'll fix bugs as they come up ... later should be the default way samson works