### PR TITLE
PAAS-7162 validate kubernetes manifests by default

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_02_195119) do
+ActiveRecord::Schema.define(version: 2020_06_26_190117) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2020_04_02_195119) do
     t.integer "triggering_deploy_id"
     t.boolean "redeploy_previous_when_failed", default: false, null: false
     t.boolean "kubernetes_ignore_kritis_vulnerabilities", default: false, null: false
+    t.boolean "kubernetes_skip_validations", default: false, null: false
     t.index ["deleted_at"], name: "index_deploys_on_deleted_at"
     t.index ["job_id", "deleted_at"], name: "index_deploys_on_job_id_and_deleted_at"
     t.index ["project_id", "deleted_at"], name: "index_deploys_on_project_id_and_deleted_at"

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -160,7 +160,7 @@ module Kubernetes
     def migrate_container_annotations
       all_containers.each do |container|
         container.keys.grep(/^samson\//).each do |key|
-          value = container.delete(key)
+          value = container[key]
           set_container_annotation container, key, value unless samson_container_config(container, key)
         end
       end

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_form.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_form.html.erb
@@ -2,4 +2,5 @@
   <%= form.input :kubernetes_rollback, as: :check_box, label: 'Rollback on failure' %>
   <%= form.input :kubernetes_reuse_build, as: :check_box, label: 'Reuse previous build', help: 'Speedup debugging when only changing kubernetes config' unless @stage.production? %>
   <%= form.input :kubernetes_ignore_kritis_vulnerabilities, as: :check_box, label: 'Ignore Kritis vulnerabilities' if ENV["KRITIS_BREAKGLASS_SUPPORTED"] %>
+  <%= form.input :kubernetes_skip_validations, as: :check_box, label: 'Skip kubernetes validations' %>
 <% end %>

--- a/plugins/kubernetes/db/migrate/20200626190117_add_kubernetes_skip_validations.rb
+++ b/plugins/kubernetes/db/migrate/20200626190117_add_kubernetes_skip_validations.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddKubernetesSkipValidations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :deploys, :kubernetes_skip_validations, :boolean, default: false, null: false
+  end
+end

--- a/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
+++ b/plugins/kubernetes/lib/samson_kubernetes/samson_plugin.rb
@@ -51,7 +51,8 @@ Samson::Hooks.callback(:deploy_permitted_params) do
   [
     :kubernetes_rollback,
     :kubernetes_reuse_build,
-    :kubernetes_ignore_kritis_vulnerabilities
+    :kubernetes_ignore_kritis_vulnerabilities,
+    :kubernetes_skip_validations
   ]
 end
 Samson::Hooks.callback(:project_permitted_params) { [:kubernetes_rollout_timeout] }


### PR DESCRIPTION
looks like a dead-end unless we also enable server-side-apply for everything

Doing it directly:
- there is no server-side validation endpoint or flag
- tried editing kubeclient-4.0.0/lib/kubeclient/common.rb to send dryRun=All and it still considered containers with extra flags valid (using grosser/none branch from exmple-kubernetes)

So only solution left was using the server-side-apply endpoint to run the validations

Error looks like this:

```
[20:13:14] JobExecution failed: Kubernetes error Deployment example-server default GroupK: failed to create typed patch object: errors:
[20:13:14]   .spec.template.spec.containers[name="extra"].samson/dockerfile: schema error: invalid atom: inlined
[20:13:14]   .spec.template.spec.containers[name="extra"].samson/preStop: schema error: invalid atom: inlined
```

deploy UI has an opt-out checkbox if something goes wrong:
<img width="476" alt="Screen Shot 2020-06-26 at 1 24 19 PM" src="https://user-images.githubusercontent.com/11367/85898049-667fcc80-b7b0-11ea-9e89-6824b7d6cfbe.png">

but also ran into 1-off errors like this even when creating:
```
[20:39:03] JobExecution failed: Kubernetes error StatefulSet example-server default GroupK: Apply failed with 1 conflict: conflict with "before-first-apply" using apps/v1: .spec.serviceName
```