### PR TITLE
suggest scaling to 0 when deletion fails

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -88,10 +88,12 @@ module Kubernetes
       # wait for delete to finish before doing further work so we don't run into duplication errors
       # - first wait is 0 since the request itself already took a few ms
       # - we wait long because deleting a deployment will wait for all its' pods to go away which can take time
+      # - foreground deletion sometimes hangs forever, so suggest to scale to 0 first
       def delete
         return true unless exist?
         request_delete
-        backoff_wait(DELETE_BACKOFF, "delete resource") do
+        error_message = "delete resource (try scaling to 0 first without deletion)"
+        backoff_wait(DELETE_BACKOFF, error_message) do
           expire_resource_cache
           return true unless exist?
         end

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -273,7 +273,9 @@ describe Kubernetes::Resource do
             resource.expects(:sleep).times(tries)
 
             e = assert_raises(RuntimeError) { resource.delete }
-            e.message.must_equal "Unable to delete resource (ConfigMap some-project pod1 Pod1)"
+            e.message.must_equal(
+              "Unable to delete resource (try scaling to 0 first without deletion) (ConfigMap some-project pod1 Pod1)"
+            )
           end
         end
       end


### PR DESCRIPTION
@zendesk/compute 

we saw a few times already that deleting a deployment that still had pods failed because kubernetes refused to delete it ... opened an kubernetes issue but nobody was able to reproduce (can't find the link)
so when deletion fails suggest scaling to 0 first which we know fixes the issue and unblocks the deployer
... not perfect but simple

### Risks
- None
