### PR TITLE
[k8s] always set blue/green on release to give unique deploy refs if …

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -25,11 +25,10 @@ module Kubernetes
     def self.build_release_with_docs(params)
       roles = params.delete(:grouped_deploy_group_roles).to_a
       release = new(params) do |release|
-        if roles.flatten(1).any? { |dgr| dgr.kubernetes_role.blue_green? }
-          release.blue_green_color = begin
-            release.previous_succeeded_release&.blue_green_color == "blue" ? "green" : "blue"
-          end
-        end
+        # We always set the blue green color but the template filler might not always use it.
+        # This allows us to support deploy-specific features like env vars from config maps.
+        release.blue_green_color =
+          release.previous_succeeded_release&.blue_green_color == "blue" ? "green" : "blue"
       end
       release.send :build_release_docs, roles if release.valid?
       release

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -19,6 +19,8 @@ module Kubernetes
     attr_reader :previous_resources
     attr_writer :deploy_group_role
 
+    delegate :blue_green?, to: :kubernetes_role
+
     def deploy
       @previous_resources = resources.map(&:resource)
       resources.each(&:deploy)
@@ -79,7 +81,7 @@ module Kubernetes
     end
 
     def blue_green_color
-      kubernetes_release.blue_green_color if kubernetes_role.blue_green?
+      kubernetes_release.blue_green_color if blue_green?
     end
 
     def prerequisite?
@@ -123,7 +125,7 @@ module Kubernetes
         env["KUBERNETES_CLUSTER_NAME"] = deploy_group.kubernetes_cluster.name.to_s
 
         # blue-green phase
-        env["BLUE_GREEN"] = blue_green_color.dup if blue_green_color
+        env["BLUE_GREEN"] = blue_green_color.dup if blue_green?
 
         # env from plugins
         deploy = kubernetes_release.deploy || Deploy.new(project: kubernetes_release.project)

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -34,7 +34,7 @@ module Kubernetes
           set_hpa_scale_target_name
         elsif Kubernetes::RoleConfigFile::SERVICE_KINDS.include?(kind)
           set_service_name
-          set_service_blue_green if blue_green_color
+          set_service_blue_green if @doc.blue_green?
         elsif Kubernetes::RoleConfigFile.primary?(template)
           set_history_limit if kind == 'Deployment'
           make_stateful_set_match_service if kind == 'StatefulSet'
@@ -47,13 +47,13 @@ module Kubernetes
           set_env unless @doc.delete_resource
           set_secrets unless @doc.delete_resource
           set_image_pull_secrets
-          set_resource_blue_green if blue_green_color
+          set_resource_blue_green if @doc.blue_green?
           set_init_containers
           set_kritis_breakglass
           set_istio_sidecar_injection
         elsif kind == 'PodDisruptionBudget'
           set_name
-          set_match_labels_blue_green if blue_green_color
+          set_match_labels_blue_green if @doc.blue_green?
         else
           set_name
         end
@@ -384,7 +384,7 @@ module Kubernetes
         else
           @doc.kubernetes_role.resource_name
         end
-      name += "-#{blue_green_color}" if blue_green_color
+      name += "-#{blue_green_color}" if @doc.blue_green?
       template.dig_set [:metadata, :name], name
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -221,7 +221,7 @@ describe Kubernetes::DeployExecutor do
       end
 
       it "does limited amounts of queries" do
-        assert_sql_queries(17) do
+        assert_sql_queries(18) do
           assert execute, out
         end
       end

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -95,7 +95,8 @@ describe Kubernetes::ReleaseDoc do
 
     describe "with blue/green enabled" do
       before do
-        Kubernetes::ReleaseDoc.any_instance.stubs(:blue_green_color).returns("green")
+        Kubernetes::Role.any_instance.stubs(:blue_green?).returns(true)
+        Kubernetes::Release.any_instance.stubs(:blue_green_color).returns("green")
       end
 
       it "sets BLUE_GREEN in the env" do

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -93,10 +93,10 @@ describe Kubernetes::Release do
     describe "blue green" do
       before { app_server.blue_green = true }
 
-      it 'does not set when not using blue_green' do
+      it 'defaults to blue when not using blue_green' do
         app_server.blue_green = false
         subject = Kubernetes::Release.build_release_with_docs(release_params)
-        subject.blue_green_color.must_be_nil
+        subject.blue_green_color.must_equal "blue"
       end
 
       it 'creates first as blue' do


### PR DESCRIPTION
…needed

In prep for #3885 this always assigns a color to a release, even if we don't use it. This ensures that top level resources like a configmap can always be given a unique name for every deploy. 

### Risks
- Low. Blue/Green naming could sneak into a k8s resource name unintentionally.