### PR TITLE
do not send github access-tokens in query params

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'sawyer'
 gem 'dalli'
 gem 'omniauth'
 gem 'omniauth-oauth2'
-gem 'omniauth-github'
+gem 'omniauth-github', git: "https://github.com/omniauth/omniauth-github.git" # needs >1.3.0
 gem 'omniauth-google-oauth2'
 gem 'omniauth-ldap'
 gem 'omniauth-gitlab'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       railties (~> 6.0.0)
 
 GIT
+  remote: https://github.com/omniauth/omniauth-github.git
+  revision: 967d76979b6bf9bb0b71b255ad204f8931f65be6
+  specs:
+    omniauth-github (1.3.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
+
+GIT
   remote: https://github.com/zendesk/vault-ruby.git
   revision: 96be391a2fd50a42871c8b9dc3c59fddbdbdc556
   ref: 96be391a2fd50a42871c8b9dc3c59fddbdbdc556
@@ -414,9 +422,6 @@ GEM
       multi_json (~> 1.7)
       omniauth (~> 1.1)
       omniauth-oauth (~> 1.0)
-    omniauth-github (1.3.0)
-      omniauth (~> 1.5)
-      omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-gitlab (1.0.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.0)
@@ -649,7 +654,7 @@ DEPENDENCIES
   octokit
   omniauth
   omniauth-bitbucket
-  omniauth-github
+  omniauth-github!
   omniauth-gitlab
   omniauth-google-oauth2
   omniauth-ldap


### PR DESCRIPTION
redo of https://github.com/zendesk/samson/pull/3713 because it only changed it so that it no longer logs, but it still sent it :(
... added debug into oauth2-1.4.3/lib/oauth2/client.rb:99 to make sure it works this time
thx to @patrobinson 🎉 

/cc @zendesk/compute 