### PR TITLE
let stream thread have an extra second so it does not randomly fail i…

### DIFF
--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -130,7 +130,8 @@ class TerminalExecutor
     end
     yield
   ensure
-    thread.kill
+    thread.join(1) # wait for it to finish to avoid race conditions
+    thread.kill # kill it if it's not yet dead
   end
 
   # http://ascii-table.com/ansi-escape-sequences.php


### PR DESCRIPTION
…n testing

@zendesk/compute 

hoping that solves some of the randomness we saw after https://github.com/zendesk/samson/pull/3751 merged

```
JobExecution#test_0002_checks out the specified commit [/home/travis/build/zendesk/samson/test/models/job_execution_test.rb:65]:
Expected: "[04:05:06] monkey"
  Actual: "[04:05:06] » cat foo"
rails test test/models/job_execution_test.rb:55
```

```
JobExecution#test_0006_records the commit properly when given an annotated tag [/home/travis/build/zendesk/samson/test/models/job_execution_test.rb:110]:
--- expected
+++ actual
@@ -1 +1 @@
-"[04:05:06] mantis shrimp"
+"[04:05:06] » export PROJECT_PERMALINK=d20200323-10636-er3h1t"
rails test test/models/job_execution_test.rb:94
```