### PR TITLE
PAAS-6288 do not run periodical deploys when samson restarts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.7.0.359)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     oauth (0.5.3)
     oauth2 (1.4.3)

--- a/lib/samson/periodical.rb
+++ b/lib/samson/periodical.rb
@@ -50,7 +50,7 @@ module Samson
           # run at startup so we are in a consistent and clean state after a restart
           # not using TimerTask `now` option since then initial constant loading would happen in multiple threads
           # and we run into fun autoload errors like `LoadError: Unable to autoload constant Job` in development/test
-          if !config[:now] && enabled
+          if enabled && !config[:consistent_start_time]
             ActiveRecord::Base.connection_pool.with_connection do
               run_once(name)
             end

--- a/test/lib/samson/periodical_test.rb
+++ b/test/lib/samson/periodical_test.rb
@@ -12,6 +12,15 @@ describe Samson::Periodical do
   ensure
     registered[:periodical_deploy].replace old
   end
+
+  def with_enabled(v)
+    old = Samson::Periodical.enabled
+    Samson::Periodical.enabled = v
+    yield
+  ensure
+    Samson::Periodical.enabled = old
+  end
+
   let(:custom_error) { Class.new(StandardError) }
 
   # kill all threads that concurrent leaves behind and make it create new ones when called again
@@ -25,14 +34,7 @@ describe Samson::Periodical do
 
   before_and_after { Samson::Periodical.instance_variable_set(:@env_settings, nil) }
 
-  around do |test|
-    begin
-      Samson::Periodical.enabled = true
-      test.call
-    ensure
-      Samson::Periodical.enabled = false
-    end
-  end
+  around { |test| with_enabled(true, &test) }
 
   around do |test|
     begin
@@ -139,9 +141,9 @@ describe Samson::Periodical do
     it "sends errors to error notifier" do
       Samson::ErrorNotifier.expects(:notify).
         with(instance_of(ArgumentError), error_message: "Samson::Periodical foo failed")
-      Samson::Periodical.register(:foo, 'bar', now: true) { raise ArgumentError }
-      tasks = Samson::Periodical.run
-      sleep 0.05 # let task execute
+      Samson::Periodical.register(:foo, 'bar', execution_interval: 0.02) { raise ArgumentError }
+      tasks = with_enabled(false) { Samson::Periodical.run }
+      sleep 0.03 # let task execute
       tasks.first.shutdown
     end
 
@@ -227,25 +229,35 @@ describe Samson::Periodical do
 
     it 'counts running tasks' do
       mutex = Mutex.new.lock
-      Samson::Periodical.register(:foo, 'bar', active: true, now: true) { mutex.lock }
-      tasks = Samson::Periodical.run
-      sleep 0.02 # Allow task to start
+      Samson::Periodical.register(:foo, 'bar', active: true, execution_interval: 0.015) { mutex.lock }
 
+      # start tasks
+      tasks = with_enabled(false) { Samson::Periodical.run }
+      sleep 0.03
       Samson::Periodical.running_task_count.must_equal 1
-      mutex.unlock
-      sleep 0.02 # Allow task to finish
 
+      # finish tasks
+      mutex.unlock
+      sleep 0.03
       Samson::Periodical.running_task_count.must_equal 0
+
       tasks.first.shutdown
     end
 
     it 'correctly counts down when task raised' do
-      Samson::ErrorNotifier.expects(:notify)
-      Samson::Periodical.register(:foo, 'bar', active: true, now: true) { raise }
-      tasks = Samson::Periodical.run
-      sleep 0.02 # Allow task to finish
+      ran = false
+      Samson::Periodical.register(:foo, 'bar', active: true, execution_interval: 0.015) do
+        ran = true
+        raise
+      end
 
+      Samson::ErrorNotifier.expects(:notify)
+      tasks = with_enabled(false) { Samson::Periodical.run }
+
+      sleep 0.02 # Allow task to finish
       Samson::Periodical.running_task_count.must_equal 0
+      assert ran
+
       tasks.first.shutdown
     end
   end


### PR DESCRIPTION
@zendesk/compute 

periodical_deploy uses consistent_start_time option ... and consistent_start_time does not make sense with instantly running it ... also now option was never used ...