### PR TITLE
add a deploy status endpoint

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -5,9 +5,11 @@ class DeploysController < ApplicationController
   include WrapInWithDeleted
   include CurrentProject
 
+  skip_before_action :login_user, only: [:status]
+  skip_before_action :verify_authenticity_token, only: [:status]
   skip_before_action :require_project, only: [:active, :active_count, :changeset]
 
-  before_action :authorize_project_deployer!, except: [:index, :show, :active, :active_count, :changeset]
+  before_action :authorize_project_deployer!, except: [:index, :show, :active, :active_count, :changeset, :status]
   before_action :find_deploy, except: [:index, :active, :active_count, :new, :create, :confirm]
   before_action :stage, only: :new
 
@@ -113,6 +115,10 @@ class DeploysController < ApplicationController
   def destroy
     @deploy.cancel(current_user)
     redirect_to [current_project, @deploy]
+  end
+
+  def status
+    render json: { status: @deploy.status }
   end
 
   def self.deploy_permitted_params

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -118,7 +118,7 @@ class DeploysController < ApplicationController
   end
 
   def status
-    render json: { status: @deploy.status }
+    render json: {status: @deploy.status}
   end
 
   def self.deploy_permitted_params

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -49,11 +49,17 @@ class Integrations::BaseController < ApplicationController
       end
     end
 
+    json = {
+      deploy_ids: deploys.map(&:id).compact,
+      messages: @recorded_log.to_s
+    }
+
+    if params[:includes].to_s.split(',').include?('status_urls')
+      json[:status_urls] = deploys.map(&:status_url).compact
+    end
+
     render(
-      json: {
-        deploy_ids: deploys.map(&:id).compact,
-        messages: @recorded_log.to_s
-      },
+      json: json,
       status: (deploys.all?(&:persisted?) ? :ok : :unprocessable_entity)
     )
   end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -232,7 +232,7 @@ class Deploy < ActiveRecord::Base
   end
 
   def as_json(methods: [])
-    hash = super(methods: [:status, :status_url, :url, :production, :commit] + methods)
+    hash = super(methods: [:status, :url, :production, :commit] + methods)
     hash["summary"] = summary_for_timeline
     hash
   end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -211,6 +211,10 @@ class Deploy < ActiveRecord::Base
     Rails.application.routes.url_helpers.project_deploy_url(project, self)
   end
 
+  def status_url
+    Rails.application.routes.url_helpers.status_project_deploy_url(project, self, format: :json)
+  end
+
   def self.csv_header
     [
       "Deploy Number", "Project Name", "Deploy Summary", "Deploy Commit", "Deploy Status", "Deploy Updated",
@@ -228,7 +232,7 @@ class Deploy < ActiveRecord::Base
   end
 
   def as_json(methods: [])
-    hash = super(methods: [:status, :url, :production, :commit] + methods)
+    hash = super(methods: [:status, :status_url, :url, :production, :commit] + methods)
     hash["summary"] = summary_for_timeline
     hash
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Samson::Application.routes.draw do
       member do
         post :buddy_check
         get :changeset
+        get :status
       end
     end
 

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -438,6 +438,13 @@ describe DeploysController do
       end
     end
 
+    describe "#status" do
+      it "renders with format .json" do
+        get :status, params: {project_id: project, id: deploy}
+        json.fetch('status').must_equal deploy.status
+      end
+    end
+
     unauthorized :get, :new, project_id: :foo, stage_id: 2
     unauthorized :post, :create, project_id: :foo, stage_id: 2
     unauthorized :post, :buddy_check, project_id: :foo, id: 1

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -8,7 +8,17 @@ describe Integrations::BaseController do
   end
 
   tests BaseTestController
-  use_test_routes BaseTestController
+
+  # We need to keep the `status_project_deploy_url` route around for the `?includes=status_url` test
+  use_test_routes BaseTestController do
+    resources :projects do
+      resources :deploys do
+        member do
+          get :status
+        end
+      end
+    end
+  end
 
   let(:sha) { "dc395381e650f3bac18457909880829fc20e34ba" }
   let(:project) { projects(:test) }

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -471,6 +471,12 @@ describe Deploy do
     end
   end
 
+  describe "#status_url" do
+    it "builds an address for a deploy status" do
+      deploy.status_url.must_equal "http://www.test-url.com/projects/foo/deploys/#{deploy.id}/status.json"
+    end
+  end
+
   describe "#short_reference" do
     it "returns the first seven characters if the reference looks like a SHA" do
       deploy = Deploy.new(reference: "8e7c20937de160905e8ffb13be72eb483ab4170a")
@@ -682,6 +688,7 @@ describe Deploy do
     it "includes simple methods status" do
       deploy.as_json.fetch("status").must_equal "succeeded"
       deploy.as_json.must_include "url"
+      deploy.as_json.must_include "status_url"
       deploy.as_json.must_include "production"
     end
 

--- a/test/models/deploy_test.rb
+++ b/test/models/deploy_test.rb
@@ -688,12 +688,15 @@ describe Deploy do
     it "includes simple methods status" do
       deploy.as_json.fetch("status").must_equal "succeeded"
       deploy.as_json.must_include "url"
-      deploy.as_json.must_include "status_url"
       deploy.as_json.must_include "production"
     end
 
     it "includes the summary" do
       deploy.as_json.fetch("summary").must_equal deploy.summary_for_timeline
+    end
+
+    it "does not include the status_url" do
+      deploy.as_json.wont_include "status_url"
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -281,7 +281,7 @@ ActionController::TestCase.class_eval do
       end
     end
 
-    def use_test_routes(controller)
+    def use_test_routes(controller, &block)
       controller_name = controller.name.underscore.sub('_controller', '')
       before do
         Rails.application.routes.draw do
@@ -293,6 +293,8 @@ ActionController::TestCase.class_eval do
               action: action
             )
           end
+
+          instance_eval(&block) if block_given?
         end
       end
 


### PR DESCRIPTION
Adds a publicly accessible endpoint to get the status of a deploy. 

This is to allow external systems to integrate with Samson and track the status of a deploy. It simply returns the status string in a JSON response, so I felt it was safe to skip all forms of auth so external systems can do this without needing to provide credentials.

### Risks
- Low: This could open the door for a rogue integration to spam the status endpoint.
