### PR TITLE
fix assets precompile that broke during rails 6.1 upgrade

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -185,13 +185,6 @@ module Samson
       end
     end
 
-    # remove initializers that use the database
-    if ENV["PRECOMPILE"]
-      bad = ["active_record.check_schema_cache_dump", "active_record.set_configs"]
-      Rails.application.initializers.find { |a| bad.include?(a.name) }.
-        context_class.instance.initializers.reject! { |a| bad.include?(a.name) }
-    end
-
     config.active_support.deprecation = :raise
 
     # avoid permission errors in production and cleanliness test failures in test
@@ -218,3 +211,10 @@ end
 require 'samson/hooks'
 require_relative "logging"
 require_relative "../app/models/job_queue" # need to load early or dev reload will lose the .enabled
+
+# remove initializers that use the database, this triggers initializer building so needs to come after all engines
+if ENV["PRECOMPILE"]
+  bad = ["active_record.check_schema_cache_dump", "active_record.set_configs"]
+  Rails.application.initializers.find { |a| bad.include?(a.name) }.
+    context_class.instance.initializers.reject! { |a| bad.include?(a.name) }
+end

--- a/lib/samson/hooks.rb
+++ b/lib/samson/hooks.rb
@@ -110,10 +110,6 @@ module Samson
         end
       end
 
-      def add_assets_to_precompile
-        engine.config.assets.precompile += ["#{name}/application.css", "#{name}/application.js"]
-      end
-
       def engine
         @engine ||= Kernel.const_get("::Samson#{@name.camelize}::SamsonPlugin")
       end
@@ -200,7 +196,6 @@ module Samson
         Samson::Hooks.plugins.
           each(&:setup_and_require).
           each(&:add_migrations).
-          each(&:add_assets_to_precompile).
           each(&:add_decorators)
       end
 


### PR DESCRIPTION
fixes https://github.com/zendesk/samson/issues/3948#
nobody noticed because old assets stayed around

/cc @zendesk/compute 