### PR TITLE
downgrade bundler to unblock deployment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -745,4 +745,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.1.4
+   1.17.3


### PR DESCRIPTION
failed with `package --all` and then with newer bundler version not being available ... unblock for now, can re-bump later

@zendesk/compute 