### PR TITLE
allow not setting replicas for deployments

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -156,7 +156,7 @@ Prefer `spec.updateStrategy.type=RollingUpdate`
 ### Server-side apply
 
 Set `metadata.annotations.samson/server_side_apply='true'` and use a valid template.
-This only works for kubernetes 1.16+ clusters, but will soon be the default way samson works,
+This only works for kubernetes 1.16+ clusters,
 see [kubernetes docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#server-side-apply) for details.
 
 ### Duplicate deployments
@@ -200,6 +200,15 @@ to make all kubernetes deploys that do not use a `metadata.labels.team` / `spec.
 Samson sets namespaces to the deploygroups `kubernetes_namespace` if no `metadata.namespace` is set in the resource.
 
 For namespace-less resources, set `metadata.namespace:` (which will result in `nil`)
+
+### Deployments without replicas
+
+When using a `HorizontalPodAutoscaler` for your `Deployment` or `StatefulSet`, it is recommended to not set `spec.replicas`.
+
+on the `Deployment`
+- set `metadata.annotations.samson/NoReplicas: "true"`
+- set `metadata.annotations.samson/server_side_apply: "true"`
+- do not set `spec.replicas`
 
 ### Using custom resource names
 

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -131,7 +131,11 @@ module Kubernetes
       end
 
       def server_side_apply?
-        @template.dig(:metadata, :annotations, :"samson/server_side_apply") == "true"
+        self.class.server_side_apply?(@template)
+      end
+
+      public_class_method def self.server_side_apply?(template)
+        template.dig(:metadata, :annotations, :"samson/server_side_apply") == "true"
       end
 
       def error_location


### PR DESCRIPTION
ideally that would be automatic, but that could break lots of things ... so using a flag to opt-in instead

also: cleaning up support for ShardedDeployment since that is EOL

### Risks
- Low: deploys failing on some kinds being configured with multiple replicas
