### PR TITLE
fix nils blowing up the new markdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
   # options: https://github.com/gjtorikian/commonmarker#extensions
   def markdown(str)
     sanitize CommonMarker.render_html(
-      str,
+      str.to_s,
       [:STRIKETHROUGH_DOUBLE_TILDE, :LIBERAL_HTML_TAG, :UNSAFE],
       [:strikethrough, :tasklist, :autolink, :table]
     )

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -80,6 +80,11 @@ describe ApplicationHelper do
       result = markdown("Hey ~~FOO~~ bar")
       result.must_equal "<p>Hey <del>FOO</del> bar</p>\n"
     end
+
+    it "supports nil" do
+      result = markdown(nil)
+      result.must_equal ""
+    end
   end
 
   describe "#controller_action" do


### PR DESCRIPTION
TypeError: text must be a String; got a NilClass!


### Risks
- Low
