### PR TITLE
stream output even when command is cancelled so we see what it does i…

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -41,23 +41,24 @@ class TerminalExecutor
       script_as_executable(script(commands)) do |command|
         output, _, pid = PTY.spawn(whitelisted_env, command, in: '/dev/null', unsetenv_others: true)
         record_pid(pid) do
-          begin
-            Timeout.timeout(timeout) do
-              stream from: output, to: @output
-              _pid, status = Process.wait2(pid)
-              status.success?
+          stream from: output, to: @output do
+            begin
+              Timeout.timeout(timeout) do
+                _pid, status = Process.wait2(pid)
+                status.success?
+              end
+            rescue Timeout::Error
+              @output.puts "Timeout: execution took longer then #{timeout}s and was terminated"
+              cancel timeout: KILL_TIMEOUT
+              false
+            rescue Errno::ECHILD
+              @output.puts "#{$!.class}: #{$!.message}"
+              cancel timeout: KILL_TIMEOUT
+              false
+            rescue JobQueue::Cancel
+              cancel timeout: @cancel_timeout
+              raise
             end
-          rescue Timeout::Error
-            @output.puts "Timeout: execution took longer then #{timeout}s and was terminated"
-            cancel timeout: KILL_TIMEOUT
-            false
-          rescue Errno::ECHILD
-            @output.puts "#{$!.class}: #{$!.message}"
-            cancel timeout: KILL_TIMEOUT
-            false
-          rescue JobQueue::Cancel
-            cancel timeout: @cancel_timeout
-            raise
           end
         end
       end
@@ -116,13 +117,20 @@ class TerminalExecutor
   end
 
   def stream(from:, to:)
-    from.each(256) do |chunk|
-      chunk.scrub!
-      ignore_cursor_movement!(chunk)
-      to.write chunk
+    thread = Thread.new do
+      begin
+        from.each(256) do |chunk|
+          chunk.scrub!
+          ignore_cursor_movement!(chunk)
+          to.write chunk
+        end
+      rescue Errno::EIO
+        nil # output was closed ... only happens on linux
+      end
     end
-  rescue Errno::EIO
-    nil # output was closed ... only happens on linux
+    yield
+  ensure
+    thread.kill
   end
 
   # http://ascii-table.com/ansi-escape-sequences.php

--- a/test/models/terminal_executor_test.rb
+++ b/test/models/terminal_executor_test.rb
@@ -39,7 +39,9 @@ describe TerminalExecutor do
     end
 
     it 'shows a nice message when child could not be found' do
-      Process.expects(:wait2).raises(Errno::ECHILD) # No child processes found
+      Process.expects(:wait2).
+        with { sleep 0.1; true }. # so we get 'not found' output
+        raises(Errno::ECHILD) # No child processes found
       subject.execute('blah').must_equal(false)
       out = output.string.sub(/.*blah: /, '').sub('command ', '') # linux has a different message
       out.must_equal "not found\r\nErrno::ECHILD: No child processes\n"
@@ -299,6 +301,11 @@ describe TerminalExecutor do
 
       it 'terminates hanging processes with -9' do
         execute_and_cancel("trap #{sleep_command.shellescape} 2; #{sleep_command}").must_equal ""
+      end
+
+      it 'shows output after trap' do
+        execute_and_cancel("ruby -e 'begin; sleep; rescue Interrupt; puts 123; STDOUT.flush; sleep 1;end'")
+        output.string.must_equal "123\r\n"
       end
     end
   end


### PR DESCRIPTION
…f it traps/prints anything as it dies

previously we interrupted streaming with the `cancel`, now we let it continue until the process is dead

@zendesk/compute 

```
[02:01:07] » ruby -e 'begin; sleep 100; rescue Exception; puts "GOT THAT #{$!.class}";end'
[02:01:08] GOT THAT Interrupt
```