### PR TITLE
Allow users to generate deploy csv report for multiple projects

### DIFF
--- a/app/controllers/csv_exports_controller.rb
+++ b/app/controllers/csv_exports_controller.rb
@@ -122,7 +122,10 @@ class CsvExportsController < ApplicationController
       end
     end
 
-    if project = params[:project]&.to_i
+    if project_permalinks = params[:project_permalinks].to_s.split(",").presence
+      project_ids_from_permalinks = Project.where(permalink: project_permalinks).pluck(:id)
+      filter['stages.project_id'] = project_ids_from_permalinks
+    elsif project = params[:project]&.to_i
       if project > 0
         filter['stages.project_id'] = project
       elsif project.to_s != params[:project]

--- a/app/controllers/csv_exports_controller.rb
+++ b/app/controllers/csv_exports_controller.rb
@@ -123,8 +123,7 @@ class CsvExportsController < ApplicationController
     end
 
     if project_permalinks = params[:project_permalinks].to_s.split(",").presence
-      project_ids_from_permalinks = Project.where(permalink: project_permalinks).pluck(:id)
-      filter['stages.project_id'] = project_ids_from_permalinks
+      filter['stages.project_id'] = Project.where(permalink: project_permalinks).pluck(:id)
     elsif project = params[:project]&.to_i
       if project > 0
         filter['stages.project_id'] = project

--- a/app/views/csv_exports/new.html.erb
+++ b/app/views/csv_exports/new.html.erb
@@ -27,7 +27,7 @@
       <div class="form-group">
         <%= label_tag :status, "Status:", class: "col-lg-2 control-label" %>
         <div class="col-lg-2">
-          <%= select_tag :status, options_for_select([['All', 'all'], ['Succeeded', 'succeeded'], ['Failed', 'failed]']], 'all'), class: "form-control" %>
+          <%= select_tag :status, options_for_select([['All', 'all'], ['Succeeded', 'succeeded'], ['Failed', 'failed']], 'all'), class: "form-control" %>
         </div>
       </div>
 
@@ -54,6 +54,7 @@
           <%= submit_tag "Create Deploys CSV Report", class: 'btn btn-default' %>
         </div>
       </div>
+      <%= hidden_field_tag :project_permalinks, params["project_permalinks"] %>
     <% end %>
   </div>
   <div class="clearfix">

--- a/test/controllers/csv_exports_controller_test.rb
+++ b/test/controllers/csv_exports_controller_test.rb
@@ -341,6 +341,11 @@ describe CsvExportsController do
         post :create, params: {bypassed: "true"}
         CsvExport.last.filters.must_equal("deploys.buddy_id" => nil, "stages.no_code_deployed" => false)
       end
+
+      it "with project_permalinks" do
+        post :create, params: { project_permalinks: Project.first.permalink }
+        CsvExport.last.filters.must_equal("stages.project_id" => [Project.first.id])
+      end
     end
   end
 

--- a/test/controllers/csv_exports_controller_test.rb
+++ b/test/controllers/csv_exports_controller_test.rb
@@ -343,7 +343,7 @@ describe CsvExportsController do
       end
 
       it "with project_permalinks" do
-        post :create, params: { project_permalinks: Project.first.permalink }
+        post :create, params: {project_permalinks: Project.first.permalink}
         CsvExport.last.filters.must_equal("stages.project_id" => [Project.first.id])
       end
     end


### PR DESCRIPTION
There is a use case where users need to get all the deploys from a certain time period for a select list of projects. 

Samson already has a similar feature in the [deploys search controller](https://github.com/zendesk/samson/blob/master/app/controllers/deploys_controller.rb#L147-L150), however, this is limited to 1000 deploys. I've copied similar logic to the csv export controller which does not have a limit on the number of deploys

Note: When using `project_permalinks`, I'm expecting another system to generate a link to the csv exports page with the intended projects. An example url: `https://samson.com/csv_exports/new?project_permalinks=projectone%2Cprojecttwo%2Cprojectthree`

### Risks
- Low
