### PR TITLE
allow force update when updating fields is forbidden

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -303,6 +303,7 @@ To enable this functionality, set the environment variable `ISTIO_INJECTION_SUPP
 ### Forcing updates when kubernetes cannot change a resource
 
 Delete old resource and create new when an update fails because it `cannot change` a resources.
+(Should not be used with `persistentVolumeReclaimPolicy` set to `Delete`)
 
 ```
 metadata.annotation.samson/force_update: "true"

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -170,10 +170,10 @@ module Kubernetes
         end
         expire_resource_cache
       rescue Samson::Hooks::UserError => e
-        raise unless e.message.include?("cannot change")
+        raise unless e.message.match?(/cannot change|Forbidden: updates to .* for fields other than/)
 
         path = [:metadata, :annotations, :"samson/force_update"]
-        if @template.dig(*path)
+        if @template.dig(*path) == "true"
           delete
           create
         else


### PR DESCRIPTION
now that we use RollingUpdate on Statefulset the "not allowed" error popped back up with a new error message ... so adding it to the list of ignores

once saw this error when delete/create was too fast, but it's easy to just press redeploy 🤷‍♂ 

```
[18:37:13]   Warning FailedCreate: create Pod example-server-0 in StatefulSet example-server failed error: The POST operation against Pod could not be completed at this time, please try again. x4
```
(the error will resolve itself since the StatefulSet keeps trying to re-create it's pods)

