### PR TITLE
use the same value to lookup extern env vars as when generating them …

### DIFF
--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -74,7 +74,7 @@ class EnvironmentVariable < ActiveRecord::Base
       end)
 
       external_groups.each_with_object({}) do |group, envs|
-        group_env = group.read[deploy_group.permalink]
+        group_env = group.read[deploy_group.name.parameterize]
         envs.merge! group_env if group_env
       end
     rescue StandardError => e

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -63,7 +63,7 @@ describe EnvironmentVariable do
       end
 
       it "add to env hash" do
-        response = {deploy_group.permalink => {"FOO" => +"one"}}
+        response = {deploy_group.name.parameterize => {"FOO" => +"one"}}
         ExternalEnvironmentVariableGroup.any_instance.expects(:read).returns(response)
         EnvironmentVariable.env(deploy, deploy_group, resolve_secrets: false).must_equal "FOO" => "one"
       end
@@ -88,7 +88,7 @@ describe EnvironmentVariable do
         project.environment_variable_groups << EnvironmentVariableGroup.first
         project.environment_variable_groups.first.update_column(:external_url, "https://foo.com")
 
-        response = {deploy_group.permalink => {"FOO" => +"one"}}
+        response = {deploy_group.name.parameterize => {"FOO" => +"one"}}
 
         ExternalEnvironmentVariableGroup.any_instance.expects(:read).returns(response)
         EnvironmentVariable.env(deploy, deploy_group, resolve_secrets: false).must_equal(


### PR DESCRIPTION
…via preview endpoint

currently they mismatch leading to dumped data not being usable