### PR TITLE
Add support for wildcard key for external env var groups

### DIFF
--- a/plugins/env/app/models/environment_variable.rb
+++ b/plugins/env/app/models/environment_variable.rb
@@ -78,7 +78,7 @@ class EnvironmentVariable < ActiveRecord::Base
         all_groups = Rails.cache.fetch("env-#{group.url}-read", expires_in: EXTERNAL_VARIABLE_CACHE_DURATION) do
           group.read
         end
-        all_groups[deploy_group.permalink]
+        all_groups[deploy_group.permalink] || all_groups["*"]
       end.compact.inject({}, :merge!)
     rescue StandardError => e
       raise Samson::Hooks::UserError, "Error reading env vars from external env-groups: #{e.message}"

--- a/plugins/env/test/models/environment_variable_test.rb
+++ b/plugins/env/test/models/environment_variable_test.rb
@@ -63,7 +63,7 @@ describe EnvironmentVariable do
       end
 
       it "add to env hash" do
-        response = {deploy_group.permalink => {"FOO" => +"one"}}
+        response = {deploy_group.permalink => {"FOO" => +"one"}, "*" => {"FOO" => "two"}}
         ExternalEnvironmentVariableGroup.any_instance.expects(:read).returns(response)
         EnvironmentVariable.env(deploy, deploy_group, resolve_secrets: false).must_equal "FOO" => "one"
       end
@@ -77,8 +77,14 @@ describe EnvironmentVariable do
         e.message.must_include "The specified key does not exist."
       end
 
+      it "uses wildcard env groups if specific deploy group not available" do
+        response = {"*" => {"FOO" => +"one"}}
+        ExternalEnvironmentVariableGroup.any_instance.expects(:read).returns(response)
+        EnvironmentVariable.env(deploy, deploy_group, resolve_secrets: false).must_equal "FOO" => "one"
+      end
+
       it "ignores env groups without deploy group" do
-        response = {"ABC" => {"FOO" => "one"}}
+        response = {"ABC" => {"FOO" => +"one"}}
         ExternalEnvironmentVariableGroup.any_instance.expects(:read).returns(response)
         EnvironmentVariable.env(deploy, deploy_group, resolve_secrets: false).must_equal({})
       end


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Add support for wildcard key for external env var groups.

Rationale is that it is cumbersome to keep having to add each new deploy group to these external env var files when the value is constant across all of them (an example is where the STATSD env var host is always "localhost" or similar).

cc @zendesk/config @zendesk/samson 

### References
- Jira link: 

### Risks
- Low: could make env var group lookup more complex
