### PR TITLE
Remove annoying gray line

### DIFF
--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -15,7 +15,7 @@
 
   <%= render 'changeset/tab_list' %>
 
-  <li><a href="#viewers" data-toggle="tab" id="viewers-link">Viewers <span class="badge">0</span></a></li>
+  <li><a href="#viewers" data-toggle="tab" id="viewers-link">Viewers <span class="badge" style="vertical-align: baseline">0</span></a></li>
 </ul>
 
 <section class="clearfix tabs">


### PR DESCRIPTION
Overrides conflicting style from bootstrap's badge class that was breaking the layout

I don't know how frowned upon inline style is, but it guarantees highest specificity, and that the style won't be picked up by any where else.

### Risks:
* Low: Could potentially shift something else by one pixel

<img width="1000" alt="Screen Shot 2021-01-27 at 10 47 46 PM" src="https://user-images.githubusercontent.com/43389660/106100760-b5e4fd00-60f1-11eb-9cd8-0d9d512ed1d1.png">
<img width="964" alt="Screen Shot 2021-01-27 at 10 47 29 PM" src="https://user-images.githubusercontent.com/43389660/106100771-b8dfed80-60f1-11eb-970c-f8fc1147810f.png">


