### PR TITLE
focus reference selection on deploy page since typeahead removes the …

### DIFF
--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -34,7 +34,7 @@ function refStatusTypeahead(options){
     $reference.typeahead(null, {
       display: 'value',
       source: engine.ttAdapter()
-    });
+    }).focus();
   }
 
   function show_status_problems(status_list, isDanger) {

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -25,7 +25,6 @@
         <div id="scrollable-dropdown-menu">
           <%= form.text_field :reference,
               class: "form-control",
-              autofocus: true,
               placeholder: "e.g. v2.1.43, master, fa0b4671",
               required: true,
               data: { prefetch_url: project_references_path(@project, format: "json") }


### PR DESCRIPTION
…focus

@zendesk/compute 

<img width="591" alt="Screen Shot 2020-03-05 at 10 19 46 PM" src="https://user-images.githubusercontent.com/11367/76057838-87858e80-5f2f-11ea-84a2-cb369e6c4f44.png">
