### PR TITLE
replace usage of HEAD with release branch to make seeding always work

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -268,7 +268,7 @@ class Project < ActiveRecord::Base
   def clone_repository
     Thread.new do
       begin
-        unless repository.commit_from_ref "HEAD" # bogus command to trigger clone
+        unless repository.commit_from_ref release_branch # bogus command to trigger clone
           Samson::ErrorNotifier.notify("Could not clone git repository #{repository_url} for project #{name}")
         end
       rescue => e

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -128,7 +128,7 @@ module Kubernetes
 
     # TODO: support dynamic folders
     def defaults
-      unless resource = role_config_file('HEAD', deploy_group: nil).primary
+      unless resource = role_config_file(project.release_branch, deploy_group: nil).primary
         return {replicas: 1, requests_cpu: 0, requests_memory: MIN_MEMORY, limits_cpu: 0.01, limits_memory: MIN_MEMORY}
       end
       spec = RoleConfigFile.templates(resource).dig(0, :spec) || raise # primary always has templates


### PR DESCRIPTION
we don't guarantee that the HEAD branch is the same as the default branch ... so when seeding we got errors around files missing or having unexpected values