### PR TITLE
Improve logging for `create_release?` logic

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -16,7 +16,7 @@ class Integrations::BaseController < ApplicationController
 
     if branch
       create_release = project.create_release?(branch, service_type, service_name)
-      record_log :info, "Branch #{branch} is release branch: #{create_release}"
+      record_log :info, "Create release for branch [#{branch}], service_type [#{service_type}], service_name [#{service_name}]: #{create_release}"
       release = find_or_create_release if create_release
     else
       record_log :info, "No branch found, assuming this is a tag and not creating a release"

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -16,7 +16,8 @@ class Integrations::BaseController < ApplicationController
 
     if branch
       create_release = project.create_release?(branch, service_type, service_name)
-      record_log :info, "Create release for branch [#{branch}], service_type [#{service_type}], service_name [#{service_name}]: #{create_release}"
+      record_log :info, "Create release for "\
+        "branch [#{branch}], service_type [#{service_type}], service_name [#{service_name}]: #{create_release}"
       release = find_or_create_release if create_release
     else
       record_log :info, "No branch found, assuming this is a tag and not creating a release"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -113,6 +113,8 @@ class Project < ActiveRecord::Base
   # Whether to create new releases when the branch is updated.
   #
   # branch - The String name of the branch in question.
+  # service_type - The Samson webhook category which triggered this request.
+  # service_name - The service which called the Samson webhook, e.g. generic
   #
   # Returns true if new releases should be created, false otherwise.
   def create_release?(branch, service_type, service_name)

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -99,7 +99,7 @@ describe Integrations::BaseController do
       post :create, params: {test_route: true, token: token, foo: "bar"}
       assert_response :success
       result = WebhookRecorder.read(project)
-      log = "INFO: Branch master is release branch: true\n"
+      log = "INFO: Create release for branch [master], service_type [ci], service_name [base_test]: true\n"
 
       result.fetch(:log).must_equal log
       result.fetch(:response_code).must_equal 200
@@ -169,7 +169,7 @@ describe Integrations::BaseController do
         post :create, params: {test_route: true, token: token}
 
         expected_messages = <<~MESSAGES
-          INFO: Branch master is release branch: true
+          INFO: Create release for branch [master], service_type [ci], service_name [base_test]: true
           INFO: Deploying to Staging
           INFO: Deploying to Production
         MESSAGES
@@ -183,7 +183,7 @@ describe Integrations::BaseController do
         post :create, params: {test_route: true, token: token}
 
         message = <<~MSG
-          INFO: Branch master is release branch: true
+          INFO: Create release for branch [master], service_type [ci], service_name [base_test]: true
           ERROR: Failed deploying to Staging: Stage is locked
           INFO: Deploying to Production
         MSG


### PR DESCRIPTION
This PR changes the log message generated after `create_release?` is called to determine if a release should be created for the current request. The previous log message didn't mention additional checks for `service_type` and `service_name` which factored into the outcome, and caused some confusion as to why releases were being skipped.

Since this log is returned in the response body from inbound webhooks, it'd be good to include this extra context.

### References
- Jira link: 

### Risks
- Low