### PR TITLE
[WIP] Add support for check_suit event type for Github Action

### DIFF
--- a/app/controllers/integrations/github_controller.rb
+++ b/app/controllers/integrations/github_controller.rb
@@ -4,7 +4,8 @@ class Integrations::GithubController < Integrations::BaseController
   WEBHOOK_HANDLERS = {
     'push' => Changeset::CodePush,
     'pull_request' => Changeset::PullRequest,
-    'issue_comment' => Changeset::IssueComment
+    'issue_comment' => Changeset::IssueComment,
+    'check_suite' => Changeset::CheckSuite
   }.freeze
 
   def self.secret_token

--- a/app/models/changeset/check_suite.rb
+++ b/app/models/changeset/check_suite.rb
@@ -12,7 +12,7 @@ class Changeset::CheckSuite
   end
 
   def self.valid_webhook?(payload)
-    payload['action'] == 'completed' && payload['check_suite']['status'] == 'completed' && payload['check_suite']['conclusion'] == 'success'
+    payload['check_suite']['status'] == 'completed' && payload['check_suite']['conclusion'] == 'success'
   end
 
   def sha

--- a/app/models/changeset/check_suite.rb
+++ b/app/models/changeset/check_suite.rb
@@ -12,7 +12,7 @@ class Changeset::CheckSuite
   end
 
   def self.valid_webhook?(payload)
-    payload['check_suite']['status'] == 'completed' && payload['check_suite']['conclusion'] == 'success'
+    payload['check_suite']['conclusion'] == 'success'
   end
 
   def sha

--- a/app/models/changeset/check_suite.rb
+++ b/app/models/changeset/check_suite.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+class Changeset::CheckSuite
+  attr_reader :repo, :data
+
+  def initialize(repo, data)
+    @repo = repo
+    @data = data
+  end
+
+  def self.changeset_from_webhook(project, payload)
+    new(project.repository_path, payload)
+  end
+
+  def self.valid_webhook?(payload)
+    payload['action'] == 'completed' && payload['check_suite']['status'] == 'completed' && payload['check_suite']['conclusion'] == 'success'
+  end
+
+  def sha
+    data['check_suite']['head_sha']
+  end
+
+  def branch
+    data['check_suite']['head_branch']
+  end
+
+  def message
+    nil
+  end
+
+  def service_type
+    'check_suite' # Samson webhook category
+  end
+end

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -163,6 +163,5 @@ describe Integrations::GithubController do
     it_does_not_deploy 'when conclusion is failure' do
       payload.deep_merge!(check_suite: {conclusion: 'failure'})
     end
-
   end
 end

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -143,7 +143,7 @@ describe Integrations::GithubController do
     before do
       Deploy.delete_all
       request.headers['X-Github-Event'] = 'check_suite'
-      project.webhooks.create!(stage: stages(:test_staging), branch: "master", source: 'check_suite')
+      project.webhooks.create!(stage: stages(:test_staging), branch: "master", source: 'any')
     end
 
     let(:payload) do

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -148,13 +148,13 @@ describe Integrations::GithubController do
 
     let(:payload) do
       {
-          action: 'completed',
-          check_suite: {
-              head_branch: 'master',
-              head_sha: '31b148e19a8ef2a033cb4ff485949c3f3d689140',
-              status: 'completed',
-              conclusion: 'success'
-          }
+        action: 'completed',
+        check_suite: {
+          head_branch: 'master',
+          head_sha: '31b148e19a8ef2a033cb4ff485949c3f3d689140',
+          status: 'completed',
+          conclusion: 'success'
+        }
       }.with_indifferent_access
     end
 

--- a/test/controllers/integrations/github_controller_test.rb
+++ b/test/controllers/integrations/github_controller_test.rb
@@ -138,4 +138,31 @@ describe Integrations::GithubController do
 
     it_deploys
   end
+
+  describe 'with a check_suite event' do
+    before do
+      Deploy.delete_all
+      request.headers['X-Github-Event'] = 'check_suite'
+      project.webhooks.create!(stage: stages(:test_staging), branch: "master", source: 'check_suite')
+    end
+
+    let(:payload) do
+      {
+          action: 'completed',
+          check_suite: {
+              head_branch: 'master',
+              head_sha: '31b148e19a8ef2a033cb4ff485949c3f3d689140',
+              status: 'completed',
+              conclusion: 'success'
+          }
+      }.with_indifferent_access
+    end
+
+    it_deploys "when conclusion is success"
+
+    it_does_not_deploy 'when conclusion is failure' do
+      payload.deep_merge!(check_suite: {conclusion: 'failure'})
+    end
+
+  end
 end

--- a/test/models/changeset/check_suite_test.rb
+++ b/test/models/changeset/check_suite_test.rb
@@ -10,6 +10,7 @@ describe Changeset::CheckSuite do
       "check_suite" => {
         "head_branch" => "master",
         "status" => "completed",
+        "head_sha" => "1234",
         "conclusion" => "success"
       }
     }
@@ -32,6 +33,18 @@ describe Changeset::CheckSuite do
     it "passes data on" do
       check_suite = Changeset::CheckSuite.changeset_from_webhook(projects(:test), data)
       check_suite.repo.must_equal "bar/foo"
+    end
+  end
+
+  describe "#service_type" do
+    it "is check_suite" do
+      check_suite.service_type.must_equal "check_suite"
+    end
+  end
+
+  describe "#sha" do
+    it "returns a sha" do
+      check_suite.sha.must_equal "1234"
     end
   end
 end

--- a/test/models/changeset/check_suite_test.rb
+++ b/test/models/changeset/check_suite_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+SingleCov.covered!
+
+describe Changeset::CheckSuite do
+  let(:data) do
+    {
+      "action" => "completed",
+      "check_suite" => {
+        "head_branch" => "master",
+        "status" => "completed",
+        "conclusion" => "success"
+      }
+    }
+  end
+  let(:check_suite) { Changeset::CheckSuite.new('foo/bar', data) }
+
+  describe "#branch" do
+    it "finds" do
+      check_suite.branch.must_equal 'master'
+    end
+  end
+
+  describe ".valid_webhook?" do
+    it "is true" do
+      Changeset::CheckSuite.valid_webhook?(data).must_equal true
+    end
+  end
+
+  describe ".changeset_from_webhook" do
+    it "passes data on" do
+      check_suite = Changeset::CheckSuite.changeset_from_webhook(projects(:test), data)
+      check_suite.repo.must_equal "bar/foo"
+    end
+  end
+end


### PR DESCRIPTION
## Add a new webhook event for GitHub - check_suite.

We want GitHub to be the controller and determine when to ping Samson (rather than the CI piece of the pipeline). When a GitHub Action completes, GitHub becomes aware of the results of the unit test, and when the result is a success, GitHub can post out to notify the world of the success, using the check_suite api payload. Samson, Spinnaker, and another CD tooling should be aware of this use-case and respond correctly.