### PR TITLE
Add support for PodTemplate in template filler

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -54,7 +54,9 @@ module Kubernetes
 
     def self.templates(resource)
       spec = resource[:spec]
-      if !spec
+      if resource[:kind] == 'PodTemplate'
+        [resource[:template]]
+      elsif !spec
         []
       elsif spec[:containers]
         [resource]

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -40,7 +40,7 @@ module Kubernetes
           make_stateful_set_match_service if kind == 'StatefulSet'
           set_pre_stop if kind == 'Deployment'
           set_name
-          set_replica_target || validate_replica_target_is_supported
+          (set_replica_target || validate_replica_target_is_supported) if kind != 'PodTemplate'
           set_spec_template_metadata
           set_docker_image unless verification
           set_resource_usage

--- a/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_config_file_test.rb
@@ -6,6 +6,8 @@ SingleCov.covered!
 describe Kubernetes::RoleConfigFile do
   let(:content) { read_kubernetes_sample_file('kubernetes_deployment.yml') }
   let(:config_file) { Kubernetes::RoleConfigFile.new(content, 'some-file.yml', project: projects(:test)) }
+  let(:content_template) { read_kubernetes_sample_file('kubernetes_podtemplate.yml') }
+  let(:config_file_template) { Kubernetes::RoleConfigFile.new(content_template, 'file.yml', project: projects(:test)) }
 
   describe "#initialize" do
     it "fails with a message that points to the broken file" do
@@ -33,6 +35,10 @@ describe Kubernetes::RoleConfigFile do
       Kubernetes::RoleValidator.any_instance.expects(:validate)
       assert content.sub!(/\n---.*/m, '')
       config_file.primary[:kind].must_equal 'DaemonSet'
+    end
+
+    it "finds a PodTemplate" do
+      config_file_template.primary[:kind].must_equal 'PodTemplate'
     end
 
     it "blows up on unsupported" do

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -786,6 +786,30 @@ describe Kubernetes::TemplateFiller do
       end
     end
 
+    describe "podtemplate" do
+      let(:result) { template.to_hash }
+      let(:containers) { result.dig_fetch(:template, :spec, :containers) }
+      let(:container) { containers.first }
+      let(:build) { builds(:docker_build) }
+      let(:image) { build.docker_repo_digest }
+
+      before do
+        raw_template.replace(
+          YAML.safe_load(
+            read_kubernetes_sample_file('kubernetes_podtemplate.yml')
+          ).deep_symbolize_keys
+        )
+      end
+
+      it "does not populate spec attribute" do
+        result.fetch(:spec, nil).must_be_nil
+      end
+
+      it "overrides image" do
+        container.fetch(:image).must_equal image
+      end
+    end
+
     describe "pod" do
       before do
         original_metadata = raw_template.fetch(:metadata)

--- a/plugins/kubernetes/test/samples/kubernetes_podtemplate.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_podtemplate.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: PodTemplate
+metadata:
+  name: some-project-rc
+  labels:
+    project: some-project
+    role: some-role
+template:
+  metadata:
+    name: some-project-pod
+    labels:
+      project: some-project
+      role: some-role
+  spec:
+    containers:
+    - name: some-project
+      image: docker-registry.zende.sk/truth_service:latest
+      resources:
+        requests:
+          cpu: 250m
+          memory: 50Mi
+        limits:
+          cpu: 500m
+          memory: 100Mi
+      ports:
+      - name: some-role-port
+        containerPort: 4242
+        protocol: TCP


### PR DESCRIPTION
Samson already modifies aspects of a Deployment/StatefulSet/DaemonSet etc. Fun fact, all of these types embed a `PodTemplateSpec`, generally at the key `.spec.template`.

Add in support for modifying a `PodTemplate` resource type directly. The reason this needs to be handled separately is its key is `.template`, rather than the `.spec.template` of these other resources.

### References
- Jira link: 

### Risks
- Low: a `PodTemplate` will not be modified correctly, which is low risk as it isn't being modified at the moment anyway
