### PR TITLE
fix n plus 1 query on project show

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -21,7 +21,8 @@
     </thead>
     <tbody>
       <% if @project.stages.to_a.any? %>
-        <%= render partial: "stage", collection: @project.stages, cached: ->(stage) { [@project.permalink, stage, Lock.cache_key, deployer_for_project?] } %>
+        <% static_cache_key = [@project.permalink, Lock.cache_key, deployer_for_project?] # avoid N+1 %>
+        <%= render partial: "stage", collection: @project.stages, cached: ->(stage) { [stage, *static_cache_key] } %>
       <% else %>
         <tr>
           <td colspan="3">

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative '../test_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered!
 
 describe DeploysController do
   def self.with_and_without_project(&block)

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -140,6 +140,15 @@ describe ProjectsController do
           assert_response :success
         end
 
+        it "does not N+1" do
+          with_caching do
+            get :show, params: {id: project.to_param} # fill cache
+            assert_nplus1_queries 2 do
+              get :show, params: {id: project.to_param}
+            end
+          end
+        end
+
         it "does not find soft deleted" do
           project.soft_delete!(validate: false)
           assert_raises ActiveRecord::RecordNotFound do

--- a/test/support/query_counter.rb
+++ b/test/support/query_counter.rb
@@ -43,7 +43,7 @@ class ActiveSupport::TestCase
     list = queries.map { |q, v| "#{q}:\n#{v.map { |x| "  #{x}" }.join("\n")}" }.join("\n")
     actual.must_equal(
       expected,
-      "Expected #{expected} nplus1 queries, but found #{queries.count}:\n#{list}"
+      "Expected #{expected} nplus1 queries, but found #{actual}:\n#{list}"
     )
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -234,6 +234,14 @@ ActiveSupport::TestCase.class_eval do
     before(&block)
     after(&block)
   end
+
+  def with_caching
+    caching = ActionController::Base.perform_caching
+    ActionController::Base.perform_caching = true
+    yield
+  ensure
+    ActionController::Base.perform_caching = caching
+  end
 end
 
 # Helpers for controller tests


### PR DESCRIPTION
before: for every stage we ask if the user is a deployer and some other checks, resulting in N+1
after: only ask once

uncached page has 8 N+1, so still plenty of work to be done, but cached page is down from 4->2

@zendesk/compute 