### PR TITLE
Allow Kubernetes connectivity validation to be public

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ Complicated to start, but easy to develop from.
 ```bash
 # install the database you want to use, samson needs mysql, postgresql, or sqlite
 sudo apt-get install mysql-dev pg-dev nodejs
-brew install postgresql sqlite mysql
+brew install postgresql sqlite mysql nodejs
 
 bin/setup # Run the setup script to use the test credentials.
 ./bin/rails s
@@ -66,7 +66,7 @@ To restart the server use `kill -USR1 <pid>` which makes it restart without losi
 ### Environment variables
 
 Set environment variables in your `.env` file, see `.env.example` for documentation on what is required/available.
-Alternatively set them directly in heroku or the process environment. 
+Alternatively set them directly in heroku or the process environment.
 
 ### Advanced features
 

--- a/plugins/kubernetes/app/models/kubernetes/cluster.rb
+++ b/plugins/kubernetes/app/models/kubernetes/cluster.rb
@@ -81,6 +81,13 @@ module Kubernetes
       Gem::Version.new(version)
     end
 
+    # Externally used by the kubernetes connectivity smoke tests
+    def connection_valid?
+      client('v1').api_valid?
+    rescue StandardError
+      false
+    end
+
     private
 
     def client_key_object
@@ -93,12 +100,6 @@ module Kubernetes
 
     def kubeconfig
       @kubeconfig ||= Kubeclient::Config.read(config_filepath)
-    end
-
-    def connection_valid?
-      client('v1').api_valid?
-    rescue StandardError
-      false
     end
 
     def test_client_connection


### PR DESCRIPTION
@zendesk/compute

## Description
- Change `connection_valid?` to be a public method since it will be used externally.
- Update setup docs.

### Risks
- Low: Method made public to be used externally, should not cause any issues.
