### PR TITLE
Update lock UI to deal with multiple locks/warnings

### DIFF
--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -20,7 +20,6 @@ class Lock < ActiveRecord::Base
   validates :user_id, presence: true
   validates :description, presence: true, if: :warning?
   validates :resource_type, inclusion: RESOURCE_TYPES
-  validate :unique_global_lock, on: :create
   validate :valid_delete_at, on: :create
 
   after_save :expire_all_cached
@@ -102,11 +101,6 @@ class Lock < ActiveRecord::Base
 
   def nil_out_blank_resource_type
     self.resource_type = resource_type.presence
-  end
-
-  # our index does not work on nils, so we have to verify by hand
-  def unique_global_lock
-    errors.add(:resource_id, :invalid) if global? && Lock.global.first
   end
 
   def valid_delete_at

--- a/app/views/deploy_groups/show.html.erb
+++ b/app/views/deploy_groups/show.html.erb
@@ -84,7 +84,7 @@
   <div class="form-group">
     <div class="col-lg-offset-2 col-lg-10" style="margin-top: 10px;">
       <%= link_to "Edit", edit_deploy_group_path(@deploy_group), class: "btn btn-primary" %>
-      <%= render "locks/button", lock: @deploy_group.lock, resource: @deploy_group %>
+      <%= render "locks/button", resource: @deploy_group %>
       | <%= link_to_history @deploy_group %>
       | <%= link_to "Deploys", deploys_path(search: {group: "DeployGroup-#{@deploy_group.id}"}) %>
       | <%= link_to "Mass stage creation", "#", data: {target: "#mass_stage_creation"}, class: 'toggle' if DeployGroup.enabled? %>

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -1,8 +1,8 @@
 <% page_title "Deploy" %>
 
-<%= breadcrumb @project, @stage, "Deploy" %>
-
 <%= render_locks @stage %>
+
+<%= breadcrumb @project, @stage, "Deploy" %>
 
 <section>
   <% data = {

--- a/app/views/environments/show.html.erb
+++ b/app/views/environments/show.html.erb
@@ -13,5 +13,5 @@
     <%= form.actions history: true %>
   <% end %>
 
-  <%= render "locks/button", lock: @environment.lock, resource: @environment %>
+  <%= render "locks/button", resource: @environment %>
 </section>

--- a/app/views/locks/_button.html.erb
+++ b/app/views/locks/_button.html.erb
@@ -1,22 +1,8 @@
 <% if can? :write, :locks, resource %>
   <% prefix ||= "" %>
-  <% warning = {resource: resource, warning: true, icon: warning_icon, text: "#{prefix}Warn", disabled: false} %>
-  <% locking = {resource: resource, warning: false, icon: lock_icon, text: "#{prefix}Lock", disabled: false} %>
+  <% warning = {resource: resource, warning: true, icon: warning_icon, text: "Add #{prefix}Warning", disabled: false} %>
+  <% locking = {resource: resource, warning: false, icon: lock_icon, text: "Add #{prefix}Lock", disabled: false} %>
 
-  <% if lock %>
-    <% if lock.warning? %>
-      <%= link_to lock, class: 'btn btn-default', method: :delete do %>
-        <%= warning_icon %> Resolve
-      <% end %>
-      <%= render '/locks/lock_button', locking.merge(disabled: true) %>
-    <% else %>
-      <%= render '/locks/lock_button', warning.merge(disabled: true) %>
-      <%= link_to lock, class: 'btn btn-default', method: :delete do %>
-        <%= lock_icon %> Unlock
-      <% end %>
-    <% end %>
-  <% else %>
-    <%= render '/locks/lock_button', warning %>
-    <%= render '/locks/lock_button', locking %>
-  <% end %>
+  <%= render '/locks/lock_button', warning %>
+  <%= render '/locks/lock_button', locking %>
 <% end %>

--- a/app/views/locks/_lock.html.erb
+++ b/app/views/locks/_lock.html.erb
@@ -1,8 +1,18 @@
-<div class="alert alert-warning">
+<div class="alert alert-<%= lock.warning? ? "warning" : "danger" %> clearfix">
+  <% if ((lock.global? && show_resolve == :global) || lock.resource_equal?(show_resolve)) && can?(:write, :locks, show_resolve) %>
+    <%= link_to lock, class: 'btn btn-default btn-sm pull-right', method: :delete do %>
+      <% if lock.warning? %>
+        <%= warning_icon %> Resolve
+      <% else %>
+        <%= lock_icon %> Unlock
+      <% end %>
+    <% end %>
+  <% end %>
+
   <% if lock.warning? %>
     <%= warning_icon %> <%= lock_affected(lock) %> Warning:
   <% else %>
-    <%= lock_icon %> Deployments to <%= lock_affected(lock) %> were locked
+    <%= lock_icon %> Deployments to <%= lock_affected(lock) %> Locked:
   <% end %>
   <%= sanitize lock.reason %>
   <i>

--- a/app/views/projects/_header.html.erb
+++ b/app/views/projects/_header.html.erb
@@ -4,8 +4,10 @@
   <%= repository_web_link(project) %>
 </h1>
 
+<%= render_locks @project %>
+
 <div class="project-lock-buttons">
-  <%= render "locks/button", lock: project.lock, resource: @project %>
+  <%= render "locks/button", resource: @project %>
 </div>
 
 <%= render "shared/project_tabs", project: project, active: tab %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,22 +1,26 @@
+<%= render_locks :global %>
+
 <%= page_title do %>
   <%= icon_tag 'star' %> Projects
 <% end %>
 
-<%= search_form do %>
-  <%= render 'shared/search_query' %>
-<% end %>
-
-<div class="row dashboard">
-  <%= render @projects %>
-</div>
-
 <div class="admin-actions">
   <% if current_user.admin? %>
     <div class="pull-right">
-      <%= render "locks/button", lock: global_locks.first, resource: nil, prefix: "Global " %>
+      <%= render "locks/button", resource: nil, prefix: "Global " %>
       <%= link_to "New", new_project_path, class: "btn btn-default" %>
     </div>
   <% end %>
 
   <%= paginate @pagy %>
 </div>
+
+<%= search_form do %>
+  <%= render 'shared/search_query' %>
+<% end %>
+
+
+<div class="row dashboard">
+  <%= render @projects %>
+</div>
+

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,7 +1,5 @@
 <% page_title @project.name %>
 
-<%= render_locks @project %>
-
 <%= render 'projects/header', project: @project, tab: "stages" %>
 
 <section class="clearfix tabs">

--- a/app/views/stages/show.html.erb
+++ b/app/views/stages/show.html.erb
@@ -2,19 +2,19 @@
 
 <%= breadcrumb @project, @stage %>
 
-<%= render_locks @stage %>
-
 <h1>
   <%= @stage.name %>
   <%= image_tag project_stage_path(@project, @stage, format: :svg, token: Rails.application.config.samson.badge_token), title: "Deploy badge" %>
 </h1>
+
+<%= render_locks @stage %>
 
 <section>
   <h2>Actions</h2>
   <div>
     <%= deploy_link @project, @stage %>
 
-    <%= render "locks/button", lock: @stage.lock, resource: @stage %>
+    <%= render "locks/button", resource: @stage %>
 
     <% if admin_for_project? %>
       <%= link_to "Edit", edit_project_stage_path(@project, @stage), class: "btn btn-default" %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -185,6 +185,16 @@ describe ApplicationHelper do
       breadcrumb.must_equal "<ul class=\"breadcrumb\"><li class=\"active\">Home</li></ul>"
     end
 
+    it "renders all stages locked" do
+      stubs(global_locks: [Lock.new])
+      breadcrumb.must_equal "<ul class=\"breadcrumb\"><li class=\"active\"><i class=\"glyphicon glyphicon-lock\"></i> Home</li></ul>"
+    end
+
+    it "renders all stages warning" do
+      stubs(global_locks: [Lock.new(warning: true)])
+      breadcrumb.must_equal "<ul class=\"breadcrumb\"><li class=\"active\"><i class=\"glyphicon glyphicon-warning-sign\"></i> Home</li></ul>"
+    end
+
     it "renders stage" do
       breadcrumb(stage).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Staging</li></ul>"
     end
@@ -203,8 +213,13 @@ describe ApplicationHelper do
       breadcrumb(project).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Foo</li></ul>"
     end
 
+    it "renders locked project" do
+      project.stubs(lock: Lock.new)
+      breadcrumb(project).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\"><i class=\"glyphicon glyphicon-lock\"></i> Foo</li></ul>"
+    end
+
     it "renders environment" do
-      breadcrumb(environment).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Production</li></ul>"
+      breadcrumb(environment).must_equal "<ul class=\"breadcrumb\"><li class=\"\"><a href=\"/\">Home</a></li><li class=\"active\">Environment Production</li></ul>"
     end
 
     it "renders deploy_group" do
@@ -335,7 +350,7 @@ describe ApplicationHelper do
     end
 
     it "links to environments" do
-      link_to_resource(environments(:production)).must_equal "<a href=\"/environments/production\">Production</a>"
+      link_to_resource(environments(:production)).must_equal "<a href=\"/environments/production\">Environment Production</a>"
     end
 
     it "links to deploy_groups" do

--- a/test/models/lock_test.rb
+++ b/test/models/lock_test.rb
@@ -40,19 +40,6 @@ describe Lock do
       end
     end
 
-    describe "#unique_global_lock" do
-      before { Lock.create!(user: user) }
-
-      it "is invalid with another global lock" do
-        refute_valid lock
-      end
-
-      it "is valid when scoped" do
-        lock.resource = stage
-        assert_valid lock
-      end
-    end
-
     describe "#nil_out_blank_resource_type" do
       it "nils blank resource_type" do
         lock.resource_type = ''


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Update lock UI and validations to deal with multiple locks/warnings nicer. No more single resolve button that only can resolve the first lock, but instead inline the button in the lock on the relevant page (ie you can only unlock on the resource's page and with permission). Also change the text on some of the warnings/locks so their scope is clearer.

![Screen Shot 2021-02-03 at 10 34 29 am](https://user-images.githubusercontent.com/153219/106676654-6def3a00-660b-11eb-90c3-9a775a9e1782.png)


![Screen Shot 2021-02-03 at 10 15 07 am](https://user-images.githubusercontent.com/153219/106676552-413b2280-660b-11eb-9b69-d17c30194645.png)

### Risks
- Low: could break locks in other weird ways, especially where multiple global locks are involved 
