### PR TITLE
give null-user a unique email so it works in exports

### DIFF
--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -17,6 +17,10 @@ class NullUser
     user&.name || 'Deleted User'
   end
 
+  def email
+    "deleted-user-#{id}"
+  end
+
   def marked_for_destruction?
     false
   end

--- a/test/models/null_user_test.rb
+++ b/test/models/null_user_test.rb
@@ -37,6 +37,12 @@ describe NullUser do
     end
   end
 
+  describe "email" do
+    it "has a placeholder" do
+      NullUser.new(1).email.must_equal 'deleted-user-1'
+    end
+  end
+
   describe "#attributes" do
     it "returns a limited list" do
       NullUser.new(11211212).attributes.must_equal("name" => "Deleted User")


### PR DESCRIPTION
saw lots of there:
```
NoMethodError: undefined method `email' for #<NullUser:0x00007f2bbc017338 @id=1148>
1
File "/data/samson/releases/20200618-194303-03744f8/app/controllers/projects_controller.rb" line 147 in block in projects_as_json
```

... easy enough to fix and can still be sorted/grouped

@zendesk/compute 