### PR TITLE
fix external builds failing when not using dockerfile=none with depre…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -14,6 +14,7 @@ module Kubernetes
       @doc = release_doc
       @template = template.deep_dup
       @index = index
+      migrate_container_annotations
     end
 
     def to_hash(verification: false)
@@ -36,7 +37,6 @@ module Kubernetes
           prefix_service_cluster_ip
           set_service_blue_green if blue_green_color
         elsif Kubernetes::RoleConfigFile.primary?(template)
-          migrate_container_annotations
           set_history_limit if kind == 'Deployment'
           make_stateful_set_match_service if kind == 'StatefulSet'
           set_pre_stop if kind == 'Deployment'

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -1236,8 +1236,8 @@ describe Kubernetes::TemplateFiller do
       template.build_selectors.must_equal [["Bar", nil]]
     end
 
-    it "ignores images that should not be built" do
-      raw_template[:spec][:template][:metadata][:annotations] = {'container-some-project-samson/dockerfile': 'none'}
+    it "ignores images that should not be built via attribute" do
+      raw_template[:spec][:template][:spec][:containers][0][:'samson/dockerfile'] = 'none'
       template.build_selectors.must_equal []
     end
 


### PR DESCRIPTION
…cated container attribute

because they did not get migrated before asking for the build_selector

fixup for https://github.com/zendesk/samson/pull/3819 where I refactored all tests to use the new annotations 🤦 

@zendesk/compute 