### PR TITLE
show that restarting failed in the UI

### DIFF
--- a/app/views/deploys/_table.html.erb
+++ b/app/views/deploys/_table.html.erb
@@ -1,3 +1,7 @@
+<% if !JobQueue.enabled && JobQueue.executing.empty? %>
+  <h2>Failed restart detected (Job-queue is disabled and there are no jobs running). Might need a hard restart.</h2>
+<% end %>
+
 <div class="timeline">
   <table class="timeline-content table">
     <thead>


### PR DESCRIPTION
I usually know what it looks like, but would be nice if it is more obvious to onlookers.

![Screen Shot 2020-02-14 at 9 26 37 AM](https://user-images.githubusercontent.com/11367/74553405-2a885100-4f0c-11ea-849c-9a1d4913fefd.png)

/cc @zendesk/eng-productivity @zendesk/compute 