### PR TITLE
allow previwing manifest without deploying

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/stages_controller.rb
@@ -9,8 +9,9 @@ class Kubernetes::StagesController < ResourceController
   # used internally for deploy tab preview as well as an external API to render manifests for external tools
   def manifest_preview
     git_ref = params[:git_ref] || current_project.release_branch || DEFAULT_BRANCH
-    git_sha = current_project.repository.commit_from_ref(git_ref)
-    raise Samson::Hooks::UserError, 'Git reference not found' if git_sha.blank?
+    git_sha =
+      current_project.repository.commit_from_ref(git_ref) ||
+      raise(Samson::Hooks::UserError, 'Git reference not found')
 
     # resolving builds can take some time, best to leave it off by default
     resolve_build = params[:resolve_build] == 'true'
@@ -41,6 +42,6 @@ class Kubernetes::StagesController < ResourceController
   private
 
   def yaml_comment(message)
-    "# #{message.split("\n").join("\n# ")}\n"
+    message.split("\n").map { |l| "# #{l}" }.join("\n")
   end
 end

--- a/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
+++ b/plugins/kubernetes/app/views/samson_kubernetes/_deploy_changeset_tab_body.html.erb
@@ -16,6 +16,6 @@
 <% elsif @stage&.kubernetes? %>
   <div class="tab-pane" id="manifests">
     <!-- using an iframe to lazy-load the manifest preview as it can be slow -->
-    <pre><iframe frameborder="0" seamless src="<%= manifest_preview_project_kubernetes_stage_url(@stage.project, @stage, :yaml) %>" width="100%" height="400"></iframe></pre>
+    <pre><iframe frameborder="0" seamless src="<%= manifest_preview_project_kubernetes_stage_url(@stage.project, @stage, format: :yaml, git_ref: @deploy.reference) %>" width="100%" height="400"></iframe></pre>
   </div>
 <% end %>


### PR DESCRIPTION
@zendesk/compute 
<img width="909" alt="Screen Shot 2020-11-04 at 11 16 58 AM" src="https://user-images.githubusercontent.com/11367/98158186-5e871600-1e8f-11eb-86f3-67edbda93740.png">
