### PR TITLE
Upgrade rack-mini-profiler to v2.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ group :debugging do
 end
 
 group :development, :staging do
-  gem 'rack-mini-profiler'
+  gem 'rack-mini-profiler', '~> 2.3.2'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ group :debugging do
 end
 
 group :development, :staging do
-  gem 'rack-mini-profiler', '~> 2.3.2'
+  gem 'rack-mini-profiler'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,7 @@ GEM
     pyu-ruby-sasl (0.0.3.3)
     racc (1.7.3)
     rack (2.2.8)
-    rack-mini-profiler (2.3.4)
+    rack-mini-profiler (3.3.0)
       rack (>= 1.2.0)
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
@@ -750,7 +750,7 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma (~> 5.6.7)
-  rack-mini-profiler (~> 2.3.2)
+  rack-mini-profiler
   rails (~> 6.1.7.6)
   rails-assets-bootstrap-select!
   rails-assets-jquery!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,7 @@ GEM
     pyu-ruby-sasl (0.0.3.3)
     racc (1.7.3)
     rack (2.2.8)
-    rack-mini-profiler (1.1.6)
+    rack-mini-profiler (2.3.4)
       rack (>= 1.2.0)
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
@@ -750,7 +750,7 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma (~> 5.6.7)
-  rack-mini-profiler
+  rack-mini-profiler (~> 2.3.2)
   rails (~> 6.1.7.6)
   rails-assets-bootstrap-select!
   rails-assets-jquery!


### PR DESCRIPTION
Upgrade rack-mini-profiler to v2.3.3 to fix the ActionView::Template:Error (undefined method `safe_append=' for {:add_to_stack=>true}:Hash). 

Followed the advice from [here](https://github.com/rails/rails/issues/42261#issuecomment-930027308)


### Risks
- Low.
