### PR TITLE
Ignore ClusterIPOutOfRange for Services

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -22,7 +22,8 @@ module Kubernetes
         "NoControllers"
       ],
       Service: [
-        "FailedToUpdateEndpointSlices"
+        "FailedToUpdateEndpointSlices",
+        "ClusterIPOutOfRange"
       ]
     }.freeze
 


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

After service cidr block change, old services are fine to be updated, so ignore the error.

### References
- Jira link: 

### Risks
- Low - might skip actual error.