### PR TITLE
PAAS-3759 ignore error happening when HPA tries to update deployment …

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -14,7 +14,8 @@ module Kubernetes
         "FailedRescale",
         "FailedGetResourceMetric",
         "FailedGetExternalMetric",
-        "FailedComputeMetricsReplicas"
+        "FailedComputeMetricsReplicas",
+        "FailedUpdateStatus"
       ],
       PodDisruptionBudget: [
         "CalculateExpectedPodCountFailed",


### PR DESCRIPTION
…while samson deploys it
```
Warning FailedUpdateStatus: Operation cannot be fulfilled on horizontalpodautoscalers.autoscaling "foo": the object has been modified; please apply your changes to the latest version and try again
```