### PR TITLE
Add external build metric

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -63,6 +63,10 @@ class BuildsController < ApplicationController
 
     start_docker_build if saved && !registering_external_build?
 
+    # Emit a metric to help users assess condition of integration between
+    # Samson and any external build system.
+    ActiveSupport::Notifications.instrument('external_build.samson', new: new, saved: saved)
+
     status = new ? :created : :ok
     respond_to_save saved, status, :new
   end

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -48,6 +48,11 @@ end
   end
 end
 
+ActiveSupport::Notifications.subscribe("external_build.samson") do |*, payload|
+  tags = ["new:#{payload.fetch(:new)}", "saved:#{payload.fetch(:saved)}"]
+  Samson.statsd.increment "builds.external", tags: tags
+end
+
 ActiveSupport::Notifications.subscribe("job_queue.samson") do |*, payload|
   [[:deploys, true], [:jobs, false]].each do |(type, is_deploy)|
     metrics = payload.fetch(type)


### PR DESCRIPTION
### Descriptions
In an setup where Samson integrates with an external build service, builds are very likely created continuously. Adding a metric to track this event can help detect some issues from the build service, broken integration or maybe Samson if the count disappears.  

### References
- Related to one of internal remediation actions.

### Risks
- Low: Only add a new metric.

@zendesk/eng-productivity 
