### PR TITLE
give us more kill timeout to handle cancel interrupt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ GITLAB_TOKEN=
 
 # EMAIL_DOMAIN= # optional, set to company.com to limit login only for people at Company
 # DEPLOY_TIMEOUT=3600 # optional, deploy timeout in seconds, defaults to 2 hours
+# DEPLOY_KILL_TIMEOUT=5 # optional, sigkill cancelled deploy process after this time, defaults to 1s
 # RAILS_MIN_THREADS=5 #
 # RAILS_MAX_THREADS=10 #
 # DEFAULT_USER_ROLE=0 # optional, overrides default role assigned to new user. See app/models/role.rb for mappings

--- a/app/models/terminal_executor.rb
+++ b/app/models/terminal_executor.rb
@@ -17,7 +17,7 @@ class TerminalExecutor
   SECRET_PREFIX = "secret://"
   HIDDEN_PREFIX = "hidden://"
   HIDDEN_TXT = "HIDDEN"
-  KILL_TIMEOUT = 1
+  KILL_TIMEOUT = Integer(ENV['DEPLOY_KILL_TIMEOUT'] || '1')
 
   CURSOR = /\e\[\d*[ABCDK]/.freeze
 


### PR DESCRIPTION
1s is a little short ...
if we do more fancy things then maybe this needs to be configurable

@zendesk/compute 