### PR TITLE
Set desired_pod_count for PodTemplate to be 0

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -446,6 +446,12 @@ module Kubernetes
       end
     end
 
+    class PodTemplate < VersionedUpdate
+      def desired_pod_count
+        0 # PodTemplates don't actually create pods
+      end
+    end
+
     class Pod < Immutable
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -314,6 +314,11 @@ describe Kubernetes::Resource do
         delete_resource!
         resource.desired_pod_count.must_equal 0
       end
+
+      it "is 0 when resource is a PodTemplate" do
+        template[:kind] = "PodTemplate"
+        resource.desired_pod_count.must_equal 0
+      end
     end
 
     describe "#request" do


### PR DESCRIPTION
PodTemplate does not actually create any pods, so zero out this value,
ensuring our deploys don't hang waiting for pods to create that never
will.

### Risks
- Low: PodTemplate is not a resource that is widely used, meaning any fallout is going to be minimal
