### PR TITLE
Improve risks parsing to allow for emojis to the left of header

### DIFF
--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -161,21 +161,7 @@ class Changeset::PullRequest
 
   def section_content(section_title, text)
     # ### Risks or Risks followed by === / ---
-    emoji_regex =
-      '(?:'\
-        '\p{RI}\p{RI}'\
-        '|\p{Emoji}'\
-          '(?:\p{EmojiModifier}'\
-          '|\uFE0F\u20E3?'\
-          '|[\uE0020-\uE007E]+\uE007F)?'\
-          '(?:\u200D\p{Emoji}'\
-            '(?:\p{EmojiModifier}'\
-            '|\uFE0F\u20E3?'\
-            '|[\uE0020-\uE007E]+\uE007F)?'\
-          ')*'\
-      ')' # translated from unicode standard: https://unicode.org/reports/tr51/#EBNF_and_Regex
-    desired_header_regexp = "^(?:\\s*#+\\s*#{emoji_regex}*\\s*#{section_title}.*"\
-      "|\\s*#{emoji_regex}*\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
+    desired_header_regexp = "^(?:\\s*#+\\s*\\W*\\s*#{section_title}.*|\\s*\\W*\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
     content_regexp = '([\W\w]*?)' # capture all section content, including new lines, but not next header
     next_header_regexp = '(?=^(?:\s*#+|.*\n\s*(?:-{2,}|={2,}\s*\n))|\z)'
 

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -161,7 +161,8 @@ class Changeset::PullRequest
 
   def section_content(section_title, text)
     # ### Risks or Risks followed by === / ---
-    desired_header_regexp = "^(?:\\s*#+\\s*\\W*\\s*#{section_title}.*|\\s*\\W*\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
+    desired_header_regexp = "^(?:\\s*#+\\s*\\W*\\s*#{section_title}.*"\
+      "|\\s*\\W*\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
     content_regexp = '([\W\w]*?)' # capture all section content, including new lines, but not next header
     next_header_regexp = '(?=^(?:\s*#+|.*\n\s*(?:-{2,}|={2,}\s*\n))|\z)'
 

--- a/app/models/changeset/pull_request.rb
+++ b/app/models/changeset/pull_request.rb
@@ -161,7 +161,21 @@ class Changeset::PullRequest
 
   def section_content(section_title, text)
     # ### Risks or Risks followed by === / ---
-    desired_header_regexp = "^(?:\\s*#+\\s*#{section_title}.*|\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
+    emoji_regex =
+      '(?:'\
+        '\p{RI}\p{RI}'\
+        '|\p{Emoji}'\
+          '(?:\p{EmojiModifier}'\
+          '|\uFE0F\u20E3?'\
+          '|[\uE0020-\uE007E]+\uE007F)?'\
+          '(?:\u200D\p{Emoji}'\
+            '(?:\p{EmojiModifier}'\
+            '|\uFE0F\u20E3?'\
+            '|[\uE0020-\uE007E]+\uE007F)?'\
+          ')*'\
+      ')' # translated from unicode standard: https://unicode.org/reports/tr51/#EBNF_and_Regex
+    desired_header_regexp = "^(?:\\s*#+\\s*#{emoji_regex}*\\s*#{section_title}.*"\
+      "|\\s*#{emoji_regex}*\\s*#{section_title}.*\\n\\s*(?:-{2,}|={2,}))\\n"
     content_regexp = '([\W\w]*?)' # capture all section content, including new lines, but not next header
     next_header_regexp = '(?=^(?:\s*#+|.*\n\s*(?:-{2,}|={2,}\s*\n))|\z)'
 


### PR DESCRIPTION
### Description
When attempting to add simple emojis to the left of section headers to improve readability at a glance:
![image](https://user-images.githubusercontent.com/1016390/114517592-1277a300-9c71-11eb-91ea-3d9e6b36afc3.png)

We noticed that the risks section failed to be parsed in samson:
![Screenshot 2021-04-14 at 1 45 57 PM](https://user-images.githubusercontent.com/8639005/114660345-bfacf280-9d27-11eb-926a-f6cf38125d9a.png)

This PR allows emojis to be added to the left of section headers without otherwise affecting current behaviour too much

### Risks
- Low: May break risks section parsing
