### PR TITLE
fix random test error

### DIFF
--- a/test/lib/samson/readonly_db_test.rb
+++ b/test/lib/samson/readonly_db_test.rb
@@ -21,7 +21,9 @@ describe Samson::ReadonlyDb do
       end
     end
 
-    it "does not add our warnings when not enabled" do
+    it "does not add our warnings when disabled" do
+      Samson::ReadonlyDb.enable
+      Samson::ReadonlyDb.disable
       e = assert_raises(ActiveRecord::ReadOnlyError) do
         User.connection_handler.while_preventing_writes do
           User.create!(name: "Foo")


### PR DESCRIPTION
if this test ran first it would not provide coverage or the "disabled" case ... and since reproducing the uninitialized case is not reliable or necessary, I'm just changing it to a reliable disabled

```
test/lib/samson/readonly_db_test.rb 
lib/samson/readonly_db.rb new uncovered lines introduced (1 current vs 0 configured)
Lines missing coverage:
lib/samson/readonly_db.rb:11:9-106
Run options: --seed 61123
```

@zendesk/compute 