### PR TITLE
re-run time formatter when updating the deploys active page

### DIFF
--- a/app/assets/javascripts/channels/deploy_notifications_channel.js
+++ b/app/assets/javascripts/channels/deploy_notifications_channel.js
@@ -1,6 +1,7 @@
 // Stream count of current deploys to users that keep a page open via app/channels/deploy_notifications_channel.rb
 // - update deploy badge
 // - reload deploys table
+// - do not immediately start to avoid server overhead when user is just clicking through the UI
 $(function(){
   setTimeout(function(){
     App.cable.subscriptions.create("DeployNotificationsChannel", {
@@ -9,7 +10,9 @@ $(function(){
         $("#current-deploys").toggle(data.count > 0).text(data.count);
 
         // reload active deploys page (noop when id is not found)
-        $('#deploys-active').load('/deploys/active?partial=true');
+        $('#deploys-active').load('/deploys/active?partial=true', function(){
+          timeAgoFormat();
+        });
       }
     });
   }, 5000);


### PR DESCRIPTION
before it would load nice initially and then timestamps break on first update

<img width="416" alt="Screen Shot 2020-06-26 at 4 51 38 PM" src="https://user-images.githubusercontent.com/11367/85909282-ec5e4080-b7cd-11ea-839b-6f2a90de6f18.png">

@zendesk/compute 
