### PR TITLE
Substitute $environment in k8s role config file

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -162,7 +162,12 @@ module Kubernetes
     # allows passing the project to reuse the repository cache when doing multiple lookups
     def role_config_file(reference, deploy_group:, project: project(), **args) # rubocop:disable Style/MethodCallWithoutArgsParentheses
       file = config_file
-      file = file.sub('$deploy_group', deploy_group.env_value) if deploy_group && dynamic_folders?
+      if deploy_group && dynamic_folders?
+        file = file.
+          sub('$deploy_group', deploy_group.env_value).
+          sub('$environment', deploy_group.environment.permalink)
+      end
+
       self.class.role_config_file(project, file, reference, **args)
     end
 

--- a/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
+++ b/plugins/kubernetes/app/views/kubernetes/roles/_form.html.erb
@@ -4,7 +4,7 @@
 
   <fieldset>
     <%= form.input :name %>
-    <%= form.input :config_file, help: "Can use $deploy_group substitution to have a dynamic file path." %>
+    <%= form.input :config_file, help: "Can use <code>$deploy_group</code> and <code>$environment</code> substitutions to have a dynamic file path." %>
     <% if @project.override_resource_names? %>
       <%= form.input :service_name, help: "Override service name with this name. Uses name from yml file if it starts with this name." %>
       <%= form.input :resource_name,


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

* Substitute $environment in k8s role config file

### References
- Jira link: https://zendesk.atlassian.net/browse/CINFRA-1273

### Risks
- Low: could break the kubernetes config file mapping logic, breaking kubernetes deploys
