### PR TITLE
do not expire project#show when other projects or stages get locked

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -23,8 +23,19 @@
     </thead>
     <tbody>
       <% if @stages.any? || @page.page != 1 %>
-        <% static_cache_key = [@project.permalink, Lock.cache_key, deployer_for_project?] # avoid N+1 %>
-        <%= render partial: "stage", collection: @stages, cached: ->(stage) { [stage, *static_cache_key] } %>
+        <%
+          # expire the cache when the project or any of the stages (and their deploy-groups/envs) gets locked
+          # a little expensive, but better than expiring when anything gets locked (confirmed that it's not doing N+1s)
+          project_locks = Lock.for_resource(@project)
+          static_cache_key = [@project.permalink, deployer_for_project?]
+
+          cache_key = ->(stage) do
+            last_lock_change = (project_locks + Lock.for_resource(stage)).map(&:updated_at).max
+            [stage, last_lock_change, *static_cache_key]
+          end
+        %>
+
+          <%= render partial: "stage", collection: @stages, cached: cache_key %>
       <% else %>
         <tr>
           <td colspan="3">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Samson::Application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = !!ENV["PERFORM_CACHING"]
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
@zendesk/compute 

before we would expire the cache when anything else was locked (other stages or projects)

confirmed that it's not doing N+1s so this should still be reasonably fast since it only adds 2 queries
```
[id:71f97882-6828-4b03-aca2-b39508ab941b] [ip:127.0.0.1]   DeployGroupsStage Load (0.5ms)  SELECT `deploy_groups_stages`.* FROM `deploy_groups_stages` WHERE `deploy_groups_stages`.`stage_id` IN (1, 4)
[id:71f97882-6828-4b03-aca2-b39508ab941b] [ip:127.0.0.1]   DeployGroup Load (16.0ms)  SELECT `deploy_groups`.* FROM `deploy_groups` WHERE `deploy_groups`.`deleted_at` IS NULL AND `deploy_groups`.`id` IN (1, 2) ORDER BY `deploy_groups`.`name_sortable` ASC
```