### PR TITLE
feat: allow setting kubernetes well-known labels

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -337,3 +337,12 @@ If a warning event fails deploys, but application owners deem them safe to ignor
 
 When using the namespaces UI to create new namespaces, set `KUBERNETES_COPY_SECRETS_TO_NEW_NAMESPACE=my-docker-auth,other-stuff`,
 it will then copy that secret from the `default` namespace to any newly created namespace.
+
+### Adding Well-Known Labels
+
+In accordance with [Kubernetes Well-Known Labels](https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-managed-by),
+Samson can set the labels:
+- `app.kubernetes.io/managed-by` to `samson`
+- `app.kubernetes.io/name` to the resource name
+
+This feature can be enabled by setting `KUBERNETES_ADD_WELL_KNOWN_LABELS=true`.

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -343,6 +343,6 @@ it will then copy that secret from the `default` namespace to any newly created 
 In accordance with [Kubernetes Well-Known Labels](https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-managed-by),
 Samson can set the labels:
 - `app.kubernetes.io/managed-by` to `samson`
-- `app.kubernetes.io/name` to the resource name
+- `app.kubernetes.io/name` to the project permalink
 
 This feature can be enabled by setting `KUBERNETES_ADD_WELL_KNOWN_LABELS=true`.

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -27,6 +27,7 @@ module Kubernetes
         set_project_labels if template.dig(:metadata, :annotations, :"samson/override_project_label")
         set_deploy_url
         set_update_timestamp
+        set_well_known_labels
 
         if RoleValidator::IMMUTABLE_NAME_KINDS.include?(kind)
           # names have a fixed pattern so we cannot override them
@@ -59,8 +60,6 @@ module Kubernetes
         else
           set_name
         end
-
-        set_well_known_labels # last in order to ensure app name has been set
 
         template
       end
@@ -641,7 +640,7 @@ module Kubernetes
         labels[:"app.kubernetes.io/managed-by"] = "samson"
 
         # do not overwrite existing name label, if already set
-        labels[:"app.kubernetes.io/name"] = template[:metadata][:name] unless labels.key?(:"app.kubernetes.io/name")
+        labels[:"app.kubernetes.io/name"] ||= project.permalink
       end
     end
 

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -1194,8 +1194,8 @@ describe Kubernetes::TemplateFiller do
 
       it "adds app.kubernetes.io/name label if not set" do
         result = template.to_hash
-        result.dig(:metadata, :labels, :"app.kubernetes.io/name").must_equal result[:metadata][:name]
-        result.dig(:spec, :template, :metadata, :labels, :"app.kubernetes.io/name").must_equal result[:metadata][:name]
+        result.dig(:metadata, :labels, :"app.kubernetes.io/name").must_equal project.permalink
+        result.dig(:spec, :template, :metadata, :labels, :"app.kubernetes.io/name").must_equal project.permalink
       end
 
       it "does not add app.kubernetes.io/name label if already set" do

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -1174,6 +1174,38 @@ describe Kubernetes::TemplateFiller do
         template.to_hash[:metadata][:annotations][:"samson/updateTimestamp"].must_equal "2018-01-01T00:00:00Z"
       end
     end
+
+    describe "well known labels" do
+      around { |t| stub_const Kubernetes::TemplateFiller, :KUBERNETES_ADD_WELL_KNOWN_LABELS, true, &t }
+
+      it "adds app.kubernetes.io/managed-by label to resources and templates" do
+        result = template.to_hash
+        result.dig(:metadata, :labels, :"app.kubernetes.io/managed-by").must_equal "samson"
+        result.dig(:spec, :template, :metadata, :labels, :"app.kubernetes.io/managed-by").must_equal "samson"
+      end
+
+      it "adds app.kubernetes.io/managed-by label to jobTemplate template" do
+        raw_template.replace(YAML.safe_load(read_kubernetes_sample_file("kubernetes_cron_job.yml")).deep_symbolize_keys)
+        doc.replica_target = 1
+        result = template.to_hash
+        result.dig(:spec, :jobTemplate, :spec, :template, :metadata, :labels, :"app.kubernetes.io/managed-by").
+          must_equal "samson"
+      end
+
+      it "adds app.kubernetes.io/name label if not set" do
+        result = template.to_hash
+        result.dig(:metadata, :labels, :"app.kubernetes.io/name").must_equal result[:metadata][:name]
+        result.dig(:spec, :template, :metadata, :labels, :"app.kubernetes.io/name").must_equal result[:metadata][:name]
+      end
+
+      it "does not add app.kubernetes.io/name label if already set" do
+        raw_template[:metadata][:labels] = {"app.kubernetes.io/name": "Bar"}
+        raw_template[:spec][:template][:metadata][:labels] = {"app.kubernetes.io/name": "Bar"}
+        result = template.to_hash
+        result.dig(:metadata, :labels, :"app.kubernetes.io/name").must_equal "Bar"
+        result.dig(:spec, :template, :metadata, :labels, :"app.kubernetes.io/name").must_equal "Bar"
+      end
+    end
   end
 
   describe "#verify" do


### PR DESCRIPTION
Signed-off-by: Amir Alavi <amir.alavi@zendesk.com>

For PR description, please view README addition.
For comparison, other deployments tools such as Spinnaker add these two labels as well. See Doc [here](https://spinnaker.io/docs/reference/providers/kubernetes-v2/#reserved-labels)

* Add description ✅ 
* ~Add screenshots when changing the UI~
* Add unit tests ✅ 

### References
N/A

### Risks
- Low: these well-known labels are not immutable nor selector labels so they should not affect functionality.
