### PR TITLE
Fix readonly mode not working on update_columns

### DIFF
--- a/lib/samson/readonly_db.rb
+++ b/lib/samson/readonly_db.rb
@@ -4,30 +4,46 @@
 # NOTE: not perfect and can be circumvented with multiline sql statements or `;`
 module Samson
   module ReadonlyDb
+    module ReadonlyEnforcer
+      # mysql, sqlite, postgres
+      [:execute, :exec_query, :execute_and_clear].each do |method|
+        eval <<~RUBY, nil, __FILE__, __LINE__ + 1 # rubocop:disable Security/Eval
+          def #{method}(sql, *)
+            Samson::ReadonlyDb.check_sql(sql)
+            super
+          end
+        RUBY
+      end
+    end
+
     ALLOWED = ["SELECT ", "SHOW ", "SET  @@SESSION.", "SET NAMES", "EXPLAIN ", "PRAGMA "].freeze
     PROMPT_CHANGE = ["(", "(readonly "].freeze
     PROMPTS = [:PROMPT_I, :PROMPT_N].freeze
 
     class << self
       def enable
-        return if @subscriber
-        @subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-          sql = payload.fetch(:sql)
-          next if sql.lstrip.start_with?(*ALLOWED)
-          raise ActiveRecord::ReadOnlyRecord, <<~MSG
-            Database is in readonly mode, cannot execute query
-            Switch off readonly with #{self}.#{method(:disable).name}
-            #{sql}
-          MSG
+        return if @enabled
+
+        if @enabled.nil? # only add patch on first enable
+          ActiveRecord::Base.connection.class.prepend(ReadonlyEnforcer)
         end
+
+        @enabled = true
         update_prompt
       end
 
       def disable
-        return unless @subscriber
-        ActiveSupport::Notifications.unsubscribe @subscriber
-        @subscriber = nil
+        @enabled = false
         update_prompt
+      end
+
+      def check_sql(sql)
+        return if !@enabled || sql.lstrip.start_with?(*ALLOWED)
+        raise ActiveRecord::ReadOnlyRecord, <<~MSG
+          Database is in readonly mode, cannot execute query
+          Switch off readonly with Samson::ReadonlyDb.disable
+          #{sql}
+        MSG
       end
 
       private
@@ -40,7 +56,7 @@ module Samson
 
         PROMPTS.each do |prompt_key|
           value = prompt.fetch(prompt_key) # change marco-polo prompt
-          change = (@subscriber ? PROMPT_CHANGE : PROMPT_CHANGE.reverse)
+          change = (@enabled ? PROMPT_CHANGE : PROMPT_CHANGE.reverse)
           value.sub!(*change) || raise("Unable to change prompt #{prompt_key} #{value.inspect}")
         end
         nil

--- a/test/lib/samson/readonly_db_test.rb
+++ b/test/lib/samson/readonly_db_test.rb
@@ -20,14 +20,24 @@ describe Samson::ReadonlyDb do
       end
     end
 
+    it "blocks low-level write when enabled" do
+      Samson::ReadonlyDb.enable
+      assert_raises(ActiveRecord::ReadOnlyRecord) do
+        User.first.update_column :name, "Nope"
+      end
+      User.first.name.must_equal "Viewer"
+    end
+
     it "allows read queries when enable" do
       Samson::ReadonlyDb.enable
       User.first!
     end
 
     it "does not add 2 hooks when enabling twice" do
-      ActiveSupport::Notifications.expects(:subscribe).times(1).returns(1)
-      2.times { Samson::ReadonlyDb.enable }
+      Samson::ReadonlyDb.enable
+      refute_difference "ActiveRecord::Base.connection.class.ancestors.size" do
+        Samson::ReadonlyDb.enable
+      end
     end
 
     it "changes the prompt by in-place modifying" do


### PR DESCRIPTION
previously it would say "this is blocked" but not actually block it
@zendesk/compute 

### Risks
 - Low: only active on console