### PR TITLE
filter by pods uid so pods that do not change their name like a state…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -21,6 +21,10 @@ module Kubernetes
         @client = client
       end
 
+      def uid
+        @pod.dig(:metadata, :uid)
+      end
+
       def live?
         completed? || (phase == 'Running' && ready?)
       end

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -78,6 +78,7 @@ module Kubernetes
         "involvedObject.name=#{name}",
         "involvedObject.kind=#{@kind}",
       ]
+      selector << "involvedObject.uid=#{@pod.uid}" if @pod
       selector << "type=#{type}" if type
       SamsonKubernetes.retry_on_connection_errors do
         events = @client.get_events(

--- a/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/api/pod_test.rb
@@ -14,7 +14,8 @@ describe Kubernetes::Api::Pod do
         labels: {
           deploy_group_id: '123',
           role_id: '234',
-        }
+        },
+        uid: '123'
       },
       status: {
         phase: "Running",
@@ -46,6 +47,12 @@ describe Kubernetes::Api::Pod do
   end
   let(:event) { {metadata: {creationTimestamp: start_time}, type: 'Normal'} }
   let(:events) { [event] }
+
+  describe "#uid" do
+    it "returns" do
+      pod.uid.must_equal '123'
+    end
+  end
 
   describe "#live?" do
     it "is done" do


### PR DESCRIPTION
…fulset do not find old errors

we had a deploy always fail because the previous deploy had error events for the same pod name

we already had `events.select! { |e| last_timestamp(e) >= @start }` but the previous pod kept running for a while because the statefulset took a minute to kill the previous generation of pods

@zendesk/compute 