### PR TITLE
Require `ErrorNotifier` before usage in Rollbar plugin

### DIFF
--- a/plugins/rollbar/config/initializers/rollbar.rb
+++ b/plugins/rollbar/config/initializers/rollbar.rb
@@ -21,6 +21,7 @@ if token = ENV['ROLLBAR_ACCESS_TOKEN']
         "ignored" if Samson::Hooks.fire(:ignore_error, options[:exception].class.name).any?
       end
 
+      require 'samson/error_notifier'
       Rollbar::UserInformer.user_information_placeholder = Samson::ErrorNotifier::USER_INFORMATION_PLACEHOLDER
       Rollbar::UserInformer.user_information = <<~HTML
         <br/><br/>


### PR DESCRIPTION
Resolve error when using the Rollbar plugin. It can't find the `Samson::ErrorNotifier::USER_INFORMATION_PLACEHOLDER` constant.

Add a require, similar to the Sentry plugin:

https://github.com/zendesk/samson/blob/495c0ac20544905a04d566ee686b2e38d105b2f2/plugins/sentry/config/initializers/sentry.rb#L14