### PR TITLE
support loading env variable groups from external urls

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 2020_04_02_195119) do
     t.string "name", null: false
     t.text "comment"
     t.string "owners"
+    t.string "external_url"
     t.index ["name"], name: "index_environment_variable_groups_on_name", unique: true, length: 191
   end
 

--- a/plugins/env/app/controllers/environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/environment_variable_groups_controller.rb
@@ -27,8 +27,11 @@ class EnvironmentVariableGroupsController < ApplicationController
 
   def create
     group.attributes = attributes
-    group.save!
-    redirect_to action: :index
+    if group.save
+      redirect_to action: :index
+    else
+      render 'form'
+    end
   end
 
   def show
@@ -36,8 +39,11 @@ class EnvironmentVariableGroupsController < ApplicationController
   end
 
   def update
-    group.update!(attributes)
-    redirect_to action: :index
+    if group.update(attributes)
+      redirect_to action: :index
+    else
+      render 'form'
+    end
   end
 
   def destroy
@@ -90,6 +96,7 @@ class EnvironmentVariableGroupsController < ApplicationController
       :name,
       :comment,
       :owners,
+      :external_url,
       AcceptsEnvironmentVariables::ASSIGNABLE_ATTRIBUTES
     )
   end

--- a/plugins/env/app/controllers/external_environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/external_environment_variable_groups_controller.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 class ExternalEnvironmentVariableGroupsController < ApplicationController
   def preview
-    @group = ExternalEnvironmentVariableGroup.find(params[:id])
+    @group =
+      if params.require(:id) == "fake"
+        ExternalEnvironmentVariableGroup.new(
+          project: Project.new,
+          name: "Preview",
+          url: params.require(:url)
+        )
+      else
+        ExternalEnvironmentVariableGroup.find(params[:id])
+      end
+
     @data = @group.read
 
     respond_to do |format|

--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -67,7 +67,13 @@ class EnvironmentVariable < ActiveRecord::Base
     end
 
     def env_vars_from_external_groups(project, deploy_group)
-      project.external_environment_variable_groups.each_with_object({}) do |group, envs|
+      external_groups = project.external_environment_variable_groups
+
+      external_groups += (project.environment_variable_groups.select(&:external_url?).map do |env_group|
+        ExternalEnvironmentVariableGroup.new(url: env_group.external_url)
+      end)
+
+      external_groups.each_with_object({}) do |group, envs|
         group_env = group.read[deploy_group.permalink]
         envs.merge! group_env if group_env
       end

--- a/plugins/env/app/models/environment_variable_group.rb
+++ b/plugins/env/app/models/environment_variable_group.rb
@@ -16,6 +16,7 @@ class EnvironmentVariableGroup < ActiveRecord::Base
   has_many :projects, through: :project_environment_variable_groups, inverse_of: :environment_variable_groups
 
   validates :name, presence: true
+  validate :validate_external_url_valid, if: :external_url?
 
   def variable_names
     environment_variables.sort_by(&:id).map(&:name).uniq
@@ -23,5 +24,13 @@ class EnvironmentVariableGroup < ActiveRecord::Base
 
   def as_json(methods: [], **options)
     super({methods: [:variable_names] + methods}.merge(options))
+  end
+
+  private
+
+  def validate_external_url_valid
+    e = ExternalEnvironmentVariableGroup.new(url: external_url, name: "Foo", project: Project.new)
+    return if e.valid?
+    errors.add :external_url, e.errors.full_messages.to_sentence
   end
 end

--- a/plugins/env/app/models/external_environment_variable_group.rb
+++ b/plugins/env/app/models/external_environment_variable_group.rb
@@ -3,12 +3,11 @@ require 'aws-sdk-s3'
 
 class ExternalEnvironmentVariableGroup < ActiveRecord::Base
   S3_URL_REGEX = /\Ahttps:\/\/([^.]+)\.s3\.amazonaws\.com\/([\w\W]+)\Z/i.freeze
-  S3_URL_FORMAT = "https://[bucket].s3.amazonaws.com/[key]?versionId=[version_id]"
+  S3_URL_FORMAT = "https://#{ENV['EXTERNAL_ENV_GROUP_S3_BUCKET']}.s3.amazonaws.com/[key]?versionId=[version_id]"
   HELP_TEXT = ENV.fetch(
     "EXTERNAL_ENV_GROUP_HELP_TEXT",
     "Use external service to manage environment variable groups"
   ).html_safe
-  attr_accessor :key, :bucket, :version_id
   audited
   default_scope -> { order(:name) }
 
@@ -21,15 +20,11 @@ class ExternalEnvironmentVariableGroup < ActiveRecord::Base
   validate :validate_s3_url
 
   def read
-    resolve_s3_url
+    key, bucket, version_id = resolve_s3_url
     default_bucket = ENV.fetch 'EXTERNAL_ENV_GROUP_S3_BUCKET'
     default_region = ENV.fetch 'EXTERNAL_ENV_GROUP_S3_REGION'
     dr_bucket      = ENV['EXTERNAL_ENV_GROUP_S3_DR_BUCKET']
     dr_region      = ENV['EXTERNAL_ENV_GROUP_S3_DR_REGION']
-    if default_bucket != bucket && dr_bucket != bucket
-      buckets = [default_bucket, dr_bucket].compact
-      raise "Invalid s3 bucket, acceptable buckets are #{buckets.join(',')}"
-    end
     Samson::Retry.with_retries(Aws::S3::Errors::ServiceError, 3) do
       response =
         begin
@@ -55,23 +50,34 @@ class ExternalEnvironmentVariableGroup < ActiveRecord::Base
   private
 
   def validate_s3_url
-    resolve_s3_url
+    return if errors[:url].any?
+    key, bucket = resolve_s3_url
+
     if key.blank? || bucket.blank?
-      errors.add(:url, 'Invalid URL, unable to get s3 key or bucket')
+      errors.add(:url, 'Invalid: unable to get s3 key or bucket')
       return
     end
+
+    default_bucket = ENV.fetch('EXTERNAL_ENV_GROUP_S3_BUCKET')
+    if bucket != default_bucket
+      errors.add(:url, "Invalid: bucket must be #{default_bucket}")
+      return
+    end
+
     read
   rescue StandardError => e
-    errors.add(:url, "Invalid URL, #{e.message}")
+    errors.add(:url, "Invalid: #{e.message}")
   end
 
+  # Resolves the S3 key and bucket name from URL
   def resolve_s3_url
-    # Resolves the S3 key and bucket name from URL
-    return unless url
     parsed_url = URI.parse url.to_s
-    @key = parsed_url.path.to_s[1..-1]
-    @bucket = parsed_url.host.to_s.chomp ".s3.amazonaws.com"
+
+    key = parsed_url.path.to_s[1..-1]
+    bucket = parsed_url.host.to_s.chomp ".s3.amazonaws.com"
+
     params = (URI.decode_www_form parsed_url.query.to_s).to_h
-    @version_id = params["versionId"]
+    version_id = params["versionId"]
+    [key, bucket, version_id]
   end
 end

--- a/plugins/env/app/views/environment_variable_groups/form.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/form.html.erb
@@ -22,10 +22,18 @@
   <% end %>
 
   <%= form_for @group, html: { class: "form-horizontal" } do |form| %>
+    <%= render 'shared/errors', object: @group %>
+
     <fieldset <%= disabled %>>
       <%= form.input :name %>
       <%= form.input :comment, as: :text_area, input_html: {size: "80x4"} %>
       <%= form.input :owners, help: "Github team names or email to contact with questions (comma separated)" %>
+      <% if ExternalEnvironmentVariableGroup.configured? %>
+        <%= form.input :external_url do %>
+          <%= form.text_field :external_url, class: "form-control", placeholder: ExternalEnvironmentVariableGroup::S3_URL_FORMAT %>
+          <%= link_to 'Preview', external_env_group_preview_path("fake", url: @group.external_url) if @group.external_url? %>
+        <% end %>
+      <% end %>
     </fieldset>
 
     <% if @group.projects.length > 0 %>

--- a/plugins/env/db/migrate/20200402190202_add_external_url_to_env_groups.rb
+++ b/plugins/env/db/migrate/20200402190202_add_external_url_to_env_groups.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddExternalUrlToEnvGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :environment_variable_groups, :external_url, :string
+  end
+end

--- a/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/environment_variable_groups_controller_test.rb
@@ -257,6 +257,13 @@ describe EnvironmentVariableGroupsController do
         end
         assert_redirected_to "/environment_variable_groups"
       end
+
+      it "shows errors" do
+        refute_difference "EnvironmentVariable.count" do
+          post :create, params: {environment_variable_group: {name: ""}}
+        end
+        assert_template "form"
+      end
     end
 
     describe "#update" do
@@ -287,6 +294,13 @@ describe EnvironmentVariableGroupsController do
       end
 
       it_updates
+
+      it "shows errors" do
+        refute_difference "EnvironmentVariable.count" do
+          put :update, params: {id: env_group.id, environment_variable_group: {name: ""}}
+        end
+        assert_template "form"
+      end
 
       it "destroys variables" do
         variable = env_group.environment_variables.first

--- a/plugins/env/test/controllers/external_environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/external_environment_variable_groups_controller_test.rb
@@ -4,10 +4,7 @@ require_relative "../test_helper"
 SingleCov.covered!
 
 describe ExternalEnvironmentVariableGroupsController do
-  before do
-    ExternalEnvironmentVariableGroup.any_instance.
-      expects(:read).times(2).returns("a" => "b")
-  end
+  with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket"
 
   let(:project) { projects(:test) }
   let(:group) do
@@ -18,10 +15,20 @@ describe ExternalEnvironmentVariableGroupsController do
       project: project
     )
   end
+
   as_a :viewer do
     describe "#preview" do
+      before do
+        ExternalEnvironmentVariableGroup.any_instance.stubs(:read).returns("a" => "b")
+      end
+
       it "renders" do
         get :preview, params: {id: group.id}
+        assert_response :success
+      end
+
+      it "renders fake group" do
+        get :preview, params: {id: "fake", url: "foo"}
         assert_response :success
       end
 

--- a/plugins/env/test/decorators/project_decorator_test.rb
+++ b/plugins/env/test/decorators/project_decorator_test.rb
@@ -88,6 +88,8 @@ describe Project do
   end
 
   describe "nested_external_environment_variable_groups" do
+    with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket"
+
     it "includes both name and url" do
       ExternalEnvironmentVariableGroup.any_instance.expects(:read).returns(true)
       project.update!(

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -144,13 +144,12 @@ describe SamsonEnv do
 
     it "links to external env var group" do
       group = ExternalEnvironmentVariableGroup.new(
-          name: "A",
-          description: "B",
-          url: "https://a-bucket.s3.amazonaws.com/key?versionId=version_id",
-          project: project
-        )
-      group.expects(:read).returns(true)
-      group.save!
+        name: "A",
+        description: "B",
+        url: "https://a-bucket.s3.amazonaws.com/key?versionId=version_id",
+        project: project
+      )
+      group.save!(validate: false)
       fire(group).must_equal ["A", ""]
     end
 


### PR DESCRIPTION
... this should make migration easier because we can just set the url on the existing env var groups

<img width="708" alt="Screen Shot 2020-04-02 at 12 10 26 PM" src="https://user-images.githubusercontent.com/11367/78292739-5e2f3280-74dc-11ea-9817-b0df40f20c04.png">


@zendesk/compute @zendesk/config @zendesk/eng-productivity 