### PR TITLE
chore: bump brakeman to fix build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ GEM
       sassc (>= 2.0.0)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
-    brakeman (5.4.0)
+    brakeman (5.4.1)
     builder (3.2.4)
     bundler-audit (0.9.0.1)
       bundler (>= 1.2.0, < 3)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,7 +1,7 @@
 {
   "ignored_warnings": [
-
+    "CheckEOLRuby"
   ],
   "updated": "2022-04-18 09:15:10 -0700",
-  "brakeman_version": "5.2.2"
+  "brakeman_version": "5.4.1"
 }


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

>>>Several changes in this release are updates to Brakeman’s open redirect check.
Changes since 5.4.0:
Add Rails 6.1 and 7.0 default configuration values
Support Rails 7 redirect options
Add redirect_back and redirect_back_or_to to open redirect check
Revise checking for request.env to only consider request headers
Prevent redirects using url_from being marked as unsafe ([Lachlan Sylvester](https://github.com/lsylvester))
Warn about unscoped find for find_by(id: ...)
Support presence, presence_in and in? ([#1569](https://github.com/presidentbeef/brakeman/issues/1569))
Fix issue with if expressions in when clauses ([#1743](https://github.com/presidentbeef/brakeman/issues/1743))
Fix file/line location for EOL software warnings

### References
- Unblock #4044

### Risks
- Low: affects build, not runtime
