### PR TITLE
avoid duplicate id warnings by not providing them

### DIFF
--- a/plugins/env/app/views/samson_env/_project_form.html.erb
+++ b/plugins/env/app/views/samson_env/_project_form.html.erb
@@ -25,8 +25,11 @@
     <% ids.each do |id| %>
       <div class="form-group env_group_inputs">
         <div class="col-lg-3">
-          <%= live_select_tag "project[environment_variable_group_ids][]",
-            options_for_select([[nil, nil]] + environment_variable_groups, id), placeholder: "Name"
+          <%= live_select_tag(
+                "project[environment_variable_group_ids][]",
+                options_for_select([[nil, nil]] + environment_variable_groups, id),
+                placeholder: "Name", id: nil
+              )
           %>
         </div>
         <div class="col-lg-2 checkbox">


### PR DESCRIPTION
<img width="622" alt="Screen Shot 2020-11-16 at 12 50 01 PM" src="https://user-images.githubusercontent.com/11367/101427367-95e44a80-38b3-11eb-9400-7c0402c39e9e.png">

@zendesk/compute 
