### PR TITLE
Allow duplicate resource names in different namespaces

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -126,13 +126,13 @@ module Kubernetes
       # do not validate on global since we hope to be on namespace soon
       return if !@project || !@project.override_resource_names?
 
-      # ignore service since we generate their names
+      # ignore services where we generate their names
       elements = @elements.reject { |e| !e[:kind] || (e[:kind] == "Service" && !self.class.keep_name?(e)) }
 
       # group by kind+name and to sure we have no duplicates
       groups = elements.group_by do |e|
         user_supplied = (ALLOWED_DUPLICATE_KINDS.include?(e.fetch(:kind)) || self.class.keep_name?(e))
-        [e.fetch(:kind), user_supplied ? e.dig(:metadata, :name) : "hardcoded"]
+        [e.fetch(:kind), e.dig(:metadata, :namespace), user_supplied ? e.dig(:metadata, :name) : "hardcoded"]
       end.values
       return if groups.all? { |group| group.size == 1 }
 

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -375,6 +375,16 @@ describe Kubernetes::RoleValidator do
         errors.to_s.must_include "Only use a maximum of 1 of each kind in a role"
       end
 
+      it "allows duplicate kinds and names in different namespaces services use hardcoded but duplicate names" do
+        role.each do |r|
+          r[:kind] = "Service"
+          r[:metadata][:name] = "same"
+          r.dig_set([:metadata, :annotations], "samson/keep_name": "true")
+        end
+        role.last[:metadata][:namespace] = "other"
+        errors.must_be_nil
+      end
+
       it "allows duplicate kinds with distinct names" do
         role.each { |r| r.dig_set([:metadata, :annotations], "samson/keep_name": "true") }
         refute errors


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Allow duplicate resource names in different namespaces. Currently when doing so you get an error:
> Only use a maximum of 1 of each kind in a role (except Service, APIService, CustomResourceDefinition, ConfigMap, Role, ClusterRole, Namespace, PodSecurityPolicy, and ClusterRoleBinding)

### References
- Jira link: 

### Risks
- Low: could have duplicates if one has the default namespace specified and the other doesn't but gets filled in later by template_filler.
