### PR TITLE
Cleanup orphaned webhooks

### DIFF
--- a/db/migrate/20200219043627_delete_orphaned_outbound_webhooks.rb
+++ b/db/migrate/20200219043627_delete_orphaned_outbound_webhooks.rb
@@ -1,0 +1,14 @@
+class DeleteOrphanedOutboundWebhooks < ActiveRecord::Migration[6.0]
+  class OutboundWebhook < ActiveRecord::Base
+  end
+
+  class OutboundWebhookStage < ActiveRecord::Base
+  end
+
+  def up
+    OutboundWebhookStage.where('outbound_webhook_id not IN (?)', OutboundWebhook.pluck(:id)).delete_all
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20200219043627_delete_orphaned_outbound_webhooks.rb
+++ b/db/migrate/20200219043627_delete_orphaned_outbound_webhooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeleteOrphanedOutboundWebhooks < ActiveRecord::Migration[6.0]
   class OutboundWebhook < ActiveRecord::Base
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_10_213328) do
+ActiveRecord::Schema.define(version: 2020_02_19_043627) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false


### PR DESCRIPTION
As part of #3608 `OutboundWebhook.find_each` was used to migrate existing webhooks, however deleted webhooks were not copied because they are not returned by that command.

This left some dangling `OutboundWebhookStage` objects, which meant when browsing to the Webhook tab on a Project which had previously deleted webhooks you'd get an exception.

This PR cleans up all `OutboundWebhookStage` objects who's OutboundWebhook has been incidentally dropped.