### PR TITLE
allow explicit recreate to get rid of current state (service NodePort…

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -316,6 +316,15 @@ Delete old resource and create new when an update fails because it `cannot chang
 metadata.annotation.samson/force_update: "true"
 ```
 
+### Forcing a delete-create to get back to a clean state
+
+Delete old resource and create new.
+Can be useful for Service migration from NodePort to ClusterIP, or similar scenarios where we want a clean slate.
+
+```
+metadata.annotation.samson/recreate: "true"
+```
+
 ### Static config per deploy group
 
 Set the kubernetes roles to `kubernetes/$deploy_group/server.yml` 

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -62,7 +62,12 @@ module Kubernetes
           if @delete_resource
             delete
           else
-            update
+            if recreate?
+              delete
+              create
+            else
+              update
+            end
           end
         else
           create
@@ -119,6 +124,10 @@ module Kubernetes
       end
 
       private
+
+      def recreate?
+        @template.dig(:metadata, :annotations, :"samson/recreate") == "true"
+      end
 
       def server_side_apply?
         @template.dig(:metadata, :annotations, :"samson/server_side_apply") == "true"
@@ -336,9 +345,8 @@ module Kubernetes
     end
 
     class Immutable < Base
-      def deploy
-        delete
-        create
+      def recreate?
+        true
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -790,6 +790,18 @@ describe Kubernetes::Resource do
         end
       end
 
+      # TODO: does not work for deployments because there we update replicas first
+      it "recreates when requested" do
+        template[:metadata][:annotations] = {"samson/recreate": "true"}
+        assert_request(:get, url, to_return: [{body: "{}"}, {status: 404}]) do
+          assert_request(:delete, url, to_return: {body: "{}"}) do
+            assert_request(:post, base_url, to_return: {body: "{}"}) do
+              resource.deploy
+            end
+          end
+        end
+      end
+
       describe "forced update" do
         def assert_recreate(error)
           assert_request(:get, url, to_return: [{body: "{}"}, {status: 404}]) do


### PR DESCRIPTION
…->ClusterIP for example)

atm moving a service from NodePort to ClusterIP needs a full delete/deploy cycle which takes ~1min and needs to be done manually
error in UI is this atm:
```
[19:57:31] JobExecution failed: Kubernetes error Service foo-service sandbox Sandbox: Service "foo-service" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
```

this option should be useful in general and make it more like ~1s

@zendesk/compute 