### PR TITLE
Show actual github user in warning message

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -326,7 +326,7 @@ class Project < ActiveRecord::Base
     return if ReleaseService.new(self).can_release?
     errors.add(
       :release_branch,
-      "could not be set. Samson's github user needs 'Write' permission to push new tags to #{repository_path}."
+      "could not be set. Add github user 'Deploy' with 'Write' permission to push new tags to #{repository_path}."
     )
   end
 


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

* Add description
* Add screenshots when changing the UI
* Add unit tests

### References
- Jira link: 

### Risks
- Low/Med/High: thing that could happen
