### PR TITLE
fix boot check crashing when logger was loaded first

### DIFF
--- a/test/lib/samson/boot_check_test.rb
+++ b/test/lib/samson/boot_check_test.rb
@@ -14,7 +14,7 @@ describe Samson::BootCheck do
       end
 
       it "does not warn when everything is ok" do
-        Thread.stubs(:list).returns([1])
+        Thread.stubs(:list).returns([stub("Thread", backtrace: ['ruby_thread_local_var'])])
         Samson::BootCheck.expects(:const_defined?)
         ActiveRecord::Base.expects(:descendants).returns([])
         ActionController::Base.expects(:descendants).returns([])


### PR DESCRIPTION
logger requires ruby concurrent and that sets up some global thread finalizer, nothing we need to worry about and hard to disable ... so let's ignore it

@zendesk/compute 