### PR TITLE
Disabled buddy bypass using environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,7 @@ PERIODICAL=stop_expired_deploys:60,remove_expired_locks:60,report_system_stats:6
 # BYPASS_EMAIL= # email destinations that are alerted about buddy_check bypasses, comma separated
 # BYPASS_DETAILS= # 'Some text explaining bypass procedure'
 # BUDDY_CHECK_TIME_LIMIT= # max minutes a deploy is pending, default: 20
+# DISABLE_BUDDY_BYPASS_FEATURE=1 # disable bypassing the buddy procedure
 
 ## StatsD reporting
 # STATSD_HOST=192.168.1.1

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -84,8 +84,11 @@ class DeploysController < ApplicationController
   end
 
   def buddy_check
-    @deploy.confirm_buddy!(current_user) if @deploy.pending?
-
+    if !Samson::BuddyCheck.bypass_enabled? && @deploy.user == current_user
+      flash.now[:alert] = "Buddy bypass is disabled"
+    else
+      @deploy.confirm_buddy!(current_user) if @deploy.pending?
+    end
     redirect_to [current_project, @deploy]
   end
 

--- a/app/views/deploys/_buddy_check.html.erb
+++ b/app/views/deploys/_buddy_check.html.erb
@@ -16,9 +16,11 @@
 
     <div>
       <%= cancel_button deploy: @deploy, project: @project %>
-      or
-      <% confirm = "Are you sure this is an emergency and you cannot find a buddy?\n#{strip_tags(details)}" %>
-      <%= link_to "Bypass", buddy_check_project_deploy_path(@project, @deploy), method: :post, data: {confirm: confirm}, class: "btn btn-danger" %>
+      <% if Samson::BuddyCheck.bypass_enabled? %>
+        or
+        <% confirm = "Are you sure this is an emergency and you cannot find a buddy?\n#{strip_tags(details)}" %>
+        <%= link_to "Bypass", buddy_check_project_deploy_path(@project, @deploy), method: :post, data: {confirm: confirm}, class: "btn btn-danger" %>
+      <% end %>
     </div>
   <% elsif deployer_for_project? %>
     <p>This deploy requires a buddy.</p>

--- a/lib/samson/buddy_check.rb
+++ b/lib/samson/buddy_check.rb
@@ -7,7 +7,7 @@ module Samson
       end
 
       def bypass_enabled?
-        !Samson::EnvCheck.set?("SKIP_BUDDY_BYPASS_FEATURE")
+        !Samson::EnvCheck.set?("DISABLE_BUDDY_BYPASS_FEATURE")
       end
 
       # how long can the same commit be deployed ?

--- a/lib/samson/buddy_check.rb
+++ b/lib/samson/buddy_check.rb
@@ -6,6 +6,10 @@ module Samson
         Samson::EnvCheck.set?("BUDDY_CHECK_FEATURE")
       end
 
+      def bypass_enabled?
+        !Samson::EnvCheck.set?("SKIP_BUDDY_BYPASS_FEATURE")
+      end
+
       # how long can the same commit be deployed ?
       def grace_period
         Integer(ENV["BUDDY_CHECK_GRACE_PERIOD"].presence || "4").hours

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -603,6 +603,19 @@ describe DeploysController do
         assert_redirected_to project_deploy_path(project, deploy)
         deploy.reload.buddy.must_equal user
       end
+
+      it 'alert when buddy bypass disabled' do
+        with_env DISABLE_BUDDY_BYPASS_FEATURE: "true" do
+          deploy.job.update_column(:user_id, user.id)
+          DeployService.stubs(:new).with(deploy.user).returns(deploy_service)
+
+          post :buddy_check, params: {project_id: project.to_param, id: deploy.id}
+
+          refute deploy.buddy
+          assert_redirected_to project_deploy_path(project, deploy)
+          assert flash[:alert]
+        end
+      end
     end
 
     describe "#destroy" do

--- a/test/lib/samson/buddy_check_test.rb
+++ b/test/lib/samson/buddy_check_test.rb
@@ -22,6 +22,24 @@ describe Samson::BuddyCheck do
     end
   end
 
+  describe ".bypass_enabled?" do
+    it "is disabled when set" do
+      with_env DISABLE_BUDDY_BYPASS_FEATURE: "1" do
+        refute Samson::BuddyCheck.bypass_enabled?
+      end
+    end
+
+    it "is enabled when false" do
+      with_env DISABLE_BUDDY_BYPASS_FEATURE: "false" do
+        assert Samson::BuddyCheck.bypass_enabled?
+      end
+    end
+
+    it "is enabled when not set" do
+      assert Samson::BuddyCheck.bypass_enabled?
+    end
+  end
+
   describe ".grace_period" do
     it "is 4 hours by default" do
       Samson::BuddyCheck.grace_period.must_equal 4.hours


### PR DESCRIPTION
* Buddy bypass feature is disabled/controlled by an environment variable.
* Setting `DISABLE_BUDDY_BYPASS_FEATURE` env, will disable the bypass feature.

### Risks
- Low/Med/High: Low
