### PR TITLE
Log project name when creating a release

### DIFF
--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -18,7 +18,7 @@ class Integrations::BaseController < ApplicationController
       create_release = project.create_release?(branch, service_type, service_name)
       record_log(
         :info,
-        "Create release for branch [#{branch}], service_type [#{service_type}], service_name [#{service_name}]: " \
+        "Create release for project [#{project.name}], branch [#{branch}], service_type [#{service_type}], service_name [#{service_name}]: " \
         "#{create_release}"
       )
       release = find_or_create_release if create_release

--- a/app/controllers/integrations/base_controller.rb
+++ b/app/controllers/integrations/base_controller.rb
@@ -18,8 +18,8 @@ class Integrations::BaseController < ApplicationController
       create_release = project.create_release?(branch, service_type, service_name)
       record_log(
         :info,
-        "Create release for project [#{project.name}], branch [#{branch}], service_type [#{service_type}], service_name [#{service_name}]: " \
-        "#{create_release}"
+        "Create release for project [#{project.name}], branch [#{branch}], service_type [#{service_type}], " \
+        "service_name [#{service_name}]: #{create_release}"
       )
       release = find_or_create_release if create_release
     else

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -109,7 +109,7 @@ describe Integrations::BaseController do
       post :create, params: {test_route: true, token: token, foo: "bar"}
       assert_response :success
       result = WebhookRecorder.read(project)
-      log = "INFO: Create release for branch [master], service_type [ci], service_name [base_test]: true\n"
+      log = "INFO: Create release for project [Foo], branch [master], service_type [ci], service_name [base_test]: true\n"
 
       project.reload
       result.fetch(:log).must_equal log
@@ -192,7 +192,7 @@ describe Integrations::BaseController do
         post :create, params: {test_route: true, token: token}
 
         expected_messages = <<~MESSAGES
-          INFO: Create release for branch [master], service_type [ci], service_name [base_test]: true
+          INFO: Create release for project [Foo], branch [master], service_type [ci], service_name [base_test]: true
           INFO: Deploying #{deploy1.id} to Staging
           INFO: Deploying #{deploy2.id} to Production
         MESSAGES
@@ -221,7 +221,7 @@ describe Integrations::BaseController do
         post :create, params: {test_route: true, token: token, includes: 'status_urls'}
 
         expected_messages = <<~MESSAGES
-          INFO: Create release for branch [master], service_type [ci], service_name [base_test]: true
+          INFO: Create release for project [Foo], branch [master], service_type [ci], service_name [base_test]: true
           INFO: Deploying #{deploy1.id} to Staging
           INFO: Deploying #{deploy2.id} to Production
         MESSAGES
@@ -241,7 +241,7 @@ describe Integrations::BaseController do
         post :create, params: {test_route: true, token: token}
 
         message = <<~MSG
-          INFO: Create release for branch [master], service_type [ci], service_name [base_test]: true
+          INFO: Create release for project [Foo], branch [master], service_type [ci], service_name [base_test]: true
           ERROR: Failed deploying to Staging: Stage is locked
           INFO: Deploying #{Deploy.first.id} to Production
         MSG

--- a/test/controllers/integrations/base_controller_test.rb
+++ b/test/controllers/integrations/base_controller_test.rb
@@ -109,7 +109,8 @@ describe Integrations::BaseController do
       post :create, params: {test_route: true, token: token, foo: "bar"}
       assert_response :success
       result = WebhookRecorder.read(project)
-      log = "INFO: Create release for project [Foo], branch [master], service_type [ci], service_name [base_test]: true\n"
+      log = "INFO: Create release for project [Foo], branch [master], service_type [ci], " \
+            "service_name [base_test]: true\n"
 
       project.reload
       result.fetch(:log).must_equal log


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

Log project name when creating a release to help track which projects are using the Create Release functionality

### References
- Jira link: 

### Risks
- Low. Project should always have a name
