### PR TITLE
Revert "Ignore ClusterIPOutOfRange for Services"

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -22,8 +22,7 @@ module Kubernetes
         "NoControllers"
       ],
       Service: [
-        "FailedToUpdateEndpointSlices",
-        "ClusterIPOutOfRange"
+        "FailedToUpdateEndpointSlices"
       ]
     }.freeze
 


### PR DESCRIPTION
Reverts zendesk/samson#3867

We don't need it anymore.