### PR TITLE
fix setting lock's delete_at

### DIFF
--- a/app/assets/javascripts/lock.js
+++ b/app/assets/javascripts/lock.js
@@ -10,7 +10,7 @@ $(function () {
   // user opens the a dropdown via bootstrap.js for the first time: initialize it
   $(document).one('shown.bs.dropdown', dialog, function () {
     var form = $(this, 'form');
-    var deleteAtInput = form.find('#lock_delete_at');
+    var deleteAtInput = form.find('.lock-input');
 
     // initialize date-picker UI
     $('.datetimepicker', this).datetimepicker();


### PR DESCRIPTION
Lock's `delete_at` was not being set in the UI when clicking on one of the `delete_in` buttons. This resulted in users unintentionally creating indefinite locks

Before:
<img width="416" alt="Screen Shot 2020-08-24 at 1 08 23 PM" src="https://user-images.githubusercontent.com/1566114/91091075-ebe5f880-e60a-11ea-95bb-4a99b2beebf3.png">

After:
<img width="421" alt="Screen Shot 2020-08-24 at 1 07 47 PM" src="https://user-images.githubusercontent.com/1566114/91091098-f30d0680-e60a-11ea-80fb-4f1b431ee93e.png">



### References
- Jira link: 

### Risks
- Low
