### PR TITLE
bump mysql to be installable on m1 macs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,7 +444,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
     net-imap (0.4.10)


### PR DESCRIPTION
somehow getting errors on old version

### Risks
- Low
