### PR TITLE
[k8s] add option to source env from a config map rather than container spec

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release.rb
@@ -21,6 +21,10 @@ module Kubernetes
       super || NullUser.new(user_id)
     end
 
+    def blue_green_color
+      super || "blue"
+    end
+
     # Creates a new Kubernetes Release and corresponding ReleaseDocs
     def self.build_release_with_docs(params)
       roles = params.delete(:grouped_deploy_group_roles).to_a

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -598,6 +598,14 @@ describe Kubernetes::TemplateFiller do
         )
       end
 
+      describe "env from configmap" do
+        let(:template) { Kubernetes::TemplateFiller.new(doc, raw_template, index: 0, env_config_map: "project-env") }
+
+        it "adds an envFrom reference" do
+          container.fetch(:envFrom).must_include(configMapRef: {name: "project-env", optional: false})
+        end
+      end
+
       describe "with multiple containers" do
         before { raw_template[:spec][:template][:spec][:containers] = [{name: 'foo'}, {name: 'bar'}] }
 


### PR DESCRIPTION
This is the rework of #3885 after merging in some incremental changes.

The env list in containers can get very large for large projects. This creates large kubernetes objects that contain lots of the same data and those objects can put lots of load on etcd (or whatever you're using). 

This change leverages a Kubernetes feature to create [all key-value pairs in a configmap as container environment variables](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables). By doing this, we can keep the env vars around in one spot and every copy of a container can reference that same spot rather than duplicate the content. 

To address race/collision problems, we use the blue/green naming scheme for the configmaps here. This allows us to ensure that the configmaps always flip-flop and the current deploy should never compete with a previous deploy. It will mean we keep exactly two copies of the configmap around which seems reasonable.

### Risks
- Medium. Containers could reference stale/incorrect env if the configmap isn't written correctly and at the right time.