### PR TITLE
Bump timeout for git commands

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -176,7 +176,7 @@ class Project < ActiveRecord::Base
     @repository ||= GitRepository.new(
       repository_url: repository_url,
       repository_dir: repository_directory,
-      executor: TerminalExecutor.new(StringIO.new, project: self)
+      executor: TerminalExecutor.new(StringIO.new, project: self, timeout: 30)
     )
   end
 


### PR DESCRIPTION
Even when using a shallow clone, we commonly hit the 5s timeout.
This is rather intermittent, but on a fresh instance with no cache it still occurs 1-2 times a day for us.