### PR TITLE
Report if jobs are executed with Kubernetes

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -113,6 +113,10 @@ class Job < ActiveRecord::Base
     JobQueue.executing?(id)
   end
 
+  def kubernetes?
+    deploy && defined?(SamsonKubernetes::SamsonPlugin) && deploy&.stage&.kubernetes
+  end
+
   def waiting_for_restart?
     !JobQueue.enabled && pending?
   end
@@ -179,6 +183,7 @@ class Job < ActiveRecord::Base
   def report_state
     payload = {
       stage: deploy&.stage&.permalink,
+      kubernetes: kubernetes?,
       project: project.permalink,
       type: deploy ? 'deploy' : 'build',
       status: status,

--- a/app/models/job_execution.rb
+++ b/app/models/job_execution.rb
@@ -142,6 +142,7 @@ class JobExecution
     payload = {
       stage: (@stage&.name || "none"),
       project: @job.project.name,
+      kubernetes: kubernetes?,
       production: @stage&.production?
     }
 

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -65,6 +65,10 @@ ActiveSupport::Notifications.subscribe("job_status.samson") do |*, payload|
     "stage:#{payload.fetch(:stage)}",
   ]
 
+  # report if things were run with kubernetes
+  kubernetes = payload.fetch(:kubernetes)
+  tags << "kubernetes:#{kubernetes}" unless kubernetes.nil?
+
   payload.fetch(:cycle_time).each do |key, value|
     Samson.statsd.timing "jobs.deploy.cycle_time.#{key}", value * 1000, tags: tags
   end

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -23,6 +23,10 @@ ActiveSupport::Notifications.subscribe("execute_job.samson") do |_, start, finis
   production = payload.fetch(:production)
   tags << "production:#{production}" unless production.nil?
 
+  # report if things were run with kubernetes
+  kubernetes = payload.fetch(:kubernetes)
+  tags << "kubernetes:#{kubernetes}" unless kubernetes.nil?
+
   Samson.statsd.batch do |statsd|
     statsd.timing "execute_shell.time", duration, tags: tags
     (payload[:parts] || {}).each do |part, time|

--- a/test/lib/samson/time_sum_test.rb
+++ b/test/lib/samson/time_sum_test.rb
@@ -26,13 +26,15 @@ describe Samson::TimeSum do
   end
 
   describe ".instrument" do
+    let(:instrument_args) { {project: "foo", stage: "bar", kubernetes: false, production: false} }
+
     it "logs" do
       Rails.logger.expects(:info).with do |payload|
         payload[:message].must_equal "Job execution finished"
         (0..10).must_include(payload[:parts][:db]) # ms
         true
       end
-      result = Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", kubernetes: false, production: false) do
+      result = Samson::TimeSum.instrument("execute_job.samson", instrument_args) do
         User.first
       end
       result.must_equal User.first
@@ -45,7 +47,7 @@ describe Samson::TimeSum do
         true
       end
       assert_raises ArgumentError do
-        Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", kubernetes: false, production: false) do
+        Samson::TimeSum.instrument("execute_job.samson", instrument_args) do
           raise ArgumentError
         end
       end

--- a/test/lib/samson/time_sum_test.rb
+++ b/test/lib/samson/time_sum_test.rb
@@ -32,7 +32,7 @@ describe Samson::TimeSum do
         (0..10).must_include(payload[:parts][:db]) # ms
         true
       end
-      result = Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", production: false) do
+      result = Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", kubernetes: false, production: false) do
         User.first
       end
       result.must_equal User.first
@@ -45,7 +45,7 @@ describe Samson::TimeSum do
         true
       end
       assert_raises ArgumentError do
-        Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", production: false) do
+        Samson::TimeSum.instrument("execute_job.samson", project: "foo", stage: "bar", kubernetes: false, production: false) do
           raise ArgumentError
         end
       end

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -22,7 +22,7 @@ describe JobExecution do
   let(:pod2) { deploy_groups(:pod2) }
   let(:deploy_group_hack) { DeployGroup.create!(name: ';|sudo make-sandwich /', environment: pod1.environment) }
   let(:project) { Project.create!(name: 'duck', repository_url: repo_temp_dir) }
-  let(:stage) { Stage.create!(name: 'stage4', project: project, deploy_groups: [pod1, pod2, deploy_group_hack], kubernetes: false) }
+  let(:stage) { Stage.create!(name: 'stage4', project: project, deploy_groups: [pod1, pod2, deploy_group_hack]) }
   let(:stage_no_groups) { Stage.create!(name: 'stage_no_groups', project: project, deploy_groups: []) }
   let(:user) { users(:admin) }
   let(:job) { project.jobs.create!(command: 'cat foo', user: user, project: project) }
@@ -318,9 +318,10 @@ describe JobExecution do
   end
 
   it "reports to statsd" do
+    expected_tags = ['project:duck', 'stage:stage4', 'production:false', 'kubernetes:false']
+
     Samson.statsd.stubs(:timing)
-    Samson.statsd.expects(:timing).
-      with('execute_shell.time', anything, tags: ['project:duck', 'stage:stage4', 'production:false', 'kubernetes:false'])
+    Samson.statsd.expects(:timing).with('execute_shell.time', anything, tags: expected_tags)
     assert execute_job
   end
 

--- a/test/models/job_execution_test.rb
+++ b/test/models/job_execution_test.rb
@@ -22,7 +22,7 @@ describe JobExecution do
   let(:pod2) { deploy_groups(:pod2) }
   let(:deploy_group_hack) { DeployGroup.create!(name: ';|sudo make-sandwich /', environment: pod1.environment) }
   let(:project) { Project.create!(name: 'duck', repository_url: repo_temp_dir) }
-  let(:stage) { Stage.create!(name: 'stage4', project: project, deploy_groups: [pod1, pod2, deploy_group_hack]) }
+  let(:stage) { Stage.create!(name: 'stage4', project: project, deploy_groups: [pod1, pod2, deploy_group_hack], kubernetes: false) }
   let(:stage_no_groups) { Stage.create!(name: 'stage_no_groups', project: project, deploy_groups: []) }
   let(:user) { users(:admin) }
   let(:job) { project.jobs.create!(command: 'cat foo', user: user, project: project) }
@@ -320,7 +320,7 @@ describe JobExecution do
   it "reports to statsd" do
     Samson.statsd.stubs(:timing)
     Samson.statsd.expects(:timing).
-      with('execute_shell.time', anything, tags: ['project:duck', 'stage:stage4', 'production:false'])
+      with('execute_shell.time', anything, tags: ['project:duck', 'stage:stage4', 'production:false', 'kubernetes:false'])
     assert execute_job
   end
 

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -389,6 +389,7 @@ describe Job do
     it 'reports for deploy' do
       assert_instrument(
         stage: job&.deploy&.stage&.permalink,
+        kubernetes: job&.deploy&.stage&.kubernetes,
         project: project.permalink,
         type: job&.deploy ? 'deploy' : 'build',
         status: 'succeeded',
@@ -403,6 +404,7 @@ describe Job do
       job.update_column(:status, 'succeeded')
       assert_instrument(
         stage: job&.deploy&.stage&.permalink,
+        kubernetes: job&.deploy&.stage&.kubernetes,
         project: project.permalink,
         type: job&.deploy ? 'deploy' : 'build',
         status: 'succeeded',


### PR DESCRIPTION
@zendesk/compute 

Add tags for metrics to indicate whether jobs are executed with Kubernetes, which will help create separation of concern when building SLOs.
