### PR TITLE
allow inlining commands for stages

### DIFF
--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -63,7 +63,8 @@ class StagesController < ResourceController
       :active_deploy,
       :lock,
       :locks,
-      :deploy_groups
+      :deploy_groups,
+      :commands
     ]
   end
 


### PR DESCRIPTION
to do an automate migration we want to use the api to check what commands exist and then update them
updating them is already supported via command_ids, but getting the, was not

![SCR-20220721-ky5](https://user-images.githubusercontent.com/11367/180322945-ea8f80a5-c87d-48b5-81a9-0ed981e8eab6.png)


### Risks
- Low
