### PR TITLE
stop lazy loading mime-types, it is no longer slow and causes warnings

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,7 +6,6 @@ DATADOG_APPLICATION_KEY=dappkey
 JENKINS_URL=http://www.test-url.com
 JENKINS_USERNAME=user@test.com
 JENKINS_API_KEY=japikey
-RUBY_MIME_TYPES_LAZY_LOAD=true
 AUTH_GITHUB=1
 GITHUB_CLIENT_ID=github-id
 GITHUB_SECRET=github-secret


### PR DESCRIPTION
`RUBY_MIME_TYPES_LAZY_LOAD) is deprecated and will be removed`
tested load time and it only adds ~0.1, so all good 🤷 

@zendesk/compute 