### PR TITLE
ignore nopods event on fresh pdbs

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -19,7 +19,8 @@ module Kubernetes
       ],
       PodDisruptionBudget: [
         "CalculateExpectedPodCountFailed",
-        "NoControllers"
+        "NoControllers",
+        "NoPods"
       ],
       Service: [
         "FailedToUpdateEndpointSlices"


### PR DESCRIPTION
starting with kubernetes 1.23 when a pdb is deployed but does not match any pods (as it happens when doing the first deploy to a new cluster) we get a warning event that then fails the deploy ... so ignore it to get back to the way we handled things before

```
controller PodDisruptionBudget labeler events:

[17:57:45]   Normal NoPods: No matching pods found x2

```

### Risks
- Low
