### PR TITLE
chore: bump brakeman to latest version to fix build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ GEM
       sassc (>= 2.0.0)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
-    brakeman (5.2.3)
+    brakeman (5.3.1)
     builder (3.2.4)
     bundler-audit (0.9.0.1)
       bundler (>= 1.2.0, < 3)


### PR DESCRIPTION
Fix build issue:

```
Run bundle exec rake $NAME
  bundle exec rake $NAME
  shell: /usr/bin/bash -e {0}
  env:
    RAILS_ENV: test
    NAME: brakeman
Brakeman 5.2.3 is not the latest version 5.3.1
Fix the found issues, or add new ignored with:
bundle exec brakeman --add-engine-path 'plugins/*' -I
Error: Process completed with exit code 1.
```

### References
- Jira link: 

### Risks
- Low/Med/High: thing that could happen
