### PR TITLE
allow requesting current logs while still deploying

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -97,6 +97,7 @@ class DeploysController < ApplicationController
           type: 'text/plain'
       end
       format.json do
+        @deploy.job.serialize_execution_output if params[:serialize_execution_output] # show live job output
         render_as_json :deploy, @deploy, nil, allowed_includes: [:job, :user, :project, :stage]
       end
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -76,7 +76,7 @@ class Job < ActiveRecord::Base
     !JobQueue.dequeue(id) && ex = execution # is executing
     return true if !ex && !active?
 
-    update_attribute(:canceller, canceller) unless self.canceller
+    update_attribute(:canceller, canceller) unless self.canceller # uncovered
 
     if ex
       JobQueue.cancel(id) # switches job status in the runner thread for consistent status in after_deploy hooks
@@ -130,6 +130,13 @@ class Job < ActiveRecord::Base
 
   def pid
     execution&.pid
+  end
+
+  # set current incomplete output
+  def serialize_execution_output
+    return unless ex = execution
+    out = ex.output.closed_copy
+    self.output = TerminalOutputScanner.new(out).to_s
   end
 
   private

--- a/app/models/output_buffer.rb
+++ b/app/models/output_buffer.rb
@@ -91,6 +91,14 @@ class OutputBuffer
     @mutex.synchronize { @listeners.delete(queue) }
   end
 
+  # make a shallow copy of the buffer so we can close and serialize it
+  def closed_copy
+    copy = OutputBuffer.new
+    copy.instance_variable_set(:@previous, @previous)
+    copy.close
+    copy
+  end
+
   private
 
   # TODO: ideally the TerminalOutputScanner should handle this, but that would require us to record the timestamp

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -162,6 +162,16 @@ describe DeploysController do
           get :show, params: {format: :json, id: deploy.to_param, includes: 'project,stage'}
           json.keys.must_equal ['deploy', 'projects', 'stages']
         end
+
+        it "can request execution output" do
+          freeze_time
+          execution = JobExecution.new("master", deploy.job)
+          execution.output.puts "X"
+          Job.any_instance.expects(:execution).returns(execution)
+          params = {project_id: project, id: deploy, includes: "job", serialize_execution_output: true}
+          get :show, params: params, format: :json
+          json.dig("jobs", 0, "output").must_equal "[04:05:06] X\n"
+        end
       end
     end
 

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -2,7 +2,7 @@
 require_relative '../test_helper'
 require 'ar_multi_threaded_transactional_tests'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered!
 
 describe Job do
   include GitRepoTestHelper
@@ -403,6 +403,24 @@ describe Job do
       )
 
       job.send(:report_state)
+    end
+  end
+
+  describe "#serialize_execution_output" do
+    before { freeze_time }
+
+    it "does nothing when finished" do
+      job.output = "X"
+      job.serialize_execution_output
+      job.output.must_equal "X"
+    end
+
+    it "serialized execution" do
+      execution = JobExecution.new("master", job)
+      job.stubs(:execution).returns(execution)
+      execution.output.puts "X"
+      job.serialize_execution_output
+      job.output.must_equal "[04:05:06] X\n"
     end
   end
 end

--- a/test/models/output_buffer_test.rb
+++ b/test/models/output_buffer_test.rb
@@ -127,6 +127,16 @@ describe OutputBuffer do
     end
   end
 
+  describe "#closed_copy" do
+    it "has the same content" do
+      buffer.write("X\n")
+      copy = buffer.closed_copy
+      refute buffer.closed?
+      assert copy.closed?
+      TerminalOutputScanner.new(copy).to_s.must_equal "[04:05:06] X\n"
+    end
+  end
+
   def build_listener
     Thread.new do
       content = []


### PR DESCRIPTION
<img width="1005" alt="Screen Shot 2020-07-14 at 1 58 24 PM" src="https://user-images.githubusercontent.com/11367/87482136-a5ea4d80-c5e5-11ea-9a3d-03a3141c72dd.png">
 
@zendesk/compute 

ideally users would stream the deploy, but that's more complicated to support / to consume