### PR TITLE
remove oauth applications from manage dropdown

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -63,9 +63,6 @@
             <li><%= link_to "Vault Servers", vault_servers_path %></li>
           <% end %>
           <li><%= link_to "Reports", csv_exports_path %></li>
-          <% if current_user&.super_admin? %>
-            <li><%= link_to "OAuth Applications", oauth_applications_path %></li>
-          <% end %>
           <%= Samson::Hooks.render_views(:manage_menu, self) %>
         </ul>
       </li>


### PR DESCRIPTION
### Description
Currently a single user could delete all access tokens if they delete the associated OAuth Application. I want to make it more difficult for a single user to make a mistake. Remove the OAuth Application option from the Manage dropdown menu. The OAuth Application UI can still be accessed via `/oauth/applications`

An alternative approach may also be to duplicate the view from the doorkeeper gem into Samson and remove the Delete link

Also happy to discuss other alternatives


### Risks
- Low. Remove option from dropdown, but the view still exists
