### PR TITLE
Stub the foobar server requests for periodical tasks

### DIFF
--- a/test/lib/samson/periodical_test.rb
+++ b/test/lib/samson/periodical_test.rb
@@ -287,6 +287,7 @@ describe Samson::Periodical do
       external_id: Samson::PeriodicalDeploy::EXTERNAL_ID
     )
     stub_request(:get, "https://www.githubstatus.com/api/v2/status.json")
+    stub_request(:get, "http://foobar.server/api")
     Samson::Periodical.send(:registered).each_key do |task|
       Samson::Periodical.run_once task
     end


### PR DESCRIPTION
@zendesk/compute 

Stub requests to `http://foobar.server/api` for periodical tasks since newer tasks that might be using the kubeclient will generate requests to this.

### Risks
- Low: Stubbing requests to `foobar.server` for newer periodical tasks
