### PR TITLE
bump dalli gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
-    dalli (2.7.6)
+    dalli (3.2.2)
     ddtrace (0.45.0)
       msgpack
     debug_inspector (0.0.3)


### PR DESCRIPTION
bump dalli gem to latest version

docs on 3.0 upgrade: https://github.com/petergoldstein/dalli/blob/main/3.0-Upgrade.md

### References
- Jira link: 

### Risks
- Low/Med/High: thing that could happen
