### PR TITLE
stop redeclaring core routes, leading to deploy#show being available …

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -207,7 +207,7 @@ class DeploysController < ApplicationController
   end
 
   def find_deploy
-    @deploy = Deploy.find(params[:id])
+    @deploy = (current_project&.deploys || Deploy).find(params[:id])
   end
 
   def deploys_scope

--- a/plugins/kubernetes/config/routes.rb
+++ b/plugins/kubernetes/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Samson::Application.routes.draw do
-  resources :projects do
+  resources :projects, only: [] do
     namespace :kubernetes do
       resources :deploy_group_roles do
         collection do

--- a/plugins/new_relic/config/routes.rb
+++ b/plugins/new_relic/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Samson::Application.routes.draw do
-  resources :projects do
+  resources :projects, only: [] do
     resources :stages do
       get :new_relic, to: 'new_relic#show'
     end

--- a/plugins/rollbar_dashboards/config/routes.rb
+++ b/plugins/rollbar_dashboards/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Samson::Application.routes.draw do
-  resources :projects do
+  resources :projects, only: [] do
     namespace :rollbar_dashboards do
       resources :dashboards, only: [] do
         collection do
@@ -11,7 +11,7 @@ Samson::Application.routes.draw do
     end
   end
 
-  resources :deploys do
+  resources :deploys, only: [] do
     namespace :rollbar_dashboards do
       resources :dashboards, only: [] do
         collection do

--- a/test/integration/cleanliness_test.rb
+++ b/test/integration/cleanliness_test.rb
@@ -287,4 +287,16 @@ describe "cleanliness" do
       TEXT
     )
   end
+
+  it "does not override default routes from plugins" do
+    core = File.read("config/routes.rb").scan(/^  resources :([^\s,]+)/).flatten
+    core.size.must_be :>, 10
+
+    routes = Dir["{#{Samson::Hooks.plugins.map(&:folder).join(",")}}/config/routes.rb"]
+    bad = routes.flat_map do |route|
+      redeclared = File.read(route).scan(/^  resources :(\S+) do/).flatten & core
+      redeclared.map { |b| "#{route} do not re-declare core object routes #{b}, use `only: []`" }
+    end
+    assert bad.empty?, bad.join("\n")
+  end
 end


### PR DESCRIPTION
…without project

found this because someone was requesting /deploys/1259606 and it actually tried to render it and then crashed

```
ActionView::Template::Error: undefined method `name' for nil:NilClass
File "/data/samson/releases/20201106-170925-1c39983/app/helpers/deploys_helper.rb" line 31 in deploy_page_title
```