### PR TITLE
feat(changeset): change how recover Pull Request ID

### DIFF
--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -23,6 +23,10 @@ class Changeset::Commit
     @author ||= Changeset::GithubUser.new(@data.author) if @data.author
   end
 
+  def summary
+    summary = @data.commit.message.split("\n").first
+  end
+
   def sha
     @data.sha
   end
@@ -33,8 +37,7 @@ class Changeset::Commit
 
   # @return [Integer, NilClass]
   def pull_request_number
-    commit_message = @data.commit.message
-    if number = commit_message[PULL_REQUEST_MERGE_MESSAGE, 1] || commit_message[PULL_REQUEST_SQUASH_MESSAGE, 1]
+    if number = summary[PULL_REQUEST_MERGE_MESSAGE, 1] || summary[PULL_REQUEST_SQUASH_MESSAGE, 1]
       Integer(number)
     end
   end

--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -24,7 +24,11 @@ class Changeset::Commit
   end
 
   def summary
-    summary = @data.commit.message.split("\n").first
+    summary_long.truncate(80)
+  end
+
+  def summary_long
+    @data.commit.message.split("\n").first
   end
 
   def sha
@@ -37,7 +41,7 @@ class Changeset::Commit
 
   # @return [Integer, NilClass]
   def pull_request_number
-    if number = summary[PULL_REQUEST_MERGE_MESSAGE, 1] || summary[PULL_REQUEST_SQUASH_MESSAGE, 1]
+    if number = summary_long[PULL_REQUEST_MERGE_MESSAGE, 1] || summary_long[PULL_REQUEST_SQUASH_MESSAGE, 1]
       Integer(number)
     end
   end

--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Changeset::Commit
-  PULL_REQUEST_MERGE_MESSAGE = /\AMerge pull request #(\d+)/.freeze
-  PULL_REQUEST_SQUASH_MESSAGE = /\A.*\(#(\d+)\)$/.freeze
+  PULL_REQUEST_MESSAGE = /\A.*\(#(\d+)\)$/.freeze
 
   attr_reader :project
 
@@ -23,11 +22,6 @@ class Changeset::Commit
     @author ||= Changeset::GithubUser.new(@data.author) if @data.author
   end
 
-  def summary
-    summary = @data.commit.message.split("\n").first
-    summary.truncate(80)
-  end
-
   def sha
     @data.sha
   end
@@ -38,7 +32,7 @@ class Changeset::Commit
 
   # @return [Integer, NilClass]
   def pull_request_number
-    if number = summary[PULL_REQUEST_MERGE_MESSAGE, 1] || summary[PULL_REQUEST_SQUASH_MESSAGE, 1]
+    if number = @data.commit.message[PULL_REQUEST_MESSAGE, 1]
       Integer(number)
     end
   end

--- a/app/models/changeset/commit.rb
+++ b/app/models/changeset/commit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Changeset::Commit
-  PULL_REQUEST_MESSAGE = /\A.*\(#(\d+)\)$/.freeze
+  PULL_REQUEST_MERGE_MESSAGE = /\AMerge pull request #(\d+)/.freeze
+  PULL_REQUEST_SQUASH_MESSAGE = /\A.*\(#(\d+)\)$/.freeze
 
   attr_reader :project
 
@@ -32,7 +33,8 @@ class Changeset::Commit
 
   # @return [Integer, NilClass]
   def pull_request_number
-    if number = @data.commit.message[PULL_REQUEST_MESSAGE, 1]
+    commit_message = @data.commit.message
+    if number = commit_message[PULL_REQUEST_MERGE_MESSAGE, 1] || commit_message[PULL_REQUEST_SQUASH_MESSAGE, 1]
       Integer(number)
     end
   end


### PR DESCRIPTION
As we could add the Pull Request ID in any place of the commit message,
we would like to change how we parse the commit message. The only
mandatory thing is to have parenthesis around it ex: (#12347).
We also remove the commit message truncation to avoid ignoring PR number
if located more than 80 characters away (at the end of the first line or
in the next lines)

* [x] Add description
* [ ] Add screenshots when changing the UI
* [ ] Add unit tests

### References
- Jira link: 

### Risks
- Med
