### PR TITLE
support opa crds so we can deploy policies and rules together

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -171,6 +171,7 @@ module Kubernetes
           end
         end
         expire_resource_cache
+        sleep 10 if ReleaseDoc::CRD_CREATING.keys.include?(kind)
       rescue Kubeclient::ResourceNotFoundError => e
         raise Samson::Hooks::UserError, e.message
       end

--- a/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_config_file.rb
@@ -7,7 +7,7 @@ module Kubernetes
     attr_reader :path, :elements
 
     # from https://github.com/helm/helm/blob/release-3.0/pkg/releaseutil/kind_sorter.go#L27-L61
-    DEPLOY_SORT_ORDER = [
+    DEPLOY_SORT_ORDER = ([
       "Namespace",
       "NetworkPolicy",
       "ResourceQuota",
@@ -40,8 +40,8 @@ module Kubernetes
       "Job",
       "CronJob",
       "Ingress",
-      "APIService",
-    ].freeze
+      "APIService"
+    ] + ReleaseDoc::CRD_CREATING.keys).freeze
 
     DEPLOY_KINDS = ['Deployment', 'DaemonSet', 'StatefulSet'].freeze
     SERVICE_KINDS = ['Service'].freeze

--- a/plugins/kubernetes/app/models/kubernetes/role_validator.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role_validator.rb
@@ -82,7 +82,7 @@ module Kubernetes
         end
 
         projects = element_groups.flat_map { |e| e.map { |r| r.dig(:metadata, :labels, :project) } }.uniq
-        errors << "metadata.labels.project must be consistent" if projects.size != 1
+        errors << "metadata.labels.project must be consistent but found #{projects.inspect}" if projects.size != 1
       end
 
       raise Samson::Hooks::UserError, errors.join(", ") if errors.any?

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -268,6 +268,17 @@ describe Kubernetes::ReleaseDoc do
         "Bar" => {"namespaced" => false}
       )
     end
+
+    it "supports opa" do
+      doc.resource_template.replace(
+        [
+          {kind: "Pod"},
+          {kind: "ConstraintTemplate", spec: {crd: {spec: {scope: "Namespaced", names: {kind: "Foo"}}}}}
+        ]
+      )
+
+      doc.custom_resource_definitions.must_equal "Foo" => {"namespaced" => true}
+    end
   end
 
   describe "#deploy" do

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -212,6 +212,26 @@ describe Kubernetes::Resource do
           assert_raises(Samson::Hooks::UserError) { resource.send(:create) }
         end
       end
+
+      describe "creating crds" do
+        let(:kind) { "ConstraintTemplate" }
+        let(:api_version) { 'constraints.gatekeeper.sh/v1beta1' }
+
+        it "waits for CRDs to be created to not fail next resource" do
+          stub_request(:get, "http://foobar.server/apis/constraints.gatekeeper.sh/v1beta1").
+            to_return(body: {
+              "resources" => [
+                {"name" => "constrainttemplate", "namespaced" => false, "kind" => "ConstraintTemplate"}
+              ]
+            }.to_json)
+
+          url = "http://foobar.server/apis/constraints.gatekeeper.sh/v1beta1/namespaces/pod1/constrainttemplate"
+          assert_request(:post, url, to_return: {body: {}.to_json}) do
+            resource.expects(:sleep).times(1)
+            resource.send(:create)
+          end
+        end
+      end
     end
 
     describe "#exist?" do

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -723,7 +723,9 @@ describe Kubernetes::RoleValidator do
       primary = role.first
       primary2 = primary.dup
       primary2[:metadata] = {labels: {role: "meh", project: "other"}}
-      validate_error([[primary], [primary2]]).must_equal "metadata.labels.project must be consistent"
+      validate_error([[primary], [primary2]]).must_equal(
+        "metadata.labels.project must be consistent but found [\"some-project\", \"other\"]"
+      )
     end
 
     it "is invalid with different role labels in a single role" do


### PR DESCRIPTION
@zendesk/compute 

testing:
- installed opa via `kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.5/deploy/gatekeeper.yaml
`
- deployed https://github.com/samson-test-org/example-kubernetes branch `grosser/opa` which includes a new policy and rule

### Risks
- Low
