### PR TITLE
remove ip_prefix feature, we no longer need it and it was always hack…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -10,8 +10,6 @@ module Kubernetes
     attr_encrypted :client_cert
     attr_encrypted :client_key
 
-    IP_PREFIX_PATTERN = /\A(?:[\d]{1,3}\.){0,2}[\d]{1,3}\z/.freeze # also used in js
-
     has_many :cluster_deploy_groups,
       class_name: 'Kubernetes::ClusterDeployGroup',
       foreign_key: :kubernetes_cluster_id,
@@ -20,7 +18,6 @@ module Kubernetes
     has_many :deploy_groups, through: :cluster_deploy_groups, inverse_of: :kubernetes_cluster
 
     validates :name, presence: true, uniqueness: {case_sensitive: false}
-    validates :ip_prefix, format: IP_PREFIX_PATTERN, allow_blank: true
     validate :test_client_connection
 
     before_destroy :ensure_unused

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -34,7 +34,6 @@ module Kubernetes
           set_hpa_scale_target_name
         elsif Kubernetes::RoleConfigFile::SERVICE_KINDS.include?(kind)
           set_service_name
-          prefix_service_cluster_ip
           set_service_blue_green if blue_green_color
         elsif Kubernetes::RoleConfigFile.primary?(template)
           set_history_limit if kind == 'Deployment'
@@ -234,17 +233,6 @@ module Kubernetes
 
       name += "-#{@index + 1}" if @index > 0
       name
-    end
-
-    # no ipv6 support
-    def prefix_service_cluster_ip
-      return unless ip = template[:spec][:clusterIP]
-      return if ip == "None"
-      return unless prefix = @doc.deploy_group.kubernetes_cluster.ip_prefix.presence
-      ip = ip.split('.')
-      prefix = prefix.split('.')
-      ip[0...prefix.size] = prefix
-      template[:spec][:clusterIP] = ip.join('.')
     end
 
     # assumed to be validated by role_validator

--- a/plugins/kubernetes/app/views/kubernetes/clusters/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/_form.html.erb
@@ -7,12 +7,6 @@
     <fieldset>
       <%= form.input :name, required: true %>
       <%= form.input :description %>
-      <%= form.input :ip_prefix,
-          label: "IP prefix",
-          pattern: Kubernetes::Cluster::IP_PREFIX_PATTERN,
-          help: "First 1 to 3 sections of an IPv4 address to replace Service clusterIP, for example 123.231"
-      %>
-
       <%= form.input :kritis_breakglass, as: :check_box, help: "Make all resources skip kritis" if ENV["KRITIS_BREAKGLASS_SUPPORTED"] %>
 
       <%= form.input :auth_method do %>

--- a/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/clusters/show.html.erb
@@ -15,13 +15,6 @@
     </div>
   </div>
 
-  <div class="form-group">
-    <label class="col-lg-2 control-label">IP prefix</label>
-    <div class="col-lg-4">
-      <p class="form-control-static"><%= @kubernetes_cluster.ip_prefix %></p>
-    </div>
-  </div>
-
   <% if ENV["KRITIS_BREAKGLASS_SUPPORTED"] %>
   <div class="form-group">
     <label class="col-lg-2 control-label">

--- a/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/clusters_controller_test.rb
@@ -131,7 +131,7 @@ describe Kubernetes::ClustersController do
     describe "#create" do
       use_example_config
       let(:params) do
-        {config_filepath: ENV.fetch("KUBE_CONFIG_FILE"), config_context: 'default', name: 'foobar', ip_prefix: '1.2'}
+        {config_filepath: ENV.fetch("KUBE_CONFIG_FILE"), config_context: 'default', name: 'foobar'}
       end
 
       before { Kubernetes::Cluster.any_instance.stubs(connection_valid?: true) } # avoid real connection

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -93,33 +93,6 @@ describe Kubernetes::Cluster do
         end
       end
     end
-
-    describe "ip_prefix" do
-      it "is valid with 1" do
-        cluster.ip_prefix = '123'
-        assert_valid cluster
-      end
-
-      it "is valid with 3" do
-        cluster.ip_prefix = '123.123.123'
-        assert_valid cluster
-      end
-
-      it "is invalid with bad values" do
-        cluster.ip_prefix = '12312.'
-        refute_valid cluster
-      end
-
-      it "is invalid with trailing ." do
-        cluster.ip_prefix = '123.'
-        refute_valid cluster
-      end
-
-      it "is invalid with 4" do
-        cluster.ip_prefix = '123.123.123.123'
-        refute_valid cluster
-      end
-    end
   end
 
   describe '#client' do

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -334,39 +334,6 @@ describe Kubernetes::TemplateFiller do
           template.to_hash[:metadata][:name].must_equal 'foo-2'
         end
       end
-
-      describe "clusterIP" do
-        let(:ip) { template.to_hash[:spec][:clusterIP] }
-
-        before do
-          doc.deploy_group.kubernetes_cluster.update_column(:ip_prefix, '123.34')
-          raw_template[:spec][:clusterIP] = "1.2.3.4"
-        end
-
-        it "replaces ip prefix" do
-          ip.must_equal '123.34.3.4'
-        end
-
-        it "replaces with trailing ." do
-          doc.deploy_group.kubernetes_cluster.update_column(:ip_prefix, '123.34.')
-          ip.must_equal '123.34.3.4'
-        end
-
-        it "does nothing when service has no clusterIP" do
-          raw_template[:spec].delete(:clusterIP)
-          ip.must_be_nil
-        end
-
-        it "does nothing when ip prefix is blank" do
-          doc.deploy_group.kubernetes_cluster.update_column(:ip_prefix, '')
-          ip.must_equal '1.2.3.4'
-        end
-
-        it "leaves None alone" do
-          raw_template[:spec][:clusterIP] = "None"
-          ip.must_equal 'None'
-        end
-      end
     end
 
     describe "statefulset" do


### PR DESCRIPTION
…y ... can be replaced with env_from_json

column will go in next PR to avoid errors

to see if projects use the feature I ran:
```
Project.find_each do |project|
  next unless release = project.kubernetes_releases.last
  next unless release.created_at > 3.months.ago
  next unless release.release_docs.any? do |rd|
    rd.resources.any? do |r|
      t = r.template
      t[:kind] == "Service" && t[:spec][:clusterIP] && t[:spec][:clusterIP] != "None"
    end
  end
  puts "Project: #{project.url}"
end

```