### PR TITLE
enforce token format to prevent hard to debug errors from invalid format

### DIFF
--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -7,7 +7,7 @@
       <%= form.select :application_id, options_for_select(Doorkeeper::Application.all.map { |a| [a.name, a.id] }), {}, {class: 'form-control'} %>
     <% end %>
     <%= form.input :description %>
-    <%= form.input :scopes, help: I18n.t('doorkeeper.applications.help.scopes') %>
+    <%= form.input :scopes, pattern: /\A[a-z ]+\z/, help: I18n.t('doorkeeper.applications.help.scopes') %>
 
     <%= form.actions %>
   <% end %>


### PR DESCRIPTION
@zendesk/compute 

I put a comma in there more than once and then wondered why it's not working.
Adding validation to the base model is hacky, so picking the easy way out.

<img width="422" alt="Screen Shot 2020-06-05 at 5 14 55 PM" src="https://user-images.githubusercontent.com/11367/83931209-4f6d3200-a750-11ea-8e8c-56c25b9261f5.png">
