### PR TITLE
do not show all users email/github handle in audits

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -2,10 +2,18 @@
 class AuditsController < ApplicationController
   def index
     query = params[:search]&.to_unsafe_h&.select { |_, v| v.present? }
-    @pagy, @audits = pagy(Audited::Audit.where(query).order(id: :desc), page: params[:page], items: 25)
+    @pagy, @audits = pagy(audit_scope.where(query).order(id: :desc), page: params[:page], items: 25)
   end
 
   def show
-    @audit = Audited::Audit.find(params.require(:id))
+    @audit = audit_scope.find(params.require(:id))
+  end
+
+  private
+
+  def audit_scope
+    scope = Audited::Audit
+    scope = scope.where.not(auditable_type: "User") if ENV["HIDE_USER_AUDITS"] # for privacy in public demo
+    scope
   end
 end

--- a/test/controllers/audits_controller_test.rb
+++ b/test/controllers/audits_controller_test.rb
@@ -47,6 +47,16 @@ describe AuditsController do
           assigns(:audits).size.must_equal 21
         end
       end
+
+      it "does not show users metadata for privacy" do
+        Audited.audit_class.as_user(user) { user.update(email: "private@foo.com") }
+        user.audits.size.must_equal 1
+        with_env HIDE_USER_AUDITS: "true" do
+          get :index
+          assert_template :index
+          response.body.wont_include user.email
+        end
+      end
     end
 
     describe "#show" do


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/3858

<img width="94" alt="Screen Shot 2020-09-23 at 8 57 34 AM" src="https://user-images.githubusercontent.com/11367/94038027-d6373080-fd7a-11ea-9484-6a632deb67be.png">
