### PR TITLE
also retry on socket-errors

### DIFF
--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -15,7 +15,7 @@ module SamsonKubernetes
   # see https://github.com/abonas/kubeclient/issues/240
   # using a method to avoid loading kubeclient on every boot ~0.1s
   def self.connection_errors
-    [OpenSSL::SSL::SSLError, Kubeclient::HttpError, Errno::ECONNREFUSED, Errno::ECONNRESET].freeze
+    [OpenSSL::SSL::SSLError, Kubeclient::HttpError, Errno::ECONNREFUSED, Errno::ECONNRESET, SocketError].freeze
   end
 
   def self.retry_on_connection_errors(&block)


### PR DESCRIPTION
```
#2505 SocketError: Failed to open TCP connection to foobar(getaddrinfo: Temporary failure in name resolution)
```

@zendesk/compute 