### PR TITLE
do not consider None as a missing risks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       sassc (>= 2.0.0)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
-    brakeman (4.9.1)
+    brakeman (4.10.0)
     builder (3.2.4)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -131,8 +131,12 @@ class Changeset::PullRequest
   def risks
     return @risks if defined?(@risks)
     @risks = parse_risks(@data.body.to_s)
-    @missing_risks = @risks.nil?
-    @risks = nil if @risks&.match?(/\A\s*\-?\s*None\Z/i)
+    if @risks&.match?(/\A\s*\-?\s*None\Z/i)
+      @risks = nil
+      @missing_risks = false
+    else
+      @missing_risks = @risks.nil?
+    end
     @risks
   end
 

--- a/app/views/changeset/_risks.html.erb
+++ b/app/views/changeset/_risks.html.erb
@@ -1,7 +1,3 @@
-<div class="alert alert-info">
-  To display risks from pull request, add a "Risks" heading in the pull request description
-</div>
-
 <% if changeset.pull_requests.any? %>
   <% changeset.pull_requests.each do |pr| %>
     <% if pr.risky? %>
@@ -10,9 +6,9 @@
     <% elsif pr.missing_risks? %>
       <div>
         <% help_icon = additional_info(
-              "Missing 'Risks' section or failed to parse risks",
-              class: 'glyphicon glyphicon-alert deployment-alert'
-            )
+            "Missing 'Risks' section or failed to parse risks (explicitly say 'None' to silence this warning)",
+            class: 'glyphicon glyphicon-alert deployment-alert'
+          )
         %>
         <h5><strong>#<%= pr.number %></strong> <%= link_to pr.title, pr.url %> <%= github_users(pr.users) %><%= help_icon %></h5>
       </div>

--- a/test/models/changeset/pull_request_test.rb
+++ b/test/models/changeset/pull_request_test.rb
@@ -520,5 +520,13 @@ describe Changeset::PullRequest do
       add_risks
       pr.missing_risks?.must_equal false
     end
+
+    it "does not consider None a missing risk" do
+      body.replace(+<<~BODY)
+        # Risks
+        None
+      BODY
+      pr.missing_risks?.must_equal false
+    end
   end
 end


### PR DESCRIPTION
PRs like
<img width="231" alt="Screen Shot 2020-09-28 at 4 24 07 PM" src="https://user-images.githubusercontent.com/11367/94495587-09c4f100-01a7-11eb-98de-75d74fafd994.png">

should not lead to deploy warnings about missing risks
also removed the permanent info heading in risks tab since it shows nicely when risks are missing

@zendesk/compute 
/cc @bquorning who found it 🎉 