### PR TITLE
Create new task to remove deploy groups from stages given an owner

### DIFF
--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -29,7 +29,8 @@ namespace :maintenance do
         puts "#{project.name} FROM and TO are the same"
       else
         empty = (from_stage.deploy_groups == [move_group])
-        puts "#{project.name} to be moved from:#{from_stage&.name}#{" (+ delete stage)" if empty} to:#{to_stage&.name}"
+        puts "#{project.name} to be moved from:#{from_stage&.name}" \
+          "#{" (+ delete stage)" if empty && delete_empty} to:#{to_stage&.name}"
         true
       end
     end
@@ -40,6 +41,40 @@ namespace :maintenance do
     actions.each do |_, from_stage, to_stage|
       from_stage.deploy_groups -= [move_group]
       to_stage.deploy_groups += [move_group]
+      from_stage.destroy! if delete_empty && from_stage.deploy_groups.empty?
+    end
+  end
+
+  desc "delete deploy groups across stages for all projects. OWNER= DELETE=dg [DELETE_EMPTY=true]"
+  task delete_deploy_group: :environment do
+    projects = Project.where(owner: ENV.fetch("OWNER"))
+    delete = ENV.fetch("DELETE")
+    delete_group = DeployGroup.find_by_permalink!(delete)
+    delete_empty = (ENV["DELETE_EMPTY"] == "true")
+
+    puts "Found #{projects.size} projects"
+
+    actions = projects.map do |project|
+      from_stage = project.stages.detect { |stage| stage.deploy_groups.map(&:permalink).include? delete }
+      [project, from_stage]
+    end
+
+    actions.select! do |project, from_stage|
+      if !from_stage
+        puts "Unable to find configured stage for #{delete_group.name} in #{project.name}"
+      else
+        empty = (from_stage.deploy_groups == [delete_group])
+        puts "#{delete_group.name} to be removed from #{from_stage&.name} in " \
+          "#{project.name} #{" (+ delete stage)" if empty && delete_empty}"
+        true
+      end
+    end
+
+    puts "Confirm? y/n"
+    abort unless $stdin.gets.strip == "y"
+
+    actions.each do |_, from_stage|
+      from_stage.deploy_groups -= [delete_group]
       from_stage.destroy! if delete_empty && from_stage.deploy_groups.empty?
     end
   end


### PR DESCRIPTION
@zendesk/compute 

- Add confirmation step that allows user to proceed with proposed actions
- Optionally delete emptied stages