### PR TITLE
Update puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 
 gem 'bundler'
 gem 'dogstatsd-ruby'
-gem 'puma'
+gem 'puma', '= 4.3.6'
 gem 'attr_encrypted'
 gem 'sawyer'
 gem 'dalli'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 
 gem 'bundler'
 gem 'dogstatsd-ruby'
-gem 'puma', '= 4.3.6'
+gem 'puma'
 gem 'attr_encrypted'
 gem 'sawyer'
 gem 'dalli'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,7 +474,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (4.0.5)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     pyu-ruby-sasl (0.0.3.3)
     racc (1.5.2)
@@ -685,7 +685,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
-  puma
+  puma (= 4.3.6)
   rack-mini-profiler
   rails (~> 6.0.3)
   rails-assets-bootstrap-select!


### PR DESCRIPTION
Older versions of puma don't work on newer versions of OSX
https://github.com/puma/puma/issues/2304 this newer version
contains this PR https://github.com/puma/puma/releases/tag/v4.3.6

I had to bump this gem to get `bundle install` to work

### Risks
- Low: updates puma with some minor bugfixes
