### PR TITLE
By default preview all objects for a role

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -72,10 +72,9 @@ module Kubernetes
     end
 
     # Temporary template we run validations on ... so can be cheap / not fully fleshed out
-    # and only be the primary since services/configmaps are not very interesting anyway
     def verification_template
       primary_config = raw_template.detect { |e| Kubernetes::RoleConfigFile.primary?(e) } || raw_template.first
-      Kubernetes::TemplateFiller.new(self, primary_config, index: 0)
+      Kubernetes::TemplateFiller.new(self, primary_config, index:)
     end
 
     def blue_green_color


### PR DESCRIPTION
When faced with migration to spinnaker we actually want to see all roles
to do a faithful comparison of manifests to ensure we got everything
right.

Currently we can only verify the "primary" document which is a good
indicator, but -- we might as well go full monty.

### References
- Jira link: GUIDEOPS-1884

### Risk
- Low: might generate more load on manifest preview, but that's a manual action, so we should be fine.