### PR TITLE
PAAS-6795 allow for some failed pods during a deployment

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -243,9 +243,14 @@ Then configure an ENV var with that same name and a value that is valid JSON.
  - To set string values as env vars, use quotes, i.e. `"foo"`
  - To set values inside of arrays use numbers as index `spec.containers.0.name`
 
-### Allow randomly not-ready pods during readiness check
+### Allow randomly not-ready pods during readiness & stability check
 
-Set `KUBERNETES_ALLOW_NOT_READY_PERCENT=10` to allow up to 10% of pods per role being not-ready,
+Set `KUBERNETES_ALLOW_NOT_READY_PERCENT=20` to allow up to 20% of pods per role being not-ready,
+this is useful when dealing with large deployments that have some random failures.
+
+### Allow randomly failing pods during readiness & stability check
+
+Set `KUBERNETES_ALLOW_FAILED_PERCENT=10` to allow up to 10% of pods per role being failed,
 this is useful when dealing with large deployments that have some random failures.
 
 ### Disabling service selector validation

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -324,7 +324,7 @@ module Kubernetes
 
       # for big deploys, do not print all the identical pods
       lines.group_by(&:itself).each_value do |group|
-        group = [group.first, "  ... #{group.size - 1} identical"] if lines.size >= 10 && group.size > 2
+        group = ["#{group.first} x#{group.size}"] if lines.size >= 10 && group.size > 2
         group.each { |l| @output.puts l }
       end
     end

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -24,7 +24,6 @@ module Kubernetes
     }.freeze
 
     attr_reader :resource, :role, :deploy_group, :kind, :details, :live, :finished, :pod
-    attr_writer :details
 
     def initialize(resource:, role: nil, deploy_group:, prerequisite: false, start:, kind:)
       @resource = resource

--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -50,7 +50,7 @@ module Kubernetes
           @details = "Live"
           @live = true
           @finished = @pod.completed?
-        elsif (@pod.events = failures(kind)) && @pod.waiting_for_resources?
+        elsif (@pod.events = bad_events(kind)) && @pod.waiting_for_resources? # TODO: rename/refactor pod.events
           @details = "Waiting for resources (#{@pod.phase}, #{@pod.reason})"
         elsif @pod.events_indicate_failure?
           @details = "Error event"
@@ -61,7 +61,7 @@ module Kubernetes
       else
         @finished = true # non-pods are never "Missing" because samson creates them directly
 
-        if failures(kind).any?
+        if bad_events(kind).any?
           @details = "Error event"
         else
           @details = "Live"
@@ -108,7 +108,7 @@ module Kubernetes
     end
 
     # ignore known events that randomly happen
-    def failures(kind)
+    def bad_events(kind)
       failures = events(type: "Warning")
       ignored =
         @resource.dig(:metadata, :annotations, :"samson/ignore_events").to_s.split(",") +

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -960,23 +960,27 @@ describe Kubernetes::DeployExecutor do
 
   describe "#print_statuses" do
     let(:status) do
-      Kubernetes::ResourceStatus.new(
+      s = Kubernetes::ResourceStatus.new(
         resource: nil,
         role: kubernetes_roles(:app_server),
         deploy_group: deploy_groups(:pod1),
         start: nil,
         kind: "Pod"
       )
+      s.instance_variable_set(:@details, "Pending")
+      s
     end
 
     it "renders" do
       executor.send(:print_statuses, "Hey:", [status], exact: false)
-      out.must_equal "Hey:\n  Pod1 app-server Pod: \n"
+      out.must_equal "Hey:\n  Pod1 app-server Pod: Pending\n"
     end
 
-    it "does not summarizes with moderate ammount of pods" do
+    it "does not summarizes with moderate amount of pods" do
       executor.send(:print_statuses, "Hey:", Array.new(3) { status.dup }, exact: false)
-      out.must_equal "Hey:\n  Pod1 app-server Pod: \n  Pod1 app-server Pod: \n  Pod1 app-server Pod: \n"
+      out.must_equal(
+        "Hey:\n  Pod1 app-server Pod: Pending\n  Pod1 app-server Pod: Pending\n  Pod1 app-server Pod: Pending\n"
+      )
     end
 
     it "does not summarizes when summary would be equal number of lines" do
@@ -990,7 +994,7 @@ describe Kubernetes::DeployExecutor do
 
     it "summarizes when too many identical statuses are shown" do
       executor.send(:print_statuses, "Hey:", Array.new(20) { status.dup }, exact: false)
-      out.must_equal "Hey:\n  Pod1 app-server Pod: \n  ... 19 identical\n"
+      out.must_equal "Hey:\n  Pod1 app-server Pod: Pending x20\n"
     end
   end
 


### PR DESCRIPTION
before we only allowed for not-ready pods (pending and such), but for big deployments there are also random failures like restarts/oomkills etc that we need to be able to ignore to avoid random deploy failures

this can be tuned via KUBERNETES_ALLOW_FAILED_PERCENT ... recommendation is <10% for that

@zendesk/compute 
/cc @craig-day @lennardseah 