### PR TITLE
PAAS-6446 only delete/select the pods belonging to the currently depl…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -251,14 +251,14 @@ module Kubernetes
         end
       end
 
-      def pods(res = resource)
-        ids = res.dig_fetch(:spec, :template, :metadata, :labels).values_at(:release_id, :deploy_group_id)
-        selector = Kubernetes::Release.pod_selector(*ids, query: true)
+      def pods(res)
+        labels = res.dig_fetch(:metadata, :labels).slice(:release_id, :deploy_group_id, :project, :role)
+        selector = labels.map { |k, v| "#{k}=#{v}" }.join(",")
         client_request(pod_client, :get_pods, label_selector: selector, namespace: namespace).fetch(:items)
       end
 
       def delete_pods
-        old_pods = pods
+        old_pods = pods(resource)
         yield
         old_pods.each do |pod|
           ignore_404 do

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -415,11 +415,9 @@ describe Kubernetes::Resource do
 
     describe "#pods" do
       it "raises a descriptive error when it fails" do
-        assert_request(:get, url, to_return: {body: {spec: {template: {metadata: {labels: {}}}}}.to_json}) do
-          assert_request(:get, /pod1\/pods/, to_timeout: []) do
-            e = assert_raises(Kubeclient::HttpError) { resource.send(:pods) }
-            e.message.must_equal "Kubernetes error some-project pod1 Pod1: Timed out connecting to server"
-          end
+        assert_request(:get, /pod1\/pods/, to_timeout: []) do
+          e = assert_raises(Kubeclient::HttpError) { resource.send(:pods, metadata: {labels: {}}) }
+          e.message.must_equal "Kubernetes error some-project pod1 Pod1: Timed out connecting to server"
         end
       end
     end
@@ -591,7 +589,7 @@ describe Kubernetes::Resource do
 
     describe "#delete" do
       it "waits for pods to be gone before allowing a new deploy" do
-        existing = {spec: {template: {metadata: {labels: {release_id: 1, deploy_group_id: 2}}}}}
+        existing = {metadata: {labels: {release_id: 1, deploy_group_id: 2}}}
         assert_request(:get, url, to_return: [{body: existing.to_json}, {status: 404}]) do
           assert_request(:delete, url, to_return: {body: "{}"}) do
             pods_url = "http://foobar.server/api/v1/namespaces/pod1/pods?labelSelector=release_id=1,deploy_group_id=2"
@@ -618,7 +616,7 @@ describe Kubernetes::Resource do
       end
 
       it "replaces existing" do
-        job = {spec: {template: {metadata: {labels: {release_id: 123, deploy_group_id: 234}}}}}
+        job = {metadata: {labels: {release_id: 123, deploy_group_id: 234}}}
         assert_request(:get, url, to_return: [{body: job.to_json}, {status: 404}]) do
           assert_request(:delete, url, to_return: {body: '{}'}) do
             assert_pods_lookup do
@@ -635,7 +633,7 @@ describe Kubernetes::Resource do
 
     describe "#delete" do
       it "deletes pods" do
-        replies = [{body: {spec: {template: {metadata: {labels: {}}}}}.to_json}, {status: 404}]
+        replies = [{body: {metadata: {labels: {}}}.to_json}, {status: 404}]
         assert_request(:get, url, to_return: replies) do
           pod = {metadata: {name: "a", namespace: "b"}}
           assert_request(:get, /pod1\/pods\?/, to_return: {body: {items: [pod]}.to_json}) do


### PR DESCRIPTION
…oyed role

we saw deployment pods getting deleted because a job was deployed at the same time 🤦‍♂ 

we could also remove the extra "cleanup old pods" logic for Job, but need to fix pods anyway, so we might as well keep it and not cause any further behavior diff right now

@zendesk/compute 