### PR TITLE
Remove reporting of unqueried metrics.

### DIFF
--- a/config/initializers/periodical.rb
+++ b/config/initializers/periodical.rb
@@ -46,7 +46,7 @@ end
 # These are unqueried and were removed at the request of the metrics cost optimization project
 # Uncomment if creating a monitor for process stats.
 # Samson::Periodical.register :report_process_stats, "Report process stats" do
-  # Samson::ProcessUtils.report_to_statsd
+#   Samson::ProcessUtils.report_to_statsd
 # end
 
 Samson::Periodical.register :repo_provider_status, "Refresh repo provider status" do

--- a/config/initializers/periodical.rb
+++ b/config/initializers/periodical.rb
@@ -43,9 +43,11 @@ Samson::Periodical.register :periodical_deploy, "Deploy periodical stages", cons
   Samson::PeriodicalDeploy.run
 end
 
-Samson::Periodical.register :report_process_stats, "Report process stats" do
-  Samson::ProcessUtils.report_to_statsd
-end
+# These are unqueried and were removed at the request of the metrics cost optimization project
+# Uncomment if creating a monitor for process stats.
+# Samson::Periodical.register :report_process_stats, "Report process stats" do
+  # Samson::ProcessUtils.report_to_statsd
+# end
 
 Samson::Periodical.register :repo_provider_status, "Refresh repo provider status" do
   Samson::RepoProviderStatus.refresh


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

The metrics cost optimization project requested that we remove the process stats being reported by Samson, which are not queried by any existing monitors. I've commented it out so that it will be easy to reinstate if we do need to monitor the process stats.

### References
- Jira link: https://zendesk.atlassian.net/browse/DPLY-3582

### Risks
- Low: only removing stats reporting that aren't being monitored.
