### PR TITLE
Fix deploy executor sum error

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -220,6 +220,10 @@ module Kubernetes
       end
     end
 
+    def sum_event_group(event_group)
+      event_group.sum { |e| e.fetch(:count, 0) }
+    end
+
     # show what happened in kubernetes internally since we might not have any logs
     # reloading the events so we see things added during+after pod restart
     def print_events(status)
@@ -228,7 +232,7 @@ module Kubernetes
 
       groups = events.group_by { |e| [e[:type], e[:reason], (e[:message] || "").split("\n").sort] }
       groups.each do |_, event_group|
-        count = event_group.sum { |e| e[:count] }
+        count = sum_event_group(event_group)
         counter = " x#{count}" if count != 1
         e = event_group.first
         @output.puts "  #{e[:type]} #{e[:reason]}: #{e[:message]}#{counter}"

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -960,6 +960,34 @@ describe Kubernetes::DeployExecutor do
     end
   end
 
+  describe "#sum_event_group" do
+    context "when counts are present" do
+      let(:events) do
+        [
+          {count: 1},
+          {count: 2}
+        ]
+      end
+
+      it "sums the counts in the event_group" do
+        executor.send(:sum_event_group, events).must_equal 3
+      end
+    end
+
+    context "when counts are missing" do
+      let(:events) do
+        [
+          {},
+          {}
+        ]
+      end
+
+      it "returns 0" do
+        executor.send(:sum_event_group, events).must_equal 0
+      end
+    end
+  end
+
   describe "#show_logs_on_deploy_if_requested" do
     it "prints errors but continues to not block the deploy" do
       Kubernetes::DeployExecutor.any_instance.stubs(:build_selectors).returns([])


### PR DESCRIPTION
/cc  @zendesk/compute @Tavio @saikambaiyyagari

* Attempted fix for https://rollbar-us.zendesk.com/Zendesk/Samson/items/2276

Which is currently causing Classic deploys to fail in `pod999`:
  https://samson.zende.sk/projects/zendesk/stages/pod-999-kubernetes
<img width="1111" alt="Screen Shot 2019-12-30 at 12 13 51" src="https://user-images.githubusercontent.com/49626717/71565011-e8db4c80-2afd-11ea-8d9c-e25d96dbd129.png">

There's probably an underlying cause to those deployment failures, but we're thinking that this exception is hiding them from us.

### References
- Jira link: 

### Risks
- Low/Med/High: thing that could happen
