### PR TITLE
podtemplate: allow setting 0 replicas

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -46,6 +46,8 @@ module Kubernetes
           set_name
           if ['Deployment', 'StatefulSet'].include?(kind)
             set_replica_target
+          elsif kind == "PodTemplate"
+            # do nothing: the template has resources so setting to 0 is nice to make them not count in the math
           else
             validate_replica_target_is_supported
           end

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -823,11 +823,17 @@ describe Kubernetes::TemplateFiller do
       end
 
       it "does not populate spec attribute" do
-        result.fetch(:spec, nil).must_be_nil
+        refute result.key? :spec
       end
 
       it "overrides image" do
         container.fetch(:image).must_equal image
+      end
+
+      it "allows 0 replicas" do
+        doc.replica_target = 0
+        result
+        refute result.key? :spec
       end
     end
 


### PR DESCRIPTION
last PR https://github.com/zendesk/samson/pull/4057 remove that feature by accident
but it's useful since podtemplates should not count into resource usage math

### Risks
- Low/Med/High: thing that could happen
