### PR TITLE
deploy new samson release when github release already exists

### DIFF
--- a/app/models/release_service.rb
+++ b/app/models/release_service.rb
@@ -24,6 +24,8 @@ class ReleaseService
 
   def push_tag_to_git_repository(version, commit)
     GITHUB.create_release(@project.repository_path, version, target_commitish: commit)
+  rescue Octokit::UnprocessableEntity => e
+    raise unless e.message.include?("code: already_exists")
   end
 
   def ensure_tag_in_git_repository(tag)


### PR DESCRIPTION
@zendesk/compute 

atm this crashes and leaves a release that is not deployed

other ideas:
- could tell users not to use release flow when someone else already creates releases in github
- could refuse to create the release (would require either reversing oder of operations or deleting a bad release ... hard)
