### PR TITLE
eta is wrong since it does not update when deploy is already running

### DIFF
--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -36,7 +36,7 @@ module StatusHelper
       content << " [Process ID: #{job.pid}]"
       if is_deploy
         content << content_tag(:br)
-        content << "ETA: #{duration_text deployable.stage.average_deploy_time}"
+        content << "Expected duration: #{duration_text deployable.stage.average_deploy_time}"
       end
     end
 

--- a/test/helpers/status_helper_test.rb
+++ b/test/helpers/status_helper_test.rb
@@ -24,13 +24,13 @@ describe StatusHelper do
       deploy.stage.update_column(:average_deploy_time, 3)
       deploy.expects(:active?).returns(true)
 
-      status_panel(deploy).must_include 'ETA: 00:00:03.'
+      status_panel(deploy).must_include 'Expected duration: 00:00:03.'
     end
 
     it 'does not show duration text for jobs' do
       job.expects(:active?).returns(true)
 
-      status_panel(job).wont_include 'ETA: 00:00:03.'
+      status_panel(job).wont_include 'Expected duration: 00:00:03.'
     end
   end
 


### PR DESCRIPTION
for example deploy running since 1h still said "ETA: 3 minutes"
<img width="274" alt="Screen Shot 2020-05-07 at 9 30 07 AM" src="https://user-images.githubusercontent.com/11367/81319998-59165380-9045-11ea-96dd-547e30c7e132.png">
