### PR TITLE
Ruby 3 preparation

### DIFF
--- a/app/channels/deploy_notifications_channel.rb
+++ b/app/channels/deploy_notifications_channel.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class DeployNotificationsChannel < ActionCable::Channel::Base
   def self.broadcast(count)
-    ActionCable.server.broadcast channel_name, count: count
+    ActionCable.server.broadcast(channel_name, {count: count})
   end
 
   # called when using javascript App.cable.subscriptions.create

--- a/app/controllers/csv_exports_controller.rb
+++ b/app/controllers/csv_exports_controller.rb
@@ -32,7 +32,7 @@ class CsvExportsController < ApplicationController
         case params[:type]
         when "users"
           options = user_filter
-          send_data UserCsvPresenter.to_csv(options), type: :csv, filename: "Users_#{options[:datetime]}.csv"
+          send_data UserCsvPresenter.to_csv(**options), type: :csv, filename: "Users_#{options[:datetime]}.csv"
         when "deploy_group_usage"
           date_time_now = Time.now.strftime "%Y%m%d_%H%M"
           send_data DeployGroupUsageCsvPresenter.to_csv, type: :csv, filename: "DeployGroupUsage_#{date_time_now}.csv"

--- a/lib/samson/secrets/vault_server.rb
+++ b/lib/samson/secrets/vault_server.rb
@@ -73,13 +73,12 @@ module Samson
 
       def create_client
         VaultClientWrapper.new(
-          DEFAULT_CLIENT_OPTIONS.merge(
-            address: address,
-            ssl_cert_store: cert_store,
-            ssl_verify: tls_verify,
-            token: token,
-            versioned_kv: versioned_kv?
-          )
+          **DEFAULT_CLIENT_OPTIONS,
+          address: address,
+          ssl_cert_store: cert_store,
+          ssl_verify: tls_verify,
+          token: token,
+          versioned_kv: versioned_kv?
         )
       end
 

--- a/plugins/kubernetes/app/models/kubernetes/resource.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource.rb
@@ -401,8 +401,8 @@ module Kubernetes
     end
 
     class PodDisruptionBudget < VersionedUpdate
-      def initialize(*)
-        super
+      def initialize(...)
+        super(...)
         @delete_resource ||= @template[:delete] # allow deletion through release_doc logic
       end
     end
@@ -427,9 +427,9 @@ module Kubernetes
       end
     end
 
-    def self.build(*args)
+    def self.build(*args, **kwargs)
       klass = "Kubernetes::Resource::#{args.first.fetch(:kind)}".safe_constantize || VersionedUpdate
-      klass.new(*args)
+      klass.new(*args, **kwargs)
     end
   end
 end

--- a/plugins/sentry/lib/samson_sentry/samson_plugin.rb
+++ b/plugins/sentry/lib/samson_sentry/samson_plugin.rb
@@ -24,5 +24,5 @@ end
 
 Samson::Hooks.callback :error do |exception, **options|
   sentry_options = options.slice(:contexts, :extra, :tags, :user, :level, :fingerprint)
-  Sentry.capture_exception(exception, sentry_options)
+  Sentry.capture_exception(exception, **sentry_options)
 end


### PR DESCRIPTION
### Context

There's a change in Ruby 3.0 that [separates positional and keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).


### Change

In preparation for the Ruby 3.0 upgrade, update classes to correctly pass keyword arguments in method calls.







