### PR TITLE
bump jenkins api client gem to unlock ruby 3 update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,13 +88,13 @@ PATH
   remote: plugins/jenkins_status_checker
   specs:
     samson_jenkins_status_checker (0.0.0)
-      jenkins_api_client (~> 1.3)
+      jenkins_api_client (~> 2.0)
 
 PATH
   remote: plugins/jenkins
   specs:
     samson_jenkins (0.0.0)
-      jenkins_api_client (~> 1.3)
+      jenkins_api_client (~> 2.0)
 
 PATH
   remote: plugins/jira
@@ -306,6 +306,8 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     byebug (8.2.5)
+    chef-utils (18.1.29)
+      concurrent-ruby
     coderay (1.1.1)
     commonmarker (0.23.8)
     concurrent-ruby (1.2.2)
@@ -373,7 +375,8 @@ GEM
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
     interception (0.5)
-    jenkins_api_client (1.5.3)
+    jenkins_api_client (2.0.0)
+      addressable (~> 2.7)
       json (>= 1.0)
       mixlib-shellout (>= 1.1.0)
       nokogiri (~> 1.6)
@@ -381,7 +384,7 @@ GEM
       terminal-table (>= 1.4.0)
       thor (>= 0.16.0)
     jmespath (1.6.2)
-    json (2.3.0)
+    json (2.6.3)
     jsonpath (1.1.2)
       multi_json
     jwt (2.2.1)
@@ -421,7 +424,8 @@ GEM
     minitest-rails (6.1.0)
       minitest (~> 5.10)
       railties (~> 6.1.0)
-    mixlib-shellout (2.2.7)
+    mixlib-shellout (3.2.7)
+      chef-utils
     mocha (1.2.1)
       metaclass (~> 0.0.1)
     momentjs-rails (2.29.4.1)
@@ -436,12 +440,12 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.7.0.359)
     nio4r (2.5.8)
-    nokogiri (1.14.0)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-darwin)
+    nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-linux)
+    nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.6)
     oauth2 (1.4.4)
@@ -628,7 +632,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (1.7.0)
+    unicode-display_width (1.8.0)
     validates_lengths_from_database (0.7.0)
       activerecord (>= 3)
     warden (1.2.7)

--- a/plugins/jenkins/samson_jenkins.gemspec
+++ b/plugins/jenkins/samson_jenkins.gemspec
@@ -3,5 +3,5 @@ Gem::Specification.new "samson_jenkins", "0.0.0" do |s|
   s.summary = "Samson jenkins integration"
   s.authors = ["Rupinder Dhanoa "]
   s.email = "rdhanoa@zendesk.com"
-  s.add_runtime_dependency "jenkins_api_client", "~> 1.3"
+  s.add_runtime_dependency "jenkins_api_client", "~> 2.0"
 end

--- a/plugins/jenkins_status_checker/samson_jenkins_status_checker.gemspec
+++ b/plugins/jenkins_status_checker/samson_jenkins_status_checker.gemspec
@@ -4,5 +4,5 @@ Gem::Specification.new 'samson_jenkins_status_checker', '0.0.0' do |s|
   s.authors = ['Yi Fei Wu']
   s.email = ['ywu@zendesk.com']
   s.files = Dir['{app,config,db,lib}/**/*']
-  s.add_runtime_dependency "jenkins_api_client", "~> 1.3"
+  s.add_runtime_dependency "jenkins_api_client", "~> 2.0"
 end


### PR DESCRIPTION
new release is mostly version bump so should be safe ... but no idea how to test this
roll back if it's broken ...

- [jenkins_api_client](https://rubygems.org/gems/jenkins_api_client) 1.5.3→2.0.0 [💎±](https://my.diffend.io/gems/jenkins_api_client/1.5.3/2.0.0) [🐙±](https://github.com/arangamani/jenkins_api_client/compare/v1.5.3...v2.0.0)

### Risks
- Low
