### PR TITLE
EP-2646 Remove option to disable global webhook in project page

### DIFF
--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -181,8 +181,13 @@
             <% end %>
             </strong>
             (
-            <%= link_to disabled ? 'Enable' : 'Disable', outbound_webhook_path(outbound_webhook, stage_id: outbound_webhook_stage.stage_id, outbound_webhook: { disabled: !disabled }), method: :patch %>,
-            <%= link_to_delete outbound_webhook_path(outbound_webhook, stage_id: outbound_webhook_stage.stage_id) %>
+            <%# Disabling a global webhook affects all projects using it %>
+            <% if outbound_webhook.global? %>
+              <%= link_to_delete outbound_webhook_path(outbound_webhook, stage_id: outbound_webhook_stage.stage_id), text: 'Unlink' %>
+            <% else %>
+              <%= link_to disabled ? 'Enable' : 'Disable', outbound_webhook_path(outbound_webhook, stage_id: outbound_webhook_stage.stage_id, outbound_webhook: { disabled: !disabled }), method: :patch %>,
+              <%= link_to_delete outbound_webhook_path(outbound_webhook, stage_id: outbound_webhook_stage.stage_id) %>
+            <% end %>
             )
           </li>
         <% end %>


### PR DESCRIPTION
#### Description
Remove the UI option to disable the global outbound webhook.

#### Screenshot
<img width="690" alt="Screenshot 2020-01-16 at 12 36 48 PM" src="https://user-images.githubusercontent.com/1161962/72561166-77213380-385d-11ea-84a1-b37475145ee6.png">

### Risks
- Low: Just a minor UI change.

@zendesk/interface @zendesk/samson 