### PR TITLE
allow background deletion when there are no pods to avoid getting stu…

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -147,7 +147,9 @@ module Kubernetes
       # ensure deletion of child resources like pods before the method completes,
       # to not run into conflicts when deploying the same resource right after
       def request_delete
-        request(:delete, name, namespace, delete_options: {propagationPolicy: "Foreground"})
+        # we saw deployment deletions that did not work in foreground, so allow scale down and then delete
+        propagation = (resource.dig(:spec, :replicas) == 0 ? "Background" : "Foreground")
+        request(:delete, name, namespace, delete_options: {propagationPolicy: propagation})
         expire_resource_cache
       end
 

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -277,6 +277,14 @@ describe Kubernetes::Resource do
           end
         end
       end
+
+      it "uses background deletion to avoid bugs with foreground deletion when we do not need to clean up pods" do
+        assert_request(:delete, url, with: ->(r) { r.body.must_include "Background" }, to_return: {body: "{}"}) do
+          assert_request(:get, url, to_return: [{body: {spec: {replicas: 0}}.to_json}, {status: 404}]) do
+            resource.delete
+          end
+        end
+      end
     end
 
     describe "#uid" do


### PR DESCRIPTION
…ck in mystery error

```
RuntimeError: Unable to delete resource (Deployment provisioning-app-server pod998 Pod998)
File "plugins/kubernetes/app/models/kubernetes/resource.rb" line 144 in backoff_wait
File "plugins/kubernetes/app/models/kubernetes/resource.rb" line 94 in delete
```