### PR TITLE
use an empty compare when project is local, to not get weird errors i…

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -68,7 +68,8 @@ class Changeset
     return NullComparison.new if empty?
 
     Rails.cache.fetch(compare_cache_key) do
-      Samson::Hooks.fire(:repo_compare, @project, @previous_commit, @reference).compact.first
+      Samson::Hooks.fire(:repo_compare, @project, @previous_commit, @reference).compact.first ||
+        NullComparison.new
     end
   rescue StandardError => e
     Changeset::NullComparison.new(error: "Repository error: #{e.message.split("::").last}")

--- a/test/models/changeset_test.rb
+++ b/test/models/changeset_test.rb
@@ -69,6 +69,13 @@ describe Changeset do
       stub_github_api("repos/foo/bar/compare/a...master", "x" => "z")
       Changeset.new(project, "a", "master").comparison.to_h.must_equal x: "z"
     end
+
+    it "creates a null compare for local projects" do
+      project.stubs(:github?)
+      project.stubs(:gitlab?)
+      comparison = Changeset.new(project, "a", "b").comparison
+      comparison.class.must_equal Changeset::NullComparison
+    end
   end
 
   describe "#commit_range_url" do


### PR DESCRIPTION
…n the template

https://github.com/zendesk/samson/issues/3800

@zendesk/compute 
