### PR TITLE
namespaces: tell users the template needs to be set when left empty

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/namespace.rb
+++ b/plugins/kubernetes/app/models/kubernetes/namespace.rb
@@ -51,10 +51,9 @@ module Kubernetes
     end
 
     def validate_template
-      unless parsed_template.is_a?(Hash)
-        return errors.add :template, "needs to be a Hash"
-      end
-      errors.add :template, "needs metadata.labels.team" unless parsed_template.dig("metadata", "labels", "team")
+      return errors.add :template, "needs to be set" if template.blank?
+      return errors.add :template, "needs to be a Hash" unless parsed_template.is_a?(Hash)
+      return errors.add :template, "needs metadata.labels.team" unless parsed_template.dig("metadata", "labels", "team")
     rescue Psych::Exception
       errors.add :template, "needs to be valid yaml"
     end

--- a/plugins/kubernetes/test/models/kubernetes/namespace_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/namespace_test.rb
@@ -17,6 +17,12 @@ describe Kubernetes::Namespace do
       refute_valid namespace
     end
 
+    it "is not valid with empty template" do
+      namespace.template = ""
+      refute_valid namespace
+      namespace.errors.full_messages.must_equal ["Template needs to be set"]
+    end
+
     it "is not valid with non-hash template" do
       namespace.template = "true"
       refute_valid namespace


### PR DESCRIPTION
previously said "it needs to be a hash" which was confusing
@zendesk/compute 