### PR TITLE
chore: bump api version to match k8s 1.25

### DIFF
--- a/plugins/kubernetes/test/samples/kubernetes_cron_job.yml
+++ b/plugins/kubernetes/test/samples/kubernetes_cron_job.yml
@@ -1,6 +1,6 @@
 ---
 # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

* update examples to reflect newer api verisons

### References
- Jira link:  https://zendesk.atlassian.net/browse/ACCEL-1269

### Risks
- None: this is a sample manifest
