### PR TITLE
PAAS-6702 allow ignorin custom bad events to stop samson logic blocki…

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -308,3 +308,11 @@ metadata.annotation.samson/force_update: "true"
 ### Static config per deploy group
 
 Set the kubernetes roles to `kubernetes/$deploy_group/server.yml` 
+
+### Ignoring warning events
+
+If a warning event fails deploys, but application owners deem them safe to ignore, add this:
+
+`metadata.annotations.samson/ignore_events="FailedCreate,AnotherEvent"`
+
+... still consider opening a samson PR if the event is universally to be ignored.

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -111,9 +111,10 @@ module Kubernetes
     # ignore known events that randomly happen
     def failures(kind)
       failures = events(type: "Warning")
-      if ignored = IGNORED_EVENT_REASONS[kind.to_sym]
-        failures.reject! { |e| ignored.include? e[:reason] }
-      end
+      ignored =
+        @resource.dig(:metadata, :annotations, :"samson/ignore_events").to_s.split(",") +
+        (IGNORED_EVENT_REASONS[kind.to_sym] || [])
+      failures.reject! { |e| ignored.include? e[:reason] } if ignored.any?
       failures
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -78,15 +78,32 @@ describe Kubernetes::ResourceStatus do
         expect_event_request { details.must_equal "Live" }
       end
 
-      it "knows failed non-pods" do
-        events[0].merge!(type: "Warning", reason: "Boom")
-        expect_event_request { details.must_equal "Error event" }
-      end
-
       it "ignores known bad events" do
         resource[:kind] = "HorizontalPodAutoscaler"
         events[0].merge!(type: "Warning", reason: "FailedGetMetrics")
         expect_event_request { details.must_equal "Live" }
+      end
+
+      describe "with bad event" do
+        before { events[0].merge!(type: "Warning", reason: "Boom") }
+
+        it "fails" do
+          expect_event_request { details.must_equal "Error event" }
+        end
+
+        it "ignores custom known bad events" do
+          resource[:metadata][:annotations] = {
+            "samson/ignore_events": "Boom"
+          }
+          expect_event_request { details.must_equal "Live" }
+        end
+
+        it "ignores non-matching custom known bad events" do
+          resource[:metadata][:annotations] = {
+            "samson/ignore_events": "Boing"
+          }
+          expect_event_request { details.must_equal "Error event" }
+        end
       end
     end
   end


### PR DESCRIPTION
…ng deploys

some StatefulSets run into FailedCreate for example, it would be great if we don't have to rush out a global samson change to accommodate that while we still don't know if this is normal or caused by something else

@zendesk/compute 