### PR TITLE
Dont error if secret visible key does not exist 

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -228,7 +228,7 @@ class SecretsController < ApplicationController
 
   def find_secret
     @secret = Samson::Secrets::Manager.read(id, include_value: true)
-    @secret[:value] = nil unless @secret.fetch(:visible)
+    @secret[:value] = nil unless @secret[:visible]
   end
 
   def find_writable_project_permalinks

--- a/test/controllers/secrets_controller_test.rb
+++ b/test/controllers/secrets_controller_test.rb
@@ -526,6 +526,12 @@ describe SecretsController do
         assert_template :show
       end
 
+      it "renders when secret only has value key" do
+        Samson::Secrets::Manager.stubs(:read).returns({value: 'test'})
+        get :show, params: {id: secret.id}
+        assert_template :show
+      end
+
       it "renders with unknown project" do
         secret.update_column(:id, 'oops/bar')
         get :show, params: {id: secret.id}


### PR DESCRIPTION


**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Secrets can be created outside of Samson, and then managed through Samson. If a secret was created outside of Samson, it is possible for the secret not to have the `visible` key and users won't be able to access that secret in Samson

### References
- Jira link: 

### Risks
- Low. There may be other issues with secrets created outside of Samson
