### PR TITLE
Disable serviceLinks

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -38,6 +38,7 @@ module Kubernetes
         elsif Kubernetes::RoleConfigFile.primary?(template)
           if kind == 'Deployment'
             set_history_limit
+            set_disable_service_links
           end
 
           make_stateful_set_match_service if kind == 'StatefulSet'
@@ -55,6 +56,7 @@ module Kubernetes
           set_init_containers
           set_kritis_breakglass
           set_istio_sidecar_injection
+
         elsif kind == 'PodDisruptionBudget'
           set_name
           set_match_labels_blue_green if blue_green_color
@@ -265,6 +267,11 @@ module Kubernetes
     # see discussion in https://github.com/kubernetes/kubernetes/issues/23597
     def set_history_limit
       template[:spec][:revisionHistoryLimit] ||= 1
+    end
+
+    # disable service links.
+    def set_disable_service_links
+      template[:spec][:template][:spec][:enableServiceLinks] ||= false
     end
 
     # replace keys in annotations by looking them up in all possible namespaces by specificity

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -116,6 +116,10 @@ describe Kubernetes::TemplateFiller do
       template.to_hash[:spec][:revisionHistoryLimit].must_equal 1
     end
 
+    it "disables serviceLinks" do
+      template.to_hash[:spec][:template][:spec][:enableServiceLinks].must_equal false
+    end
+
     it "can verify without builds" do
       doc.kubernetes_release.builds = []
       template.to_hash(verification: true)


### PR DESCRIPTION
To not pollute env of the containers, disable serviceLinks by default.
If the deployment explicitly has it, keep as is.

Some back story:
- [Docker legacy `--links`](https://docs.docker.com/network/links/) - what causes this.
- [K8 feature PR](https://github.com/kubernetes/kubernetes/pull/68754)
- [K8 issue raised](https://github.com/kubernetes/kubernetes/issues/60099)

### Risks
- Med - changing default behavior might break existing deployments that rely on it.