### PR TITLE
Use resource discovery endpoint to determine namespaced kinds

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -5,32 +5,6 @@ module Kubernetes
     # not perfect since the actual rules are stricter
     VALID_LABEL_VALUE = /\A[a-zA-Z0-9]([-a-zA-Z0-9.]*[a-zA-Z0-9])?\z/.freeze # also used in js ... cannot use /i
 
-    # TODO: lookup dynamically
-    NAMESPACELESS_KINDS = [
-      'ComponentStatus',
-      'Namespace',
-      'Node',
-      'PersistentVolume',
-      'MutatingWebhookConfiguration',
-      'ValidatingWebhookConfiguration',
-      'CustomResourceDefinition',
-      'APIService',
-      'TokenReview',
-      'SelfSubjectAccessReview',
-      'SelfSubjectRulesReview',
-      'SubjectAccessReview',
-      'CertificateSigningRequest',
-      'PodSecurityPolicy',
-      'NodeMetrics',
-      'PodSecurityPolicy',
-      'ClusterRoleBinding',
-      'ClusterRole',
-      'PriorityClass',
-      'StorageClass',
-      'VolumeAttachment',
-      'ImageSecurityPolicy'
-    ].freeze
-
     # for non-namespace deployments: names that should not be changed since they will break dependencies
     IMMUTABLE_NAME_KINDS = [
       'APIService', 'CustomResourceDefinition', 'ConfigMap', 'Role', 'ClusterRole', 'Namespace', 'PodSecurityPolicy',

--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -116,12 +116,6 @@ module Kubernetes
     def validate_namespace
       return unless namespace = @project&.kubernetes_namespace&.name
 
-      @elements.each do |e|
-        if NAMESPACELESS_KINDS.include?(e[:kind]) && e.dig(:metadata, :namespace)
-          @errors << "Do not set namespace for #{e[:kind]}"
-        end
-      end
-
       namespaces = []
       @elements.each { |e| namespaces << e.dig(:metadata, :namespace) if e[:metadata].key?(:namespace) }
       namespaces.uniq!

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -22,7 +22,7 @@ module Kubernetes
         kind = template[:kind]
 
         set_via_env_json
-        set_namespace if namespaced_kind?(kind)
+        set_namespace
         set_project_labels if template.dig(:metadata, :annotations, :"samson/override_project_label")
         set_deploy_url
 
@@ -234,7 +234,13 @@ module Kubernetes
 
     # assumed to be validated by role_validator
     def set_namespace
-      return if template[:metadata].key?(:namespace)
+      namespace_needed = !!namespaced_kind?(template[:kind])
+      namespace_set = !!template.dig(:metadata, :namespace)
+      return if namespace_set == namespace_needed
+
+      if namespace_set && !namespace_needed
+        raise Samson::Hooks::UserError, "#{template[:kind]} should not have a namespace"
+      end
       template[:metadata][:namespace] = project.kubernetes_namespace&.name || @doc.deploy_group.kubernetes_namespace
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -22,7 +22,7 @@ module Kubernetes
         kind = template[:kind]
 
         set_via_env_json
-        set_namespace unless Kubernetes::RoleValidator::NAMESPACELESS_KINDS.include? kind
+        set_namespace if namespaced_kind?(kind)
         set_project_labels if template.dig(:metadata, :annotations, :"samson/override_project_label")
         set_deploy_url
 
@@ -84,6 +84,20 @@ module Kubernetes
     end
 
     private
+
+    def namespaced_kind?(kind)
+      cluster = @doc.deploy_group.kubernetes_cluster
+      api_version = template.fetch(:apiVersion)
+
+      resources = Rails.cache.fetch(["template-filler-resources", api_version, cluster]) do
+        # TODO: don't use private API - https://github.com/abonas/kubeclient/issues/428
+        cluster.client(api_version).send(:fetch_entities)
+      end
+
+      resource = resources["resources"].find { |r| r["kind"] == kind } ||
+        raise(Samson::Hooks::UserError, "Cluster \"#{cluster.name}\" does not support #{api_version} #{kind}")
+      resource.fetch("namespaced")
+    end
 
     def set_via_env_json
       data = {}

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -131,12 +131,12 @@ describe Kubernetes::ReleaseDoc do
         end
 
         it "adds when first is not a Deployment" do
-          template.unshift(kind: "ConfigMap", metadata: {})
+          template.unshift(apiVersion: "v1", kind: "ConfigMap", metadata: {})
           create!.resource_template[3][:spec][:minAvailable].must_equal 1
         end
 
         it "ignores when there is no deployment" do
-          template.replace([{kind: "ConfigMap", metadata: {}}])
+          template.replace([{apiVersion: "v1", kind: "ConfigMap", metadata: {}}])
           refute create!.resource_template[1]
         end
 

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -340,12 +340,6 @@ describe Kubernetes::RoleValidator do
         errors.must_equal ["Only use configured namespace \"test\", not [nil]"]
       end
 
-      it "fails when namespace is set on namespace-less kind" do
-        role[0][:kind] = "CustomResourceDefinition"
-        role[0][:metadata][:namespace] = "test"
-        errors.must_equal ["Do not set namespace for CustomResourceDefinition"]
-      end
-
       describe "with invalid namespace" do
         before { role[0][:metadata][:namespace] = "bar" }
 

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -117,7 +117,8 @@ class ActiveSupport::TestCase
         {"name" => "replicasets/scale", "namespaced" => true, "kind" => "Scale"},
         {"name" => "replicasets/status", "namespaced" => true, "kind" => "ReplicaSet"},
         {"name" => "replicationcontrollers", "namespaced" => true, "kind" => "ReplicationControllerDummy"},
-        {"name" => "replicationcontrollers/scale", "namespaced" => true, "kind" => "Scale"}
+        {"name" => "replicationcontrollers/scale", "namespaced" => true, "kind" => "Scale"},
+        {"name" => "statefulsets", "namespaced" => true, "kind" => "StatefulSet"}
       ]
     },
     "batch/v1" => {
@@ -154,13 +155,13 @@ class ActiveSupport::TestCase
     "apiregistration.k8s.io/v1beta1" => {
       "kind" => "APIResourceList",
       "resources" => [
-        {"name" => "apiservices", "namespaced" => true, "kind" => "APIService"}
+        {"name" => "apiservices", "namespaced" => false, "kind" => "APIService"}
       ]
     },
     "apiextensions.k8s.io/v1beta1" => {
       "kind" => "APIResourceList",
       "resources" => [
-        {"name" => "customresourcedefinitions", "namespaced" => true, "kind" => "CustomResourceDefinition"}
+        {"name" => "customresourcedefinitions", "namespaced" => false, "kind" => "CustomResourceDefinition"}
       ]
     },
     "rbac.authorization.k8s.io/v1" => {
@@ -170,6 +171,13 @@ class ActiveSupport::TestCase
         {"name" => "clusterroles", "namespaced" => false, "kind" => "ClusterRole"},
         {"name" => "rolebindings", "namespaced" => true, "kind" => "RoleBinding"},
         {"name" => "roles", "namespaced" => true, "kind" => "Role"}
+      ]
+    },
+    # example of custom, deployment-like CRDs
+    "zendesk.com/v1alpha1" => {
+      "kind" => "APIResourceList",
+      "resources" => [
+        {"name" => "shardeddeployments", "namespaced" => true, "kind" => "ShardedDeployment"}
       ]
     }
   }.freeze


### PR DESCRIPTION
Use resource discovery endpoint to determine namespaced kinds, allowing namespaceless Custom Resources to work correctly (that currently return 404s since they are not known).

### References
https://zendesk.atlassian.net/browse/PAAS-5276

### Risks
- Low: could break existing deployments expecting previous namespace behaviour
