### PR TITLE
only rescue vault read error if vault is not configured

### DIFF
--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -48,8 +48,8 @@ module Samson
               if value = read(id)
                 found[id] = value
               end
-            rescue VaultClientManager::VaultServerNotConfigured # deploy group has no vault server
-              nil
+            rescue VaultClientManager::VaultServerNotConfigured
+              nil # ignore if deploy group has no vault server or deploy group no longer exists
             end
           end
           found

--- a/lib/samson/secrets/hashicorp_vault_backend.rb
+++ b/lib/samson/secrets/hashicorp_vault_backend.rb
@@ -48,7 +48,7 @@ module Samson
               if value = read(id)
                 found[id] = value
               end
-            rescue # deploy group has no vault server or deploy group no longer exists
+            rescue VaultClientManager::VaultServerNotConfigured # deploy group has no vault server
               nil
             end
           end

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -144,10 +144,6 @@ describe Samson::Secrets::HashicorpVaultBackend do
     it "leaves out vaules from deploy groups that have no vault server so KeyResolver works" do
       backend.read_multi(['production/foo/pod100/bar']).must_equal({})
     end
-
-    it "leaves out vaules from unknown deploy groups" do
-      backend.read_multi(['production/foo/pod1nope/bar']).must_equal({})
-    end
   end
 
   describe ".delete" do

--- a/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
+++ b/test/lib/samson/secrets/hashicorp_vault_backend_test.rb
@@ -141,8 +141,20 @@ describe Samson::Secrets::HashicorpVaultBackend do
       end
     end
 
-    it "leaves out vaules from deploy groups that have no vault server so KeyResolver works" do
+    it "raises an error if client is not authorized" do
+      assert_raises Vault::HTTPClientError do
+        assert_vault_request :get, "production/foo/pod2/bar", status: 403 do
+          backend.read_multi(['production/foo/pod2/bar'])
+        end
+      end
+    end
+
+    it "leaves out values from deploy groups that have no vault server so KeyResolver works" do
       backend.read_multi(['production/foo/pod100/bar']).must_equal({})
+    end
+
+    it "leaves out values from unknown deploy groups" do
+      backend.read_multi(['production/foo/pod1nope/bar']).must_equal({})
     end
   end
 


### PR DESCRIPTION
Only rescue specific errors when `read_multi` fails. This is to account for when the request is not authorized or there is some other issue with vault (issue related to an incident)

### References
- Jira link: 

### Risks
- Medium: could cause issues if something expects `read_multi` to return nil instead of an error. 
