### PR TITLE
change CsvExport filters column from string to text

### DIFF
--- a/app/models/csv_export.rb
+++ b/app/models/csv_export.rb
@@ -2,6 +2,8 @@
 class CsvExport < ActiveRecord::Base
   belongs_to :user, inverse_of: :csv_exports
   serialize :filters, JSON
+  attribute :filters, :text, default: {}
+
   STATUS_VALUES = ['pending', 'started', 'finished', 'downloaded', 'failed', 'deleted'].freeze
 
   before_destroy :delete_file

--- a/db/migrate/20200923223936_change_csv_export_filter_to_text.rb
+++ b/db/migrate/20200923223936_change_csv_export_filter_to_text.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeCsvExportFilterToText < ActiveRecord::Migration[6.0]
+  def change
+    change_column :csv_exports, :filters, :text, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_27_172257) do
+ActiveRecord::Schema.define(version: 2020_09_23_223936) do
 
   create_table "audits" do |t|
     t.integer "auditable_id", null: false
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2020_08_27_172257) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "filters", default: "{}", null: false
+    t.text "filters"
     t.string "status", default: "pending", null: false
   end
 

--- a/test/fixtures/csv_exports.yml
+++ b/test/fixtures/csv_exports.yml
@@ -1,3 +1,4 @@
 pending:
   user: viewer
   status: pending
+  filters: '{}'


### PR DESCRIPTION
Now that multiple project ids can be filtered, it is possible for the csvexport filters to be more than 255 characters.

Change the column type to text

I still need to test this on staging before merging to see if there are any additional edge cases

One weird thing when investigating was the CsvExports were able to be saved even if the filters were more than 255 characters, but it would drop the additional characters (but this would lead to an error later when trying to load the report as the filter couldn't be deserialized)
From the db:
```
"{\"deploys.created_at\":\"2020-04-01..2020-09-23\",\"environments.production\":true,\"stages.project_id\":[5,6,7,12,13,14,21,30,31,55,56,57,61,69,79,80,83,87,89,91,92,103,109,112,122,129,161,166,168,173,187,188,191,200,203,206,208,216,217,218,219,221,223,225,226,"
```



### Risks
- Low
