### PR TITLE
Fix paste bug in project environment variables

### DIFF
--- a/plugins/env/app/assets/javascripts/env/application.js
+++ b/plugins/env/app/assets/javascripts/env/application.js
@@ -93,7 +93,7 @@
   function parseAndAdd(pasted) {
     var env = parseEnv(pasted);
 
-    var $row = $(".paste_env_variables").prev().prev();
+    var $row = $(".paste_env_variables").prev().prev().prev();
     var selectedEnv = $row.find("select").val();
 
 


### PR DESCRIPTION
There is a bug in the "Paste" feature that prevents us from creating an environment variable from a string.

The Javascript selector that is supposed to find a previous environment variable to create a copy ends up creating a copy of the wrong HTML element. 

Adding one more call to previous fixes the issue.

As a future improvement, we should consider creating a proper id or class for environment variables so we can find them easily instead of walking the DOM like this.

Input:
![image](https://user-images.githubusercontent.com/1295942/99317724-80d84680-2834-11eb-8089-a2a5cc7162a2.png)

Result:
![image](https://user-images.githubusercontent.com/1295942/99317771-90578f80-2834-11eb-817c-9634d97c059d.png)

### References
- Jira link: https://zendesk.atlassian.net/browse/SCALE-1566

### Risks
- Low
