### PR TITLE
do not send nils back in the list of included objects

### DIFF
--- a/app/controllers/concerns/json_renderer.rb
+++ b/app/controllers/concerns/json_renderer.rb
@@ -21,9 +21,12 @@ module JsonRenderer
       includes.each do |association_name|
         resources.each do |resource, resource_as_json|
           associated = resource.public_send(association_name)
-          if associated.is_a?(ActiveRecord::Base) || associated.nil?
-            resource_as_json["#{association_name}_id"] ||= associated&.id
+          if associated.is_a?(ActiveRecord::Base)
+            resource_as_json["#{association_name}_id"] ||= associated.id
             (associations[association_name.pluralize] ||= []) << associated
+          elsif associated.nil?
+            resource_as_json["#{association_name}_id"] ||= nil
+            associations[association_name.pluralize] ||= []
           else
             resource_as_json["#{association_name.singularize}_ids"] = associated.map(&:id)
             (associations[association_name] ||= []).concat associated

--- a/test/controllers/concerns/json_renderer_test.rb
+++ b/test/controllers/concerns/json_renderer_test.rb
@@ -57,6 +57,12 @@ describe "JsonRenderer Integration" do
       json['deploy_groups'].first.keys.must_include "kubernetes_cluster_id"
     end
 
+    it "does not render missing has_one as nil" do
+      Kubernetes::Cluster.delete_all
+      get '/deploy_groups.json', params: {includes: 'kubernetes_cluster'}
+      json['kubernetes_clusters'].must_equal []
+    end
+
     it "can add custom things via yield" do
       project = projects(:test)
       stage = stages(:test_staging)


### PR DESCRIPTION
notices that stages?includes=locks had locks array with nil values, but they should not be there

@zendesk/compute 