### PR TITLE
karmada: ignore sync errors since they are temporary

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -25,6 +25,11 @@ module Kubernetes
       ],
       Service: [
         "FailedToUpdateEndpointSlices"
+      ],
+      # karmada can fail to sync a resource when something else also updated the resource,
+      # this does not necessarily indicate that sync will be broken forever
+      All: [
+        'ApplyPolicyFailed'
       ]
     }.freeze
 
@@ -117,8 +122,9 @@ module Kubernetes
       failures = events(type: "Warning")
       ignored =
         @resource.dig(:metadata, :annotations, :"samson/ignore_events").to_s.split(",") +
-        (IGNORED_EVENT_REASONS[kind.to_sym] || [])
-      failures.reject! { |e| ignored.include? e[:reason] } if ignored.any?
+        (IGNORED_EVENT_REASONS[kind.to_sym] || []) +
+        IGNORED_EVENT_REASONS[:All]
+      failures.reject! { |e| ignored.include? e[:reason] }
       failures
     end
   end

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -110,6 +110,11 @@ describe Kubernetes::ResourceStatus do
           }
           expect_event_request { details.must_equal "Error event" }
         end
+
+        it "ignores karmada sync" do
+          events[0][:reason] = "ApplyPolicyFailed"
+          expect_event_request { details.must_equal "Live" }
+        end
       end
     end
   end


### PR DESCRIPTION
```
[20:32:39]   Normal SyncSucceed: Successfully applied resource(kube-system/kube-service-watcher) to cluster eks-sandbox x3

[20:32:39]   Warning SyncFailed: Failed to create or update resource(kube-system/kube-service-watcher) in member cluster(eks-sandbox): Operation cannot be fulfilled on deployments.apps "kube-service-watcher": the object has been modified; please apply your changes to the latest version and try again x2
```

but after a few reconciles it's just fine, so need to ignore these


### Risks
- Low
