### PR TITLE
allow users to request associated project locks

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -72,7 +72,8 @@ class ProjectsController < ResourceController
   def allowed_includes
     [
       :environment_variable_groups,
-      :environment_variables_with_scope
+      :environment_variables_with_scope,
+      :lock
     ] + Samson::Hooks.fire(:project_allowed_includes).flatten(1)
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -192,6 +192,15 @@ describe ProjectsController do
             project.keys.must_include "external_environment_variable_groups"
           end
         end
+
+        it "renders locks if requested" do
+          Lock.create!(user: user, resource: project)
+          get :show, params: {id: project.to_param, includes: "lock", format: :json}
+          assert_response :success
+          project = JSON.parse(response.body)
+          project.keys.must_include "locks"
+          refute_empty project['locks']
+        end
       end
     end
 


### PR DESCRIPTION
Add `locks` as an `?includes` option when requesting project info via the API

### Risks
- Low
