### PR TITLE
Use api check releases

### DIFF
--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -168,6 +168,7 @@ class JobExecution
   end
 
   def resolve_ref_to_commit
+    @repository.update_mirror
     commit = @repository.commit_from_ref(@reference)
     tag = @repository.fuzzy_tag_from_ref(@reference)
     if commit

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -97,6 +97,7 @@ class Release < ActiveRecord::Base
     tag = GITHUB.compare(project.repository_path, commit, commit)
     self.commit = tag[:base_commit][:sha]
   rescue Octokit::NotFound
+    ::Rails.logger.info("Couldn't convert #{commit} to tag")
   end
 end
 Samson::Hooks.load_decorators(Release)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -94,7 +94,9 @@ class Release < ActiveRecord::Base
 
   def convert_ref_to_sha
     return if commit.blank? || commit =~ Build::SHA1_REGEX
-    self.commit = project.repository.commit_from_ref(commit)
+    tag = GITHUB.compare(project.repository_path, commit, commit)
+    self.commit = tag[:base_commit][:sha]
+  rescue Octokit::NotFound
   end
 end
 Samson::Hooks.load_decorators(Release)

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -7,7 +7,7 @@ class Release < ActiveRecord::Base
   belongs_to :author, class_name: "User", inverse_of: false
 
   before_validation :assign_release_number
-  before_validation :covert_ref_to_sha
+  before_validation :convert_ref_to_sha
 
   validates :number, format: {with: NUMBER_REGEX, message: "may only contain numbers and decimals."}
   validates :commit, format: {with: Build::SHA1_REGEX, message: "can only be a full sha"}, on: :create
@@ -92,7 +92,7 @@ class Release < ActiveRecord::Base
     current_version.to_s.dup.sub!(/\d+$/) { |d| d.to_i + 1 }
   end
 
-  def covert_ref_to_sha
+  def convert_ref_to_sha
     return if commit.blank? || commit =~ Build::SHA1_REGEX
     self.commit = project.repository.commit_from_ref(commit)
   end

--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -27,11 +27,9 @@ class ReleaseService
   end
 
   def ensure_tag_in_git_repository(tag)
-    tries = Integer(ENV["RELEASE_TAG_IN_REPO_RETRIES"] || 4)
-    Samson::Retry.until_result tries: tries, wait_time: 1, error: "Unable to find ref" do
-      @project.repository.update_mirror
-      @project.repository.commit_from_ref(tag)
-    end
+    GITHUB.release_for_tag(@project.repository_path, tag)
+  rescue Octokit::NotFound
+    raise "Failed find release for tag #{tag}"
   end
 
   def start_deploys(release)

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -48,6 +48,7 @@ describe ReleasesController do
 
     describe "#show" do
       it "renders continuous versions" do
+        GITHUB.stubs(:compare).returns(base_commit: {sha: 'abcd'})
         get :show, params: {project_id: project.to_param, id: release.version}
         assert_template 'show'
       end
@@ -82,7 +83,7 @@ describe ReleasesController do
     describe "#create" do
       let(:release_params) { {commit: "abcd"} }
       before do
-        GitRepository.any_instance.expects(:commit_from_ref).with('abcd').returns('a' * 40)
+        GITHUB.stubs(:compare).returns(base_commit: {sha: "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"})
         GITHUB.stubs(:release_for_tag)
         GITHUB.stubs(:create_release).returns('{}')
       end

--- a/test/controllers/releases_controller_test.rb
+++ b/test/controllers/releases_controller_test.rb
@@ -83,13 +83,12 @@ describe ReleasesController do
       let(:release_params) { {commit: "abcd"} }
       before do
         GitRepository.any_instance.expects(:commit_from_ref).with('abcd').returns('a' * 40)
-        GITHUB.stubs(:create_release)
+        GITHUB.stubs(:release_for_tag)
+        GITHUB.stubs(:create_release).returns('{}')
       end
 
       it "creates a new release" do
         GitRepository.any_instance.expects(:fuzzy_tag_from_ref).with('abcd').returns("v2")
-        GitRepository.any_instance.expects(:commit_from_ref).with('v124').returns('a' * 40)
-
         assert_difference "Release.count", +1 do
           post :create, params: {project_id: project.to_param, release: release_params}
           assert_redirected_to "/projects/foo/releases/v124"

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -251,6 +251,7 @@ describe JobExecution do
   end
 
   it 'errors if job commit resultion fails, but checkout works' do
+    GitRepository.any_instance.expects(:update_mirror).twice.returns true
     GitRepository.any_instance.expects(:commit_from_ref).returns nil
     execute_job
     assert_equal 'errored', job.status


### PR DESCRIPTION
This is the alternative as suggested in #3739

Instead of trying to do a `git clone` while processing a web request, we instead use the Github API to fetch releases and validate the release we've created.

This unmasks a different bug though, in that the code to checkout a release before a deployment is run doesn't update the mirror first (it calls `ensure_mirror_updated` but that doesn't do as it says on the tin).

We have to call `update_mirror` explicitly, otherwise deployments fail because the mirror is not fresh and therefore doesn't contain the release we're about to deploy.