### PR TITLE
feat: use SleepAction for prestop hooks instead of ExecAction

### DIFF
--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -222,7 +222,7 @@ To make Samson leave your resource name alone, set `metadata.annotations.samson/
 When not using kubernetes services to route requests, requests can be lost during a deployment,
 since old pods shut down before everyone all clients are refreshed.
 
-To prevent this, samson can automatically add `container[].lifecycle.preStop` `/bin/sleep <INT>`
+To prevent this, samson can automatically add `container[].lifecycle.preStop.sleep.seconds: <INT>`
 and increase the `spec.terminationGracePeriodSeconds` if necessary.
 
 (will only add if `preStop` hook is not set and pod `metadata.annotations.container-nameofcontainer-samson/preStop` is not set to `disabled` and container has ports)

--- a/plugins/kubernetes/app/models/kubernetes/template_filler.rb
+++ b/plugins/kubernetes/app/models/kubernetes/template_filler.rb
@@ -643,7 +643,7 @@ module Kubernetes
       # add prestop sleep
       sleep_time = Integer(ENV['KUBERNETES_PRESTOP_SLEEP_DURATION'] || '3')
       containers.each do |container|
-        (container[:lifecycle] ||= {})[:preStop] = {exec: {command: ["/bin/sleep", sleep_time.to_s]}}
+        (container[:lifecycle] ||= {})[:preStop] = {sleep: {seconds: sleep_time}}
       end
 
       # shut down after prestop sleeping is done

--- a/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
+++ b/plugins/kubernetes/test/models/kubernetes/template_filler_test.rb
@@ -904,7 +904,7 @@ describe Kubernetes::TemplateFiller do
 
         it "adds preStop to avoid 502 errors when server addresses are cached for a few seconds" do
           template.to_hash.dig_fetch(:spec, :template, :spec, :containers, 0, :lifecycle).must_equal(
-            preStop: {exec: {command: ["/bin/sleep", "3"]}}
+            preStop: {sleep: {seconds: 3}}
           )
         end
 


### PR DESCRIPTION
**Note**: Samson is a public repo, do not include Zendesk-internal information, urls, etc.

* SleepAction is now offered in Kubernetes 1.30 or later by default (alpha in 1.29)
https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3960-pod-lifecycle-sleep-action/README.md


⚠️ this is a breaking change for clusters on old version
### References
- Jira link: 

### Risks
- Low: will break deployments for clusters older than 1.30
