### PR TITLE
PAAS-6412 allow 1 deployment for each version by appending tag to nam…

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -308,3 +308,10 @@ metadata.annotation.samson/force_update: "true"
 ### Static config per deploy group
 
 Set the kubernetes roles to `kubernetes/$deploy_group/server.yml`
+
+### Name per tag (experimental)
+
+Set `metadata.annotations.samson/append_tag_to_name = "true"` to get the current tag appended to the name and available as `NAME_AS_JSON`,
+and tag available as `TAG_AS_JSON` env vars.
+This can be useful when trying to deploy each version as a separate stack.
+NOTE: use `samson/keep_name` to override the name with the env var via `set_via_env_json`. 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -119,6 +119,13 @@ module Kubernetes
         data.merge!(YAML.safe_load(yaml))
       end
 
+      env = static_env
+      if template.dig(:metadata, :annotations, :"samson/append_tag_to_name") == "true"
+        tag = env.fetch(:TAG)
+        env["TAG_AS_JSON"] = tag.to_json
+        env["NAME_AS_JSON"] = "#{template.dig_fetch(:metadata, :name)}-#{tag}".to_json
+      end
+
       # set values
       data.each do |path, v|
         path = self.class.dig_path(path)

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -131,12 +131,12 @@ describe Kubernetes::ReleaseDoc do
         end
 
         it "adds when first is not a Deployment" do
-          template.unshift(apiVersion: "v1", kind: "ConfigMap", metadata: {})
+          template.unshift(apiVersion: "v1", kind: "ConfigMap", metadata: {labels: {project: "foo", role: "bar"}})
           create!.resource_template[3][:spec][:minAvailable].must_equal 1
         end
 
         it "ignores when there is no deployment" do
-          template.replace([{apiVersion: "v1", kind: "ConfigMap", metadata: {}}])
+          template.replace([{apiVersion: "v1", kind: "ConfigMap", metadata: {labels: {project: "foo", role: "bar"}}}])
           refute create!.resource_template[1]
         end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -1114,6 +1114,22 @@ describe Kubernetes::TemplateFiller do
         resource_label.must_be_nil
       end
     end
+
+    describe "append_tag_to_name" do
+      it "can configure a matching pair" do
+        raw_template[:metadata][:annotations] = {
+          "samson/keep_name": "true",
+          "samson/append_tag_to_name": "true",
+          "samson/set_via_env_json-metadata.name": "NAME_AS_JSON",
+          "samson/set_via_env_json-spec.matches_service": "NAME_AS_JSON",
+          "samson/set_via_env_json-spec.template.metadata.labels.tag": "TAG_AS_JSON"
+        }
+        t = template.to_hash
+        t.dig(:metadata, :name).must_equal "some-project-rc-master"
+        t.dig(:spec, :matches_service).must_equal "some-project-rc-master"
+        t.dig(:spec, :template, :metadata, :labels, :tag).must_equal "master"
+      end
+    end
   end
 
   describe "#verify" do


### PR DESCRIPTION
…e and making tag+name available for replacement

hacky, so keeping it all in 1 place (instead of removing keep_name requirement with more logic)

@zendesk/compute 
@fsat 