### PR TITLE
use new framework defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,8 +41,8 @@ module Samson
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
-    # TODO: use 6.0 ... check migration etc
-    config.load_defaults 5.2
+    config.load_defaults 6.0
+    config.autoloader = :classic # TODO: use :zeitwerk, but that clashes with app/decorators
 
     # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
     config.force_ssl = (ENV["FORCE_SSL"] == "1")


### PR DESCRIPTION
as per https://medium.com/@dylansreile/rails-6-0-new-framework-defaults-what-they-do-and-how-to-safely-uncomment-them-586146f371e8 there seems to be nothing to risky here 🤷‍♂ 

zeitwerk did not work, but that can be it's own PR

@zendesk/compute 

### Risks
 - Medium: random errors from cookies/caching change 