### PR TITLE
show parsing errors in seeding stage so they can be fixed early

### DIFF
--- a/plugins/kubernetes/app/controllers/kubernetes/namespaces_controller.rb
+++ b/plugins/kubernetes/app/controllers/kubernetes/namespaces_controller.rb
@@ -21,10 +21,7 @@ class Kubernetes::NamespacesController < ResourceController
     errors = []
 
     project.kubernetes_roles.not_deleted.each do |role|
-      config = role.role_config_file(
-        reference,
-        project: project, ignore_missing: true, ignore_errors: false, deploy_group: nil
-      )
+      config = role.role_config_file(reference, project: project, ignore_missing: true, deploy_group: nil)
       unless config
         errors << "Unable to read #{role.config_file}"
         next

--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -503,8 +503,7 @@ module Kubernetes
       # - only do this for one single deploy group since they are all identical
       element_groups = grouped_deploy_group_roles.first.map do |deploy_group_role|
         deploy_group_role.kubernetes_role.role_config_file(
-          @job.commit,
-          ignore_errors: false, deploy_group: deploy_group_role.deploy_group
+          @job.commit, deploy_group: deploy_group_role.deploy_group
         ).elements
       end.compact
       Kubernetes::RoleValidator.validate_groups(element_groups)

--- a/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
@@ -86,11 +86,17 @@ module Kubernetes
             limits_memory: defaults.fetch(:limits_memory)
           )
         else
-          dgr = DeployGroupRole.new(kubernetes_role: role, deploy_group: deploy_group)
-          dgr.errors.add(:base, "Role has no defaults")
-          dgr
+          show_seeding_error role, deploy_group, "Unable to read defaults from role config file"
         end
+      rescue Samson::Hooks::UserError => e
+        show_seeding_error role, deploy_group, e.message
       end
+    end
+
+    private_class_method def self.show_seeding_error(role, deploy_group, text)
+      dgr = DeployGroupRole.new(kubernetes_role: role, deploy_group: deploy_group)
+      dgr.errors.add(:base, text)
+      dgr
     end
 
     def requests_below_limits

--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -213,7 +213,7 @@ module Kubernetes
       @raw_template ||=
         kubernetes_role.role_config_file(
           kubernetes_release.git_sha,
-          project: kubernetes_release.project, pull: true, ignore_errors: false, deploy_group: deploy_group
+          project: kubernetes_release.project, pull: true, deploy_group: deploy_group
         ).elements
     end
   end

--- a/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/deploy_group_roles/_form.html.erb
@@ -2,7 +2,7 @@
   <%= redirect_to_field %>
   <%= render 'shared/errors', object: form.object %>
   <%
-    defaults = form.object.kubernetes_role&.defaults || {}
+    defaults = form.object.kubernetes_role&.defaults || {} rescue {}
     updating = form.object.persisted?
   %>
 

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -420,14 +420,14 @@ describe Kubernetes::Role do
       role.defaults.must_be_nil
     end
 
-    it "ignores when there is no config" do
+    it "fails when there is no config" do
       GitRepository.any_instance.stubs(file_content: nil)
-      role.defaults.must_be_nil
+      assert_raises(Samson::Hooks::UserError) { role.defaults }
     end
 
-    it "ignores when config is invalid" do
+    it "fails when config is invalid" do
       assert config_content_yml.sub!('Service', 'Deployment')
-      refute role.defaults
+      assert_raises(Samson::Hooks::UserError) { role.defaults }
     end
   end
 
@@ -484,7 +484,7 @@ describe Kubernetes::Role do
         expects(:file_content).with('kubernetes/pod100/foo.yaml', "master", anything).
         returns(read_kubernetes_sample_file('kubernetes_job.yml'))
       role.config_file = "kubernetes/$deploy_group/foo.yaml"
-      assert role.role_config_file("master", deploy_group: deploy_groups(:pod100), ignore_errors: false)
+      assert role.role_config_file("master", deploy_group: deploy_groups(:pod100))
     end
   end
 end


### PR DESCRIPTION
I often get asked why seeding did not work in xyz case and mostly the answer is some validation failing
and instead of reproducing that locally to debug let's just show it in the UI so debugging is easier

@zendesk/compute 