### PR TITLE
use apply to sync namespaces to avoid get+post

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/namespaces_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/namespaces_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Kubernetes::NamespacesController < ResourceController
   before_action :authorize_admin!, except: [:show, :index, :preview]
   before_action :set_resource, only: [:show, :update, :destroy, :new, :create, :sync]
@@ -53,7 +54,7 @@ class Kubernetes::NamespacesController < ResourceController
   end
 
   def sync_all
-    warnings = apply_namespaces Kubernetes::Cluster.all, Kubernetes::Namespace.all
+    warnings = apply_namespaces Kubernetes::Cluster.all.to_a, Kubernetes::Namespace.all.to_a
     show_namespace_warnings warnings
     redirect_to action: :index
   end
@@ -66,7 +67,7 @@ class Kubernetes::NamespacesController < ResourceController
   private
 
   def create_callback
-    warnings = apply_namespaces Kubernetes::Cluster.all, [@kubernetes_namespace]
+    warnings = apply_namespaces Kubernetes::Cluster.all.to_a, [@kubernetes_namespace]
     warnings += copy_secrets(
       ENV['KUBERNETES_COPY_SECRETS_TO_NEW_NAMESPACE'].to_s.split(","),
       from: 'default',
@@ -97,24 +98,45 @@ class Kubernetes::NamespacesController < ResourceController
   end
 
   def sync_namespace
-    warnings = apply_namespaces Kubernetes::Cluster.all, [@kubernetes_namespace]
+    warnings = apply_namespaces Kubernetes::Cluster.all.to_a, [@kubernetes_namespace]
     show_namespace_warnings warnings
   end
 
+  # update namespace only if required to be efficient and even if it the samson request times out to eventually complete
   # @return [Array<String>] errors
   def apply_namespaces(clusters, namespaces)
-    Samson::Parallelizer.map clusters.to_a.product(namespaces) do |cluster, namespace|
-      begin
-        SamsonKubernetes.retry_on_connection_errors do
-          cluster.client('v1').apply_namespace(
-            Kubeclient::Resource.new(namespace.manifest), field_manager: "samson", force: true
-          )
-        end
-        nil
-      rescue StandardError => e
-        "Failed to apply namespace #{namespace.name} in cluster #{cluster.name}: #{e.message}"
+    Samson::Parallelizer.map clusters do |cluster|
+      client = cluster.client("v1")
+      existing_namespaces = client.get_namespaces.fetch(:items).each_with_object({}) do |ns, h|
+        h[ns.dig(:metadata, :name)] = ns
       end
-    end.compact
+      namespaces.map do |namespace|
+        manifest = namespace.manifest
+        next unless apply_needed?(existing_namespaces[namespace.name], manifest)
+
+        begin
+          SamsonKubernetes.retry_on_connection_errors do
+            client.apply_namespace(Kubeclient::Resource.new(manifest), field_manager: "samson", force: true)
+          end
+          nil
+        rescue StandardError => e
+          "Failed to apply namespace #{namespace.name} in cluster #{cluster.name}: #{e.message}"
+        end
+      end
+    end.flatten(1).compact
+  end
+
+  # Only update if we change or add anything.
+  # This breaks the ability to remove a label that was added earlier, but it allows full sync to work efficiently
+  # and eventually succeed even if a single samson request times out.
+  # Compares annotations and labels, since nothing else makes sense to change (not spec, managedFields, uid etc)
+  def apply_needed?(existing_namespace, manifest)
+    return true unless existing_namespace
+    [[:metadata, :annotations], [:metadata, :labels]].any? do |path|
+      actual = existing_namespace.dig(*path) || {}
+      expected = manifest.dig(*path) || (next false)
+      !(expected <= actual) # rubocop:disable Style/InverseMethods
+    end
   end
 
   def show_namespace_warnings(warnings)

--- a/plugins/kubernetes/app/models/kubernetes/namespace.rb
+++ b/plugins/kubernetes/app/models/kubernetes/namespace.rb
@@ -18,6 +18,8 @@ module Kubernetes
 
     def manifest
       parsed_template.deep_symbolize_keys.deep_merge(
+        apiVersion: "v1",
+        kind: "Namespace",
         metadata: {
           name: name,
           annotations: {

--- a/plugins/kubernetes/test/models/kubernetes/namespace_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/namespace_test.rb
@@ -75,12 +75,20 @@ describe Kubernetes::Namespace do
     let(:url) { "http://www.test-url.com/kubernetes/namespaces/#{namespace.id}" }
 
     it "is a hash" do
-      namespace.manifest.must_equal metadata: {name: "test", annotations: {"samson/url": url}, labels: {team: "foo"}}
+      namespace.manifest.must_equal(
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: {name: "test", annotations: {"samson/url": url}, labels: {team: "foo"}}
+      )
     end
 
     it "merges template" do
       namespace.template = {"metadata" => {"name" => "no", "foo" => "bar"}}.to_yaml
-      namespace.manifest.must_equal metadata: {name: "test", foo: "bar", annotations: {"samson/url": url}}
+      namespace.manifest.must_equal(
+        apiVersion: "v1",
+        kind: "Namespace",
+        metadata: {name: "test", foo: "bar", annotations: {"samson/url": url}}
+      )
     end
   end
 end


### PR DESCRIPTION
we can't apply a List since that's not an api
but this should cut down on requests
also moved the parallelization further down so work gets dealt out equally and no threads are done early

@zendesk/compute 