### PR TITLE
pods that couldnt be scheduled because out of cpu/memory are the same…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/api/pod.rb
+++ b/plugins/kubernetes/app/models/kubernetes/api/pod.rb
@@ -3,7 +3,13 @@ module Kubernetes
   module Api
     class Pod
       INIT_CONTAINER_KEY = :'pod.beta.kubernetes.io/init-containers'
-      WAITING_FOR_RESOURCES = ["FailedScheduling", "FailedCreatePodSandBox", "FailedAttachVolume"].freeze
+      WAITING_FOR_RESOURCES = [
+        "FailedScheduling",
+        "FailedCreatePodSandBox",
+        "FailedAttachVolume",
+        "OutOfcpu",
+        "OutOfmemory"
+      ].freeze
 
       attr_writer :events
 


### PR DESCRIPTION
… as waiting for capacity

This is a new error that we haven't seen before, so could be from a new underlying issue or from cluster upgrade, but it seems innocent.

**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

@zendesk/compute 
