### PR TITLE
[k8s] create a configmap of env vars to keep container def clean

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -30,7 +30,7 @@ module Kubernetes
         release.blue_green_color =
           release.previous_succeeded_release&.blue_green_color == "blue" ? "green" : "blue"
       end
-      release.send :build_release_docs, roles if release.valid?
+      release.send(:build_release_docs, roles) if release.valid?
       release
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -67,14 +67,6 @@ module Kubernetes
       deploy.previous_succeeded_deploy&.kubernetes_release
     end
 
-    def blue_green?
-      roles.flatten(1).any? { |dgr| dgr.kubernetes_role.blue_green? }
-    end
-
-    def blue_green_color
-      super || "blue"
-    end
-
     private
 
     # Creates a ReleaseDoc per DeployGroupRole

--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -67,6 +67,14 @@ module Kubernetes
       deploy.previous_succeeded_deploy&.kubernetes_release
     end
 
+    def blue_green?
+      roles.flatten(1).any? { |dgr| dgr.kubernetes_role.blue_green? }
+    end
+
+    def blue_green_color
+      super || "blue"
+    end
+
     private
 
     # Creates a ReleaseDoc per DeployGroupRole

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -262,6 +262,39 @@ describe Kubernetes::ReleaseDoc do
         create!.resource_template.size.must_equal 2
       end
     end
+
+    describe "env ConfigMap" do
+      it "does not add one by default" do
+        assert create!.resource_template.none? { |t| t[:kind] == "ConfigMap" }
+      end
+
+      describe "when requested" do
+        let(:container) { template.dig(0, :spec, :template, :spec, :containers, 0) }
+
+        before do
+          template.dig(0, :metadata)[:annotations] = {"samson/env_from_config_map": true}
+          create!
+        end
+
+        it "adds a configmap of static env" do
+          # deployment, service, configmap
+          create!.resource_template.size.must_equal 3
+        end
+
+        it "adds envFrom for the correct container" do
+          config_map_name = "#{template.dig(0, :metadata, :name)}-blue-env"
+          filled_container = create!.resource_template.dig(0, :spec, :template, :spec, :containers, 0)
+
+          filled_container[:envFrom].must_include(configMapRef: {name: config_map_name, optional: false})
+        end
+
+        it "copies the namespace" do
+          template[0][:metadata][:namespace] = "custom"
+          map = create!.resource_template[2]
+          map.dig(:metadata, :namespace).must_equal "custom"
+        end
+      end
+    end
   end
 
   describe "#raw_template" do

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -90,7 +90,7 @@ describe Kubernetes::Release do
       Kubernetes::Release.build_release_with_docs(release_params).release_docs.must_be :empty?
     end
 
-    describe "blue green" do
+    describe "#blue_green_color" do
       before { app_server.blue_green = true }
 
       it 'defaults to blue when not using blue_green' do

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -506,7 +506,7 @@ describe Kubernetes::TemplateFiller do
 
         it "adds env vars to init containers when requested" do
           with_init_container name: 'foo', "samson/set_env_vars": "true"
-          spec_init_containers.dig(0, :env, 0, :name).must_equal "REVISION"
+          assert spec_init_containers.dig(0, :env).any? { |v| v[:name] == "REVISION" }
         end
       end
 
@@ -596,6 +596,14 @@ describe Kubernetes::TemplateFiller do
         container.fetch(:env).select { |e| e[:name] == 'TAG' }.must_equal(
           [{name: 'TAG', value: 'OVERRIDE'}]
         )
+      end
+
+      describe "env from configmap" do
+        let(:template) { Kubernetes::TemplateFiller.new(doc, raw_template, index: 0, env_config_map: "project-env") }
+
+        it "adds an envFrom reference" do
+          container.fetch(:envFrom).must_include(configMapRef: {name: "project-env", optional: false})
+        end
       end
 
       describe "with multiple containers" do


### PR DESCRIPTION
The env list in containers can get very large for large projects. This creates large kubernetes objects that contain lots of the same data and those objects can put lots of load on etcd (or whatever you're using). 

This change leverages a Kubernetes feature to create [all key-value pairs in a configmap as container environment variables](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables). By doing this, we can keep the env vars around in one spot and every copy of a container can reference that same spot rather than duplicate the content. 

**TODO:**

- [x] ~try to remove the change of `to_hash` to `to_a` and eliminate the flatmap. This is a big sweeping change that would be nice to avoid.~ This was removed and the `to_hash` was left as-is.
- [x] figure out if there is an order dependency/race here. What happens when the configmap updates before the container spec. Is there a window where a workload could get rescheduled elsewhere running the old image but read in the new configmap? 
- [x] look into versioning these configmaps to alleviate the potential race mentioned.

To address the race/collision problems above, we use the blue/green naming scheme for the configmaps here. This involved some changes to the core release logic, but should be low impact. The most notable change is we will always assign a phase to a release, even if we don't use the phase name in the resource names. This allows us to ensure that the configmaps always flip-flop and the current deploy should never compete with a previous deploy. It will mean we keep exactly two copies of the configmap around which seems reasonable.

### Risks
- Medium. Containers could reference stale/incorrect env if the configmap isn't written correctly and at the right time.