### PR TITLE
Allow seeding secrets for newly created namespaces

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -327,3 +327,8 @@ If a warning event fails deploys, but application owners deem them safe to ignor
 `metadata.annotations.samson/ignore_events="FailedCreate,AnotherEvent"`
 
 ... still consider opening a samson PR if the event is universally to be ignored.
+
+### Copying secrets to created namespaces
+
+When using the namespaces UI to create new namespaces, set `KUBERNETES_COPY_SECRETS_TO_NEW_NAMESPACE=my-docker-auth,other-stuff`,
+it will then copy that secret from the `default` namespace to any newly created namespace.

--- a/plugins/kubernetes/test/controllers/kubernetes/namespaces_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/namespaces_controller_test.rb
@@ -222,5 +222,20 @@ describe Kubernetes::NamespacesController do
         refute flash[:warn]
       end
     end
+
+    describe "#copy_secrets" do
+      it "copies secrets" do
+        stub_request(:get, "http://foobar.server/api/v1/namespaces/f/secrets/s").to_return(body: {metadata: {}}.to_json)
+        stub_request(:post, "http://foobar.server/api/v1/namespaces/t/secrets").to_return(body: '{}')
+        @controller.send(:copy_secrets, ["s"], from: "f", to: "t").must_equal []
+      end
+
+      it "shows errors" do
+        stub_request(:get, "http://foobar.server/api/v1/namespaces/f/secrets/s").to_return(status: 404)
+        @controller.send(:copy_secrets, ["s"], from: "f", to: "t").must_equal(
+          ["Failed to copy secret s to t in cluster test: 404 Not Found"]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
@zendesk/compute 

verification:
- kubectl create secret generic foo -n default --from-literal=foo=bar
- set KUBERNETES_COPY_SECRETS_TO_NEW_NAMESPACE=foo
- create namespace bar
- kubectl get secrets -n bar