### PR TITLE
nicely show github action statuses that do not have a description

### DIFF
--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -73,7 +73,8 @@ function refStatusTypeahead(options){
       var item = $("<li>");
       $ref_problem_list.append(item);
       // State and status comes from GitHub or Samson
-      item.html(status.state + ": " + status.description);
+      var description = (status.description.toString() === "" ? status.context : status.description);
+      item.html(status.state + ": " + description);
       if(status.target_url) {
         item.append(' <a href="' + status.target_url + '">details</a>');
       }

--- a/app/assets/javascripts/ref_status_typeahead.js
+++ b/app/assets/javascripts/ref_status_typeahead.js
@@ -72,8 +72,9 @@ function refStatusTypeahead(options){
       if (status.state === "success") return;
       var item = $("<li>");
       $ref_problem_list.append(item);
-      // State and status comes from GitHub or Samson
-      var description = (status.description.toString() === "" ? status.context : status.description);
+      // State and status comes from GitHub or Samson,
+      // safe to use .html for context/description since we sanitize in commit_statuses_controller.rb
+      var description = (status.description && status.description !== "" ? status.description : status.context);
       item.html(status.state + ": " + description);
       if(status.target_url) {
         item.append(' <a href="' + status.target_url + '">details</a>');

--- a/app/controllers/commit_statuses_controller.rb
+++ b/app/controllers/commit_statuses_controller.rb
@@ -7,6 +7,13 @@ class CommitStatusesController < ApplicationController
   def show
     stage = current_project.stages.find_by_permalink!(params.require(:stage_id))
     commit_status = CommitStatus.new(stage.project, params.require(:ref), stage: stage)
-    render json: {state: commit_status.state, statuses: commit_status.statuses}
+    statuses = commit_status.statuses
+    # strip dangerous tags so we can safely display as html in ref_status_typeahead.js
+    statuses.each do |status|
+      [:context, :description].each do |key|
+        status[key] = ActionController::Base.helpers.strip_tags(status[key]) if status[key]
+      end
+    end
+    render json: {state: commit_status.state, statuses: statuses}
   end
 end

--- a/test/controllers/commit_statuses_controller_test.rb
+++ b/test/controllers/commit_statuses_controller_test.rb
@@ -10,47 +10,46 @@ describe CommitStatusesController do
 
   as_a :project_deployer do
     describe '#show' do
+      def call
+        CommitStatus.stubs(new: stub(commit_status_data))
+        get :show, params: valid_params
+      end
+
       let(:stage) { stages(:test_staging) }
       let(:project) { projects(:test) }
       let(:valid_params) { {project_id: project.to_param, stage_id: stage.to_param, id: 'test/test', ref: 'bar'} }
+      let(:commit_status_data) do
+        {
+          state: 'pending',
+          statuses: [{status: 'pending', description: 'the Travis build is still running'}]
+        }
+      end
+
+      it 'responds with the status' do
+        call
+        response.body.must_equal(JSON.dump(commit_status_data))
+      end
+
+      it "escapes html so we can display in js" do
+        status = commit_status_data[:statuses][0]
+        status[:context] = status[:description] = "<a>hi</a><script>no</script>"
+        call
+        response.body.must_equal(JSON.dump(commit_status_data))
+      end
 
       it "fails with unknown project" do
-        assert_raises ActiveRecord::RecordNotFound do
-          get :show, params: valid_params.merge(project_id: 'baz')
-        end
+        valid_params[:project_id] = 'baz'
+        assert_raises(ActiveRecord::RecordNotFound) { call }
       end
 
       it "fails with unknown stage" do
         stage.update_column(:project_id, 3)
-        assert_raises(ActiveRecord::RecordNotFound) { get :show, params: valid_params }
+        assert_raises(ActiveRecord::RecordNotFound) { call }
       end
 
       it "fails without ref" do
-        assert_raises ActionController::ParameterMissing do
-          get :show, params: valid_params.merge(ref: nil)
-        end
-      end
-
-      describe 'valid' do
-        let(:commit_status_data) do
-          {
-            state: 'pending',
-            statuses: [{status: 'pending', description: 'the Travis build is still running'}]
-          }
-        end
-
-        before do
-          CommitStatus.stubs(new: stub(commit_status_data))
-          get :show, params: valid_params
-        end
-
-        it 'responds ok' do
-          response.status.must_equal(200)
-        end
-
-        it 'responds with the status' do
-          response.body.must_equal(JSON.dump(commit_status_data))
-        end
+        valid_params.delete :ref
+        assert_raises(ActionController::ParameterMissing) { call }
       end
     end
   end


### PR DESCRIPTION
<img width="228" alt="Screen Shot 2021-03-03 at 12 03 33 PM" src="https://user-images.githubusercontent.com/11367/109865180-9d985e80-7c18-11eb-870a-35cc75f1ae00.png">
