### PR TITLE
support the same 100 per_page for deploys as the other controllers do

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -204,7 +204,7 @@ class DeploysController < ApplicationController
       end
     end
     deploys = deploys.where.not(deleted_at: nil) if search_deleted
-    pagy(deploys, page: params[:page], items: 30)
+    pagy(deploys, page: params[:page], items: [Integer(params[:per_page] || "30"), 100].min)
   end
 
   def stage


### PR DESCRIPTION
was building some generic logic and stumbled over deploys always returning 30 and then my pagination logic thinking it was the last page :/

@zendesk/compute

### Risks
- Low: slowness for large pages
