### PR TITLE
add some metrics for secret_cache

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -79,6 +79,10 @@ ActiveSupport::Notifications.subscribe("system_stats.samson") do |*, payload|
   payload.each { |key, value| Samson.statsd.gauge key.to_s, value }
 end
 
+ActiveSupport::Notifications.subscribe("secret_cache.samson") do |*, payload|
+  Samson.statsd.increment "secret_cache.#{payload[:action]}"
+end
+
 # basic web stats
 ActiveSupport::Notifications.subscribe("process_action.action_controller") do |_, start, finish, _, payload|
   duration = 1000.0 * (finish - start)

--- a/lib/samson/secrets/manager.rb
+++ b/lib/samson/secrets/manager.rb
@@ -163,13 +163,16 @@ module Samson
         end
 
         def expire_lookup_cache
+          ActiveSupport::Notifications.instrument("secret_cache.samson", {action: "expire"})
           cache.delete(SECRET_LOOKUP_CACHE)
         end
 
         private
 
         def fetch_lookup_cache
+          ActiveSupport::Notifications.instrument("secret_cache.samson", {action: "fetch"})
           cache.fetch(SECRET_LOOKUP_CACHE) do
+            ActiveSupport::Notifications.instrument("secret_cache.samson", {action: "rebuild"})
             backend.ids.each_slice(1000).each_with_object({}) do |slice, all|
               read_multi(slice, include_value: true).each do |id, secret|
                 all[id] = lookup_cache_value(secret)


### PR DESCRIPTION

I want to add some metrics to check how often the secrets cache gets fetched, rebuilt, and expired to investigate an issue

### References
- Jira link: 

### Risks
- Low: send some metrics on secrets cache
