### PR TITLE
ignore UnmanagedPods warnings so we can deploy when we detach pods

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -20,7 +20,8 @@ module Kubernetes
       PodDisruptionBudget: [
         "CalculateExpectedPodCountFailed",
         "NoControllers",
-        "NoPods"
+        "NoPods",
+        "UnmanagedPods"
       ],
       Service: [
         "FailedToUpdateEndpointSlices"


### PR DESCRIPTION
as part of internal tooling we detach pods from their replicaset,
during this time we get 
```
[20:25:16]   Warning UnmanagedPods: Pods selected by this PodDisruptionBudget <meta> were found to be unmanaged. As a result, the status of the PDB cannot be calculated correctly, which may result in undefined behavior. To account for these pods please set ".spec.minAvailable" field of the PDB to an integer value.
```
to avoid blocking deploys we now ignore them
(new warning in kubernetes 1.27 so this should not change any existing behavior users expect)

### Risks
- Low
