### PR TITLE
allow overwriting static env vars if user requests it

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -243,6 +243,12 @@ Then configure an ENV var with that same name and a value that is valid JSON.
  - To set string values as env vars, use quotes, i.e. `"foo"`
  - To set values inside of arrays use numbers as index `spec.containers.0.name`
 
+### Allowing to override static/db env vars
+
+If you want to override or remove env vars like PROJECT,ROLE,TAG ... set this:
+
+`metadata.annotations.container-nameofcontainer-samson/keep_env_var: "TAG,ROLE"`
+
 ### Allow randomly not-ready pods during readiness & stability check
 
 Set `KUBERNETES_ALLOW_NOT_READY_PERCENT=20` to allow up to 20% of pods per role being not-ready,

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -511,10 +511,18 @@ module Kubernetes
       end
 
       env_containers.each do |c|
+        extra = all
         env = (c[:env] ||= [])
-        env.concat all
 
-        # unique, but keep last elements
+        # keep container env var if requested, so static+plugin env can be overwritten
+        if keep = samson_container_config(c, :"samson/keep_env_var").to_s.split(/, ?| /).presence
+          extra = all.dup
+          keep.each { |var| extra.delete_if { |e| e[:name] == var } }
+        end
+
+        env.concat extra
+
+        # unique, but keep user configured overrides
         env.reverse!
         env.uniq! { |h| h[:name] }
         env.reverse!

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -612,6 +612,14 @@ describe Kubernetes::TemplateFiller do
         end
       end
 
+      it "does not override container env var when requested" do
+        raw_template[:spec][:template][:spec][:containers].first[:env] = [{name: 'TAG', value: 'OVERRIDE'}]
+        raw_template[:spec][:template][:spec][:containers].first[:"samson/keep_env_var"] = "TAG"
+        container.fetch(:env).select { |e| e[:name] == 'TAG' }.must_equal(
+          [{name: 'TAG', value: 'OVERRIDE'}]
+        )
+      end
+
       describe "with multiple containers" do
         before { raw_template[:spec][:template][:spec][:containers] = [{name: 'foo'}, {name: 'bar'}] }
 


### PR DESCRIPTION
alternative to https://github.com/zendesk/samson/pull/3780 without "might break lots of things" concern ... new logic only for those that request it

- also allows overriding plugin/db env vars
- when container does not set the var it was asked to keep it come out as unset