### PR TITLE
use kubernetes propagationPolicy to do deletion logic for us

### DIFF
--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -770,7 +770,7 @@ describe Kubernetes::DeployExecutor do
       end
 
       it "does not crash when rollback fails" do
-        Kubernetes::Resource::Deployment.any_instance.stubs(:revert).raises("Weird error")
+        Kubernetes::Resource::Base.any_instance.stubs(:revert).raises("Weird error")
 
         refute execute, out
 
@@ -782,7 +782,7 @@ describe Kubernetes::DeployExecutor do
 
       it "does not rollback when deploy disabled it" do
         deploy.update_column(:kubernetes_rollback, false)
-        Kubernetes::Resource::Deployment.any_instance.expects(:revert).never
+        Kubernetes::Resource::Base.any_instance.expects(:revert).never
 
         refute execute, out
 
@@ -1227,7 +1227,6 @@ describe Kubernetes::DeployExecutor do
         :get, "#{deployments_url}/test-app-server-green",
         to_return: [{body: "{}"}, {body: "{}"}, {status: 404}] # green did exist and gets deleted
       )
-      assert_request(:put, "#{deployments_url}/test-app-server-green", to_return: {body: "{}"}) # set green to 0
       assert_request(:delete, "#{deployments_url}/test-app-server-green", to_return: {body: "{}"}) # delete green
 
       executor.expects(:wait_for_resources_to_complete).returns([true, []])
@@ -1250,7 +1249,6 @@ describe Kubernetes::DeployExecutor do
         ]
       )
       assert_request(:post, deployments_url, to_return: {body: "{}"}) # blue was created
-      assert_request(:put, "#{deployments_url}/test-app-server-blue", to_return: {body: "{}"}) # set blue to 0
       assert_request(:delete, "#{deployments_url}/test-app-server-blue", to_return: {body: "{}"}) # delete blue
 
       executor.expects(:wait_for_resources_to_complete).returns([false, []])

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -317,9 +317,9 @@ describe Kubernetes::ReleaseDoc do
       stub_request(:put, service_url).to_return(body: '{"RE":"SOURCE"}')
 
       # check and update deployment
-      Kubernetes::Resource::Deployment.any_instance.stubs(:ensure_not_updating_match_labels)
+      Kubernetes::Resource::Base.any_instance.stubs(:ensure_not_updating_match_labels)
       client.expects(:get_deployment).returns(DE: "PLOY")
-      client.expects(:update_deployment).returns("Rest client resonse")
+      client.expects(:update_deployment).returns("Rest client response")
 
       doc.deploy
       doc.instance_variable_get(:@previous_resources).must_equal([{SER: "VICE"}, {DE: "PLOY"}])
@@ -330,9 +330,9 @@ describe Kubernetes::ReleaseDoc do
     it "reverts all resources" do
       doc.instance_variable_set(:@previous_resources, [{SER: "VICE"}, {DE: "PLOY"}])
       resources = doc.send(:resources)
-      resources.detect { |r| r.is_a? Kubernetes::Resource::Deployment }.
+      resources.detect { |r| r.kind == "Deployment" }.
         expects(:revert).with(DE: "PLOY")
-      resources.detect { |r| r.is_a? Kubernetes::Resource::Service }.
+      resources.detect { |r| r.kind == "Service" }.
         expects(:revert).with(SER: "VICE")
       doc.revert
     end

--- a/plugins/kubernetes/test/models/kubernetes/release_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_test.rb
@@ -129,7 +129,7 @@ describe Kubernetes::Release do
 
     it "can scope queries by resource namespace" do
       release = kubernetes_releases(:test_release)
-      Kubernetes::Resource::Deployment.any_instance.stubs(namespace: "default")
+      Kubernetes::Resource::Base.any_instance.stubs(namespace: "default")
       stub_request(:get, %r{http://foobar.server/api/v1/namespaces/default/pods}).to_return(body: {
         resourceVersion: "1",
         items: [{}, {}]


### PR DESCRIPTION
previously we manually cleaned up pods to prevent bugs when deleting and creating right after
with propagationPolicy we no longer need to do that since we know that all children are cleaned up when the parent resource is deleted. This is similar to how kubectl waits with the deletion of the parent until all children are deleted too.


### Risks
- Low: risk is leaving pods behind when deleting (verified locally)
- Low: strange things happening because deletion order is not the default order kubectl uses