### PR TITLE
Ignore FailedToUpdateEndpointSlices

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -20,6 +20,9 @@ module Kubernetes
       PodDisruptionBudget: [
         "CalculateExpectedPodCountFailed",
         "NoControllers"
+      ],
+      Service: [
+        "FailedToUpdateEndpointSlices"
       ]
     }.freeze
 

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -71,7 +71,7 @@ describe Kubernetes::ResourceStatus do
     end
 
     describe "non-pods" do
-      before { resource[:kind] = "Service" }
+      before { resource[:kind] = "NonIgnoredKind" }
 
       it "knows created non-pods" do
         events.clear
@@ -81,6 +81,12 @@ describe Kubernetes::ResourceStatus do
       it "ignores known bad events" do
         resource[:kind] = "HorizontalPodAutoscaler"
         events[0].merge!(type: "Warning", reason: "FailedGetMetrics")
+        expect_event_request { details.must_equal "Live" }
+      end
+
+      it "ignores known bad events for service" do
+        resource[:kind] = "Service"
+        events[0].merge!(type: "Warning", reason: "FailedToUpdateEndpointSlices")
         expect_event_request { details.must_equal "Live" }
       end
 


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

```
[17:21:11]   Warning FailedToUpdateEndpointSlices: Error updating Endpoint Slices for Service xxx/classic: Error updating classic-c6cbh EndpointSlice for Service xxx/classic: Operation cannot be fulfilled on endpointslices.discovery.k8s.io "classic-c6cbh": the object has been modified; please apply your changes to the latest version and try again x3

```

### References
- Jira link: 

### Risks
- Low