### PR TITLE
karmada: ignore sync failure errors since they are temporary

### DIFF
--- a/plugins/kubernetes/app/models/kubernetes/resource_status.rb
+++ b/plugins/kubernetes/app/models/kubernetes/resource_status.rb
@@ -29,7 +29,8 @@ module Kubernetes
       # karmada can fail to sync a resource when something else also updated the resource,
       # this does not necessarily indicate that sync will be broken forever
       All: [
-        'ApplyPolicyFailed'
+        'ApplyPolicyFailed',
+        'SyncFailed'
       ]
     }.freeze
 

--- a/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/resource_status_test.rb
@@ -111,8 +111,13 @@ describe Kubernetes::ResourceStatus do
           expect_event_request { details.must_equal "Error event" }
         end
 
-        it "ignores karmada sync" do
+        it "ignores karmada sync for policy failed" do
           events[0][:reason] = "ApplyPolicyFailed"
+          expect_event_request { details.must_equal "Live" }
+        end
+
+        it "ignores karmada syn for sync failed" do
+          events[0][:reason] = "SyncFailed"
           expect_event_request { details.must_equal "Live" }
         end
       end


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

```
[21:10:10]   Normal ScalingReplicaSet: Scaled up replica set gatekeeper-controller-manager-7f4d5cb774 to 2 from 1
[21:10:10]   Warning SyncFailed: Failed to create or update resource(gatekeeper-system/gatekeeper-controller-manager) in member cluster(eks-sandbox): Operation cannot be fulfilled on deployments.apps "gatekeeper-controller-manager": the object has been modified; please apply your changes to the latest version and try again
[21:10:10]   Normal ScalingReplicaSet: Scaled down replica set gatekeeper-controller-manager-f66b56897 to 0 from 1 x3
[21:10:10] 
[21:10:10] Sandbox gatekeeper HorizontalPodAutoscaler gatekeeper-controller-manager events:
[21:10:10]   Normal ScheduleBindingSucceed: Binding has been scheduled successfully. x7
[21:10:10]   Normal ApplyPolicySucceed: Apply cluster policy(duplicate) succeed x2
```

### References
- Jira link: 

### Risks
- Low
