### PR TITLE
do not fail when comitter had an invalid email

### DIFF
--- a/plugins/jenkins/app/models/samson/jenkins.rb
+++ b/plugins/jenkins/app/models/samson/jenkins.rb
@@ -250,8 +250,15 @@ module Samson
       end
 
       emails.compact!
-      emails.select! { |e| e.include?('@') }
-      emails.map! { |x| Mail::Address.new(x) }
+      emails.map! do |a|
+        begin
+          Mail::Address.new(a)
+        rescue
+          nil
+        end
+      end
+      emails.compact!
+      emails.select!(&:domain)
       if restricted_domain = ENV["EMAIL_DOMAIN"]
         emails.select! { |x| x.domain.casecmp(restricted_domain) == 0 }
       end

--- a/plugins/jenkins/test/models/samson/jenkins_test.rb
+++ b/plugins/jenkins/test/models/samson/jenkins_test.rb
@@ -203,7 +203,7 @@ describe Samson::Jenkins do
         jenkins.build.must_equal 1
       end
 
-      it "does not send invalid emails that can come from comitters" do
+      it "does not send emails to addresses without domain that can come from committers" do
         with_env EMAIL_DOMAIN: 'example.com' do
           deploy.user.email = 'invalid'
           deploy.stubs(:buddy).returns(buddy)
@@ -211,6 +211,14 @@ describe Samson::Jenkins do
           stub_get_build_id_from_queue(1)
           jenkins.build.must_equal 1
         end
+      end
+
+      it "does not send emails to invalid addresses that can come from committers" do
+        deploy.user.email = '49699333+dependabot[bot]@users.noreply.github.com'
+        deploy.stubs(:buddy).returns(buddy)
+        stub_build_with_parameters("emails": "deployerbuddy@example.com")
+        stub_get_build_id_from_queue(1)
+        jenkins.build.must_equal 1
       end
 
       it "includes committer emails when jenkins_email_committers flag is set" do


### PR DESCRIPTION
`[04:31:21] Finish hook failed: Mail::AddressList can not parse |49699333+dependabot[bot]@users.noreply.github.com|: Only able to parse up to "49699333+dependabot"
`

@zendesk/compute 

### Risks
- Low: jenkins hook failing or not sending to all emails
