### PR TITLE
PAAS-6266 show errors on replicasets since they do not show on deploy…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -48,7 +48,7 @@ module Kubernetes
     # ... needs to check doc namespace too since it might be not overwritten
     # ... assumes that there is only 1 namespace per release_doc
     # ... supports that the same namespace might exist on different clusters
-    def clients
+    def clients(version)
       scopes = release_docs.map do |release_doc|
         deploy_group = DeployGroup.with_deleted { release_doc.deploy_group }
         [
@@ -61,7 +61,7 @@ module Kubernetes
       end
 
       # avoiding doing a .uniq on clients which might trigger api calls
-      scopes.uniq.map { |group, query| [group.kubernetes_cluster.client('v1'), query] }
+      scopes.uniq.map { |group, query| [group.kubernetes_cluster.client(version), query] }
     end
 
     def previous_succeeded_release

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -115,7 +115,7 @@ describe Kubernetes::Release do
 
   describe "#clients" do
     it "is empty when there are no deploy groups" do
-      release.clients.must_equal []
+      release.clients("v1").must_equal []
     end
 
     it "returns scoped queries" do
@@ -124,7 +124,7 @@ describe Kubernetes::Release do
         resourceVersion: "1",
         items: [{}, {}]
       }.to_json)
-      release.clients.map { |c, q| c.get_pods(q).fetch(:items) }.first.size.must_equal 2
+      release.clients("v1").map { |c, q| c.get_pods(q).fetch(:items) }.first.size.must_equal 2
     end
 
     it "can scope queries by resource namespace" do
@@ -134,7 +134,7 @@ describe Kubernetes::Release do
         resourceVersion: "1",
         items: [{}, {}]
       }.to_json)
-      release.clients.map { |c, q| c.get_pods(q).fetch(:items) }.first.size.must_equal 2
+      release.clients("v1").map { |c, q| c.get_pods(q).fetch(:items) }.first.size.must_equal 2
     end
   end
 


### PR DESCRIPTION
…ment or pods

1 extra request per deploy check to make sure we catch errors on the ReplicaSet too
... we could reduce that even more by not checking when there are "any" pods, but I'm worried then we'd miss situations where only some pods come up

@zendesk/compute 

```
[17:47:34] GroupK server ReplicaSet example-server-9bb76ff6 events:
[17:47:34]   Warning FailedCreate: Error creating: admission webhook "validation.gatekeeper.sh" denied the request```