### PR TITLE
bump brakeman to 4.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       sassc (>= 2.0.0)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
-    brakeman (4.9.0)
+    brakeman (4.9.1)
     builder (3.2.4)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)


### PR DESCRIPTION
Brakeman CI [job](https://github.com/zendesk/samson/pull/3853/checks?check_run_id=1087152705) was failing with
```
Brakeman 4.9.0 is not the latest version 4.9.1
```

bump brakeman to latest version

### Risks
- Low