### PR TITLE
Added external_environment_variable_groups as allowed includes

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -74,9 +74,8 @@ class ProjectsController < ResourceController
   def allowed_includes
     [
       :environment_variable_groups,
-      :environment_variables_with_scope,
-      (:external_environment_variable_groups if ExternalEnvironmentVariableGroup.configured?)
-    ]
+      :environment_variables_with_scope
+    ] + Samson::Hooks.fire(:project_allowed_includes).flatten(1)
   end
 
   def resource_params

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -75,6 +75,7 @@ class ProjectsController < ResourceController
     [
       :environment_variable_groups,
       :environment_variables_with_scope,
+      (:external_environment_variable_groups if ExternalEnvironmentVariableGroup.configured?)
     ]
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -215,6 +215,10 @@ class Project < ActiveRecord::Base
     )
   end
 
+  def external_environment_variable_groups
+    ExternalEnvironmentVariableGroup.find_by_project_id(id)
+  end
+
   def as_json(methods: [], **options)
     super(
       {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -215,10 +215,6 @@ class Project < ActiveRecord::Base
     )
   end
 
-  def external_environment_variable_groups
-    ExternalEnvironmentVariableGroup.find_by_project_id(id)
-  end
-
   def as_json(methods: [], **options)
     super(
       {

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -61,7 +61,8 @@ module Samson
       :repo_provider_status,
       :repo_commit_from_ref,
       :repo_compare,
-      :validate_deploy
+      :validate_deploy,
+      :project_allowed_includes
     ].freeze
 
     # Hooks that are slow and we want performance info on

--- a/plugins/env/app/controllers/external_environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/external_environment_variable_groups_controller.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 class ExternalEnvironmentVariableGroupsController < ApplicationController
+  def index
+    @groups = ExternalEnvironmentVariableGroup.all
+    respond_to do |format|
+      format.html
+      format.json { render json: {groups: @groups} }
+    end
+  end
+
   def preview
     @group =
       if params.require(:id) == "fake"

--- a/plugins/env/app/controllers/external_environment_variable_groups_controller.rb
+++ b/plugins/env/app/controllers/external_environment_variable_groups_controller.rb
@@ -3,7 +3,6 @@ class ExternalEnvironmentVariableGroupsController < ApplicationController
   def index
     @groups = ExternalEnvironmentVariableGroup.all
     respond_to do |format|
-      format.html
       format.json { render json: {groups: @groups} }
     end
   end

--- a/plugins/env/app/views/environment_variable_groups/form.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/form.html.erb
@@ -31,7 +31,7 @@
       <% if ExternalEnvironmentVariableGroup.configured? %>
         <%= form.input :external_url do %>
           <%= form.text_field :external_url, class: "form-control", placeholder: ExternalEnvironmentVariableGroup::S3_URL_FORMAT %>
-          <%= link_to 'Preview', external_env_group_preview_path("fake", url: @group.external_url) if @group.external_url? %>
+          <%= link_to 'Preview', preview_external_environment_variable_group_path("fake", url: @group.external_url) if @group.external_url? %>
         <% end %>
       <% end %>
     </fieldset>

--- a/plugins/env/app/views/external_environment_variable_groups/_fields.html.erb
+++ b/plugins/env/app/views/external_environment_variable_groups/_fields.html.erb
@@ -19,7 +19,7 @@
         <%= link_to_history fields.object, counter: false %>
       </div>
       <div class="col-lg-1 checkbox external-env-group-links">
-        <%= link_to 'Preview', external_env_group_preview_path(fields.object) %>
+        <%= link_to 'Preview', preview_external_environment_variable_group_path(fields.object) %>
       </div>
       <div class="col-lg-1 checkbox external-env-group-links">
         <%= fields.label :_destroy do %>

--- a/plugins/env/config/routes.rb
+++ b/plugins/env/config/routes.rb
@@ -6,6 +6,9 @@ Samson::Application.routes.draw do
     end
   end
 
+  get '/external_environment_variable_groups(:format)',
+    to: 'external_environment_variable_groups#index', as: 'external_env_group_index'
+
   get '/external_environment_variable_groups/:id/preview',
     to: 'external_environment_variable_groups#preview', as: 'external_env_group_preview'
   resources :environment_variables, only: [:index, :destroy]

--- a/plugins/env/config/routes.rb
+++ b/plugins/env/config/routes.rb
@@ -5,12 +5,11 @@ Samson::Application.routes.draw do
       get :preview
     end
   end
-
-  get '/external_environment_variable_groups(:format)',
-    to: 'external_environment_variable_groups#index', as: 'external_env_group_index'
-
-  get '/external_environment_variable_groups/:id/preview',
-    to: 'external_environment_variable_groups#preview', as: 'external_env_group_preview'
+  resources :external_environment_variable_groups do
+    member do
+      get :preview
+    end
+  end
   resources :environment_variables, only: [:index, :destroy]
   resources :projects, only: [] do
     resource :environment, only: [:show], controller: 'env/environment'

--- a/plugins/env/lib/samson_env/samson_plugin.rb
+++ b/plugins/env/lib/samson_env/samson_plugin.rb
@@ -145,3 +145,7 @@ Samson::Hooks.view :deploy_form, 'samson_env'
 Samson::Hooks.callback :deploy_permitted_params do
   AcceptsEnvironmentVariables::ASSIGNABLE_ATTRIBUTES
 end
+
+Samson::Hooks.callback :project_allowed_includes do
+  ExternalEnvironmentVariableGroup.configured? ? [:external_environment_variable_groups] : []
+end

--- a/plugins/env/test/controllers/external_environment_variable_groups_controller_test.rb
+++ b/plugins/env/test/controllers/external_environment_variable_groups_controller_test.rb
@@ -32,6 +32,15 @@ describe ExternalEnvironmentVariableGroupsController do
         assert_response :success
       end
 
+      describe "a json GET to #index" do
+        it "succeeds" do
+          get :index, format: :json
+          assert_response :success
+          json_response = JSON.parse response.body
+          json_response.keys.must_include 'groups'
+        end
+      end
+
       describe "a json GET to #preview" do
         it "succeeds" do
           get :preview, params: {id: group.id}, format: :json

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -233,4 +233,12 @@ describe SamsonEnv do
       )
     end
   end
+
+  describe :project_allowed_includes do
+    it "includes the project_allowed_includes attributes" do
+      Samson::Hooks.fire(:project_allowed_includes).must_include(
+        external_environment_variable_groups: []
+      )
+    end
+  end
 end

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -234,10 +234,19 @@ describe SamsonEnv do
     end
   end
 
-  describe :project_allowed_includes do
-    it "includes the project_allowed_includes attributes" do
+  describe ':project_allowed_includes with external env configured' do
+    with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket"
+    it "includes external env var groups" do
       Samson::Hooks.fire(:project_allowed_includes).must_include(
-        external_environment_variable_groups: []
+        [:external_environment_variable_groups]
+      )
+    end
+  end
+
+  describe ':project_allowed_includes without external env configured' do
+    it "does not include external env var groups" do
+      Samson::Hooks.fire(:project_allowed_includes).must_equal(
+        [[]]
       )
     end
   end

--- a/plugins/env/test/samson_env/samson_plugin_test.rb
+++ b/plugins/env/test/samson_env/samson_plugin_test.rb
@@ -234,17 +234,16 @@ describe SamsonEnv do
     end
   end
 
-  describe ':project_allowed_includes with external env configured' do
-    with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket"
-    it "includes external env var groups" do
-      Samson::Hooks.fire(:project_allowed_includes).must_include(
-        [:external_environment_variable_groups]
-      )
+  describe :project_allowed_includes do
+    it "includes external env var groups with external env configured" do
+      with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket" do
+        Samson::Hooks.fire(:project_allowed_includes).must_include(
+          [:external_environment_variable_groups]
+        )
+      end
     end
-  end
 
-  describe ':project_allowed_includes without external env configured' do
-    it "does not include external env var groups" do
+    it "does not include external env var groups when not configured" do
       Samson::Hooks.fire(:project_allowed_includes).must_equal(
         [[]]
       )

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -174,6 +174,13 @@ describe ProjectsController do
           project = JSON.parse(response.body)
           project.keys.must_include "environment_variables_with_scope"
         end
+
+        it "renders with external_environment_variable_groups if present" do
+          get :show, params: {id: project.to_param, includes: "external_environment_variable_groups", format: :json}
+          assert_response :success
+          project = JSON.parse(response.body)
+          project.keys.must_include "external_environment_variable_groups"
+        end
       end
     end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -4,8 +4,6 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe ProjectsController do
-  with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket"
-
   def fields_disabled?
     assert_select 'fieldset' do |fs|
       return fs.attr('disabled').present?
@@ -177,11 +175,13 @@ describe ProjectsController do
           project.keys.must_include "environment_variables_with_scope"
         end
 
-        it "renders with external_environment_variable_groups if present" do
-          get :show, params: {id: project.to_param, includes: "external_environment_variable_groups", format: :json}
-          assert_response :success
-          project = JSON.parse(response.body)
-          project.keys.must_include "external_environment_variable_groups"
+        it "renders with external_environment_variable_groups if requested" do
+          with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket" do
+            get :show, params: {id: project.to_param, includes: "external_environment_variable_groups", format: :json}
+            assert_response :success
+            project = JSON.parse(response.body)
+            project.keys.must_include "external_environment_variable_groups"
+          end
         end
       end
     end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -4,6 +4,8 @@ require_relative '../test_helper'
 SingleCov.covered!
 
 describe ProjectsController do
+  with_env EXTERNAL_ENV_GROUP_S3_REGION: "us-east-1", EXTERNAL_ENV_GROUP_S3_BUCKET: "a-bucket"
+
   def fields_disabled?
     assert_select 'fieldset' do |fs|
       return fs.attr('disabled').present?


### PR DESCRIPTION
For tooling that depends on samson export data there is currently no
good way of pulling what external groups are configured for a project.

Add endpoints to list all external env groups, and allow them as an
include on a projects json export.

**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

### References
- Jira link: https://zendesk.atlassian.net/browse/EPEMEA-372

### Risks
- Low: This only adds export of metadata for external env groups