### PR TITLE
always set update timestamp so we can see when the resource was last …

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -160,7 +160,6 @@ module Kubernetes
         :"samson/override_project_label",
         :"samson/keep_name"
       )
-      annotations[:"samson/updateTimestamp"] = Time.now.utc.iso8601
 
       budget = {
         apiVersion: "policy/v1beta1",

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -25,6 +25,7 @@ module Kubernetes
         set_namespace
         set_project_labels if template.dig(:metadata, :annotations, :"samson/override_project_label")
         set_deploy_url
+        set_update_timestamp
 
         if RoleValidator::IMMUTABLE_NAME_KINDS.include?(kind)
           # names have a fixed pattern so we cannot override them
@@ -617,6 +618,10 @@ module Kubernetes
       if sleep_time + buffer > grace_period
         pod_template[:spec][:terminationGracePeriodSeconds] = sleep_time + buffer
       end
+    end
+
+    def set_update_timestamp
+      (template.dig(:metadata, :annotations) || {})[:"samson/updateTimestamp"] = Time.now.utc.iso8601
     end
 
     def init_containers

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -1121,7 +1121,7 @@ describe Kubernetes::TemplateFiller do
       end
     end
 
-    describe 'istio sidecar injection' do
+    describe "istio sidecar injection" do
       with_env ISTIO_INJECTION_SUPPORTED: "true"
 
       before { doc.deploy_group_role.inject_istio_annotation = true }
@@ -1160,6 +1160,13 @@ describe Kubernetes::TemplateFiller do
         pod_annotation.must_be_nil
         pod_label.must_be_nil
         resource_label.must_be_nil
+      end
+    end
+
+    describe "updateTimestamp" do
+      it "sets updateTimestamp" do
+        Time.stubs(:now).returns(Time.parse("2018-01-01"))
+        template.to_hash[:metadata][:annotations][:"samson/updateTimestamp"].must_equal "2018-01-01T00:00:00Z"
       end
     end
   end


### PR DESCRIPTION
…changed

previously it was set inconsistently on only automatic pdbs,
but it's cheap to do and can be useful for debugging in the cluster, so let's set it everywhere

@zendesk/compute 

### Risks
Low: failing when an object has no metadata / does not support annotations