### PR TITLE
replace with json: allow use of \\. to avoid splitting

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -74,7 +74,7 @@ module Kubernetes
 
     def self.dig_path(path)
       path = path.split(/\.(labels|annotations)\./) # make sure we do not split inside of labels or annotations
-      path[0..0] = path[0].split(".")
+      path[0..0] = path[0].split(/(?<=[^\\])\./)
       path.map! { |k| k.match?(/^\d+$/) ? Integer(k) : k.to_sym }
     end
 

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -73,8 +73,14 @@ module Kubernetes
     end
 
     def self.dig_path(path)
-      path = path.split(/\.(labels|annotations)\./) # make sure we do not split inside of labels or annotations
+      # make sure we do not split inside of labels or annotations
+      path = path.split(/\.(labels|annotations)\./)
+
+      # split on . but not on \\.
       path[0..0] = path[0].split(/(?<=[^\\])\./)
+      path.map! { |k| k.gsub("\\.", ".") }
+
+      # support numbers for array index
       path.map! { |k| k.match?(/^\d+$/) ? Integer(k) : k.to_sym }
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -1032,6 +1032,13 @@ describe Kubernetes::TemplateFiller do
         template.to_hash[:metadata][:annotations][:"foo.bar/baz"].must_equal "bar"
       end
 
+      it "sets annotations with . in the keyname" do
+        raw_template[:metadata][:annotations] = {
+          "samson/set_via_env_json-metadata.annotations.foo.bar/baz\\.zende\\.sk" => "FOO"
+        }
+        template.to_hash[:metadata][:annotations][:"foo.bar/baz.zende.sk"].must_equal "bar"
+      end
+
       it "sets labels with ." do
         raw_template[:metadata][:annotations] = {
           "samson/set_via_env_json-metadata.labels.foo.bar/baz" => "FOO"

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -1032,11 +1032,11 @@ describe Kubernetes::TemplateFiller do
         template.to_hash[:metadata][:annotations][:"foo.bar/baz"].must_equal "bar"
       end
 
-      it "sets annotations with . in the keyname" do
+      it "can set arbitrary paths that include dots by escaping them" do
         raw_template[:metadata][:annotations] = {
-          "samson/set_via_env_json-metadata.annotations.foo.bar/baz\\.zende\\.sk" => "FOO"
+          "samson/set_via_env_json-metadata.baz\\.zende\\.sk/foo" => "FOO"
         }
-        template.to_hash[:metadata][:annotations][:"foo.bar/baz.zende.sk"].must_equal "bar"
+        template.to_hash[:metadata][:"baz.zende.sk/foo"].must_equal "bar"
       end
 
       it "sets labels with ." do


### PR DESCRIPTION
### Risks
- Low: deploys failing because we split incorrectly
