### PR TITLE
update mini-profiler so it does not show raw html

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,7 +465,7 @@ GEM
       nio4r (~> 2.0)
     pyu-ruby-sasl (0.0.3.3)
     rack (2.0.8)
-    rack-mini-profiler (0.10.2)
+    rack-mini-profiler (1.1.4)
       rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)


### PR DESCRIPTION
dev only ... before it just spewed raw html

<img width="148" alt="Screen Shot 2020-01-06 at 1 06 53 PM" src="https://user-images.githubusercontent.com/11367/71849000-d759ed80-3085-11ea-9d54-9ed21c2c313b.png">

@zendesk/compute 

### Risks
 - None