### PR TITLE
use maxUnavailable for automated poddisruptionbudgets since they do n…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -169,37 +169,34 @@ module Kubernetes
           annotations: annotations
         },
         spec: {
-          minAvailable: target,
+          maxUnavailable: target,
           selector: {matchLabels: deployment.dig_fetch(:spec, :selector, :matchLabels).dup}
         }
       }
+
       if deployment[:metadata].key? :namespace
         budget[:metadata][:namespace] = deployment.dig(:metadata, :namespace)
       end
-      budget[:delete] = true if target == 0
+
+      # not HA: don't bother, overhead for 0 or 1 replica deployments, but we don't know if a bad budget existed before
+      budget[:delete] = true if replica_target <= 1
+
       raw_template << budget
     end
 
+    # covert minAvailable to maxUnavailable because that never results in blocking the cluster from draining nodes
+    # (math can go wrong and PDBs cannot be drained for example because HPA scaled the deployment down)
     def disruption_budget_target(deployment)
       min_available = deployment.dig(:metadata, :annotations, :"samson/minAvailable")
       return if min_available == "disabled"
 
-      # NOTE: overhead for 0 or 1 replica deployments, but we don't know if a bad budget existed before
       min_available ||= ENV["KUBERNETES_AUTO_MIN_AVAILABLE"]
       return unless min_available
 
-      non_blocking = replica_target - 1
-      return 0 if non_blocking <= 0
-
       if percent = min_available.to_s[/\A(\d+)\s*%\z/, 1] # "30%" -> 30 / "30 %" -> 30
-        percent = Integer(percent)
-        if percent >= 100
-          raise Samson::Hooks::UserError, "minAvailable of >= 100% would result in eviction deadlock, pick lower"
-        else
-          "#{[percent, non_blocking.to_f / replica_target * 100].min.to_i}%"
-        end
+        "#{[100 - Integer(percent), 1].max}%"
       else
-        [non_blocking, Integer(min_available)].min
+        [replica_target - Integer(min_available), 1].max
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -132,55 +132,35 @@ describe Kubernetes::ReleaseDoc do
         refute create!.resource_template[2]
       end
 
-      it "adds valid relative PodDisruptionBudget when sometimes invalid is requested" do
-        template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '99%'}
-        create!.resource_template[2][:spec][:minAvailable].must_equal '50%'
-      end
-
-      it "fails when completely invalid is requested" do
+      it "adds valid PodDisruptionBudget when sometimes invalid is requested" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '100%'}
-        assert_raises(Samson::Hooks::UserError) { create! }
+        create!.resource_template[2][:spec][:maxUnavailable].must_equal '1%'
       end
 
       it "adds absolute PodDisruptionBudget when requested" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '1'}
-        create!.resource_template[2][:spec][:minAvailable].must_equal 1
+        create!.resource_template[2][:spec][:maxUnavailable].must_equal 1
       end
 
-      describe "with relative budget" do
-        before { template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '30%'} }
-
-        it "adds relative PodDisruptionBudget" do
-          Time.stubs(:now).returns(Time.parse("2018-01-01"))
-          budget = create!.resource_template[2]
-          budget[:spec][:minAvailable].must_equal '30%'
-          budget[:metadata][:annotations][:"samson/updateTimestamp"].must_equal "2018-01-01T00:00:00Z"
-          refute budget.key?(:delete)
-        end
-
-        it "can use deploy group default namespace via template filler" do
-          template.dig(0, :metadata).delete :namespace
-          budget = create!.resource_template[2]
-          budget[:metadata][:namespace].must_equal "pod1"
-        end
-
-        it "can use custom namespace" do
-          template[0][:metadata][:namespace] = "custom"
-          budget = create!.resource_template[2]
-          budget[:metadata][:namespace].must_equal "custom"
-        end
+      it "adds relative PodDisruptionBudget" do
+        template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '30%'}
+        Time.stubs(:now).returns(Time.parse("2018-01-01"))
+        budget = create!.resource_template[2]
+        budget[:spec][:maxUnavailable].must_equal '70%'
+        budget[:metadata][:annotations][:"samson/updateTimestamp"].must_equal "2018-01-01T00:00:00Z"
+        refute budget.key?(:delete)
       end
 
       describe "with auto-add" do
         with_env KUBERNETES_AUTO_MIN_AVAILABLE: "1"
 
         it "add default" do
-          create!.resource_template[2][:spec][:minAvailable].must_equal 1
+          create!.resource_template[2][:spec][:maxUnavailable].must_equal 1
         end
 
         it "adds when first is not a Deployment" do
           template.unshift(apiVersion: "v1", kind: "ConfigMap", metadata: {labels: {project: "foo", role: "bar"}})
-          create!.resource_template[3][:spec][:minAvailable].must_equal 1
+          create!.resource_template[3][:spec][:maxUnavailable].must_equal 1
         end
 
         it "ignores when there is no deployment" do
@@ -231,9 +211,9 @@ describe Kubernetes::ReleaseDoc do
         assert create!.resource_template[2][:metadata][:annotations].key?(:"samson/keep_name")
       end
 
-      it "deletes when set to 0" do
+      it "allows full disruption when set to 0" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '0'}
-        create!.resource_template[2][:delete].must_equal true
+        create!.resource_template[2][:spec][:maxUnavailable].must_equal 2
       end
 
       it "deletes when set to 0 via relative" do
@@ -251,7 +231,7 @@ describe Kubernetes::ReleaseDoc do
       it "fixes when creating a deadlock by setting a absolute value" do
         template.dig(0, :metadata)[:annotations] = {"samson/minAvailable": '2'}
         create!
-        create!.resource_template[2][:spec][:minAvailable].must_equal 1
+        create!.resource_template[2][:spec][:maxUnavailable].must_equal 1
       end
 
       it "does not add a second PDB" do


### PR DESCRIPTION
…ever block draining nodes

- can also use percentages now since we are on a more modern kubernetes version
- changed: requesting minAvailabel:0 previously deleted the PDB but now keeps it ... does not matter much / was never documented

/cc @zendesk/config @zendesk/eng-productivity 