### PR TITLE
kubernetes 1.15 no longer needs delete/create workflow for PDPs

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -479,7 +479,7 @@ module Kubernetes
     class Pod < Immutable
     end
 
-    class PodDisruptionBudget < Immutable
+    class PodDisruptionBudget < VersionedUpdate
       def initialize(*)
         super
         @delete_resource ||= @template[:delete] # allow deletion through release_doc logic

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -932,8 +932,10 @@ describe Kubernetes::Resource do
 
     describe "#deploy" do
       it "updates" do
-        assert_create_and_delete_requests do
-          resource.deploy
+        assert_request(:get, url, to_return: [{body: '{}'}]) do
+          assert_request(:put, url, to_return: {body: '{}'}) do
+            resource.deploy
+          end
         end
       end
 
@@ -943,15 +945,6 @@ describe Kubernetes::Resource do
           assert_request(:delete, url, to_return: {body: '{}'}) do
             resource.deploy
           end
-        end
-      end
-    end
-
-    describe "#revert" do
-      it "deletes and then creates without resourceVersion because that is not allowed" do
-        with = ->(request) { request.body.wont_include "resourceVersion"; true }
-        assert_create_and_delete_requests(with: with) do
-          resource.revert(template.deep_merge(metadata: {resourceVersion: '123'}))
         end
       end
     end


### PR DESCRIPTION
@zendesk/compute 

even though we check after deleting this still happened ... so just get rid of the code and problem solved 🤷 

```
[05:38:41] JobExecution failed: Kubernetes error PodDisruptionBudget foo pod11 Pod11: poddisruptionbudgets.policy "foo" already exists

```