### PR TITLE
remove duplicate client-ip from logs

### DIFF
--- a/config/logging.rb
+++ b/config/logging.rb
@@ -49,8 +49,7 @@ if ENV["RAILS_LOG_WITH_LOGRAGE"]
     request = event.payload[:headers].instance_variable_get(:@req)
     {
       params: params,
-      user_id: request.env['warden']&.user&.id,
-      client_ip: request.remote_ip
+      user_id: request.env['warden']&.user&.id
     }
   end
   config.lograge.formatter = Lograge::Formatters::Logstash.new


### PR DESCRIPTION
https://github.com/zendesk/samson/pull/3878 added ip logging to every line, so no need to have them in lograge lines too

```
[id:1737a672-caf4-44fb-ae87-463ff8052ac0] [ip:127.0.0.1] 
{"method":"GET","path":"/","format":"html","controller":"ProjectsController","action":"index","status":200,"duration":1456.17,
"view":1369.34,"db":20.01,"params":{},"user_id":2,"@timestamp":"2020-11-25T19:34:52.165Z","@version":"1","message":"[200] GET / (ProjectsController#index)"}
```

@zendesk/compute 