### PR TITLE
allow search for deploy started time

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -251,9 +251,9 @@ module ApplicationHelper
     end
   end
 
-  def search_form(options = {}, &block)
+  def search_form(top_pad: true, **options, &block)
     form_tag '?', options.merge(method: :get, class: "clearfix") do
-      button = submit_tag("Search", class: "btn btn-default form-control", style: "margin-top: 25px")
+      button = submit_tag("Search", class: "btn btn-default form-control", style: ("margin-top: 25px" if top_pad))
       capture(&block) << content_tag(:div, button, class: "col-md-1 clearfix")
     end
   end

--- a/app/views/deploys/index.html.erb
+++ b/app/views/deploys/index.html.erb
@@ -7,7 +7,7 @@
 
 <section class="tabs deploy-search">
   <div class="row">
-    <%= search_form do %>
+    <%= search_form top_pad: false do %>
       <div class="col-sm-2">
         <%= label_tag 'Deployer name' %>
         <%= text_field_tag 'search[deployer]', params.dig(:search, :deployer), class: "form-control" %>
@@ -30,10 +30,28 @@
       <%= search_select :status, Job::VALID_STATUSES, size: 1 %>
       <%= search_select :group, Environment.env_deploy_group_array %>
       <%= search_select :time_format, User::TIME_FORMATS, selected: params.dig(:search, :time_format) || current_user.time_format, label: 'Time', size: 1 %>
-      <div class="col-sm-1">
-        <%= label_tag :Deleted %>
-        <%= check_box_tag 'search[deleted]', "Project,Stage,Deploy", params.dig(:search, :deleted) %>
-      </div>
+
+      <details>
+        <summary><%= label_tag :more %></summary>
+        <br/>
+        <br/>
+        <br/>
+
+        <div class="col-sm-1">
+          <%= label_tag :deleted %>
+          <%= check_box_tag 'search[deleted]', "Project,Stage,Deploy", params.dig(:search, :deleted) %>
+        </div>
+
+        <div class="col-md-2">
+          <%= label_tag 'Started from' %>
+          <%= text_field_tag 'search[created_at][]', params.dig(:search, :created_at, 0), placeholder: "YYYY-MM-DD HH:MM:SS" %>
+        </div>
+
+        <div class="col-md-2">
+          <%= label_tag 'Started to' %>
+          <%= text_field_tag 'search[created_at][]', params.dig(:search, :created_at, 1), placeholder: "YYYY-MM-DD HH:MM:SS" %>
+        </div>
+      </details>
     <% end %>
   </div>
 

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -367,6 +367,23 @@ describe DeploysController do
         assigns[:deploys].map(&:id).sort.must_equal expected.map(&:id).sort
       end
 
+      it "ignores empty update fields" do
+        get :index, params: {search: {updated_at: ["", ""]}}, format: "json"
+        assert_response :ok
+      end
+
+      it "warns when only submitting single date field" do
+        get :index, params: {search: {updated_at: ["", "2020-02-10"]}}, format: "json"
+        assert_response :ok
+        assert flash[:alert]
+      end
+
+      it "fails when submitting to many date fields" do
+        assert_raises ArgumentError do
+          get :index, params: {search: {updated_at: ["A", "A", "A"]}}, format: "json"
+        end
+      end
+
       it "filters by deleted" do
         Deploy.last.soft_delete!
         get :index, params: {search: {deleted: "Project,Stage,Deploy"}}, format: "json"

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -579,6 +579,11 @@ describe ApplicationHelper do
       result.must_include "method=\"get\""
       result.must_include "class=\"btn btn-default form-control\""
     end
+
+    it "can redner without padding" do
+      search_form { "Hello" }.must_include "margin-top"
+      search_form(top_pad: false) { "Hello" }.wont_include "margin-top"
+    end
   end
 
   describe "#search_select" do


### PR DESCRIPTION
<img width="1124" alt="Screen Shot 2020-04-23 at 5 14 54 PM" src="https://user-images.githubusercontent.com/11367/80161718-1b65f500-8586-11ea-9f60-1b480b9aaa87.png">

![image](https://user-images.githubusercontent.com/11367/80161771-46e8df80-8586-11ea-9f97-59754762b1ae.png)

<img width="1178" alt="Screen Shot 2020-04-23 at 5 13 23 PM" src="https://user-images.githubusercontent.com/11367/80161720-1c972200-8586-11ea-9186-f96692181a11.png">

@zendesk/compute 

some UI caveats are that it does not auto-expand when the fields are filled out / does not work when to or from are not filled out ... but good start 🤷 