### PR TITLE
Changes lockable to have many locks

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -62,6 +62,7 @@ class StagesController < ResourceController
       :last_succeeded_deploy,
       :active_deploy,
       :lock,
+      :locks,
       :deploy_groups
     ]
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,7 +84,7 @@ module ApplicationHelper
     when UserProjectRole then ["Role for ##{resource.user.name}", resource.user]
     when Project, Stage
       name = resource.name
-      name = (resource.lock.warning? ? warning_icon : lock_icon) + " " + name if with_locks && resource.lock
+      name = (resource.lock.first.warning? ? warning_icon : lock_icon) + " " + name if with_locks && resource.lock.first
       [name, resource.is_a?(Project) ? resource : [resource.project, resource]]
     when Deploy then ["Deploy ##{resource.id}", [resource.project, resource]]
     when SecretSharingGrant then [resource.key, resource]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,7 +84,7 @@ module ApplicationHelper
     when UserProjectRole then ["Role for ##{resource.user.name}", resource.user]
     when Project, Stage
       name = resource.name
-      name = (resource.lock.first.warning? ? warning_icon : lock_icon) + " " + name if with_locks && resource.lock.first
+      name = (resource.lock.warning? ? warning_icon : lock_icon) + " " + name if with_locks && resource.lock
       [name, resource.is_a?(Project) ? resource : [resource.project, resource]]
     when Deploy then ["Deploy ##{resource.id}", [resource.project, resource]]
     when SecretSharingGrant then [resource.key, resource]

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -4,7 +4,8 @@ module Lockable
   extend ActiveSupport::Concern
 
   included do
-    has_many :lock, as: :resource, dependent: :destroy
+    has_one :lock, as: :resource, dependent: :destroy
+    has_many :locks, as: :resource, dependent: :destroy
   end
 
   def locked_by?(lock)

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -4,6 +4,7 @@ module Lockable
   extend ActiveSupport::Concern
 
   included do
+    # Lock is deprecated, only gives one lock, locks gives all.
     has_one :lock, as: :resource, dependent: :destroy
     has_many :locks, as: :resource, dependent: :destroy
   end

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -4,7 +4,7 @@ module Lockable
   extend ActiveSupport::Concern
 
   included do
-    has_one :lock, as: :resource, dependent: :destroy
+    has_many :lock, as: :resource, dependent: :destroy
   end
 
   def locked_by?(lock)


### PR DESCRIPTION
Something that is lockable can have more than one lock. When getting `?includes=lock` currently one lock is returned, this allows for all locks associated with a lockable to be returned.
