### PR TITLE
check readinessProbe of the container that failed instead of the first

### DIFF
--- a/app/models/image_builder.rb
+++ b/app/models/image_builder.rb
@@ -63,7 +63,7 @@ class ImageBuilder
             executor.verbose_command(build_command)
           )
         end
-        executor.output.messages.scan(/Successfully built ([a-f\d]{12,})/).last&.first
+        executor.output.messages.scan(/(?:Successfully built |writing image sha256:)([a-f\d]{12,})/).last&.last
       end
     end
 


### PR DESCRIPTION
@zendesk/compute 

### Risks
- Low: random other deploy failures if the parsing does not work
