### PR TITLE
prevent writing from console builtin rails helper

### DIFF
--- a/lib/samson/readonly_db.rb
+++ b/lib/samson/readonly_db.rb
@@ -1,52 +1,40 @@
 # frozen_string_literal: true
 
 # Make Activerecord readonly by blocking write requests
-# NOTE: not perfect and can be circumvented with multiline sql statements or `;`
 module Samson
   module ReadonlyDb
-    module ReadonlyEnforcer
-      # mysql, sqlite, postgres
-      [:execute, :exec_query, :execute_and_clear].each do |method|
-        eval <<~RUBY, nil, __FILE__, __LINE__ + 1 # rubocop:disable Security/Eval
-          def #{method}(sql, *)
-            Samson::ReadonlyDb.check_sql(sql)
-            super
-          end
-        RUBY
-      end
-    end
-
-    ALLOWED = ["SELECT ", "SHOW ", "SET  @@SESSION.", "SET NAMES", "EXPLAIN ", "PRAGMA "].freeze
     PROMPT_CHANGE = ["(", "(readonly "].freeze
     PROMPTS = [:PROMPT_I, :PROMPT_N].freeze
 
+    module ErrorInformer
+      def initialize(message)
+        message += "\nSwitch off readonly with Samson::ReadonlyDb.disable" if Samson::ReadonlyDb.enabled?
+        super
+      end
+    end
+
     class << self
       def enable
-        return if @enabled
-
-        if @enabled.nil? # only add patch on first enable
-          ActiveRecord::Base.connection.class.prepend(ReadonlyEnforcer)
-        end
-
-        @enabled = true
-        update_prompt
+        ActiveRecord::ReadOnlyError.prepend ErrorInformer if @enabled.nil?
+        toggle true
       end
 
       def disable
-        @enabled = false
-        update_prompt
+        toggle false
       end
 
-      def check_sql(sql)
-        return if !@enabled || sql.lstrip.start_with?(*ALLOWED)
-        raise ActiveRecord::ReadOnlyRecord, <<~MSG
-          Database is in readonly mode, cannot execute query
-          Switch off readonly with Samson::ReadonlyDb.disable
-          #{sql}
-        MSG
+      def enabled?
+        @enabled
       end
 
       private
+
+      def toggle(to)
+        return if !!@enabled == to
+        @enabled = to
+        ActiveRecord::Base.connection_handler.prevent_writes = to
+        update_prompt
+      end
 
       # TODO: modify normal prompt when marco-polo is not enabled
       # TODO: pry support


### PR DESCRIPTION
much cleaner and hopefully less edge-cases :)

found via https://blog.saeloun.com/2019/12/10/rails-block-writes-to-database-connection-while-prevent-writes

@zendesk/compute
/cc @alkesh26