### PR TITLE
Show error when no deploy groups set

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
+++ b/plugins/kubernetes/app/models/kubernetes/deploy_executor.rb
@@ -376,9 +376,13 @@ module Kubernetes
     def grouped_deploy_group_roles
       @grouped_deploy_group_roles ||= begin
         ignored_role_ids = @job.deploy.stage.kubernetes_stage_roles.where(ignored: true).pluck(:kubernetes_role_id)
+        deploy_groups = @job.deploy.stage.deploy_groups.to_a
+
+        raise(Samson::Hooks::UserError, "No deploy groups are configured for this stage.") if deploy_groups.empty?
+
         deploy_group_roles = Kubernetes::DeployGroupRole.where(
           project_id: @job.project_id,
-          deploy_group: @job.deploy.stage.deploy_groups.map(&:id)
+          deploy_group: deploy_groups.map(&:id)
         ).where.not(kubernetes_role_id: ignored_role_ids)
 
         # roles that exist in the repo for this sha
@@ -387,7 +391,7 @@ module Kubernetes
           reject { |role| ignored_role_ids.include?(role.id) }
 
         # check that all roles have a matching deploy_group_role and all roles are configured
-        @job.deploy.stage.deploy_groups.map do |deploy_group|
+        deploy_groups.map do |deploy_group|
           # fail early here, this was randomly not there, also fixes an n+1
           deploy_group.kubernetes_cluster || raise
 

--- a/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/deploy_executor_test.rb
@@ -342,6 +342,15 @@ describe Kubernetes::DeployExecutor do
         e.message.must_include "Missing env variables [\"FOO\", \"BAR\"]"
       end
 
+      it "fails before building when deploy groups are empty" do
+        stage.update(deploy_groups: [])
+
+        e = assert_raises Samson::Hooks::UserError do
+          refute execute
+        end
+        e.message.must_equal "No deploy groups are configured for this stage."
+      end
+
       it "fails before building when role config is missing" do
         GitRepository.any_instance.stubs(:file_content).with('kubernetes/resque_worker.yml', commit, anything).
           returns(nil)


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Show error when no deploy groups set.
Previously this was triggering a nil exception.

### Risks
- Low: could break Kubernetes deployments
