### PR TITLE
Wait for new pods to come up when OutOfcpu/OutOfmemory happens

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -147,6 +147,11 @@ module Kubernetes
       end
 
       pods = fetch_grouped(:pods, 'v1')
+
+      # Pods that get OutOfcpu/OutOfmemory will be marked as Failed.
+      # Scheduler will create a replacement pod. Need to ignore Failed pods when reporting statuses.
+      pods.reject! { |p| p.dig(:status, :phase) == 'Failed' && p.dig(:spec, :restartPolicy) != 'Never' }
+
       replica_sets = fetch_replica_sets(release_docs)
       non_pod_statuses +
         release_docs.flat_map do |release_doc|

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -502,12 +502,22 @@ describe Kubernetes::DeployExecutor do
     end
 
     it "stops when detecting a failure" do
+      pod_reply.dig_set([:items, 0, :spec, :restartPolicy], 'Never')
       pod_status[:phase] = "Failed"
 
       refute execute
 
       out.must_include "resque-worker Pod: Failed\n"
       out.must_include "UNSTABLE"
+    end
+
+    it "waits for new pods when scheduling fails" do
+      pod_status[:phase] = "Failed"
+
+      refute execute
+
+      out.must_include "resque-worker Pod: Missing\n"
+      out.must_include "TIMEOUT, pods took too long to get live"
     end
 
     describe "replica sets" do


### PR DESCRIPTION
Found that in some cases deploys are marked as failed because pods are failed with reason 
`OutOfcpu` or `OutOfmemory`. Scheduler re-schedules such pods, but Samson treated this as an error.

related PRs: https://github.com/zendesk/samson/pull/3772 and https://github.com/zendesk/samson/pull/3779

### Risks
- Low - might get timeouts during deploy.