### PR TITLE
kubernetes increased min memory

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -20,7 +20,7 @@ module Kubernetes
       "" => 1,
       'm' => 0.001
     }.freeze
-    MIN_MEMORY = 4
+    MIN_MEMORY = 6
 
     self.table_name = 'kubernetes_roles'
     GENERATED = '-change-me-'

--- a/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
+++ b/plugins/kubernetes/test/controllers/kubernetes/deploy_group_roles_controller_test.rb
@@ -96,7 +96,7 @@ describe Kubernetes::DeployGroupRolesController do
             kubernetes_role_id: kubernetes_roles(:app_server).id,
             deploy_group_id: deploy_group.id,
             requests_cpu: 0.5,
-            requests_memory: 5,
+            requests_memory: 7,
             limits_cpu: 1,
             limits_memory: 10,
             replicas: 1

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -355,9 +355,9 @@ describe Kubernetes::Role do
       role.defaults.must_equal(
         replicas: 1,
         requests_cpu: 0,
-        requests_memory: 4,
+        requests_memory: 6,
         limits_cpu: 0.01,
-        limits_memory: 4
+        limits_memory: 6
       )
     end
 
@@ -438,7 +438,7 @@ describe Kubernetes::Role do
         project: project,
         replicas: 1,
         requests_cpu: 0.5,
-        requests_memory: 5,
+        requests_memory: 7,
         limits_cpu: 1,
         limits_memory: 10,
         deploy_group: deploy_groups(:pod2)


### PR DESCRIPTION
@zendesk/compute 
```
  Warning  Failed     4s (x3 over 20s)  kubelet            Error: Error response from daemon: Minimum memory limit allowed is 6MB
```