### PR TITLE
cache external env group reads since they repeat a lot

### DIFF
--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -4,6 +4,7 @@ require 'validates_lengths_from_database'
 class EnvironmentVariable < ActiveRecord::Base
   FAILED_LOOKUP_MARK = ' X' # SpaceX
   PARENT_PRIORITY = ["Deploy", "Stage", "Project", "EnvironmentVariableGroup"].freeze
+  EXTERNAL_VARIABLE_CACHE_DURATION = 5.minutes
 
   include GroupScope
   extend Inlinable
@@ -74,8 +75,11 @@ class EnvironmentVariable < ActiveRecord::Base
       end)
 
       external_groups.each_with_object({}) do |group, envs|
-        group_env = group.read[deploy_group.permalink]
-        envs.merge! group_env if group_env
+        all_groups = Rails.cache.fetch("env-#{group.url}-read", expires_in: EXTERNAL_VARIABLE_CACHE_DURATION) do
+          group.read
+        end
+        next unless group_env = all_groups[deploy_group.permalink]
+        envs.merge! group_env
       end
     rescue StandardError => e
       raise Samson::Hooks::UserError, "Error reading env vars from external env-groups: #{e.message}"

--- a/plugins/env/app/views/environment_variable_groups/form.html.erb
+++ b/plugins/env/app/views/environment_variable_groups/form.html.erb
@@ -29,7 +29,7 @@
       <%= form.input :comment, as: :text_area, input_html: {size: "80x4"} %>
       <%= form.input :owners, help: "Github team names or email to contact with questions (comma separated)" %>
       <% if ExternalEnvironmentVariableGroup.configured? %>
-        <%= form.input :external_url do %>
+        <%= form.input :external_url, help: "Cached for #{distance_of_time_in_words(EnvironmentVariable::EXTERNAL_VARIABLE_CACHE_DURATION)}" do %>
           <%= form.text_field :external_url, class: "form-control", placeholder: ExternalEnvironmentVariableGroup::S3_URL_FORMAT %>
           <%= link_to 'Preview', preview_external_environment_variable_group_path("fake", url: @group.external_url) if @group.external_url? %>
         <% end %>

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -95,6 +95,11 @@ describe EnvironmentVariable do
           "FOO" => "one", "Z" => "A", "X" => "Y"
         )
       end
+
+      it "caches aws calls" do
+        ExternalEnvironmentVariableGroup.any_instance.expects(:read).returns({})
+        2.times { EnvironmentVariable.env(deploy, deploy_group, resolve_secrets: false) }
+      end
     end
 
     describe "with an assigned group and variables" do


### PR DESCRIPTION
saw lots of slow down in samson once we switched to external env groups, this should help