### PR TITLE
Return the release reference to the calling client

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -53,6 +53,7 @@ class Integrations::BaseController < ApplicationController
       deploy_ids: deploys.map(&:id).compact,
       messages: @recorded_log.to_s
     }
+    json[:release] = release if release
 
     if params[:includes].to_s.split(',').include?('status_urls')
       json[:status_urls] = deploys.map(&:status_url).compact


### PR DESCRIPTION
With some of our migration work in the deploy process, we want to be
able to trigger some calls to Samson to create releases, but then have
the version name returned so we can perform further tasks on that tag.

I'm using clone in this code because the underlying deploy stage uses hash modifying operations, namely `.delete`.

### Risks
- Low: could cause errors, but will still result in deploys/releases
