### PR TITLE
Remove annoying gray line

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -685,7 +685,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
-  puma (= 4.3.6)
+  puma
   rack-mini-profiler
   rails (~> 6.0.3)
   rails-assets-bootstrap-select!

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -146,6 +146,11 @@ h3 {
 
 }
 
+// lower vertical padding that we inherit from bootstrap so it does not get too big for tab nav
+.badge {
+  padding: 2px 7px;
+}
+
 .nav-tabs {
   border-bottom: none;
 

--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -15,7 +15,7 @@
 
   <%= render 'changeset/tab_list' %>
 
-  <li><a href="#viewers" data-toggle="tab" id="viewers-link">Viewers <span class="badge">0</span></a></li>
+  <li><a href="#viewers" data-toggle="tab" id="viewers-link">Viewers <span class="badge" style="vertical-align: baseline">0</span></a></li>
 </ul>
 
 <section class="clearfix tabs">

--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -15,7 +15,7 @@
 
   <%= render 'changeset/tab_list' %>
 
-  <li><a href="#viewers" data-toggle="tab" id="viewers-link">Viewers <span class="badge" style="vertical-align: baseline">0</span></a></li>
+  <li><a href="#viewers" data-toggle="tab" id="viewers-link">Viewers <span class="badge">0</span></a></li>
 </ul>
 
 <section class="clearfix tabs">


### PR DESCRIPTION
same as https://github.com/zendesk/samson/pull/3921

but:
- global
- symmetric since we don't mess with the baseline

<img width="248" alt="Screen Shot 2021-01-28 at 9 01 49 AM" src="https://user-images.githubusercontent.com/11367/106172272-7ba64a80-6147-11eb-8630-ec3a670068cd.png">
<img width="296" alt="Screen Shot 2021-01-28 at 9 01 47 AM" src="https://user-images.githubusercontent.com/11367/106172276-7c3ee100-6147-11eb-90fe-23448d99f4e2.png">

@zendesk/compute 