### PR TITLE
Support token scopes with underscores

### DIFF
--- a/app/views/access_tokens/new.html.erb
+++ b/app/views/access_tokens/new.html.erb
@@ -7,7 +7,7 @@
       <%= form.select :application_id, options_for_select(Doorkeeper::Application.all.map { |a| [a.name, a.id] }), {}, {class: 'form-control'} %>
     <% end %>
     <%= form.input :description %>
-    <%= form.input :scopes, pattern: /\A[a-z ]+\z/, help: I18n.t('doorkeeper.applications.help.scopes') %>
+    <%= form.input :scopes, pattern: /\A[a-z_ ]+\z/, help: I18n.t('doorkeeper.applications.help.scopes') %>
 
     <%= form.actions %>
   <% end %>


### PR DESCRIPTION
Some of the controllers like `deploy_groups` have underscores in their names and we should be able to add them to our token scope.

### References
- Jira link: 

### Risks
- Low/Med/High: thing that could happen
