### PR TITLE
send correct canceller in slack notifications

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -59,6 +59,7 @@ class JobExecution
       @job.failed!
     end
   rescue JobQueue::Cancel
+    @job.reload # fetch canceller, set by job.rb, so notifications are correct
     @job.cancelling!
     raise
   rescue => e

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -134,7 +134,7 @@ class Project < ActiveRecord::Base
       # This is GitLab, which allows similar characters in repository names, but
       # also follows a subgroup convention which can contain an n-number of paths
       # underneath the organization group.
-      repository_url.scan(%r{[:/]([A-Za-z0-9-/]+/[\w.-]+?)(?:\.git)?$}).join
+      repository_url.scan(%r{[:/]([A-Za-z0-9\-/]+/[\w.-]+?)(?:\.git)?$}).join
     else
       # GitHub allows underscores, hyphens and dots in repo names
       # but only hyphens in user/organisation names (as well as alphanumeric).

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -265,7 +265,7 @@ describe Job do
 
     it "cancels an executing job" do
       # get the job running
-      ex = JobExecution.new('master', job) { sleep 10 }
+      ex = JobExecution.new('master', Job.find(job.id)) { sleep 10 }
       JobQueue.perform_later(ex)
       sleep 0.1 # make the job spin up properly
       assert JobQueue.executing?(ex.id)
@@ -275,8 +275,8 @@ describe Job do
       maxitest_wait_for_extra_threads
 
       # it is cancelled ?
-      assert job.cancelled? # job execution callbacks sets it to cancelled
-      job.canceller.must_equal user
+      assert ex.job.cancelled? # job execution callbacks sets it to cancelled
+      ex.job.canceller.must_equal user
     end
 
     it "cancels an stopped job" do


### PR DESCRIPTION
what I received when cancelling my own deploy:
```
Samson is cancelling Michael Grosser's deploy
```

when I reproduce via console:
```
s = SlackWebhookNotification.new(d, [])
s.send :deploy_callback_content
Michael Grosser cancelled Michael Grosser's deploy
```

... so there is a race condition :)

@zendesk/compute