### PR TITLE
Make move_deploy_group task confirm, support non-exact matches, delete emptied stages

### DIFF
--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -1,27 +1,46 @@
 # frozen_string_literal: true
 
 namespace :maintenance do
-  # FROM and TO can handle multiple deploy groups to not mess with projects that have each deploy group in a single stage.
-  desc "move deploy groups between two stages for all projects. OWNER= FROM=dg1,dg2 TO=dg3,dg4 MOVE=dg2"
-  task :move_deploy_group do
+  # FROM and TO handles multiple deploy groups to not mess with projects that have each deploy group in a single stage.
+  desc "move deploy groups across stages for all projects. OWNER= FROM=dg1,dg2 TO=dg3,dg4 MOVE=dg2 [DELETE_EMPTY=true]"
+  task move_deploy_group: :environment do
     projects = Project.where(owner: ENV.fetch("OWNER"))
     from = ENV.fetch("FROM").split(",")
-    to = ENV.fetch("FROM").split(",")
+    to = ENV.fetch("TO").split(",")
     move = ENV.fetch("MOVE")
     move_group = DeployGroup.find_by_permalink!(move)
+    delete_empty = (ENV["DELETE_EMPTY"] == "true")
 
     raise "MOVE needs to be included in FROM" unless from.include? move
     puts "found #{projects.size} projects"
 
-    projects.each do |project|
+    actions = projects.map do |project|
       from_stage = project.stages.detect { |stage| from & stage.deploy_groups.map(&:permalink) == from }
       to_stage = project.stages.detect { |stage| to & stage.deploy_groups.map(&:permalink) == to }
+      [project, from_stage, to_stage]
+    end
 
-      puts "found #{project.name} -- from: #{from_stage&.name} -- to: #{to_stage&.name}"
-      next if !from_stage || !to_stage || from_stage == to_stage
+    actions.select! do |project, from_stage, to_stage|
+      if !from_stage
+        puts "#{project.name} Unable to find FROM"
+      elsif !to_stage
+        puts "#{project.name} Unable to find TO"
+      elsif from_stage == to_stage
+        puts "#{project.name} FROM and TO are the same"
+      else
+        empty = (from_stage.deploy_groups == [move_group])
+        puts "#{project.name} to be moved from:#{from_stage&.name}#{" (+ delete stage)" if empty} to:#{to_stage&.name}"
+        true
+      end
+    end
+
+    puts "Confirm? y/n"
+    abort unless $stdin.gets.strip == "y"
+
+    actions.each do |_, from_stage, to_stage|
       from_stage.deploy_groups -= [move_group]
       to_stage.deploy_groups += [move_group]
-      from_stage.destroy! if from_stage.deploy_groups.empty?
+      from_stage.destroy! if delete_empty && from_stage.deploy_groups.empty?
     end
   end
 end

--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -1,21 +1,27 @@
 # frozen_string_literal: true
 
 namespace :maintenance do
+  # FROM and TO can handle multiple deploy groups to not mess with projects that have each deploy group in a single stage.
   desc "move deploy groups between two stages for all projects. OWNER= FROM=dg1,dg2 TO=dg3,dg4 MOVE=dg2"
   task :move_deploy_group do
     projects = Project.where(owner: ENV.fetch("OWNER"))
+    from = ENV.fetch("FROM").split(",")
+    to = ENV.fetch("FROM").split(",")
+    move = ENV.fetch("MOVE")
+    move_group = DeployGroup.find_by_permalink!(move)
+
+    raise "MOVE needs to be included in FROM" unless from.include? move
     puts "found #{projects.size} projects"
+
     projects.each do |project|
-      canary = project.stages.detect do |stage|
-        stage.deploy_groups.map(&:permalink) == ENV.fetch("FROM").split(",")
-      end
-      phase1 = project.stages.detect do |stage|
-        stage.deploy_groups.map(&:permalink) == ENV.fetch("TO").split(",")
-      end
-      puts "found #{project.name} -- #{canary&.name} -- #{phase1&.name}"
-      next if !canary || !phase1
-      canary.deploy_groups -= [DeployGroup.find_by_permalink(ENV.fetch("MOVE"))]
-      phase1.deploy_groups += [DeployGroup.find_by_permalink(ENV.fetch("MOVE"))]
+      from_stage = project.stages.detect { |stage| from & stage.deploy_groups.map(&:permalink) == from }
+      to_stage = project.stages.detect { |stage| to & stage.deploy_groups.map(&:permalink) == to }
+
+      puts "found #{project.name} -- from: #{from_stage&.name} -- to: #{to_stage&.name}"
+      next if !from_stage || !to_stage || from_stage == to_stage
+      from_stage.deploy_groups -= [move_group]
+      to_stage.deploy_groups += [move_group]
+      from_stage.destroy! if from_stage.deploy_groups.empty?
     end
   end
 end


### PR DESCRIPTION
@zendesk/compute 

- Add confirmation step that allows user to proceed with proposed actions
- Support non-exact matches
- Optionally delete emptied stages