### PR TITLE
also force-update when switching from nodeport to clusterip

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -182,7 +182,9 @@ module Kubernetes
         end
         expire_resource_cache
       rescue Samson::Hooks::UserError => e
-        raise unless e.message.match?(/cannot change|Forbidden: updates to .* for fields other than/)
+        raise unless e.message.match?(
+          /cannot change|Forbidden: updates to .* for fields other than|Forbidden: may not be used when/
+        )
 
         path = [:metadata, :annotations, :"samson/force_update"]
         if @template.dig(*path) == "true"


### PR DESCRIPTION
force update did not trigger on `spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'`

### Risks
- None
