### PR TITLE
allow the user who created the global lock to still deploy

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -15,6 +15,8 @@ class Job < ActiveRecord::Base
 
   validate :validate_globally_unlocked
 
+  attr_accessor :bypass_global_lock_check
+
   ACTIVE_STATUSES = %w[pending running cancelling].freeze
   VALID_STATUSES = ACTIVE_STATUSES + %w[failed errored succeeded cancelled].freeze
   SUMMARY_ACTION = {
@@ -142,6 +144,7 @@ class Job < ActiveRecord::Base
   private
 
   def validate_globally_unlocked
+    return if bypass_global_lock_check
     return unless lock = Lock.global.first
     return if lock.warning?
     errors.add(:base, 'all stages are locked')

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -94,7 +94,9 @@ class Stage < ActiveRecord::Base
     before_command = attributes.delete(:before_command)
     deploys.create(attributes.merge(release: !no_code_deployed, project: project)) do |deploy|
       commands = before_command.to_s.dup << script
-      deploy.build_job(project: project, user: user, command: commands, commit: deploy.reference)
+      deploy.build_job(
+        project: project, user: user, command: commands, commit: deploy.reference, bypass_global_lock_check: true
+      )
     end
   end
 

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -188,13 +188,20 @@ describe Job do
   end
 
   describe "#validate_globally_unlocked" do
-    def create
-      Job.create(command: "", user: user, project: project)
+    def create(**args)
+      Job.create(command: "", user: user, project: project, **args)
     end
 
-    it 'does not allow a job to be created when locked' do
-      Lock.create!(user: users(:admin))
-      create.errors.to_h.must_equal(base: 'all stages are locked')
+    describe "when globally locked" do
+      before { Lock.create!(user: users(:admin)) }
+
+      it 'does not allow a job to be created' do
+        create.errors.to_h.must_equal(base: 'all stages are locked')
+      end
+
+      it 'allows deploys from the lock owner to bypass the lock' do
+        create(bypass_global_lock_check: true).errors.to_h.must_equal({})
+      end
     end
 
     it 'allows a job to be created when warning' do


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/3864

a looong time ago we added #215 which was to prevent any activity when all stages were locked
this still makes sense, but whoever created the global lock should be allowed to still deploy (since we assume they know what they are doing)

@zendesk/compute 

