### PR TITLE
status review cleanup

### DIFF
--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -2,11 +2,6 @@
 // TODO: show 500 errors to the user
 function refStatusTypeahead(options){
   var $reference = $("#deploy_reference");
-  var $ref_status_container = $("#ref-problem-warning");
-  var $ref_problem_list = $("#ref-problem-list");
-  var status_check_timeout = null;
-  var $tag_form_group = $reference.parent();
-  var $submit_button = $ref_status_container.closest('form').find(':submit');
   if(!$reference.get(0)) { return; }
 
   function initializeTypeahead() {
@@ -37,58 +32,66 @@ function refStatusTypeahead(options){
     }).focus();
   }
 
-  function show_status_problems(status_list, isDanger) {
-    $ref_status_container.removeClass("hidden");
-    $ref_status_container.toggleClass('alert-danger', isDanger);
-    $ref_status_container.toggleClass('alert-warning', !isDanger);
+  // reset problem UI to default state, then apply changes
+  function show_status_problems(status_list, state) {
+    var $ref_status_container = $("#ref-problem-warning");
+    $ref_status_container.addClass("hidden");
+    $ref_status_container.removeClass('alert-danger alert-warning');
 
+    var $tag_form_group = $reference.parent();
+    $tag_form_group.removeClass("has-success has-error has-warning");
+
+    switch(state) {
+      case "default":
+        return;
+      case "success":
+        $tag_form_group.addClass("has-success");
+        return;
+      case "pending": // fallthrough
+      case "missing":
+        $tag_form_group.addClass("has-warning");
+        $ref_status_container.addClass('alert-warning');
+        break;
+      case "failure": // fallthrough
+      case "error": // fallthrough
+      case "fatal":
+        $tag_form_group.addClass("has-error");
+        $ref_status_container.addClass('alert-danger');
+        break;
+      default:
+        alert("Unexpected response: " + response.toString());
+        return;
+    }
+
+    $ref_status_container.removeClass("hidden");
+
+    // show list of problems
+    var $ref_problem_list = $("#ref-problem-list");
     $ref_problem_list.empty();
     $.each(status_list, function(idx, status) {
-      if (status.state != "success") {
-        var item = $("<li>");
-        $ref_problem_list.append(item);
-        // State and status comes from GitHub or Samson
-        item.html(status.state + ": " + status.description);
-        if(status.target_url) {
-          item.append(' <a href="' + status.target_url + '">details</a>');
-        }
+      if (status.state === "success") return;
+      var item = $("<li>");
+      $ref_problem_list.append(item);
+      // State and status comes from GitHub or Samson
+      item.html(status.state + ": " + status.description);
+      if(status.target_url) {
+        item.append(' <a href="' + status.target_url + '">details</a>');
       }
     });
   }
 
-  function check_status(ref) {
-    $submit_button.prop("disabled", false);
-    $reference.addClass("loading");
+  // check status of reference and show user problems we found
+  function check_status($field) {
+    $field.addClass("loading");
+    var val = $field.val();
 
     $.ajax({
       url: $("#new_deploy").data("commit-status-url"),
-      data: { ref: ref },
+      data: { ref: val },
       success: function(response) {
-        $reference.removeClass("loading");
-        switch(response.state) {
-          case "success":
-            $ref_status_container.addClass("hidden");
-            $tag_form_group.addClass("has-success");
-            break;
-          case "pending":
-          case "missing":
-            $tag_form_group.addClass("has-warning");
-            show_status_problems(response.statuses, false);
-            break;
-          case "failure":
-          case "error":
-            $tag_form_group.addClass("has-error");
-            show_status_problems(response.statuses, false);
-            break;
-          case "fatal":
-            $tag_form_group.addClass("has-error");
-            $submit_button.prop("disabled", true);
-            show_status_problems(response.statuses, true);
-            break;
-          default:
-            alert("Unexpected response: " + response.toString());
-            break;
-        }
+        if($field.val() !== val) return; // reply from old request
+        $field.removeClass("loading");
+        show_status_problems(response.statuses, response.state);
       }
     });
   }
@@ -96,12 +99,13 @@ function refStatusTypeahead(options){
   initializeTypeahead();
 
   // Continuously polling for change to account for autofill which does not trigger input/change events
+  // when user stops typing for a bit, we check the reference status, if user keeps typing then cancel the previous timeout
+  var status_check_timeout = null;
   $reference.pollForChange(100, function() {
-    $ref_status_container.addClass("hidden");
-    $tag_form_group.removeClass("has-success has-warning has-error");
+    show_status_problems([], "default"); // clear
 
-    var ref = $(this).val().trim();
-    $(this).val(ref); // store back trimmed value, so user sees what we see
+    var ref = $reference.val().trim();
+    $reference.val(ref); // store back trimmed value, so user sees what we see
 
     if(status_check_timeout) {
       clearTimeout(status_check_timeout);
@@ -110,7 +114,7 @@ function refStatusTypeahead(options){
     if(options.changed) options.changed();
 
     if(ref !== "") {
-      status_check_timeout = setTimeout(function() { check_status(ref); }, 200);
+      status_check_timeout = setTimeout(function() { check_status($reference); }, 200);
     }
   });
 

--- a/app/assets/stylesheets/deploys.scss
+++ b/app/assets/stylesheets/deploys.scss
@@ -146,7 +146,9 @@ td.status {
   border: 2px dashed gray;
 }
 
+// same style as `.has-error .form-control` but for success
 .has-success #deploy_reference {
-  border: 2px dashed limegreen;
+  border-color: limegreen;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 


### PR DESCRIPTION
addressing several issues:
- success style did not match error/warning style, always looking as if it's still loading
- blocking the review button blocks users when js goes bad ... but clicking it does not do anything bad
- code was a spaghetti mess, all kinds of functions were messing with the styles
- quickly typing showed irrelevant/distracting "unknown revision maste" message fixes https://github.com/zendesk/samson/issues/3805

initial:
<img width="840" alt="Screen Shot 2020-06-20 at 4 24 45 PM" src="https://user-images.githubusercontent.com/11367/85213474-ad367800-b313-11ea-905c-0ac5cd54d537.png">

success:
<img width="821" alt="Screen Shot 2020-06-20 at 4 29 38 PM" src="https://user-images.githubusercontent.com/11367/85213463-85dfab00-b313-11ea-965c-cef265dbf9ea.png">

warning:
<img width="1364" alt="Screen Shot 2020-06-20 at 4 21 48 PM" src="https://user-images.githubusercontent.com/11367/85213473-a60f6a00-b313-11ea-9b1b-e677c1116005.png">

error:
<img width="1364" alt="Screen Shot 2020-06-20 at 4 21 52 PM" src="https://user-images.githubusercontent.com/11367/85213477-c0e1de80-b313-11ea-9eb7-d99e83174b9f.png">