### PR TITLE
Bump dogstatsd-ruby from 3.3.0 to 5.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
       msgpack
     debug_inspector (0.0.3)
     diffy (3.4.2)
-    dogstatsd-ruby (3.3.0)
+    dogstatsd-ruby (5.6.1)
     domain_name (0.6.20240107)
     doorkeeper (5.6.8)
       railties (>= 5)


### PR DESCRIPTION
### [dogstatsd-ruby](https://github.com/DataDog/dogstatsd-ruby)

**Major** version upgrade :chart_with_upwards_trend::exclamation: 3.3.0 → 5.6.1

[_[change-log](https://github.com/DataDog/dogstatsd-ruby/blob/v5.6.1/CHANGELOG.md), [source-code](https://github.com/DataDog/dogstatsd-ruby/tree/v5.6.1), [gem-diff](https://my.diffend.io/gems/dogstatsd-ruby/3.3.0/5.6.1)_]






A change of **401** commits. See the full changes on [the compare page](https://github.com/DataDog/dogstatsd-ruby/compare/v3.3.0...v5.6.1).
