### PR TITLE
Add wait time on retries

### DIFF
--- a/lib/samson/secrets/vault_client_manager.rb
+++ b/lib/samson/secrets/vault_client_manager.rb
@@ -103,7 +103,7 @@ module Samson
       private
 
       def with_retries(&block)
-        Vault.with_retries(Vault::HTTPConnectionError, attempts: 3, &block)
+        Vault.with_retries(Vault::HTTPConnectionError, attempts: 5, wait_time: 0.1, &block)
       end
 
       # - local server for deploy-group specific id

--- a/lib/samson/secrets/vault_client_manager.rb
+++ b/lib/samson/secrets/vault_client_manager.rb
@@ -103,7 +103,7 @@ module Samson
       private
 
       def with_retries(&block)
-        Vault.with_retries(Vault::HTTPConnectionError, attempts: 5, wait_time: 0.1, &block)
+        Vault.with_retries(Vault::HTTPConnectionError, attempts: 5, &block)
       end
 
       # - local server for deploy-group specific id

--- a/test/lib/samson/secrets/vault_client_manager_test.rb
+++ b/test/lib/samson/secrets/vault_client_manager_test.rb
@@ -122,7 +122,7 @@ describe Samson::Secrets::VaultClientManager do
         :put,
         "http://vault-land.com/v1/auth/token/renew-self",
         to_timeout: [],
-        times: 12 # 2 servers with 1 initial try and 3 re-tries
+        times: 12 # 2 servers with 1 initial try and 5 re-tries
       ) { manager.renew_token }
     end
   end

--- a/test/lib/samson/secrets/vault_client_manager_test.rb
+++ b/test/lib/samson/secrets/vault_client_manager_test.rb
@@ -122,7 +122,7 @@ describe Samson::Secrets::VaultClientManager do
         :put,
         "http://vault-land.com/v1/auth/token/renew-self",
         to_timeout: [],
-        times: 8 # 2 servers with 1 initial try and 3 re-tries
+        times: 12 # 2 servers with 1 initial try and 3 re-tries
       ) { manager.renew_token }
     end
   end


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

## Description
When accessing a vault through the vault client, 3 retries without any wait time between them can sometimes cause rate-limiting problems for larger deployments. By upping the retries and adding a short wait time for those retries, this should allow larger deployments to successfully access secrets without adding an unnecessary burden on smaller deploys. 

### Risks
- Low/Med/High: Low: While accessing the vault may take slightly longer in some cases, this time delay is intentional. My only real concern is that we may actually want the wait time to be longer. 