### PR TITLE
PodDisruptionBudget: use the new policy/v1 api

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/release_doc.rb
+++ b/plugins/kubernetes/app/models/kubernetes/release_doc.rb
@@ -157,7 +157,7 @@ module Kubernetes
       )
 
       budget = {
-        apiVersion: "policy/v1beta1",
+        apiVersion: "policy/v1",
         kind: "PodDisruptionBudget",
         metadata: {
           name: deployment.dig(:metadata, :name),

--- a/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/cluster_test.rb
@@ -109,7 +109,7 @@ describe Kubernetes::Cluster do
     end
 
     it 'can build for other types' do
-      cluster.client('policy/v1beta1').api_endpoint.to_s.must_equal 'http://foobar.server/apis'
+      cluster.client('policy/v1').api_endpoint.to_s.must_equal 'http://foobar.server/apis'
     end
   end
 

--- a/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/release_doc_test.rb
@@ -236,7 +236,7 @@ describe Kubernetes::ReleaseDoc do
       end
 
       it "does not add a second PDB" do
-        template[1][:apiVersion] = "policy/v1beta1"
+        template[1][:apiVersion] = "policy/v1"
         template[1][:kind] = "PodDisruptionBudget"
         create!
         create!.resource_template.size.must_equal 2

--- a/plugins/kubernetes/test/models/kubernetes/resource_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_test.rb
@@ -772,7 +772,7 @@ describe Kubernetes::Resource do
 
   describe Kubernetes::Resource::PodDisruptionBudget do
     let(:kind) { 'PodDisruptionBudget' }
-    let(:api_version) { 'policy/v1beta1' }
+    let(:api_version) { 'policy/v1' }
 
     describe "#deploy" do
       it "updates" do

--- a/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_validator_test.rb
@@ -118,7 +118,7 @@ describe Kubernetes::RoleValidator do
       before do
         role.push(
           kind: 'PodDisruptionBudget',
-          apiVersion: 'policy/v1beta1',
+          apiVersion: 'policy/v1',
           metadata: {name: 'foo', labels: labels},
           spec: {selector: {matchLabels: labels}}
         )

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -950,7 +950,7 @@ describe Kubernetes::TemplateFiller do
 
     describe "PodDisruptionBudget" do
       before do
-        raw_template[:apiVersion] = 'policy/v1beta1'
+        raw_template[:apiVersion] = 'policy/v1'
         raw_template[:kind] = 'PodDisruptionBudget'
         raw_template[:spec][:template][:spec].delete(:containers)
       end
@@ -984,7 +984,7 @@ describe Kubernetes::TemplateFiller do
       end
 
       it "modified budgets so we do not get errors when 2 budgets match the same pod" do
-        raw_template[:apiVersion] = 'policy/v1beta1'
+        raw_template[:apiVersion] = 'policy/v1'
         raw_template[:kind] = 'PodDisruptionBudget'
         raw_template[:spec].delete(:template)
         hash = template.to_hash

--- a/plugins/kubernetes/test/test_helper.rb
+++ b/plugins/kubernetes/test/test_helper.rb
@@ -146,7 +146,7 @@ class ActiveSupport::TestCase
         {"name" => "horizontalpodautoscalers/status", "namespaced" => true, "kind" => "HorizontalPodAutoscaler"},
       ]
     },
-    "policy/v1beta1" => {
+    "policy/v1" => {
       "kind" => "APIResourceList",
       "resources" => [
         {"name" => "poddisruptionbudgets", "namespaced" => true, "kind" => "PodDisruptionBudget"}


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

* Add description:  **policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+**
* Add screenshots when changing: the UI **N/A**
* Add unit tests: **N/A**

### References
- Jira link: N/A

### Risks
- Low, if a cluster is using a version older than v1.21, it will break
