### PR TITLE
kubernetes: dynamic file name based on deploy_group permalink

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -334,6 +334,12 @@ metadata.annotations.samson/recreate: "true"
 
 Set the kubernetes roles to `kubernetes/$deploy_group/server.yml` 
 
+You may also reference the permalink of a deploy group via `kubernetes/$deploy_group_permalink/server.yml`
+
+### Static config per environment
+
+Set the kubernetes roles to `kubernetes/$environment/server.yml`
+
 ### Ignoring warning events
 
 If a warning event fails deploys, but application owners deem them safe to ignore, add this:

--- a/plugins/kubernetes/app/models/kubernetes/role.rb
+++ b/plugins/kubernetes/app/models/kubernetes/role.rb
@@ -164,6 +164,7 @@ module Kubernetes
       file = config_file
       if deploy_group && dynamic_folders?
         file = file.
+          sub('$deploy_group_permalink', deploy_group.permalink).
           sub('$deploy_group', deploy_group.env_value).
           sub('$environment', deploy_group.environment.permalink)
       end

--- a/plugins/kubernetes/test/models/kubernetes/role_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/role_test.rb
@@ -492,5 +492,13 @@ describe Kubernetes::Role do
       role.config_file = "kubernetes/$deploy_group/foo.yaml"
       assert role.role_config_file("master", deploy_group: deploy_groups(:pod100))
     end
+
+    it "can read from dynamic deploy_group_permalink" do
+      GitRepository.any_instance.
+        expects(:file_content).with('kubernetes/pod100/foo.yaml', "master", anything).
+        returns(read_kubernetes_sample_file('kubernetes_job.yml'))
+      role.config_file = "kubernetes/$deploy_group_permalink/foo.yaml"
+      assert role.role_config_file("master", deploy_group: deploy_groups(:pod100))
+    end
   end
 end


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

* Add description: Provide the ability to perform dynamic file name substitution based on deploy_group permalink
* Add screenshots when changing the UI ❌ 
* Add unit tests ✔️ 

### References
- Jira link: 

### Risks
- Low: only impacts new apps with this new pattern in the file name
