### PR TITLE
tag logs with request-id so we can find everything that belongs toget…

### DIFF
--- a/lib/samson/syslog_formatter.rb
+++ b/lib/samson/syslog_formatter.rb
@@ -2,8 +2,35 @@
 
 require 'syslog/logger'
 
+class Syslog::Logger
+  # called by activesupport in dev mode ... not implemented since we'd need to make the base class use @level threadsafe
+  def silence
+    yield
+  end
+end
+
 module Samson
   class SyslogFormatter < Syslog::Logger::Formatter
+    # called by activesupport / implementation copied from activesupport
+    def tagged(*tags)
+      tags = tags.flatten # same as in activesupport, since it gets called with [[]]
+      current_tags.concat tags
+      yield
+    ensure
+      current_tags.pop tags.size
+    end
+
+    # called by activesupport / implementation copied from activesupport
+    def clear_tags!
+      current_tags.clear
+    end
+
+    # called by activesupport / implementation copied from activesupport
+    def current_tags
+      thread_key = (@thread_key ||= "syslog_logging_tags:#{object_id}")
+      Thread.current[thread_key] ||= []
+    end
+
     def call(severity, timestamp, _progname, message)
       message_h =
         if message.is_a?(String) && message.start_with?('{')
@@ -17,11 +44,13 @@ module Samson
         else
           {message: message}
         end
+
       {
         level: severity,
         "@timestamp": timestamp,
         application: "samson",
-        host: Rails.application.config.samson.uri.host
+        host: Rails.application.config.samson.uri.host,
+        tags: current_tags
       }.merge(message_h).to_json
     end
   end

--- a/test/lib/samson/syslog_formatter_test.rb
+++ b/test/lib/samson/syslog_formatter_test.rb
@@ -5,54 +5,95 @@ require_relative '../../test_helper'
 SingleCov.covered!
 
 describe Samson::SyslogFormatter do
-  describe '.json' do
-    before do
-      @output = StringIO.new
-      @logger = Logger.new(@output)
-      @logger.formatter = Samson::SyslogFormatter.new
-      @log_template = {level: "INFO", "@timestamp": Time.now, application: "samson", host: "www.test-url.com"}
+  before { freeze_time }
+
+  describe "#call" do
+    let(:output) { StringIO.new }
+    let(:logger) do
+      l = Logger.new(output)
+      l.formatter = Samson::SyslogFormatter.new
+      l
+    end
+    let(:log_template) do
+      {level: "INFO", "@timestamp": Time.now.as_json, application: "samson", host: "www.test-url.com", tags: []}
     end
 
-    def output_matcher(message, output)
-      @log_template[:"@timestamp"] = Time.now
-      @logger.info(message)
-      expected = @log_template.merge(output)
-      @output.string.must_equal(expected.to_json)
+    def clean_log
+      output.string.gsub("}{", "}\n{").split("\n").map do |line|
+        line = JSON.parse(line, symbolize_names: true)
+        line.delete_if { |k, v| log_template[k] == v }
+        line
+      end
     end
 
     it 'returns a json formatted log' do
-      travel_to Time.parse("2017-05-01 01:00 +0000").utc do
-        message = 'test'
-        output_matcher(message, message: message)
-      end
+      logger.info('test')
+      clean_log.must_equal [{message: 'test'}]
     end
 
-    it 'allows Hash and appends to log' do
-      travel_to Time.parse("2017-05-01 01:00 +0000").utc do
-        message = {content: "xyz", data: "123"}
-        output_matcher(message, message)
-      end
+    it 'merges Hash into log' do
+      message = {content: "xyz", data: "123"}
+      logger.info(message)
+      clean_log.must_equal [message]
     end
 
     it 'returns original message with invalid json' do
-      travel_to Time.parse("2017-05-01 01:00 +0000").utc do
-        message = "{\"content\",\"xyz\",\"data\",\"123\"}"
-        output_matcher(message, message: message)
-      end
+      message = "{\"content\",\"xyz\",\"data\",\"123\"}"
+      logger.info(message)
+      clean_log.must_equal [{message: message}]
     end
 
-    it 'parse and format json messages' do
-      travel_to Time.parse("2017-05-01 01:00 +0000").utc do
-        message = {content: "xyz"}
-        output_matcher(message.to_json, message)
-      end
+    it 'merges json messages into log' do
+      message = {content: "xyz"}
+      logger.info(message.to_json)
+      clean_log.must_equal [message]
     end
 
     it 'skips parser when message isn`t hash' do
-      travel_to Time.parse("2017-05-01 01:00 +0000").utc do
-        message = "[1,2]"
-        output_matcher(message, message: message)
+      message = "[1,2]"
+      logger.info(message)
+      clean_log.must_equal [{message: message}]
+    end
+
+    it "can add/remove tags" do
+      logger.info("1")
+      logger.formatter.tagged(["foo"]) do
+        logger.info("2")
+        logger.formatter.tagged(["bar", "baz"]) do
+          logger.info("3")
+        end
+        logger.info("4")
       end
+      logger.info("5")
+      clean_log.must_equal [
+        {message: "1"},
+        {tags: ["foo"], message: "2"},
+        {tags: ["foo", "bar", "baz"], message: "3"},
+        {tags: ["foo"], message: "4"},
+        {message: "5"}
+      ]
+    end
+
+    it "can clear tags" do
+      logger.info("1")
+      logger.formatter.tagged(["foo", "bar"]) do
+        logger.formatter.clear_tags!
+        logger.info("2")
+      end
+      logger.info("3")
+      clean_log.must_equal [
+        {message: "1"},
+        {message: "2"},
+        {message: "3"}
+      ]
+    end
+  end
+end
+
+describe Syslog::Logger do
+  describe "#silence" do
+    it "does nothing" do
+      Syslog::Logger.new.silence { 1 }.must_equal 1
     end
   end
 end


### PR DESCRIPTION
…her easily

syslog:
```
{"level":1,"@timestamp":"2020-11-13T23:24:41.875+00:00","application":"samson","host":"localhost","tags":["id:abba4100-ac9e-48bb-9c43-ed98d37a7aa0","ip:127.0.0.1"],"message":"  Rendered plugins/env/app/views/samson_env/_manage_menu.html.erb (Duration: 0.5ms | Allocations: 175)"}
```

regula logs:
```
[id:f61578ad-026f-46c0-89cf-6d4e797c9bee] [ip:127.0.0.1]   Rendered layouts/_footer.html.erb (Duration: 0.5ms | Allocations: 279)
```

@zendesk/compute 