### PR TITLE
safely deserialize k8 yaml

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -111,7 +111,8 @@ module Samson
       Date,
       Time,
       ActiveSupport::HashWithIndifferentAccess,
-      BigDecimal
+      BigDecimal,
+      Symbol
     ]
 
     # Used for all Samson specific configuration.

--- a/plugins/kubernetes/app/models/kubernetes/util.rb
+++ b/plugins/kubernetes/app/models/kubernetes/util.rb
@@ -20,14 +20,11 @@ module Kubernetes
     end
 
     def self.yaml_safe_load_stream(contents, filename)
-      documents = []
-
-      YAML.parse_stream(contents, filename: filename).children.each do |child|
+      YAML.parse_stream(contents, filename: filename).children.map do |child|
         temp_stream = Psych::Nodes::Stream.new
         temp_stream.children << child
-        documents << YAML.safe_load(temp_stream.to_yaml, [Symbol], aliases: true)
+        YAML.safe_load(temp_stream.to_yaml, [Symbol], aliases: true)
       end
-      documents
     end
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/util.rb
+++ b/plugins/kubernetes/app/models/kubernetes/util.rb
@@ -6,14 +6,7 @@ module Kubernetes
 
       if filename.ends_with?('.yml', '.yaml')
         # NOTE: this will always return an array of entries
-        documents = []
-
-        YAML.parse_stream(contents, filename: filename).children.each do |child|
-          temp_stream = Psych::Nodes::Stream.new
-          temp_stream.children << child
-          documents << YAML.safe_load(temp_stream.to_yaml, [Symbol], aliases: true)
-        end
-        documents
+        yaml_safe_load_stream(contents, filename)
       elsif filename.ends_with?('.json')
         JSON.parse(contents)
       else
@@ -24,6 +17,17 @@ module Kubernetes
     def self.log(message, extra_info = {})
       msg_log = {message: message}.merge(extra_info).to_json
       Rails.logger.info(msg_log)
+    end
+
+    def self.yaml_safe_load_stream(contents, filename)
+      documents = []
+
+      YAML.parse_stream(contents, filename: filename).children.each do |child|
+        temp_stream = Psych::Nodes::Stream.new
+        temp_stream.children << child
+        documents << YAML.safe_load(temp_stream.to_yaml, [Symbol], aliases: true)
+      end
+      documents
     end
   end
 end

--- a/plugins/kubernetes/app/models/kubernetes/util.rb
+++ b/plugins/kubernetes/app/models/kubernetes/util.rb
@@ -6,7 +6,14 @@ module Kubernetes
 
       if filename.ends_with?('.yml', '.yaml')
         # NOTE: this will always return an array of entries
-        YAML.load_stream(contents, filepath)
+        documents = []
+
+        YAML.parse_stream(contents, filename: filename).children.each do |child|
+          temp_stream = Psych::Nodes::Stream.new
+          temp_stream.children << child
+          documents << YAML.safe_load(temp_stream.to_yaml, [Symbol], aliases: true)
+        end
+        documents
       elsif filename.ends_with?('.json')
         JSON.parse(contents)
       else

--- a/plugins/kubernetes/test/models/kubernetes/util_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/util_test.rb
@@ -41,5 +41,14 @@ describe Kubernetes::Util do
       output[0].must_equal('name' => 'foo', 'value' => 999)
       output[1].must_equal('name' => 'other_key', 'value' => 1000, 'password' => 12345)
     end
+
+    it 'only loads allowed classes' do
+      yaml_input = <<~YAML
+        ---
+          - !ruby/object:Gem::Installer
+              i: x
+      YAML
+      assert_raises(Psych::DisallowedClass) { Kubernetes::Util.parse_file(yaml_input, 'file.yaml') }
+    end
   end
 end


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Using [YAML.load_stream](https://github.com/zendesk/samson/blob/107efb4a252425966aac5e77d0c3670f9b5d7229/plugins/kubernetes/app/models/kubernetes/util.rb#L9) is unsafe and allows instantiating arbitrary classes which may lead to remote code execution (RCE)

I had to use multiple streams because Samson needs to support multiple documents in a single yaml file

### References
- Jira link: 

### Risks
- Medium? Some k8 deploys may fail if it is using a disallowed class