### PR TITLE
make zeitwerk work by renaming plugin base class

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -156,7 +156,7 @@ class JobExecution
 
   # ideally the plugin should handle this, but that was even hackier
   def kubernetes?
-    defined?(SamsonKubernetes::Engine) && @stage&.kubernetes
+    defined?(SamsonKubernetes::SamsonPlugin) && @stage&.kubernetes
   end
 
   def setup(dir)

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,6 @@ module Samson
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     config.load_defaults 6.0
-    config.autoloader = :classic # TODO: use :zeitwerk, but that clashes with app/decorators
 
     # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
     config.force_ssl = (ENV["FORCE_SSL"] == "1")

--- a/lib/generators/plugin/templates/samson_plugin.rb.erb
+++ b/lib/generators/plugin/templates/samson_plugin.rb.erb
@@ -1,5 +1,5 @@
 module Samson<%= class_name %>
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -113,7 +113,7 @@ module Samson
       end
 
       def engine
-        @engine ||= Kernel.const_get("::Samson#{@name.camelize}::Engine")
+        @engine ||= Kernel.const_get("::Samson#{@name.camelize}::SamsonPlugin")
       end
 
       private
@@ -133,7 +133,7 @@ module Samson
     class << self
       def plugins
         @plugins ||= begin
-          Gem.find_files("*/samson_plugin.rb").
+          Gem.find_files("samson_*/samson_plugin.rb").
             map { |path| Plugin.new(path) }.
             select { |p| active_plugin?(p.name) }.
             sort_by(&:name)

--- a/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
+++ b/plugins/airbrake/lib/samson_airbrake/samson_plugin.rb
@@ -3,7 +3,7 @@
 require 'airbrake'
 
 module SamsonAirbrake
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
     def self.exception_debug_info(notice)
       return unless notice
       return 'Airbrake did not return an error id' unless id = notice['id']
@@ -14,7 +14,7 @@ end
 
 Samson::Hooks.callback :error do |exception, sync: false, **options|
   if sync
-    SamsonAirbrake::Engine.exception_debug_info(Airbrake.notify_sync(exception, options))
+    SamsonAirbrake::SamsonPlugin.exception_debug_info(Airbrake.notify_sync(exception, options))
   else
     Airbrake.notify(exception, options)
   end

--- a/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
+++ b/plugins/airbrake/test/samson_airbrake/samson_plugin_test.rb
@@ -8,15 +8,15 @@ describe SamsonAirbrake do
   describe '.exception_debug_info' do
     it 'returns error debug info' do
       notice = {'id' => '1'}
-      SamsonAirbrake::Engine.exception_debug_info(notice).must_equal 'Error https://airbrake.io/locate/1'
+      SamsonAirbrake::SamsonPlugin.exception_debug_info(notice).must_equal 'Error https://airbrake.io/locate/1'
     end
 
     it 'returns nil if airbrake fails' do
-      SamsonAirbrake::Engine.exception_debug_info(nil).must_be_nil
+      SamsonAirbrake::SamsonPlugin.exception_debug_info(nil).must_be_nil
     end
 
     it 'returns airbrake id error if there is no id' do
-      SamsonAirbrake::Engine.exception_debug_info({}).must_equal 'Airbrake did not return an error id'
+      SamsonAirbrake::SamsonPlugin.exception_debug_info({}).must_equal 'Airbrake did not return an error id'
     end
   end
 
@@ -25,7 +25,7 @@ describe SamsonAirbrake do
       mock_notice = mock
       mock_exception = mock
       Airbrake.expects(:notify_sync).with(mock_exception, foo: 'bar').once.returns(mock_notice)
-      SamsonAirbrake::Engine.expects(:exception_debug_info).with(mock_notice).once
+      SamsonAirbrake::SamsonPlugin.expects(:exception_debug_info).with(mock_notice).once
 
       Samson::Hooks.only_callbacks_for_plugin('airbrake', :error) do
         Samson::Hooks.fire(:error, mock_exception, foo: 'bar', sync: true)

--- a/plugins/airbrake_hook/lib/samson_airbrake_hook/samson_plugin.rb
+++ b/plugins/airbrake_hook/lib/samson_airbrake_hook/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonAirbrakeHook
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   class Notification

--- a/plugins/airbrake_hook/test/samson_airbrake_hook/samson_plugin_test.rb
+++ b/plugins/airbrake_hook/test/samson_airbrake_hook/samson_plugin_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 
 SingleCov.covered!
 
-describe SamsonAirbrakeHook::Engine do
+describe SamsonAirbrakeHook::SamsonPlugin do
   describe :after_deploy do
     def notify
       Samson::Hooks.fire :after_deploy, deploy, stub(output: nil)

--- a/plugins/assertible/lib/samson_assertible/samson_plugin.rb
+++ b/plugins/assertible/lib/samson_assertible/samson_plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SamsonAssertible
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   class Notification

--- a/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
+++ b/plugins/aws_ecr/lib/samson_aws_ecr/samson_plugin.rb
@@ -2,7 +2,7 @@
 require 'aws-sdk-ecr'
 
 module SamsonAwsEcr
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
     AMAZON_REGISTRY = /\A.*\.dkr.ecr.([\w\-]+).amazonaws.com\z/.freeze
 
     class << self
@@ -64,6 +64,6 @@ end
 # need credentials to pull (via Dockerfile FROM) and push images
 # ATM this only authenticates the default docker registry and not any extra registries
 Samson::Hooks.callback :before_docker_repository_usage do |build|
-  SamsonAwsEcr::Engine.ensure_repositories(build)
-  SamsonAwsEcr::Engine.refresh_credentials
+  SamsonAwsEcr::SamsonPlugin.ensure_repositories(build)
+  SamsonAwsEcr::SamsonPlugin.refresh_credentials
 end

--- a/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
+++ b/plugins/aws_ecr/test/samson_aws_ecr/samson_plugin_test.rb
@@ -3,9 +3,9 @@ require_relative '../test_helper'
 
 SingleCov.covered! uncovered: 2
 
-describe SamsonAwsEcr::Engine do
+describe SamsonAwsEcr::SamsonPlugin do
   def clear_client
-    SamsonAwsEcr::Engine.instance_variable_set(:@ecr_clients, nil)
+    SamsonAwsEcr::SamsonPlugin.instance_variable_set(:@ecr_clients, nil)
   end
 
   let(:stage) { stages(:test_staging) }
@@ -42,7 +42,7 @@ describe SamsonAwsEcr::Engine do
 
     run_inside_of_temp_directory
 
-    before { SamsonAwsEcr::Engine.stubs(:ecr_client).returns(ecr_client) }
+    before { SamsonAwsEcr::SamsonPlugin.stubs(:ecr_client).returns(ecr_client) }
 
     describe '.refresh_credentials' do
       it "changes the username and password" do
@@ -138,7 +138,7 @@ describe SamsonAwsEcr::Engine do
     it 'is caches' do
       assert_request(:get, %r{/latest/meta-data/iam/security-credentials/}, times: 3) do
         Array.new(2).map do
-          SamsonAwsEcr::Engine.send(:ecr_client, DockerRegistry.first).object_id
+          SamsonAwsEcr::SamsonPlugin.send(:ecr_client, DockerRegistry.first).object_id
         end.uniq.size.must_equal 1
       end
     end
@@ -147,12 +147,12 @@ describe SamsonAwsEcr::Engine do
   describe '.active?' do
     it "is inactive when not on ecr" do
       DockerRegistry.first.instance_variable_get(:@uri).host = 'xyz.com'
-      refute SamsonAwsEcr::Engine.active?
+      refute SamsonAwsEcr::SamsonPlugin.active?
     end
 
     it "is active when on ecr" do
       assert_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/", times: 3) do
-        assert SamsonAwsEcr::Engine.active?
+        assert SamsonAwsEcr::SamsonPlugin.active?
       end
     end
   end

--- a/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
+++ b/plugins/aws_sts/lib/samson_aws_sts/samson_plugin.rb
@@ -5,7 +5,7 @@ module SamsonAwsSts
   SESSION_DURATION_MIN = 900 # 15 minutes
   SESSION_DURATION_MAX = [SESSION_DURATION_MIN, Rails.application.config.samson.deploy_timeout].max
 
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   def self.sts_client

--- a/plugins/datadog/lib/samson_datadog/samson_plugin.rb
+++ b/plugins/datadog/lib/samson_datadog/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonDatadog
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   class << self

--- a/plugins/datadog_tracer/lib/samson_datadog_tracer/samson_plugin.rb
+++ b/plugins/datadog_tracer/lib/samson_datadog_tracer/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonDatadogTracer
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   class << self

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -9,7 +9,7 @@ module SamsonEnv
     </ul>
   TEXT
 
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   class << self

--- a/plugins/flowdock/lib/samson_flowdock/samson_plugin.rb
+++ b/plugins/flowdock/lib/samson_flowdock/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonFlowdock
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/gcloud/lib/samson_gcloud/samson_plugin.rb
+++ b/plugins/gcloud/lib/samson_gcloud/samson_plugin.rb
@@ -7,7 +7,7 @@ module SamsonGcloud
   SCAN_WAIT_PERIOD = 10.minutes
   SCAN_SLEEP_PERIOD = 5.seconds
 
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   class << self

--- a/plugins/github/lib/samson_github/samson_plugin.rb
+++ b/plugins/github/lib/samson_github/samson_plugin.rb
@@ -5,7 +5,7 @@ module SamsonGithub
   # however 'https://www.githubstatus.com' also works
   STATUS_URL = ENV["GITHUB_STATUS_URL"] || 'https://www.githubstatus.com'
 
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/gitlab/lib/samson_gitlab/samson_plugin.rb
+++ b/plugins/gitlab/lib/samson_gitlab/samson_plugin.rb
@@ -3,7 +3,7 @@ require 'gitlab'
 require 'git_diff_parser'
 
 module SamsonGitlab
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
     Gitlab.configure do |config|
       config.endpoint = "#{Rails.application.config.samson.gitlab.web_url}/api/v4"
       config.private_token = ENV['GITLAB_TOKEN']

--- a/plugins/jenkins/lib/samson_jenkins/samson_plugin.rb
+++ b/plugins/jenkins/lib/samson_jenkins/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonJenkins
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/jenkins_status_checker/lib/samson_jenkins_status_checker/samson_plugin.rb
+++ b/plugins/jenkins_status_checker/lib/samson_jenkins_status_checker/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonJenkinsStatusChecker
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/jira/lib/samson_jira/samson_plugin.rb
+++ b/plugins/jira/lib/samson_jira/samson_plugin.rb
@@ -3,7 +3,7 @@
 require 'base64'
 
 module SamsonJira
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   def self.jira_base_url

--- a/plugins/kubernetes/app/controllers/kubernetes/clusters_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/clusters_controller.rb
@@ -21,7 +21,7 @@ class Kubernetes::ClustersController < ResourceController
   end
 
   def seed_ecr
-    SamsonAwsEcr::Engine.refresh_credentials
+    SamsonAwsEcr::SamsonPlugin.refresh_credentials
     @kubernetes_cluster.namespaces.each do |namespace|
       update_secret namespace
     end

--- a/plugins/kubernetes/app/views/kubernetes/clusters/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/_form.html.erb
@@ -39,7 +39,7 @@
       </div>
 
       <%= form.actions delete: true do %>
-        <% if Samson::Hooks.active_plugin?('aws_ecr') && SamsonAwsEcr::Engine.active? && @kubernetes_cluster.persisted? %>
+        <% if Samson::Hooks.active_plugin?('aws_ecr') && SamsonAwsEcr::SamsonPlugin.active? && @kubernetes_cluster.persisted? %>
           <%= link_to "Seed ECR", seed_ecr_kubernetes_cluster_path(@kubernetes_cluster), class: "btn btn-default", data: {method: :post} %>
         <% end %>
       <% end %>

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SamsonKubernetes
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
     initializer "refinery.assets.precompile" do |app|
       app.config.assets.precompile.append %w[kubernetes/icon.png]
     end

--- a/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
@@ -65,7 +65,7 @@ describe Kubernetes::ClustersController do
       let(:secrets_url) { "http://foobar.server/api/v1/namespaces/foobar/secrets" }
 
       before do
-        SamsonAwsEcr::Engine.expects(:refresh_credentials)
+        SamsonAwsEcr::SamsonPlugin.expects(:refresh_credentials)
         DockerRegistry.first.username = 'user'
         DockerRegistry.first.password = 'pass'
       end
@@ -99,7 +99,7 @@ describe Kubernetes::ClustersController do
       end
 
       it "renders when ECR plugin is active" do
-        SamsonAwsEcr::Engine.expects(:active?).returns(true)
+        SamsonAwsEcr::SamsonPlugin.expects(:active?).returns(true)
         get :new
         assert_template :new
       end

--- a/plugins/ledger/lib/samson_ledger/samson_plugin.rb
+++ b/plugins/ledger/lib/samson_ledger/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonLedger
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/new_relic/lib/samson_new_relic/samson_plugin.rb
+++ b/plugins/new_relic/lib/samson_new_relic/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonNewRelic
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   def self.find_api_key

--- a/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
+++ b/plugins/pipelines/lib/samson_pipelines/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonPipelines
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   class << self

--- a/plugins/prerequisite_stages/lib/samson_prerequisite_stages/samson_plugin.rb
+++ b/plugins/prerequisite_stages/lib/samson_prerequisite_stages/samson_plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SamsonPrerequisiteStages
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 
   def self.validate_deployed_to_all_prerequisite_stages(stage, reference, commit)

--- a/plugins/prerequisite_stages/test/samson_prerequisite_stages/samson_plugin_test.rb
+++ b/plugins/prerequisite_stages/test/samson_prerequisite_stages/samson_plugin_test.rb
@@ -17,7 +17,7 @@ describe SamsonPrerequisiteStages do
     deploy.project.stubs(:repo_commit_from_ref).with(stage2.deploys.first.reference).returns(production_commit)
   end
 
-  describe SamsonPrerequisiteStages::Engine do
+  describe SamsonPrerequisiteStages::SamsonPlugin do
     describe '.validate_deployed_to_all_prerequisite_stages' do
       it 'shows unmet prerequisite stages' do
         stage1.expects(:undeployed_prerequisite_stages).with(staging_commit).returns([stage2])

--- a/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
+++ b/plugins/rollbar/lib/samson_rollbar/samson_plugin.rb
@@ -4,7 +4,7 @@ require 'rollbar'
 require 'rollbar/user_informer'
 
 module SamsonRollbar
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/rollbar_dashboards/lib/samson_rollbar_dashboards/samson_plugin.rb
+++ b/plugins/rollbar_dashboards/lib/samson_rollbar_dashboards/samson_plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SamsonRollbarDashboards
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
     config.assets.precompile.append ['rollbar_dashboards/icon.png', 'rollbar_dashboards/deploy_dashboard.js']
   end
 

--- a/plugins/rollbar_hook/lib/samson_rollbar_hook/samson_plugin.rb
+++ b/plugins/rollbar_hook/lib/samson_rollbar_hook/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonRollbarHook
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/slack_app/lib/samson_slack_app/samson_plugin.rb
+++ b/plugins/slack_app/lib/samson_slack_app/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonSlackApp
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/slack_webhooks/lib/samson_slack_webhooks/samson_plugin.rb
+++ b/plugins/slack_webhooks/lib/samson_slack_webhooks/samson_plugin.rb
@@ -2,7 +2,7 @@
 require 'faraday'
 
 module SamsonSlackWebhooks
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 

--- a/plugins/zendesk/lib/samson_zendesk/samson_plugin.rb
+++ b/plugins/zendesk/lib/samson_zendesk/samson_plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module SamsonZendesk
-  class Engine < Rails::Engine
+  class SamsonPlugin < Rails::Engine
   end
 end
 


### PR DESCRIPTION
All plugins had to rename their engine too ... this will break existing plugins, but at least it won't be silent ... they can stay backwards compatible by defining both the Engine and the SamsonPlugin

@zendesk/compute 