### PR TITLE
Handle stale state for Checks

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -8,7 +8,7 @@ class CommitStatus
   STATE_PRIORITY = [:success, :pending, :missing, :failure, :error, :fatal].freeze
   UNDETERMINED = ["pending", "missing"].freeze
   CHECK_STATE = {
-    error: ['action_required', 'cancelled', 'timed_out'],
+    error: ['action_required', 'cancelled', 'timed_out', 'stale'],
     failure: ['failure'],
     success: ['success', 'neutral', 'skipped']
   }.freeze

--- a/test/models/commit_status_test.rb
+++ b/test/models/commit_status_test.rb
@@ -285,6 +285,12 @@ describe CommitStatus do
         status.state.must_equal 'pending'
       end
 
+      it 'returns error if github stale the check suites' do
+        stub_github_api(check_suite_url, check_suites: [{conclusion: 'stale', id: 1}])
+
+        status.state.must_equal 'error'
+      end
+
       it 'maps check status to state equivalent' do
         stub_github_api(check_suite_url, check_suites: [{conclusion: 'action_required', id: 1}])
 


### PR DESCRIPTION
Added code to handle `stale` state for GitHub checks suites.

https://developer.github.com/v3/checks/runs/
```
If a check run is in a incomplete state for more than 14 days, then the check run's conclusion becomes stale and appears on GitHub as stale with . Only GitHub can mark check runs as stale
```