### PR TITLE
Scan the repository URL correctly for gitlab projects.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -130,7 +130,7 @@ class Project < ActiveRecord::Base
 
   # The user/repo part of the repository URL.
   def repository_path
-    if self.gitlab?
+    if gitlab?
       # This is GitLab, which allows similar characters in repository names, but
       # also follows a subgroup convention which can contain an n-number of paths
       # underneath the organization group.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -130,9 +130,16 @@ class Project < ActiveRecord::Base
 
   # The user/repo part of the repository URL.
   def repository_path
-    # GitHub allows underscores, hyphens and dots in repo names
-    # but only hyphens in user/organisation names (as well as alphanumeric).
-    repository_url.scan(%r{[:/]([A-Za-z0-9-]+/[\w.-]+?)(?:\.git)?$}).join
+    if self.gitlab?
+      # This is GitLab, which allows similar characters in repository names, but
+      # also follows a subgroup convention which can contain an n-number of paths
+      # underneath the organization group.
+      repository_url.scan(%r{[:/]([A-Za-z0-9-/]+/[\w.-]+?)(?:\.git)?$}).join
+    else
+      # GitHub allows underscores, hyphens and dots in repo names
+      # but only hyphens in user/organisation names (as well as alphanumeric).
+      repository_url.scan(%r{[:/]([A-Za-z0-9-]+/[\w.-]+?)(?:\.git)?$}).join
+    end
   end
 
   def repository_directory

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -169,6 +169,11 @@ describe Project do
       project = Project.new(repository_url: "https://github.com/foo/bar")
       project.repository_path.must_equal "foo/bar"
     end
+
+    it "handles gitlab ssh URLs that nest projects under organization groups" do
+      project = Project.new(repository_url: "git@gitlab.com:foo/bar/baz.git")
+      project.repository_path.must_equal "foo/bar/baz"
+    end
   end
 
   describe 'project repository initialization' do


### PR DESCRIPTION
* Allows gitlab project URLs to be scanned properly. Previously the ref checker for GitLab didn't function with projects in subgroups under a GitLab organization. @grosser 's change to make the ref check more strict made this a blocker. In the past one could just bypass the Review button. It also fixes the URL generated with the GitLab cat icon in the project details page.

### References

### Risks
- Low, impacts only gitlab projects.