### PR TITLE
execute tasks with consistent start time on the first time the start …

### DIFF
--- a/lib/samson/periodical.rb
+++ b/lib/samson/periodical.rb
@@ -35,6 +35,9 @@ module Samson
           merge(env_settings(name)).
           merge(block: block, description: description).
           merge(options)
+
+        # we do not do initial runs when using consistent_start_time, so we need to run at the first invocation
+        registered[name][:now] = true if options[:consistent_start_time]
       end
 
       # works with cron like setup for .run_once and in process execution via .run

--- a/test/lib/samson/periodical_test.rb
+++ b/test/lib/samson/periodical_test.rb
@@ -154,6 +154,18 @@ describe Samson::Periodical do
       tasks = Samson::Periodical.run
       tasks.first.shutdown
     end
+
+    # cannot use 0.1s since % math and scheduler do not support it
+    it "runs consistent_start_time task when they are first due" do
+      freeze_time # we need to make sure the scheduler always wait 1s
+      ran = []
+      Samson::Periodical.register(:foo, 'bar', consistent_start_time: true, execution_interval: 1) { ran << 1 }
+      Samson::Periodical.run
+      sleep 0.8
+      ran.size.must_equal 0
+      sleep 0.3
+      ran.size.must_equal 1
+    end
   end
 
   describe ".configs_from_string" do


### PR DESCRIPTION
…time comes by

we saw periodical deploys always skipping after we deployed that same day
turns out when we removed `now: true` we did not account for consistent_start time / did not have any test pointing that out

@zendesk/compute 