### PR TITLE
Increase MAX_LIMITS_TO_REQUESTS_RATIO

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_group_role.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Kubernetes
   class DeployGroupRole < ActiveRecord::Base
-    MAX_LIMITS_TO_REQUESTS_RATIO = 10
+    MAX_LIMITS_TO_REQUESTS_RATIO = 100
     NO_CPU_LIMIT_ALLOWED = Samson::EnvCheck.set?("KUBERNETES_NO_CPU_LIMIT_ALLOWED")
 
     self.table_name = 'kubernetes_deploy_group_roles'


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Increase MAX_LIMITS_TO_REQUESTS_RATIO as we occasionally need for pods with small cpu request (e.g. 0.1) to have larger limit (e.g. 3 cpu).

### Risks
- Low: increased chance of misconfiguring limits too high
