### PR TITLE
do not crash when reverting with server-side-apply

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -34,7 +34,7 @@ module Kubernetes
 
     class Base
       TICK = 2 # seconds
-      UNSETTABLE_METADATA = [:selfLink, :uid, :resourceVersion, :generation, :creationTimestamp].freeze
+      UNSETTABLE_METADATA = [:selfLink, :uid, :resourceVersion, :generation, :creationTimestamp, :managedFields].freeze
       attr_reader :template, :deploy_group
 
       def initialize(template, deploy_group, autoscaled:, delete_resource:)


### PR DESCRIPTION
atm always fails with `[20:53:51] FAILED: Kubernetes error example-server default Minikube: metadata.managedFields must be nil
`

should also fix not being able to revert when a deployment was edited with kubectl

@zendesk/compute 

### Risks
 - None