### PR TITLE
fix reloading breaking plugins decorators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       sassc (>= 2.0.0)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
-    brakeman (4.10.0)
+    brakeman (4.10.1)
     builder (3.2.4)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -92,7 +92,7 @@ module Samson
         @name = File.basename(@folder).sub(/-[^-]*\z/, '').sub(/\Asamson_/, "")
       end
 
-      def load
+      def setup_and_require
         lib = "#{@folder}/lib"
         $LOAD_PATH << lib
         require @path
@@ -193,12 +193,12 @@ module Samson
       end
 
       def load_decorators(klass)
-        @class_decorators[klass.name].each { |path| require_dependency(path) }
+        @class_decorators[klass.name].each { |path| load(path) }
       end
 
       def plugin_setup
         Samson::Hooks.plugins.
-          each(&:load).
+          each(&:setup_and_require).
           each(&:add_migrations).
           each(&:add_assets_to_precompile).
           each(&:add_decorators)


### PR DESCRIPTION
previously the require_dependency did not get reloaded since it's not in the autoload-path
this lead to errors like `(undefined method `environment_variables' for #<Deploy:0x00007fb519ffb2b8>` when modifying anything in a model