### PR TITLE
shorten generated labels so we do not run into kubernetes validation …

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -396,7 +396,7 @@ module Kubernetes
     # Adding the Release ID to allow us to track the progress of a new release from the UI.
     def set_spec_template_metadata
       release_doc_metadata.each do |key, value|
-        pod_template.dig_fetch(:metadata, :labels)[key] ||= value.to_s.parameterize.tr('_', '-')
+        pod_template.dig_fetch(:metadata, :labels)[key] ||= value.to_s.parameterize.tr('_', '-').slice(0, 63)
       end
     end
 


### PR DESCRIPTION
…errors

```
[23:36:11] JobExecution failed: Kubernetes error Deployment.apps "foo" is invalid: spec.template.labels: Invalid value: "foobarbaz-edata-12881-split-drdb-tasks-out-into-dedicated-collector-instance": must be no more than 63 characters
```