### PR TITLE
Remove deprecated docker login --email flag

### DIFF
--- a/app/models/image_builder.rb
+++ b/app/models/image_builder.rb
@@ -33,8 +33,7 @@ class ImageBuilder
         credentials = DockerRegistry.all.select { |r| r.password && r.username }.map do |r|
           username = r.username.shellescape
           password = r.password.shellescape
-          email = (docker_major_version >= 17 ? "" : "--email no@example.com ")
-          "docker login --username #{username} --password #{password} #{email}#{r.host.shellescape}"
+          "docker login --username #{username} --password #{password}"
         end
 
         # run commands and then cleanup after
@@ -119,21 +118,6 @@ class ImageBuilder
       end
 
       digest
-    end
-
-    # TODO: same as in config/initializers/docker.rb ... dry it up
-    def docker_major_version
-      @@docker_major_version ||=
-        begin
-          Timeout.timeout(0.2) { read_docker_version[/(\d+)\.\d+\.\d+/, 1].to_i }
-        rescue Timeout::Error
-          0
-        end
-    end
-
-    # just here to get stubbed
-    def read_docker_version
-      `docker -v 2>/dev/null`
     end
   end
 end

--- a/app/models/image_builder.rb
+++ b/app/models/image_builder.rb
@@ -33,7 +33,7 @@ class ImageBuilder
         credentials = DockerRegistry.all.select { |r| r.password && r.username }.map do |r|
           username = r.username.shellescape
           password = r.password.shellescape
-          "docker login --username #{username} --password #{password}"
+          "docker login --username #{username} --password #{password} #{r.host.shellescape}"
         end
 
         # run commands and then cleanup after

--- a/test/models/image_builder_test.rb
+++ b/test/models/image_builder_test.rb
@@ -135,22 +135,6 @@ describe ImageBuilder do
 
       before do
         DockerRegistry.expects(:all).returns([DockerRegistry.new("http://fo+o:ba+r@ba+z.com")])
-        ImageBuilder.class_variable_set(:@@docker_major_version, nil)
-      end
-
-      it "uses email flag when docker is old" do
-        ImageBuilder.expects(:read_docker_version).returns("1.12.0")
-        called[1].must_equal "docker login --username fo\\+o --password ba\\+r --email no@example.com ba\\+z.com"
-      end
-
-      it "uses email flag when docker check fails" do
-        ImageBuilder.expects(:read_docker_version).raises(Timeout::Error)
-        called[1].must_equal "docker login --username fo\\+o --password ba\\+r --email no@example.com ba\\+z.com"
-      end
-
-      it "does not use email flag on newer docker versions" do
-        ImageBuilder.expects(:read_docker_version).returns("17.0.0")
-        called[1].must_equal "docker login --username fo\\+o --password ba\\+r ba\\+z.com"
       end
 
       it "can do a real docker check" do


### PR DESCRIPTION
The `--email` flag was removed on `06/2017` (https://docs.docker.com/engine/release-notes/17.06/#17060-ce)
Lets not support that flag anymore in Samson


### Risks
- Low. Docker login won't work if anyone is using a very old version of docker
